### PR TITLE
chore: add CLAUDE.md and Cursor rules

### DIFF
--- a/.cursor/rules/github-issues.mdc
+++ b/.cursor/rules/github-issues.mdc
@@ -1,0 +1,53 @@
+---
+description: GitHub issue and PR conventions for tachigo
+globs:
+alwaysApply: true
+---
+
+# GitHub Issue 慣例
+
+## 標題前綴
+
+所有 issue 標題必須有前綴：
+
+| 前綴 | 用途 |
+|---|---|
+| `[backend]` | 後端開發任務（Go） |
+| `[frontend]` | 前端開發任務（React / TypeScript） |
+| `[discussion]` | 架構決策、設計討論，尚未有結論 |
+
+範例：
+- `[backend] PointsService — 雙帳本記帳`
+- `[frontend] Extension — 點數餘額顯示`
+- `[discussion] Token 經濟設計與 Soulbound 衝突`
+
+## Label
+
+| Label | 用途 |
+|---|---|
+| `feature` | 開發任務 |
+| `discussion` | 討論票（搭配 `[discussion]` 前綴使用） |
+
+## Issue 內容格式
+
+開發任務需包含：
+
+- **背景** — 這個功能是為了解決什麼問題
+- **任務** — 具體要做什麼（用 checklist）
+- **介面／規格** — Go interface、API 規格、或 component props
+- **參考** — 現有的範本檔案路徑
+- **完成條件** — PR merge 前必須達成的條件（checklist）
+
+## PR 慣例
+
+- 所有 PR 目標分支：`develop`
+- Branch 命名：`<type>/<short-description>`
+  - 例：`feat/points-service`、`fix/bits-receipt`、`docs/architecture`
+
+## Commit 格式
+
+```
+<type>: <short description>
+```
+
+Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`

--- a/.cursor/rules/github-issues.mdc
+++ b/.cursor/rules/github-issues.mdc
@@ -38,16 +38,29 @@ alwaysApply: true
 - **參考** — 現有的範本檔案路徑
 - **完成條件** — PR merge 前必須達成的條件（checklist）
 
-## PR 慣例
+## 開發流程
 
-- 所有 PR 目標分支：`develop`
-- Branch 命名：`<type>/<short-description>`
-  - 例：`feat/points-service`、`fix/bits-receipt`、`docs/architecture`
+1. 從 `develop` 拉新的 feature branch
+2. 開發完成後推上 remote
+3. 發 PR，目標分支：`develop`（不直接推 `main`）
+
+## Branch 命名
+
+`<type>/<short-description>`
+
+例：`feat/points-service`、`fix/bits-receipt`、`docs/architecture`
 
 ## Commit 格式
 
+每個 commit 必須用 `refs #<issue號碼>` 標記相關 issue，方便日後追溯規格與討論。
+
 ```
 <type>: <short description>
+
+refs #27
 ```
+
+- 實作過程中的 commit 用 `refs #號碼`
+- PR 的最後一個 commit 或 PR 描述用 `closes #號碼`（merge 後自動關閉 issue）
 
 Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# tachigo — Claude Code Guidelines
+
+## GitHub Issue 慣例
+
+### 標題前綴
+
+所有 issue 標題必須有前綴：
+
+| 前綴 | 用途 |
+|---|---|
+| `[backend]` | 後端開發任務（Go） |
+| `[frontend]` | 前端開發任務（React / TypeScript） |
+| `[discussion]` | 架構決策、設計討論，尚未有結論 |
+
+範例：
+- `[backend] PointsService — 雙帳本記帳`
+- `[frontend] Extension — 點數餘額顯示`
+- `[discussion] Token 經濟設計與 Soulbound 衝突`
+
+### Label
+
+| Label | 用途 |
+|---|---|
+| `feature` | 開發任務 |
+| `discussion` | 討論票（搭配 `[discussion]` 前綴使用） |
+
+### Issue 內容格式
+
+開發任務（`[backend]` / `[frontend]`）需包含：
+
+- **背景** — 這個功能是為了解決什麼問題
+- **任務** — 具體要做什麼（用 checklist）
+- **介面／規格** — Go interface、API 規格、或 component props
+- **參考** — 現有的範本檔案路徑
+- **完成條件** — PR merge 前必須達成的條件（checklist）
+
+討論票（`[discussion]`）不需要固定格式，但要列出待決定的問題點。
+
+---
+
+## PR 慣例
+
+- 所有 PR 目標分支：`develop`（不直接推 `main`）
+- branch 命名：`<type>/<short-description>`，例如 `feat/points-service`、`fix/bits-receipt`、`docs/architecture`
+
+## Commit 訊息格式
+
+```
+<type>: <short description>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
+
+---
+
+## 專案結構
+
+```
+tachigo/
+├── backend/          # Go API (Gin + GORM + PostgreSQL)
+├── tachimint/        # Twitch Extension 前端 (React + TypeScript)
+├── dashboard/        # 後台管理介面 (React + TypeScript) ← 建置中
+└── docs/             # 設計文件
+```
+
+## 開發指令
+
+```bash
+make dev    # 啟動所有服務（hot reload）
+make down   # 停止所有服務
+
+# 執行後端測試
+docker compose run --no-deps --rm app go test ./...
+```
+
+## 架構參考
+
+見 [docs/architecture.md](docs/architecture.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,18 +38,44 @@
 
 ---
 
-## PR 慣例
+## 開發流程
 
-- 所有 PR 目標分支：`develop`（不直接推 `main`）
-- branch 命名：`<type>/<short-description>`，例如 `feat/points-service`、`fix/bits-receipt`、`docs/architecture`
+1. 從 `develop` 拉新的 feature branch：
+
+   ```bash
+   git checkout develop
+   git pull
+   git checkout -b feat/points-service
+   ```
+
+2. 開發完成後推上 remote：
+
+   ```bash
+   git push -u origin feat/points-service
+   ```
+
+3. 在 GitHub 發 PR，目標分支：`develop`（不直接推 `main`）
+
+## Branch 命名
+
+`<type>/<short-description>`
+
+例：`feat/points-service`、`fix/bits-receipt`、`docs/architecture`
 
 ## Commit 訊息格式
+
+每個 commit 必須用 `refs #<issue號碼>` 標記相關 issue，方便日後追溯當初的規格與討論。
 
 ```
 <type>: <short description>
 
+refs #27
+
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
+
+- 實作過程中的 commit 用 `refs #號碼`
+- PR 的最後一個 commit 或 PR 描述用 `closes #號碼`（merge 後自動關閉 issue）
 
 Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` — Claude Code 自動讀取的專案規範（issue 慣例、開發流程、commit 格式）
- `.cursor/rules/github-issues.mdc` — Cursor 對應的 rule 檔

組員 clone repo 後，AI 工具會自動套用這份慣例。

🤖 Generated with [Claude Code](https://claude.com/claude-code)