### PR TITLE
[backend] watch-to-points MVP — data layer and backend flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,15 @@ docker compose run --no-deps --rm app go test ./...
 |---|---|---|
 | `README.md` | 所有人 | 開發環境建置（快速上手） |
 | `docs/` | 工程師 | 架構設計、API 規格、技術決策 |
+| `plans/` | 工程師 | 實作計畫（每個功能開始前先寫） |
 | GitHub Wiki | 全體人員 | 產品說明、功能介紹、非技術文件 |
+
+### plans/ 慣例
+
+- 每個功能或修改在開始實作前，先在 `plans/` 建立計畫文件
+- 檔名：`<feature-slug>.md`，例如 `watch-points-channel-config.md`
+- 計畫文件包含：背景、架構決策、待實作 checklist、驗證方式
+- 完成後在文件頂端標注 `狀態：已完成`
 
 ## 架構參考
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -50,12 +50,12 @@ func main() {
 		log.Fatalf("migration failed: %v", err)
 	}
 
-	// Partial unique index: only one active session per (opaque_user_id, channel_id).
+	// Partial unique index: only one active session per (user_id, channel_id).
 	// GORM AutoMigrate does not support partial indexes via struct tags, so we
 	// create it manually with CREATE INDEX IF NOT EXISTS (idempotent).
 	if err := db.Exec(`
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
-		ON watch_sessions (twitch_user_id, channel_id)
+		ON watch_sessions (user_id, channel_id)
 		WHERE is_active = true
 	`).Error; err != nil {
 		log.Fatalf("failed to create partial index: %v", err)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -42,8 +42,23 @@ func main() {
 		&models.Web3Nonce{},
 		&models.EmailVerification{},
 		&models.PasswordReset{},
+		// Points & watch-time
+		&models.PointsLedger{},
+		&models.PointsTransaction{},
+		&models.WatchSession{},
 	); err != nil {
 		log.Fatalf("migration failed: %v", err)
+	}
+
+	// Partial unique index: only one active session per (opaque_user_id, channel_id).
+	// GORM AutoMigrate does not support partial indexes via struct tags, so we
+	// create it manually with CREATE INDEX IF NOT EXISTS (idempotent).
+	if err := db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
+		ON watch_sessions (opaque_user_id, channel_id)
+		WHERE is_active = true
+	`).Error; err != nil {
+		log.Fatalf("failed to create partial index: %v", err)
 	}
 
 	// Wire services

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -55,7 +55,7 @@ func main() {
 	// create it manually with CREATE INDEX IF NOT EXISTS (idempotent).
 	if err := db.Exec(`
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
-		ON watch_sessions (opaque_user_id, channel_id)
+		ON watch_sessions (twitch_user_id, channel_id)
 		WHERE is_active = true
 	`).Error; err != nil {
 		log.Fatalf("failed to create partial index: %v", err)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -68,6 +68,7 @@ func main() {
 	extSvc := services.NewExtensionService(db, cfg, authSvc)
 	mailer := services.NewMailer(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.Username, cfg.SMTP.Password, cfg.SMTP.From)
 	emailAuthSvc := services.NewEmailAuthService(db, cfg, mailer)
+	watchSvc := services.NewWatchService(db)
 
 	// CORS origins from env, default to localhost for dev
 	originsEnv := os.Getenv("ALLOWED_ORIGINS")
@@ -76,7 +77,7 @@ func main() {
 		allowedOrigins = strings.Split(originsEnv, ",")
 	}
 
-	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, allowedOrigins)
+	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, watchSvc, allowedOrigins)
 
 	addr := ":" + cfg.Server.Port
 	log.Printf("server starting on %s (env=%s)", addr, cfg.Server.Env)

--- a/backend/internal/handlers/watch_handler.go
+++ b/backend/internal/handlers/watch_handler.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+type WatchHandler struct {
+	watchSvc *services.WatchService
+}
+
+func NewWatchHandler(watchSvc *services.WatchService) *WatchHandler {
+	return &WatchHandler{watchSvc: watchSvc}
+}
+
+// StartSession handles POST /extension/watch/start
+func (h *WatchHandler) StartSession(c *gin.Context) {
+	claims := middleware.MustExtClaims(c)
+
+	session, err := h.watchSvc.StartSession(claims.OpaqueUserID, claims.ChannelID)
+	if err != nil {
+		internal(c)
+		return
+	}
+	ok(c, session)
+}
+
+// Heartbeat handles POST /extension/watch/heartbeat
+func (h *WatchHandler) Heartbeat(c *gin.Context) {
+	claims := middleware.MustExtClaims(c)
+
+	result, err := h.watchSvc.Heartbeat(claims.OpaqueUserID, claims.ChannelID)
+	if err != nil {
+		if errors.Is(err, services.ErrNoActiveSession) {
+			badRequest(c, "no active session")
+			return
+		}
+		internal(c)
+		return
+	}
+	ok(c, gin.H{
+		"session":       result.Session,
+		"points_earned": result.PointsEarned,
+	})
+}
+
+// EndSession handles POST /extension/watch/end
+func (h *WatchHandler) EndSession(c *gin.Context) {
+	claims := middleware.MustExtClaims(c)
+
+	if err := h.watchSvc.EndSession(claims.OpaqueUserID, claims.ChannelID); err != nil {
+		internal(c)
+		return
+	}
+	ok(c, gin.H{"ended": true})
+}
+
+// GetBalance handles GET /extension/watch/balance
+func (h *WatchHandler) GetBalance(c *gin.Context) {
+	claims := middleware.MustExtClaims(c)
+
+	spendable, cumulative, err := h.watchSvc.GetBalance(claims.OpaqueUserID)
+	if err != nil {
+		internal(c)
+		return
+	}
+	ok(c, gin.H{
+		"spendable_balance": spendable,
+		"cumulative_total":  cumulative,
+	})
+}

--- a/backend/internal/handlers/watch_handler.go
+++ b/backend/internal/handlers/watch_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 
 	"github.com/tachigo/tachigo/internal/middleware"
 	"github.com/tachigo/tachigo/internal/services"
@@ -17,11 +18,25 @@ func NewWatchHandler(watchSvc *services.WatchService) *WatchHandler {
 	return &WatchHandler{watchSvc: watchSvc}
 }
 
+type watchBody struct {
+	ChannelID string `json:"channel_id" binding:"required"`
+}
+
 // StartSession handles POST /extension/watch/start
 func (h *WatchHandler) StartSession(c *gin.Context) {
-	claims := middleware.MustExtClaims(c)
+	claims := middleware.MustClaims(c)
+	var body watchBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
 
-	session, err := h.watchSvc.StartSession(claims.UserID, claims.ChannelID)
+	session, err := h.watchSvc.StartSession(userID, body.ChannelID)
 	if err != nil {
 		internal(c)
 		return
@@ -31,9 +46,19 @@ func (h *WatchHandler) StartSession(c *gin.Context) {
 
 // Heartbeat handles POST /extension/watch/heartbeat
 func (h *WatchHandler) Heartbeat(c *gin.Context) {
-	claims := middleware.MustExtClaims(c)
+	claims := middleware.MustClaims(c)
+	var body watchBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
 
-	result, err := h.watchSvc.Heartbeat(claims.UserID, claims.ChannelID)
+	result, err := h.watchSvc.Heartbeat(userID, body.ChannelID)
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSession) {
 			badRequest(c, "no active session")
@@ -50,20 +75,40 @@ func (h *WatchHandler) Heartbeat(c *gin.Context) {
 
 // EndSession handles POST /extension/watch/end
 func (h *WatchHandler) EndSession(c *gin.Context) {
-	claims := middleware.MustExtClaims(c)
+	claims := middleware.MustClaims(c)
+	var body watchBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
 
-	if err := h.watchSvc.EndSession(claims.UserID, claims.ChannelID); err != nil {
+	if err := h.watchSvc.EndSession(userID, body.ChannelID); err != nil {
 		internal(c)
 		return
 	}
 	ok(c, gin.H{"ended": true})
 }
 
-// GetBalance handles GET /extension/watch/balance
+// GetBalance handles GET /extension/watch/balance?channel_id=...
 func (h *WatchHandler) GetBalance(c *gin.Context) {
-	claims := middleware.MustExtClaims(c)
+	claims := middleware.MustClaims(c)
+	channelID := c.Query("channel_id")
+	if channelID == "" {
+		badRequest(c, "channel_id is required")
+		return
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
 
-	spendable, cumulative, err := h.watchSvc.GetBalance(claims.UserID)
+	spendable, cumulative, err := h.watchSvc.GetBalance(userID, channelID)
 	if err != nil {
 		internal(c)
 		return

--- a/backend/internal/handlers/watch_handler.go
+++ b/backend/internal/handlers/watch_handler.go
@@ -21,7 +21,7 @@ func NewWatchHandler(watchSvc *services.WatchService) *WatchHandler {
 func (h *WatchHandler) StartSession(c *gin.Context) {
 	claims := middleware.MustExtClaims(c)
 
-	session, err := h.watchSvc.StartSession(claims.OpaqueUserID, claims.ChannelID)
+	session, err := h.watchSvc.StartSession(claims.UserID, claims.ChannelID)
 	if err != nil {
 		internal(c)
 		return
@@ -33,7 +33,7 @@ func (h *WatchHandler) StartSession(c *gin.Context) {
 func (h *WatchHandler) Heartbeat(c *gin.Context) {
 	claims := middleware.MustExtClaims(c)
 
-	result, err := h.watchSvc.Heartbeat(claims.OpaqueUserID, claims.ChannelID)
+	result, err := h.watchSvc.Heartbeat(claims.UserID, claims.ChannelID)
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSession) {
 			badRequest(c, "no active session")
@@ -52,7 +52,7 @@ func (h *WatchHandler) Heartbeat(c *gin.Context) {
 func (h *WatchHandler) EndSession(c *gin.Context) {
 	claims := middleware.MustExtClaims(c)
 
-	if err := h.watchSvc.EndSession(claims.OpaqueUserID, claims.ChannelID); err != nil {
+	if err := h.watchSvc.EndSession(claims.UserID, claims.ChannelID); err != nil {
 		internal(c)
 		return
 	}
@@ -63,7 +63,7 @@ func (h *WatchHandler) EndSession(c *gin.Context) {
 func (h *WatchHandler) GetBalance(c *gin.Context) {
 	claims := middleware.MustExtClaims(c)
 
-	spendable, cumulative, err := h.watchSvc.GetBalance(claims.OpaqueUserID)
+	spendable, cumulative, err := h.watchSvc.GetBalance(claims.UserID)
 	if err != nil {
 		internal(c)
 		return

--- a/backend/internal/middleware/ext_auth.go
+++ b/backend/internal/middleware/ext_auth.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+const extClaimsKey = "ext_claims"
+
+// ExtJWTAuth validates a Twitch Extension Bearer token and stores claims in context.
+func ExtJWTAuth(extSvc *services.ExtensionService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		header := c.GetHeader("Authorization")
+		if !strings.HasPrefix(header, "Bearer ") {
+			c.AbortWithStatusJSON(401, gin.H{"success": false, "error": "authorization header required"})
+			return
+		}
+
+		token := strings.TrimPrefix(header, "Bearer ")
+		claims, err := extSvc.VerifyExtJWT(token)
+		if err != nil {
+			c.AbortWithStatusJSON(401, gin.H{"success": false, "error": "invalid extension token"})
+			return
+		}
+
+		c.Set(extClaimsKey, claims)
+		c.Next()
+	}
+}
+
+// MustExtClaims returns the Extension JWT claims stored by ExtJWTAuth middleware.
+// Panics with a clear message if called outside an ext-authenticated route or
+// if the stored value is not *services.ExtensionClaims.
+func MustExtClaims(c *gin.Context) *services.ExtensionClaims {
+	v, ok := c.Get(extClaimsKey)
+	if !ok {
+		panic("MustExtClaims: ext_claims not found in context — is ExtJWTAuth middleware applied?")
+	}
+	claims, ok := v.(*services.ExtensionClaims)
+	if !ok {
+		panic("MustExtClaims: ext_claims value is not *services.ExtensionClaims")
+	}
+	return claims
+}

--- a/backend/internal/middleware/ext_auth.go
+++ b/backend/internal/middleware/ext_auth.go
@@ -11,6 +11,10 @@ import (
 const extClaimsKey = "ext_claims"
 
 // ExtJWTAuth validates a Twitch Extension Bearer token and stores claims in context.
+//
+// Returns 401 if the JWT is missing or invalid.
+// Returns 403 if the JWT is valid but the viewer has not authorized the Extension
+// (claims.UserID is empty — only opaque_user_id is present).
 func ExtJWTAuth(extSvc *services.ExtensionService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		header := c.GetHeader("Authorization")
@@ -23,6 +27,11 @@ func ExtJWTAuth(extSvc *services.ExtensionService) gin.HandlerFunc {
 		claims, err := extSvc.VerifyExtJWT(token)
 		if err != nil {
 			c.AbortWithStatusJSON(401, gin.H{"success": false, "error": "invalid extension token"})
+			return
+		}
+
+		if claims.UserID == "" {
+			c.AbortWithStatusJSON(403, gin.H{"success": false, "error": "extension authorization required"})
 			return
 		}
 

--- a/backend/internal/models/points.go
+++ b/backend/internal/models/points.go
@@ -1,0 +1,65 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// TxSource identifies the origin of a points transaction.
+type TxSource string
+
+const (
+	TxSourceBits      TxSource = "bits"
+	TxSourceWatchTime TxSource = "watch_time"
+	TxSourceSpend     TxSource = "spend"
+)
+
+// PointsLedger is the single, platform-wide source of truth for a viewer's
+// points balance. Points are not scoped to a channel — they are earned and
+// spent across the entire platform.
+type PointsLedger struct {
+	ID               uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	OpaqueUserID     string    `gorm:"type:varchar(255);not null;uniqueIndex"         json:"opaque_user_id"`
+	CumulativeTotal  int64     `gorm:"not null;default:0"                             json:"cumulative_total"`
+	SpendableBalance int64     `gorm:"not null;default:0"                             json:"spendable_balance"`
+	CreatedAt        time.Time `                                                      json:"created_at"`
+	UpdatedAt        time.Time `                                                      json:"updated_at"`
+}
+
+func (p *PointsLedger) BeforeCreate(tx *gorm.DB) error {
+	if p.ID == uuid.Nil {
+		p.ID = uuid.New()
+	}
+	return nil
+}
+
+// PointsTransaction records every change to a viewer's points balance.
+//
+// WatchSessionID rules by source:
+//   - "watch_time" → always non-nil; links to the session that triggered the reward
+//   - "bits"       → always nil; no session context
+//   - "spend"      → always nil; consumption has no session context
+//
+// No FK constraint on watch_session_id — sessions may be archived or purged
+// independently without orphaning the transaction history.
+type PointsTransaction struct {
+	ID             uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	LedgerID       uuid.UUID  `gorm:"type:uuid;not null;index"                       json:"ledger_id"`
+	WatchSessionID *uuid.UUID `gorm:"type:uuid;index"                                json:"watch_session_id"`
+	Source         TxSource   `gorm:"type:varchar(50);not null"                      json:"source"`
+	Delta          int64      `gorm:"not null"                                       json:"delta"`
+	BalanceAfter   int64      `gorm:"not null"                                       json:"balance_after"`
+	Note           *string    `gorm:"type:text"                                      json:"note"`
+	CreatedAt      time.Time  `                                                      json:"created_at"`
+
+	Ledger PointsLedger `gorm:"foreignKey:LedgerID" json:"-"`
+}
+
+func (p *PointsTransaction) BeforeCreate(tx *gorm.DB) error {
+	if p.ID == uuid.Nil {
+		p.ID = uuid.New()
+	}
+	return nil
+}

--- a/backend/internal/models/points.go
+++ b/backend/internal/models/points.go
@@ -21,7 +21,7 @@ const (
 // spent across the entire platform.
 type PointsLedger struct {
 	ID               uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	OpaqueUserID     string    `gorm:"type:varchar(255);not null;uniqueIndex"         json:"opaque_user_id"`
+	TwitchUserID     string    `gorm:"type:varchar(255);not null;uniqueIndex"         json:"twitch_user_id"`
 	CumulativeTotal  int64     `gorm:"not null;default:0"                             json:"cumulative_total"`
 	SpendableBalance int64     `gorm:"not null;default:0"                             json:"spendable_balance"`
 	CreatedAt        time.Time `                                                      json:"created_at"`

--- a/backend/internal/models/points.go
+++ b/backend/internal/models/points.go
@@ -16,21 +16,22 @@ const (
 	TxSourceSpend     TxSource = "spend"
 )
 
-// PointsLedger is the single, platform-wide source of truth for a viewer's
-// points balance. Points are not scoped to a channel — they are earned and
-// spent across the entire platform.
+// PointsLedger is the per-channel points balance for a viewer.
+// Each viewer has one ledger per channel; balances are not shared across channels.
 type PointsLedger struct {
-	ID               uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	TwitchUserID     string    `gorm:"type:varchar(255);not null;uniqueIndex"         json:"twitch_user_id"`
-	CumulativeTotal  int64     `gorm:"not null;default:0"                             json:"cumulative_total"`
-	SpendableBalance int64     `gorm:"not null;default:0"                             json:"spendable_balance"`
-	CreatedAt        time.Time `                                                      json:"created_at"`
-	UpdatedAt        time.Time `                                                      json:"updated_at"`
+	ID               uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"             json:"id"`
+	UserID           uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:idx_ledger_user_channel"     json:"user_id"`
+	ChannelID        string    `gorm:"type:varchar(255);not null;uniqueIndex:idx_ledger_user_channel" json:"channel_id"`
+	CumulativeTotal  int64     `gorm:"not null;default:0"                                         json:"cumulative_total"`
+	SpendableBalance int64     `gorm:"not null;default:0"                                         json:"spendable_balance"`
+	CreatedAt        time.Time `                                                                   json:"created_at"`
+	UpdatedAt        time.Time `                                                                   json:"updated_at"`
 }
 
 func (p *PointsLedger) BeforeCreate(tx *gorm.DB) error {
 	if p.ID == uuid.Nil {
-		p.ID = uuid.New()
+		id, _ := uuid.NewV7()
+		p.ID = id
 	}
 	return nil
 }
@@ -59,7 +60,8 @@ type PointsTransaction struct {
 
 func (p *PointsTransaction) BeforeCreate(tx *gorm.DB) error {
 	if p.ID == uuid.Nil {
-		p.ID = uuid.New()
+		id, _ := uuid.NewV7()
+		p.ID = id
 	}
 	return nil
 }

--- a/backend/internal/models/watch_session.go
+++ b/backend/internal/models/watch_session.go
@@ -31,7 +31,8 @@ type WatchSession struct {
 
 func (w *WatchSession) BeforeCreate(tx *gorm.DB) error {
 	if w.ID == uuid.Nil {
-		w.ID = uuid.New()
+		id, _ := uuid.NewV7()
+		w.ID = id
 	}
 	return nil
 }

--- a/backend/internal/models/watch_session.go
+++ b/backend/internal/models/watch_session.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// WatchSession records a viewer's active or completed watch session in a channel.
+// Only one active session (is_active=true) is allowed per (opaque_user_id, channel_id) pair.
+// The partial unique index is created manually in main.go — GORM does not support
+// partial indexes via struct tags.
+//
+// Session lifecycle:
+//
+//	active  : is_active = true,  ended_at = NULL
+//	finished: is_active = false, ended_at = <timestamp>
+type WatchSession struct {
+	ID                 uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	OpaqueUserID       string     `gorm:"type:varchar(255);not null;index"               json:"opaque_user_id"`
+	ChannelID          string     `gorm:"type:varchar(255);not null;index"               json:"channel_id"`
+	AccumulatedSeconds int64      `gorm:"not null;default:0"                             json:"accumulated_seconds"`
+	RewardedSeconds    int64      `gorm:"not null;default:0"                             json:"rewarded_seconds"`
+	LastHeartbeatAt    time.Time  `gorm:"not null;default:now()"                         json:"last_heartbeat_at"`
+	IsActive           bool       `gorm:"not null;default:true;index"                    json:"is_active"`
+	EndedAt            *time.Time `                                                      json:"ended_at"`
+	CreatedAt          time.Time  `                                                      json:"created_at"`
+	UpdatedAt          time.Time  `                                                      json:"updated_at"`
+}
+
+func (w *WatchSession) BeforeCreate(tx *gorm.DB) error {
+	if w.ID == uuid.Nil {
+		w.ID = uuid.New()
+	}
+	return nil
+}

--- a/backend/internal/models/watch_session.go
+++ b/backend/internal/models/watch_session.go
@@ -18,7 +18,7 @@ import (
 //	finished: is_active = false, ended_at = <timestamp>
 type WatchSession struct {
 	ID                 uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	OpaqueUserID       string     `gorm:"type:varchar(255);not null;index"               json:"opaque_user_id"`
+	TwitchUserID       string     `gorm:"type:varchar(255);not null;index"               json:"twitch_user_id"`
 	ChannelID          string     `gorm:"type:varchar(255);not null;index"               json:"channel_id"`
 	AccumulatedSeconds int64      `gorm:"not null;default:0"                             json:"accumulated_seconds"`
 	RewardedSeconds    int64      `gorm:"not null;default:0"                             json:"rewarded_seconds"`

--- a/backend/internal/models/watch_session.go
+++ b/backend/internal/models/watch_session.go
@@ -8,7 +8,7 @@ import (
 )
 
 // WatchSession records a viewer's active or completed watch session in a channel.
-// Only one active session (is_active=true) is allowed per (opaque_user_id, channel_id) pair.
+// Only one active session (is_active=true) is allowed per (user_id, channel_id) pair.
 // The partial unique index is created manually in main.go — GORM does not support
 // partial indexes via struct tags.
 //
@@ -18,7 +18,7 @@ import (
 //	finished: is_active = false, ended_at = <timestamp>
 type WatchSession struct {
 	ID                 uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	TwitchUserID       string     `gorm:"type:varchar(255);not null;index"               json:"twitch_user_id"`
+	UserID             uuid.UUID  `gorm:"type:uuid;not null;index"                       json:"user_id"`
 	ChannelID          string     `gorm:"type:varchar(255);not null;index"               json:"channel_id"`
 	AccumulatedSeconds int64      `gorm:"not null;default:0"                             json:"accumulated_seconds"`
 	RewardedSeconds    int64      `gorm:"not null;default:0"                             json:"rewarded_seconds"`

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -16,6 +16,7 @@ func New(
 	addrSvc *services.AddressService,
 	extSvc *services.ExtensionService,
 	emailAuthSvc *services.EmailAuthService,
+	watchSvc *services.WatchService,
 	allowedOrigins []string,
 ) *gin.Engine {
 	r := gin.New()
@@ -27,6 +28,7 @@ func New(
 	addrH := handlers.NewAddressHandler(addrSvc)
 	extH := handlers.NewExtensionHandler(extSvc)
 	emailH := handlers.NewEmailAuthHandler(emailAuthSvc)
+	watchH := handlers.NewWatchHandler(watchSvc)
 
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})
@@ -68,6 +70,16 @@ func New(
 	{
 		ext.POST("/auth/login", extH.Login)
 		ext.POST("/bits/complete", extH.BitsComplete)
+
+		// Watch-time points (requires Extension JWT)
+		watch := ext.Group("/watch")
+		watch.Use(middleware.ExtJWTAuth(extSvc))
+		{
+			watch.POST("/start", watchH.StartSession)
+			watch.POST("/heartbeat", watchH.Heartbeat)
+			watch.POST("/end", watchH.EndSession)
+			watch.GET("/balance", watchH.GetBalance)
+		}
 	}
 
 	// ── Authenticated routes ──────────────────────────────────────────────

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -71,9 +71,9 @@ func New(
 		ext.POST("/auth/login", extH.Login)
 		ext.POST("/bits/complete", extH.BitsComplete)
 
-		// Watch-time points (requires Extension JWT)
+		// Watch-time points (requires tachigo JWT — viewer must log in first)
 		watch := ext.Group("/watch")
-		watch.Use(middleware.ExtJWTAuth(extSvc))
+		watch.Use(middleware.JWTAuth(authSvc))
 		{
 			watch.POST("/start", watchH.StartSession)
 			watch.POST("/heartbeat", watchH.Heartbeat)

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -101,6 +101,42 @@ func migrateTestDB(db *gorm.DB) error {
 			expires_at DATETIME NOT NULL,
 			created_at DATETIME
 		)`,
+		`CREATE TABLE IF NOT EXISTS watch_sessions (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			accumulated_seconds INTEGER NOT NULL DEFAULT 0,
+			rewarded_seconds INTEGER NOT NULL DEFAULT 0,
+			last_heartbeat_at DATETIME NOT NULL,
+			is_active INTEGER NOT NULL DEFAULT 1,
+			ended_at DATETIME,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
+			ON watch_sessions (user_id, channel_id)
+			WHERE is_active = 1`,
+		`CREATE TABLE IF NOT EXISTS points_ledgers (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			cumulative_total INTEGER NOT NULL DEFAULT 0,
+			spendable_balance INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_ledger_user_channel
+			ON points_ledgers (user_id, channel_id)`,
+		`CREATE TABLE IF NOT EXISTS points_transactions (
+			id TEXT PRIMARY KEY,
+			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
+			watch_session_id TEXT,
+			source TEXT NOT NULL,
+			delta INTEGER NOT NULL,
+			balance_after INTEGER NOT NULL,
+			note TEXT,
+			created_at DATETIME
+		)`,
 	}
 	for _, s := range stmts {
 		if err := db.Exec(s).Error; err != nil {

--- a/backend/internal/services/watch_service.go
+++ b/backend/internal/services/watch_service.go
@@ -14,6 +14,15 @@ import (
 // staleThreshold is how long without a heartbeat before a session is considered stale.
 const staleThreshold = 2 * time.Minute
 
+// newUUID generates a time-ordered UUID v7. Falls back to random v4 on failure.
+func newUUID() uuid.UUID {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return uuid.New()
+	}
+	return id
+}
+
 var ErrNoActiveSession = errors.New("no active session")
 
 type WatchService struct {
@@ -31,14 +40,14 @@ func NewWatchService(db *gorm.DB) *WatchService {
 //
 // The entire lookup + conditional close + create runs inside a single transaction
 // with a row-level lock so concurrent requests cannot race into the partial-unique
-// index constraint on (twitch_user_id, channel_id) WHERE is_active = true.
-func (s *WatchService) StartSession(twitchUserID, channelID string) (*models.WatchSession, error) {
+// index constraint on (user_id, channel_id) WHERE is_active = true.
+func (s *WatchService) StartSession(userID uuid.UUID, channelID string) (*models.WatchSession, error) {
 	var result models.WatchSession
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var session models.WatchSession
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", twitchUserID, channelID).
+			Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
 			First(&session).Error
 
 		if err == nil {
@@ -59,8 +68,8 @@ func (s *WatchService) StartSession(twitchUserID, channelID string) (*models.Wat
 		}
 
 		newSession := models.WatchSession{
-			ID:              uuid.New(),
-			TwitchUserID:    twitchUserID,
+			ID:              newUUID(),
+			UserID:          userID,
 			ChannelID:       channelID,
 			LastHeartbeatAt: time.Now(),
 			IsActive:        true,
@@ -75,7 +84,7 @@ func (s *WatchService) StartSession(twitchUserID, channelID string) (*models.Wat
 			tx.RollbackTo("sp_new_session")
 			var existing models.WatchSession
 			if qErr := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-				Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", twitchUserID, channelID).
+				Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
 				First(&existing).Error; qErr == nil {
 				result = existing
 				return nil
@@ -105,14 +114,14 @@ type HeartbeatResult struct {
 //     reading the same state and double-awarding points.
 //   - PointsLedger is updated via an atomic INSERT … ON CONFLICT DO UPDATE, which
 //     prevents balance overwrites under concurrent writes.
-func (s *WatchService) Heartbeat(twitchUserID, channelID string) (*HeartbeatResult, error) {
+func (s *WatchService) Heartbeat(userID uuid.UUID, channelID string) (*HeartbeatResult, error) {
 	var result HeartbeatResult
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		// Lock the row so concurrent heartbeats queue up rather than racing.
 		var session models.WatchSession
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", twitchUserID, channelID).
+			Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
 			First(&session).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNoActiveSession
@@ -122,6 +131,14 @@ func (s *WatchService) Heartbeat(twitchUserID, channelID string) (*HeartbeatResu
 
 		now := time.Now()
 		delta := now.Sub(session.LastHeartbeatAt)
+
+		// Ignore heartbeats that arrive too quickly — likely a client retry.
+		// Normal cadence is 30 s; anything under 20 s is anomalous.
+		if delta < 20*time.Second {
+			result = HeartbeatResult{Session: &session, PointsEarned: 0}
+			return nil
+		}
+
 		if delta > 30*time.Second {
 			delta = 30 * time.Second
 		}
@@ -147,20 +164,24 @@ func (s *WatchService) Heartbeat(twitchUserID, channelID string) (*HeartbeatResu
 
 		if pointsToAward > 0 {
 			// Atomic upsert: avoid read-modify-write by letting the database do the arithmetic.
+			// UUID and timestamps are passed as parameters for SQLite test compatibility
+			// (gen_random_uuid() and NOW() are PostgreSQL-only).
+			ledgerID := newUUID()
+			upsertTime := time.Now()
 			if err := tx.Exec(`
-				INSERT INTO points_ledgers (id, twitch_user_id, spendable_balance, cumulative_total, created_at, updated_at)
-				VALUES (gen_random_uuid(), ?, ?, ?, NOW(), NOW())
-				ON CONFLICT (twitch_user_id) DO UPDATE SET
+				INSERT INTO points_ledgers (id, user_id, channel_id, spendable_balance, cumulative_total, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT (user_id, channel_id) DO UPDATE SET
 					spendable_balance = points_ledgers.spendable_balance + EXCLUDED.spendable_balance,
 					cumulative_total  = points_ledgers.cumulative_total  + EXCLUDED.cumulative_total,
-					updated_at        = NOW()
-			`, twitchUserID, pointsToAward, pointsToAward).Error; err != nil {
+					updated_at        = ?
+			`, ledgerID, userID, channelID, pointsToAward, pointsToAward, upsertTime, upsertTime, upsertTime).Error; err != nil {
 				return err
 			}
 
 			// Fetch the balance that was just written (within the same tx for consistency).
 			var ledger models.PointsLedger
-			if err := tx.Where("twitch_user_id = ?", twitchUserID).First(&ledger).Error; err != nil {
+			if err := tx.Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
 				return err
 			}
 
@@ -188,21 +209,21 @@ func (s *WatchService) Heartbeat(twitchUserID, channelID string) (*HeartbeatResu
 
 // EndSession marks the viewer's active session in the given channel as ended.
 // If no active session exists the call is a no-op (idempotent).
-func (s *WatchService) EndSession(twitchUserID, channelID string) error {
+func (s *WatchService) EndSession(userID uuid.UUID, channelID string) error {
 	now := time.Now()
 	return s.db.Model(&models.WatchSession{}).
-		Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", twitchUserID, channelID).
+		Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
 		Updates(map[string]interface{}{
 			"is_active": false,
 			"ended_at":  now,
 		}).Error
 }
 
-// GetBalance returns the viewer's current spendable balance and cumulative total.
-// Returns (0, 0, nil) if no ledger exists yet.
-func (s *WatchService) GetBalance(twitchUserID string) (spendable, cumulative int64, err error) {
+// GetBalance returns the viewer's current spendable balance and cumulative total
+// for the given channel. Returns (0, 0, nil) if no ledger exists yet.
+func (s *WatchService) GetBalance(userID uuid.UUID, channelID string) (spendable, cumulative int64, err error) {
 	var ledger models.PointsLedger
-	if err := s.db.Where("twitch_user_id = ?", twitchUserID).First(&ledger).Error; err != nil {
+	if err := s.db.Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return 0, 0, nil
 		}

--- a/backend/internal/services/watch_service.go
+++ b/backend/internal/services/watch_service.go
@@ -1,0 +1,212 @@
+package services
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+// staleThreshold is how long without a heartbeat before a session is considered stale.
+const staleThreshold = 2 * time.Minute
+
+var ErrNoActiveSession = errors.New("no active session")
+
+type WatchService struct {
+	db *gorm.DB
+}
+
+func NewWatchService(db *gorm.DB) *WatchService {
+	return &WatchService{db: db}
+}
+
+// StartSession returns or creates an active watch session.
+//   - active and not stale → return existing session
+//   - active but stale     → close old session, create new
+//   - no active session    → create new
+//
+// The entire lookup + conditional close + create runs inside a single transaction
+// with a row-level lock so concurrent requests cannot race into the partial-unique
+// index constraint on (opaque_user_id, channel_id) WHERE is_active = true.
+func (s *WatchService) StartSession(opaqueUserID, channelID string) (*models.WatchSession, error) {
+	var result models.WatchSession
+
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var session models.WatchSession
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("opaque_user_id = ? AND channel_id = ? AND is_active = true", opaqueUserID, channelID).
+			First(&session).Error
+
+		if err == nil {
+			if time.Since(session.LastHeartbeatAt) <= staleThreshold {
+				result = session
+				return nil
+			}
+			// Stale: close it before opening a new one.
+			now := time.Now()
+			if err := tx.Model(&session).Updates(map[string]interface{}{
+				"is_active": false,
+				"ended_at":  now,
+			}).Error; err != nil {
+				return err
+			}
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		newSession := models.WatchSession{
+			ID:              uuid.New(),
+			OpaqueUserID:    opaqueUserID,
+			ChannelID:       channelID,
+			LastHeartbeatAt: time.Now(),
+			IsActive:        true,
+		}
+		// Use a savepoint so that if Create fails (e.g. another concurrent request
+		// just won the race and inserted first), we can roll back to a clean state
+		// within the same transaction and re-query instead of aborting entirely.
+		// Without this, PostgreSQL marks the transaction as aborted on any error,
+		// making subsequent queries impossible.
+		tx.SavePoint("sp_new_session")
+		if err := tx.Create(&newSession).Error; err != nil {
+			tx.RollbackTo("sp_new_session")
+			var existing models.WatchSession
+			if qErr := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+				Where("opaque_user_id = ? AND channel_id = ? AND is_active = true", opaqueUserID, channelID).
+				First(&existing).Error; qErr == nil {
+				result = existing
+				return nil
+			}
+			return err
+		}
+		result = newSession
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// HeartbeatResult contains the outcome of a single heartbeat call.
+type HeartbeatResult struct {
+	Session      *models.WatchSession
+	PointsEarned int64
+}
+
+// Heartbeat advances the session timer and awards points if a full minute has accumulated.
+//
+// Concurrency protections:
+//   - SELECT FOR UPDATE on the session row prevents two concurrent heartbeats from
+//     reading the same state and double-awarding points.
+//   - PointsLedger is updated via an atomic INSERT … ON CONFLICT DO UPDATE, which
+//     prevents balance overwrites under concurrent writes.
+func (s *WatchService) Heartbeat(opaqueUserID, channelID string) (*HeartbeatResult, error) {
+	var result HeartbeatResult
+
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		// Lock the row so concurrent heartbeats queue up rather than racing.
+		var session models.WatchSession
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("opaque_user_id = ? AND channel_id = ? AND is_active = true", opaqueUserID, channelID).
+			First(&session).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNoActiveSession
+			}
+			return err
+		}
+
+		now := time.Now()
+		delta := now.Sub(session.LastHeartbeatAt)
+		if delta > 30*time.Second {
+			delta = 30 * time.Second
+		}
+		// Use integer division on the duration to avoid float truncation issues
+		// (e.g. 29.9s should count as 29s, not silently floor via float cast).
+		deltaSeconds := int64(delta / time.Second)
+
+		newAccumulated := session.AccumulatedSeconds + deltaSeconds
+		pendingSeconds := newAccumulated - session.RewardedSeconds
+		pointsToAward := pendingSeconds / 60
+		newRewarded := session.RewardedSeconds + pointsToAward*60
+
+		if err := tx.Model(&session).Updates(map[string]interface{}{
+			"accumulated_seconds": newAccumulated,
+			"rewarded_seconds":    newRewarded,
+			"last_heartbeat_at":   now,
+		}).Error; err != nil {
+			return err
+		}
+		session.AccumulatedSeconds = newAccumulated
+		session.RewardedSeconds = newRewarded
+		session.LastHeartbeatAt = now
+
+		if pointsToAward > 0 {
+			// Atomic upsert: avoid read-modify-write by letting the database do the arithmetic.
+			if err := tx.Exec(`
+				INSERT INTO points_ledgers (id, opaque_user_id, spendable_balance, cumulative_total, created_at, updated_at)
+				VALUES (gen_random_uuid(), ?, ?, ?, NOW(), NOW())
+				ON CONFLICT (opaque_user_id) DO UPDATE SET
+					spendable_balance = points_ledgers.spendable_balance + EXCLUDED.spendable_balance,
+					cumulative_total  = points_ledgers.cumulative_total  + EXCLUDED.cumulative_total,
+					updated_at        = NOW()
+			`, opaqueUserID, pointsToAward, pointsToAward).Error; err != nil {
+				return err
+			}
+
+			// Fetch the balance that was just written (within the same tx for consistency).
+			var ledger models.PointsLedger
+			if err := tx.Where("opaque_user_id = ?", opaqueUserID).First(&ledger).Error; err != nil {
+				return err
+			}
+
+			txRecord := &models.PointsTransaction{
+				LedgerID:       ledger.ID,
+				WatchSessionID: &session.ID,
+				Source:         models.TxSourceWatchTime,
+				Delta:          pointsToAward,
+				BalanceAfter:   ledger.SpendableBalance,
+			}
+			if err := tx.Create(txRecord).Error; err != nil {
+				return err
+			}
+		}
+
+		result = HeartbeatResult{Session: &session, PointsEarned: pointsToAward}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// EndSession marks the viewer's active session in the given channel as ended.
+// If no active session exists the call is a no-op (idempotent).
+func (s *WatchService) EndSession(opaqueUserID, channelID string) error {
+	now := time.Now()
+	return s.db.Model(&models.WatchSession{}).
+		Where("opaque_user_id = ? AND channel_id = ? AND is_active = true", opaqueUserID, channelID).
+		Updates(map[string]interface{}{
+			"is_active": false,
+			"ended_at":  now,
+		}).Error
+}
+
+// GetBalance returns the viewer's current spendable balance and cumulative total.
+// Returns (0, 0, nil) if no ledger exists yet.
+func (s *WatchService) GetBalance(opaqueUserID string) (spendable, cumulative int64, err error) {
+	var ledger models.PointsLedger
+	if err := s.db.Where("opaque_user_id = ?", opaqueUserID).First(&ledger).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+	return ledger.SpendableBalance, ledger.CumulativeTotal, nil
+}

--- a/backend/internal/services/watch_service.go
+++ b/backend/internal/services/watch_service.go
@@ -31,14 +31,14 @@ func NewWatchService(db *gorm.DB) *WatchService {
 //
 // The entire lookup + conditional close + create runs inside a single transaction
 // with a row-level lock so concurrent requests cannot race into the partial-unique
-// index constraint on (opaque_user_id, channel_id) WHERE is_active = true.
-func (s *WatchService) StartSession(opaqueUserID, channelID string) (*models.WatchSession, error) {
+// index constraint on (twitch_user_id, channel_id) WHERE is_active = true.
+func (s *WatchService) StartSession(twitchUserID, channelID string) (*models.WatchSession, error) {
 	var result models.WatchSession
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var session models.WatchSession
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("opaque_user_id = ? AND channel_id = ? AND is_active = true", opaqueUserID, channelID).
+			Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", twitchUserID, channelID).
 			First(&session).Error
 
 		if err == nil {
@@ -60,7 +60,7 @@ func (s *WatchService) StartSession(opaqueUserID, channelID string) (*models.Wat
 
 		newSession := models.WatchSession{
 			ID:              uuid.New(),
-			OpaqueUserID:    opaqueUserID,
+			TwitchUserID:    twitchUserID,
 			ChannelID:       channelID,
 			LastHeartbeatAt: time.Now(),
 			IsActive:        true,
@@ -75,7 +75,7 @@ func (s *WatchService) StartSession(opaqueUserID, channelID string) (*models.Wat
 			tx.RollbackTo("sp_new_session")
 			var existing models.WatchSession
 			if qErr := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-				Where("opaque_user_id = ? AND channel_id = ? AND is_active = true", opaqueUserID, channelID).
+				Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", twitchUserID, channelID).
 				First(&existing).Error; qErr == nil {
 				result = existing
 				return nil
@@ -105,14 +105,14 @@ type HeartbeatResult struct {
 //     reading the same state and double-awarding points.
 //   - PointsLedger is updated via an atomic INSERT … ON CONFLICT DO UPDATE, which
 //     prevents balance overwrites under concurrent writes.
-func (s *WatchService) Heartbeat(opaqueUserID, channelID string) (*HeartbeatResult, error) {
+func (s *WatchService) Heartbeat(twitchUserID, channelID string) (*HeartbeatResult, error) {
 	var result HeartbeatResult
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		// Lock the row so concurrent heartbeats queue up rather than racing.
 		var session models.WatchSession
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("opaque_user_id = ? AND channel_id = ? AND is_active = true", opaqueUserID, channelID).
+			Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", twitchUserID, channelID).
 			First(&session).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNoActiveSession
@@ -148,19 +148,19 @@ func (s *WatchService) Heartbeat(opaqueUserID, channelID string) (*HeartbeatResu
 		if pointsToAward > 0 {
 			// Atomic upsert: avoid read-modify-write by letting the database do the arithmetic.
 			if err := tx.Exec(`
-				INSERT INTO points_ledgers (id, opaque_user_id, spendable_balance, cumulative_total, created_at, updated_at)
+				INSERT INTO points_ledgers (id, twitch_user_id, spendable_balance, cumulative_total, created_at, updated_at)
 				VALUES (gen_random_uuid(), ?, ?, ?, NOW(), NOW())
-				ON CONFLICT (opaque_user_id) DO UPDATE SET
+				ON CONFLICT (twitch_user_id) DO UPDATE SET
 					spendable_balance = points_ledgers.spendable_balance + EXCLUDED.spendable_balance,
 					cumulative_total  = points_ledgers.cumulative_total  + EXCLUDED.cumulative_total,
 					updated_at        = NOW()
-			`, opaqueUserID, pointsToAward, pointsToAward).Error; err != nil {
+			`, twitchUserID, pointsToAward, pointsToAward).Error; err != nil {
 				return err
 			}
 
 			// Fetch the balance that was just written (within the same tx for consistency).
 			var ledger models.PointsLedger
-			if err := tx.Where("opaque_user_id = ?", opaqueUserID).First(&ledger).Error; err != nil {
+			if err := tx.Where("twitch_user_id = ?", twitchUserID).First(&ledger).Error; err != nil {
 				return err
 			}
 
@@ -188,10 +188,10 @@ func (s *WatchService) Heartbeat(opaqueUserID, channelID string) (*HeartbeatResu
 
 // EndSession marks the viewer's active session in the given channel as ended.
 // If no active session exists the call is a no-op (idempotent).
-func (s *WatchService) EndSession(opaqueUserID, channelID string) error {
+func (s *WatchService) EndSession(twitchUserID, channelID string) error {
 	now := time.Now()
 	return s.db.Model(&models.WatchSession{}).
-		Where("opaque_user_id = ? AND channel_id = ? AND is_active = true", opaqueUserID, channelID).
+		Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", twitchUserID, channelID).
 		Updates(map[string]interface{}{
 			"is_active": false,
 			"ended_at":  now,
@@ -200,9 +200,9 @@ func (s *WatchService) EndSession(opaqueUserID, channelID string) error {
 
 // GetBalance returns the viewer's current spendable balance and cumulative total.
 // Returns (0, 0, nil) if no ledger exists yet.
-func (s *WatchService) GetBalance(opaqueUserID string) (spendable, cumulative int64, err error) {
+func (s *WatchService) GetBalance(twitchUserID string) (spendable, cumulative int64, err error) {
 	var ledger models.PointsLedger
-	if err := s.db.Where("opaque_user_id = ?", opaqueUserID).First(&ledger).Error; err != nil {
+	if err := s.db.Where("twitch_user_id = ?", twitchUserID).First(&ledger).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return 0, 0, nil
 		}

--- a/backend/internal/services/watch_service_test.go
+++ b/backend/internal/services/watch_service_test.go
@@ -1,0 +1,290 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+// seedWatchUser inserts a minimal users row so FK constraints pass in watch tests.
+func seedWatchUser(t *testing.T, svc *WatchService) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := svc.db.Exec(
+		`INSERT INTO users (id, role, is_active, email_verified, created_at, updated_at)
+		 VALUES (?, 'viewer', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		id,
+	).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+// backdateHeartbeat manually sets last_heartbeat_at to simulate elapsed time.
+func backdateHeartbeat(t *testing.T, svc *WatchService, sessionID uuid.UUID, ago time.Duration) {
+	t.Helper()
+	ts := time.Now().Add(-ago)
+	if err := svc.db.Model(&models.WatchSession{}).
+		Where("id = ?", sessionID).
+		Update("last_heartbeat_at", ts).Error; err != nil {
+		t.Fatalf("backdate heartbeat: %v", err)
+	}
+}
+
+// reloadSession fetches the latest DB state of a session.
+func reloadSession(t *testing.T, svc *WatchService, id uuid.UUID) *models.WatchSession {
+	t.Helper()
+	var s models.WatchSession
+	if err := svc.db.First(&s, "id = ?", id).Error; err != nil {
+		t.Fatalf("reload session: %v", err)
+	}
+	return &s
+}
+
+// ─── StartSession ─────────────────────────────────────────────────────────────
+
+func TestStartSession_CreatesNewSession(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	s, err := svc.StartSession(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.UserID != userID {
+		t.Errorf("user_id: want %s, got %s", userID, s.UserID)
+	}
+	if s.ChannelID != "ch_abc" {
+		t.Errorf("channel_id: want ch_abc, got %s", s.ChannelID)
+	}
+	if !s.IsActive {
+		t.Error("expected is_active = true")
+	}
+	if s.EndedAt != nil {
+		t.Error("expected ended_at = nil")
+	}
+}
+
+func TestStartSession_ReturnsExistingActive(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	s1, _ := svc.StartSession(userID, "ch_abc")
+	s2, err := svc.StartSession(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s1.ID != s2.ID {
+		t.Errorf("expected same session ID, got %s vs %s", s1.ID, s2.ID)
+	}
+}
+
+func TestStartSession_ClosesStaleAndCreatesNew(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	s1, _ := svc.StartSession(userID, "ch_abc")
+	backdateHeartbeat(t, svc, s1.ID, 3*time.Minute) // exceed staleThreshold (2 min)
+
+	s2, err := svc.StartSession(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s1.ID == s2.ID {
+		t.Error("expected new session after stale close")
+	}
+
+	old := reloadSession(t, svc, s1.ID)
+	if old.IsActive {
+		t.Error("expected old session is_active = false")
+	}
+	if old.EndedAt == nil {
+		t.Error("expected old session ended_at to be set")
+	}
+}
+
+func TestStartSession_DifferentChannels(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	sA, _ := svc.StartSession(userID, "ch_A")
+	sB, _ := svc.StartSession(userID, "ch_B")
+
+	if sA.ID == sB.ID {
+		t.Error("expected different sessions for different channels")
+	}
+}
+
+// ─── Heartbeat ───────────────────────────────────────────────────────────────
+
+func TestHeartbeat_NoActiveSession(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	_, err := svc.Heartbeat(userID, "ch_abc")
+	if err != ErrNoActiveSession {
+		t.Errorf("want ErrNoActiveSession, got %v", err)
+	}
+}
+
+func TestHeartbeat_IgnoresFastHeartbeat(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	svc.StartSession(userID, "ch_abc")
+
+	// Heartbeat immediately (< 20 s elapsed) — should be a no-op.
+	result, err := svc.Heartbeat(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PointsEarned != 0 {
+		t.Errorf("expected 0 points for fast heartbeat, got %d", result.PointsEarned)
+	}
+	if result.Session.AccumulatedSeconds != 0 {
+		t.Errorf("expected accumulated_seconds unchanged (0), got %d", result.Session.AccumulatedSeconds)
+	}
+}
+
+func TestHeartbeat_AccumulatesSecondsNoBelowMinute(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	s, _ := svc.StartSession(userID, "ch_abc")
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+
+	result, err := svc.Heartbeat(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Session.AccumulatedSeconds <= 0 {
+		t.Error("expected accumulated_seconds > 0")
+	}
+	if result.PointsEarned != 0 {
+		t.Errorf("expected 0 points (< 60 s), got %d", result.PointsEarned)
+	}
+}
+
+func TestHeartbeat_AwardsPointsAt60Seconds(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	channelID := "ch_abc"
+
+	// Three heartbeats of ~25 s each → 75 s accumulated → 1 point.
+	s, _ := svc.StartSession(userID, channelID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+	svc.Heartbeat(userID, channelID) // +25 s = 25
+
+	s = reloadSession(t, svc, s.ID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+	svc.Heartbeat(userID, channelID) // +25 s = 50
+
+	s = reloadSession(t, svc, s.ID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+	result, err := svc.Heartbeat(userID, channelID) // +25 s = 75 → 1 point
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PointsEarned != 1 {
+		t.Errorf("expected 1 point at 75 s, got %d", result.PointsEarned)
+	}
+
+	spendable, cumulative, _ := svc.GetBalance(userID, channelID)
+	if spendable != 1 || cumulative != 1 {
+		t.Errorf("balance: want (1,1), got (%d,%d)", spendable, cumulative)
+	}
+}
+
+func TestHeartbeat_CapsLargeGapAt30Seconds(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	s, _ := svc.StartSession(userID, "ch_abc")
+	backdateHeartbeat(t, svc, s.ID, 10*time.Minute) // simulate long disconnect
+
+	result, err := svc.Heartbeat(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Session.AccumulatedSeconds > 30 {
+		t.Errorf("expected delta capped at 30 s, got %d accumulated", result.Session.AccumulatedSeconds)
+	}
+}
+
+// ─── EndSession ──────────────────────────────────────────────────────────────
+
+func TestEndSession_ClosesActiveSession(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	s, _ := svc.StartSession(userID, "ch_abc")
+	if err := svc.EndSession(userID, "ch_abc"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	closed := reloadSession(t, svc, s.ID)
+	if closed.IsActive {
+		t.Error("expected is_active = false after EndSession")
+	}
+	if closed.EndedAt == nil {
+		t.Error("expected ended_at to be set")
+	}
+}
+
+func TestEndSession_Idempotent(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	// No session exists — should not error.
+	if err := svc.EndSession(userID, "ch_abc"); err != nil {
+		t.Errorf("unexpected error with no session: %v", err)
+	}
+
+	// Call twice after creating a session — should not error.
+	svc.StartSession(userID, "ch_abc")
+	svc.EndSession(userID, "ch_abc")
+	if err := svc.EndSession(userID, "ch_abc"); err != nil {
+		t.Errorf("unexpected error on second EndSession: %v", err)
+	}
+}
+
+// ─── GetBalance ──────────────────────────────────────────────────────────────
+
+func TestGetBalance_NoLedger(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	spendable, cumulative, err := svc.GetBalance(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spendable != 0 || cumulative != 0 {
+		t.Errorf("want (0,0), got (%d,%d)", spendable, cumulative)
+	}
+}
+
+func TestGetBalance_PerChannelIsolation(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	// Earn 1 point on ch_A only (three 25 s heartbeats = 75 s).
+	sA, _ := svc.StartSession(userID, "ch_A")
+	for i := 0; i < 3; i++ {
+		sA = reloadSession(t, svc, sA.ID)
+		backdateHeartbeat(t, svc, sA.ID, 25*time.Second)
+		svc.Heartbeat(userID, "ch_A")
+	}
+
+	spA, _, _ := svc.GetBalance(userID, "ch_A")
+	spB, _, _ := svc.GetBalance(userID, "ch_B")
+
+	if spA == 0 {
+		t.Error("expected non-zero balance for ch_A after earning points")
+	}
+	if spB != 0 {
+		t.Errorf("expected 0 balance for ch_B (never watched), got %d", spB)
+	}
+}

--- a/backend/migrations/003_watch_points.sql
+++ b/backend/migrations/003_watch_points.sql
@@ -14,7 +14,7 @@
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS watch_sessions (
     id                  UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-    twitch_user_id      VARCHAR(255) NOT NULL,
+    user_id             UUID         NOT NULL REFERENCES users(id),
     channel_id          VARCHAR(255) NOT NULL,
     accumulated_seconds BIGINT       NOT NULL DEFAULT 0,
     rewarded_seconds    BIGINT       NOT NULL DEFAULT 0,
@@ -25,28 +25,29 @@ CREATE TABLE IF NOT EXISTS watch_sessions (
     updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_watch_sessions_twitch_user_id ON watch_sessions (twitch_user_id);
-CREATE INDEX IF NOT EXISTS idx_watch_sessions_channel_id     ON watch_sessions (channel_id);
-CREATE INDEX IF NOT EXISTS idx_watch_sessions_is_active      ON watch_sessions (is_active);
+CREATE INDEX IF NOT EXISTS idx_watch_sessions_user_id    ON watch_sessions (user_id);
+CREATE INDEX IF NOT EXISTS idx_watch_sessions_channel_id ON watch_sessions (channel_id);
+CREATE INDEX IF NOT EXISTS idx_watch_sessions_is_active  ON watch_sessions (is_active);
 
--- Partial unique index: only one active session per (twitch_user_id, channel_id).
+-- Partial unique index: only one active session per (user_id, channel_id).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
-    ON watch_sessions (twitch_user_id, channel_id)
+    ON watch_sessions (user_id, channel_id)
     WHERE is_active = TRUE;
 
 -- ---------------------------------------------------------------------------
 -- points_ledgers
--- Single, platform-wide balance per viewer.
--- Table name is "points_ledgers" (GORM plural) — not "points_ledger".
--- Points are NOT scoped to a channel; they are a platform currency.
+-- Per-channel balance per viewer. Points are scoped to each channel;
+-- balances are not shared across channels.
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS points_ledgers (
     id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-    twitch_user_id    VARCHAR(255) NOT NULL UNIQUE,
+    user_id           UUID         NOT NULL REFERENCES users(id),
+    channel_id        VARCHAR(255) NOT NULL,
     cumulative_total  BIGINT       NOT NULL DEFAULT 0,
     spendable_balance BIGINT       NOT NULL DEFAULT 0,
     created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, channel_id)
 );
 
 -- ---------------------------------------------------------------------------

--- a/backend/migrations/003_watch_points.sql
+++ b/backend/migrations/003_watch_points.sql
@@ -1,0 +1,79 @@
+-- migrations/003_watch_points.sql
+-- Reference schema for watch-time points system — Phase 1 (data layer).
+-- GORM AutoMigrate handles this automatically in dev.
+-- Use this for manual DB setup or production migrations.
+-- All statements are idempotent (IF NOT EXISTS).
+
+-- ---------------------------------------------------------------------------
+-- watch_sessions
+-- Tracks a viewer's active or completed session per channel.
+--
+-- Session lifecycle:
+--   active  : is_active = TRUE,  ended_at = NULL
+--   finished: is_active = FALSE, ended_at = <timestamp>
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS watch_sessions (
+    id                  UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    opaque_user_id      VARCHAR(255) NOT NULL,
+    channel_id          VARCHAR(255) NOT NULL,
+    accumulated_seconds BIGINT       NOT NULL DEFAULT 0,
+    rewarded_seconds    BIGINT       NOT NULL DEFAULT 0,
+    last_heartbeat_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    is_active           BOOLEAN      NOT NULL DEFAULT TRUE,
+    ended_at            TIMESTAMPTZ  NULL,
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_watch_sessions_opaque_user_id ON watch_sessions (opaque_user_id);
+CREATE INDEX IF NOT EXISTS idx_watch_sessions_channel_id     ON watch_sessions (channel_id);
+CREATE INDEX IF NOT EXISTS idx_watch_sessions_is_active      ON watch_sessions (is_active);
+
+-- Partial unique index: only one active session per (opaque_user_id, channel_id).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
+    ON watch_sessions (opaque_user_id, channel_id)
+    WHERE is_active = TRUE;
+
+-- ---------------------------------------------------------------------------
+-- points_ledgers
+-- Single, platform-wide balance per viewer.
+-- Table name is "points_ledgers" (GORM plural) — not "points_ledger".
+-- Points are NOT scoped to a channel; they are a platform currency.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS points_ledgers (
+    id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    opaque_user_id    VARCHAR(255) NOT NULL UNIQUE,
+    cumulative_total  BIGINT       NOT NULL DEFAULT 0,
+    spendable_balance BIGINT       NOT NULL DEFAULT 0,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- ---------------------------------------------------------------------------
+-- points_transactions
+-- Immutable log of every balance change.
+--
+-- watch_session_id rules by source:
+--   "watch_time" → always non-null (links to the rewarding session)
+--   "bits"       → always null
+--   "spend"      → always null
+--
+-- No FK constraint on watch_session_id — sessions may be archived
+-- independently without orphaning transaction history.
+--
+-- MVP: no CHECK constraint on source; can be added later:
+--   CHECK (source IN ('watch_time', 'bits', 'spend'))
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS points_transactions (
+    id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    ledger_id        UUID         NOT NULL REFERENCES points_ledgers(id),
+    watch_session_id UUID         NULL,
+    source           VARCHAR(50)  NOT NULL,
+    delta            BIGINT       NOT NULL,
+    balance_after    BIGINT       NOT NULL,
+    note             TEXT,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_points_transactions_ledger_id        ON points_transactions (ledger_id);
+CREATE INDEX IF NOT EXISTS idx_points_transactions_watch_session_id ON points_transactions (watch_session_id);

--- a/backend/migrations/003_watch_points.sql
+++ b/backend/migrations/003_watch_points.sql
@@ -14,7 +14,7 @@
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS watch_sessions (
     id                  UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-    opaque_user_id      VARCHAR(255) NOT NULL,
+    twitch_user_id      VARCHAR(255) NOT NULL,
     channel_id          VARCHAR(255) NOT NULL,
     accumulated_seconds BIGINT       NOT NULL DEFAULT 0,
     rewarded_seconds    BIGINT       NOT NULL DEFAULT 0,
@@ -25,13 +25,13 @@ CREATE TABLE IF NOT EXISTS watch_sessions (
     updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_watch_sessions_opaque_user_id ON watch_sessions (opaque_user_id);
+CREATE INDEX IF NOT EXISTS idx_watch_sessions_twitch_user_id ON watch_sessions (twitch_user_id);
 CREATE INDEX IF NOT EXISTS idx_watch_sessions_channel_id     ON watch_sessions (channel_id);
 CREATE INDEX IF NOT EXISTS idx_watch_sessions_is_active      ON watch_sessions (is_active);
 
--- Partial unique index: only one active session per (opaque_user_id, channel_id).
+-- Partial unique index: only one active session per (twitch_user_id, channel_id).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
-    ON watch_sessions (opaque_user_id, channel_id)
+    ON watch_sessions (twitch_user_id, channel_id)
     WHERE is_active = TRUE;
 
 -- ---------------------------------------------------------------------------
@@ -42,7 +42,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS points_ledgers (
     id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-    opaque_user_id    VARCHAR(255) NOT NULL UNIQUE,
+    twitch_user_id    VARCHAR(255) NOT NULL UNIQUE,
     cumulative_total  BIGINT       NOT NULL DEFAULT 0,
     spendable_balance BIGINT       NOT NULL DEFAULT 0,
     created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),

--- a/docs/feature-discussion.md
+++ b/docs/feature-discussion.md
@@ -281,6 +281,7 @@ Phase 3：
 - [ ] 私人直播的範圍：一對一 vs 小組（Phase 3 再討論）
 - [ ] Dashboard 的權限設計：Agency 管理者 vs Streamer 各自能看到什麼？
 - [ ] Saleor 的部署與 tachigo 後端的 API 串接介面
+- [ ] **auth_providers 拆表** — 見 [Issue #58](https://github.com/nurockplayer/tachigo/issues/58)：目前 STI 設計將 Twitch `opaque_user_id`（Extension 專屬）與真實 `user_id`（需 OAuth 授權）混存於同一欄位；Phase 2 做 claim 上鏈時需要橋接，屆時評估是否拆成 `twitch_providers` / `google_providers` / `web3_providers` 各自的表
 
 ---
 
@@ -291,6 +292,7 @@ Phase 3：
 - [GitHub Issue #15](https://github.com/nurockplayer/tachigo/issues/15) — 商城與 Token 消費機制
 - [GitHub Issue #17](https://github.com/nurockplayer/tachigo/issues/17) — Token 經濟設計與 Soulbound 衝突
 - [GitHub Issue #18](https://github.com/nurockplayer/tachigo/issues/18) — 後台管理介面
+- [GitHub Issue #58](https://github.com/nurockplayer/tachigo/issues/58) — auth_providers STI vs Concrete Table Inheritance
 
 ---
 

--- a/docs/watch-to-points-design.md
+++ b/docs/watch-to-points-design.md
@@ -59,7 +59,7 @@ watch_sessions ──heartbeat──▶ points_transactions ◀── points_led
 | 欄位 | 型別 | 說明 |
 |---|---|---|
 | `id` | UUID PK | |
-| `twitch_user_id` | VARCHAR(255) NOT NULL | 觀眾識別碼（來自 tachigo 帳號） |
+| `user_id` | UUID NOT NULL FK → users.id | 觀眾的 tachigo 帳號 ID |
 | `channel_id` | VARCHAR(255) NOT NULL | 頻道 ID |
 | `accumulated_seconds` | BIGINT default 0 | 本 session 累積觀看秒數 |
 | `rewarded_seconds` | BIGINT default 0 | 已換算為點數的秒數（防止重複發） |
@@ -71,7 +71,7 @@ watch_sessions ──heartbeat──▶ points_transactions ◀── points_led
 
 ```sql
 CREATE UNIQUE INDEX idx_watch_sessions_active_user_channel
-  ON watch_sessions (twitch_user_id, channel_id)
+  ON watch_sessions (user_id, channel_id)
   WHERE is_active = TRUE;
 ```
 
@@ -91,12 +91,12 @@ finished: is_active = false, ended_at = <timestamp>
 | 欄位 | 型別 | 說明 |
 |---|---|---|
 | `id` | UUID PK | |
-| `twitch_user_id` | VARCHAR(255) NOT NULL | 觀眾識別碼 |
+| `user_id` | UUID NOT NULL FK → users.id | 觀眾的 tachigo 帳號 ID |
 | `channel_id` | VARCHAR(255) NOT NULL | 頻道識別碼 |
 | `cumulative_total` | BIGINT default 0 | 歷史累積點數（只增不減，用於成就、統計） |
 | `spendable_balance` | BIGINT default 0 | 可消費點數餘額 |
 
-**Unique index：** `(twitch_user_id, channel_id)`
+**Unique index：** `(user_id, channel_id)`
 
 `spendable_balance` 與 `cumulative_total` 會分叉：花掉點數後 `spendable_balance` 下降，`cumulative_total` 不變。
 
@@ -126,14 +126,14 @@ finished: is_active = false, ended_at = <timestamp>
 
 ## API 端點
 
-所有 watch 端點使用標準 tachigo JWT（`Authorization: Bearer <tachigo_jwt>`），由 `ExtJWTAuth` middleware 保護。`twitch_user_id` 與 `channel_id` 從 JWT claims 取出，不由前端傳入（防止偽造）。
+所有 watch 端點使用標準 tachigo JWT（`Authorization: Bearer <tachigo_jwt>`），由 `JWTAuth` middleware 保護。`user_id` 從 JWT claims 取出；`channel_id` 由前端透過 request body 傳入（tachigo JWT 不含頻道資訊）。
 
-| Method | Path | 說明 |
-|---|---|---|
-| POST | `/api/v1/extension/watch/start` | 開始或取回活躍 session |
-| POST | `/api/v1/extension/watch/heartbeat` | 更新計時，達門檻時發點 |
-| POST | `/api/v1/extension/watch/end` | 主動結束 session（盡力送出） |
-| GET | `/api/v1/extension/watch/balance` | 查詢當前頻道點數餘額 |
+| Method | Path | 說明 | Body / Param |
+|---|---|---|---|
+| POST | `/api/v1/extension/watch/start` | 開始或取回活躍 session | `{ "channel_id": "..." }` |
+| POST | `/api/v1/extension/watch/heartbeat` | 更新計時，達門檻時發點 | `{ "channel_id": "..." }` |
+| POST | `/api/v1/extension/watch/end` | 主動結束 session（盡力送出） | `{ "channel_id": "..." }` |
+| GET | `/api/v1/extension/watch/balance` | 查詢當前頻道點數餘額 | `?channel_id=...` |
 
 ---
 
@@ -205,7 +205,7 @@ Server **無法主動偵測** client 斷線，因此採用兩層機制：
 
 ```go
 tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-    Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", ...).
+    Where("user_id = ? AND channel_id = ? AND is_active = true", ...).
     First(&session)
 ```
 
@@ -214,9 +214,9 @@ tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 ### Heartbeat — Atomic Upsert
 
 ```sql
-INSERT INTO points_ledgers (id, twitch_user_id, channel_id, ...)
+INSERT INTO points_ledgers (id, user_id, channel_id, ...)
 VALUES (gen_random_uuid(), ?, ?, ...)
-ON CONFLICT (twitch_user_id, channel_id) DO UPDATE SET
+ON CONFLICT (user_id, channel_id) DO UPDATE SET
     spendable_balance = points_ledgers.spendable_balance + EXCLUDED.spendable_balance,
     cumulative_total  = points_ledgers.cumulative_total  + EXCLUDED.cumulative_total,
     updated_at        = NOW()
@@ -283,6 +283,21 @@ ON CONFLICT (twitch_user_id, channel_id) DO UPDATE SET
 - `GET /api/v1/points/transactions`：交易記錄
 - Bits 發點整合（`source = "bits"`）
 - Claim 上鏈（`spendable_balance → Soulbound ERC-20 mint`）
+
+---
+
+## 架構改動對照
+
+本節記錄設計過程中的關鍵決策轉折，說明舊設計、新設計與原因。
+
+| 項目 | 舊設計 | 新設計 | 原因 |
+|---|---|---|---|
+| 觀眾識別鍵 | `twitch_user_id VARCHAR(255)` | `user_id UUID FK → users.id` | 流程是「先登入才授權」，帳號主體是 tachigo `users`，Twitch 是附掛的 auth provider |
+| 點數帳本範圍 | 全平台共用一本 | 每個觀眾 × 每個頻道各自獨立 | 每個實況主的點數互不流通，`points_ledgers` 唯一鍵改為 `(user_id, channel_id)` |
+| Watch 路由 middleware | `ExtJWTAuth`（驗 Extension JWT） | `JWTAuth`（驗 tachigo JWT） | watch 端點已要求先登入取得 tachigo JWT，Extension JWT 不再適用 |
+| `channel_id` 來源 | 從 Extension JWT claims 直接取出 | 由前端透過 request body 傳入 | tachigo JWT 不含頻道資訊；`balance` 端點用 query param |
+| `WatchService` 參數型別 | `twitchUserID string` | `userID uuid.UUID` | 對應識別鍵型別變更，與 `users.id` FK 一致 |
+| `GetBalance` 簽名 | `GetBalance(twitchUserID string)` | `GetBalance(userID uuid.UUID, channelID string)` | 帳本改為 per-channel，查詢時需同時提供 user 與 channel |
 
 ---
 

--- a/docs/watch-to-points-design.md
+++ b/docs/watch-to-points-design.md
@@ -1,56 +1,84 @@
 # Watch-to-Points 設計文件
 
 > **狀態：** 實作中（refs #59）
-> **最後更新：** 2026-03-31
+> **最後更新：** 2026-04-01
 
 ---
 
 ## 概述
 
-觀眾在 Twitch Extension 觀看直播時定時發送 heartbeat，後端累積觀看秒數，每 60 秒發放 1 點。點數記錄在全平台共用帳本（`points_ledgers`），不區分頻道。
+觀眾在 Twitch Extension 觀看直播時定時發送 heartbeat（每 30 秒），後端累積觀看秒數並依頻道設定的速率發點。點數記錄在 **per-channel 帳本**（`points_ledgers`），每位觀眾在每個頻道各有獨立餘額，頻道點數彼此不互通。兌換時才將頻道點數轉換為統一平台幣並上鏈 mint（Phase 2）。
 
 ---
 
 ## 認證流程
 
 ```
+前置條件：觀眾必須先在 tachigo 完成登入並授權連結 Twitch 帳號
+
 觀眾開啟 Extension
   → 前端呼叫 POST /api/v1/extension/auth/login（帶 Extension JWT）
-  → 後端 LoginWithExtension：找到或建立 users 記錄，回傳 tachigo JWT
+  → 後端 LoginWithExtension：
+      以 Extension JWT 中的 twitch_user_id 查詢已連結的 tachigo 帳號
+      找到 → 回傳 tachigo JWT
+      找不到 → 401，提示觀眾先至 tachigo 登入並授權 Twitch
   → 前端存下 tachigo JWT
 
 觀眾開始觀看
-  → 前端呼叫 POST /api/v1/extension/watch/start（帶 tachigo JWT + channel_id）
+  → 前端呼叫 POST /api/v1/extension/watch/start（帶 tachigo JWT）
   → 定時呼叫 POST /api/v1/extension/watch/heartbeat（每 30 秒）
   → 離開時盡力呼叫 POST /api/v1/extension/watch/end（見「Session 結束機制」）
 ```
 
-**為什麼先登入才能累積點數：**
-- 使用 `users.id UUID` 作為識別鍵，確保 FK 完整性
-- 點數帳本直接與帳號系統關聯，Phase 2 claim 上鏈不需要額外橋接
-- 避免匿名觀眾累積後無法認領的問題
+**為什麼必須先登入 tachigo 再授權 Twitch：**
+
+- 帳號主體是 tachigo 使用者，Twitch 是附掛的 auth provider
+- 確保點數帳本有明確的 `user_id` 歸屬，Phase 2 claim 上鏈不需額外橋接
+- 避免匿名觀眾累積點數後無法認領的問題
 
 ---
 
 ## 資料模型
+
+### 三張表的職責
+
+```
+watch_sessions ──heartbeat──▶ points_transactions ◀── points_ledgers
+                                                           ▲
+                                                      atomic upsert
+```
+
+| 表 | 職責 |
+|---|---|
+| `watch_sessions` | 記錄「現在誰在看哪個頻道」，是暫時的觀看狀態 |
+| `points_ledgers` | 每位觀眾在每個頻道的點數帳戶，存當下餘額 |
+| `points_transactions` | 不可修改的流水帳，每次發點都記一筆 |
 
 ### watch_sessions
 
 | 欄位 | 型別 | 說明 |
 |---|---|---|
 | `id` | UUID PK | |
-| `user_id` | UUID FK → users.id | 識別觀眾（需已登入） |
-| `channel_id` | VARCHAR(255) | 頻道 ID（來自前端） |
+| `twitch_user_id` | VARCHAR(255) NOT NULL | 觀眾識別碼（來自 tachigo 帳號） |
+| `channel_id` | VARCHAR(255) NOT NULL | 頻道 ID |
 | `accumulated_seconds` | BIGINT default 0 | 本 session 累積觀看秒數 |
-| `rewarded_seconds` | BIGINT default 0 | 已換算為點數的秒數 |
+| `rewarded_seconds` | BIGINT default 0 | 已換算為點數的秒數（防止重複發） |
 | `last_heartbeat_at` | TIMESTAMPTZ NOT NULL default now() | 最後 heartbeat 時間 |
 | `is_active` | BOOLEAN NOT NULL default true | 是否為進行中 session |
 | `ended_at` | TIMESTAMPTZ NULL | session 結束時間 |
 
-**Partial unique index：** `(user_id, channel_id) WHERE is_active = true`
-→ 每個觀眾在每個頻道同時只能有一個活躍 session
+**Partial unique index**（GORM 不支援，在 `main.go` 手動建）：
+
+```sql
+CREATE UNIQUE INDEX idx_watch_sessions_active_user_channel
+  ON watch_sessions (twitch_user_id, channel_id)
+  WHERE is_active = TRUE;
+```
+
+同一個觀眾在同一個頻道只能有一個 active session，歷史 session（`is_active = false`）不受限，保留查詢用。
 
 **Session lifecycle：**
+
 ```
 active  : is_active = true,  ended_at = NULL
 finished: is_active = false, ended_at = <timestamp>
@@ -58,14 +86,19 @@ finished: is_active = false, ended_at = <timestamp>
 
 ### points_ledgers
 
-全平台共用帳本，每位觀眾只有一本，不區分頻道。
+**每位觀眾 × 每個頻道各有一本獨立帳本。** 頻道點數彼此不互通；Phase 2 兌換時才將頻道點數轉換為統一平台幣並上鏈 mint。
 
 | 欄位 | 型別 | 說明 |
 |---|---|---|
 | `id` | UUID PK | |
-| `user_id` | UUID UNIQUE FK → users.id | |
-| `cumulative_total` | BIGINT default 0 | 歷史累積點數（只增不減） |
+| `twitch_user_id` | VARCHAR(255) NOT NULL | 觀眾識別碼 |
+| `channel_id` | VARCHAR(255) NOT NULL | 頻道識別碼 |
+| `cumulative_total` | BIGINT default 0 | 歷史累積點數（只增不減，用於成就、統計） |
 | `spendable_balance` | BIGINT default 0 | 可消費點數餘額 |
+
+**Unique index：** `(twitch_user_id, channel_id)`
+
+`spendable_balance` 與 `cumulative_total` 會分叉：花掉點數後 `spendable_balance` 下降，`cumulative_total` 不變。
 
 ### points_transactions
 
@@ -73,41 +106,64 @@ finished: is_active = false, ended_at = <timestamp>
 |---|---|---|
 | `id` | UUID PK | |
 | `ledger_id` | UUID FK → points_ledgers.id | |
-| `watch_session_id` | UUID NULL | watch_time 來源必填，bits/spend 為 NULL |
+| `watch_session_id` | UUID NULL | `watch_time` 來源必填，`bits` / `spend` 為 NULL |
 | `source` | VARCHAR(50) | `watch_time` / `bits` / `spend` |
 | `delta` | BIGINT | 變動量（正 = 獲得，負 = 消費） |
-| `balance_after` | BIGINT | 交易後餘額快照 |
+| `balance_after` | BIGINT | 交易後餘額快照（查歷史不用重算） |
 | `note` | TEXT NULL | 備註 |
+
+**`watch_session_id` 無 FK constraint**：session 可能被清除或封存，不設 FK 避免 transaction 歷史變 orphan。
+
+`source` 與 `watch_session_id` 的規則：
+
+| source | watch_session_id |
+|---|---|
+| `watch_time` | 一定有值（指向觸發這次發點的 session） |
+| `bits` | NULL |
+| `spend` | NULL |
 
 ---
 
 ## API 端點
 
-所有 watch 端點使用標準 tachigo JWT（`Authorization: Bearer <tachigo_jwt>`），由 `JWTAuth` middleware 保護。
+所有 watch 端點使用標準 tachigo JWT（`Authorization: Bearer <tachigo_jwt>`），由 `ExtJWTAuth` middleware 保護。`twitch_user_id` 與 `channel_id` 從 JWT claims 取出，不由前端傳入（防止偽造）。
 
-| Method | Path | 說明 | Body |
-|---|---|---|---|
-| POST | `/api/v1/extension/watch/start` | 開始或取回活躍 session | `{ "channel_id": "..." }` |
-| POST | `/api/v1/extension/watch/heartbeat` | 更新計時，達門檻時發點 | `{ "channel_id": "..." }` |
-| POST | `/api/v1/extension/watch/end` | 主動結束 session（盡力送出） | `{ "channel_id": "..." }` |
-| GET | `/api/v1/extension/watch/balance` | 查詢點數餘額 | — |
+| Method | Path | 說明 |
+|---|---|---|
+| POST | `/api/v1/extension/watch/start` | 開始或取回活躍 session |
+| POST | `/api/v1/extension/watch/heartbeat` | 更新計時，達門檻時發點 |
+| POST | `/api/v1/extension/watch/end` | 主動結束 session（盡力送出） |
+| GET | `/api/v1/extension/watch/balance` | 查詢當前頻道點數餘額 |
 
 ---
 
 ## 發點邏輯
 
-```
+```text
 每次 heartbeat：
+  若 now - last_heartbeat_at < 20s → 忽略（視為重送），直接回傳 points_earned: 0
+
+  secondsPerPoint = channel_configs[channel_id].seconds_per_point  ← 從 DB 讀取，預設 60
   delta = min(now - last_heartbeat_at, 30s)  ← 上限 30 秒，防止長時間斷線後補算過多
   accumulated_seconds += delta
   pending = accumulated_seconds - rewarded_seconds
-  points_to_award = pending / 60             ← 每 60 秒發 1 點
-  rewarded_seconds += points_to_award * 60
+  points_to_award = pending / secondsPerPoint
+  rewarded_seconds += points_to_award * secondsPerPoint
 
 若 points_to_award > 0：
-  → Atomic upsert points_ledgers
+  → Atomic upsert points_ledgers（以 twitch_user_id + channel_id 定位帳本）
   → 寫入 points_transactions（帶 watch_session_id）
 ```
+
+`rewarded_seconds` 的設計讓「已發點的秒數」與「已累積秒數」分開追蹤，跨多個 heartbeat 也不會漏發或重複發。
+
+**防作弊機制：**
+
+| 規則 | 值 | 目的 |
+|---|---|---|
+| 最小 heartbeat 間隔 | 20 秒 | 擋掉異常重送，正常 30s 間隔不會觸發 |
+| 最大單次 delta | 30 秒 | 斷線後重連不補算過多 |
+| `seconds_per_point` 最小值 | 1 | DB constraint，防止除以零或無限發點 |
 
 ---
 
@@ -118,6 +174,7 @@ Server **無法主動偵測** client 斷線，因此採用兩層機制：
 ### 層一：Client 主動呼叫 EndSession（理想路徑）
 
 前端在以下時機呼叫 `POST /extension/watch/end`：
+
 - 觀眾關閉 Extension 面板
 - 瀏覽器 `beforeunload` event
 
@@ -125,17 +182,18 @@ Server **無法主動偵測** client 斷線，因此採用兩層機制：
 
 ### 層二：Server 偵測 Stale Session（保底機制）
 
-若某 session 的 `last_heartbeat_at` 超過 `staleThreshold`（目前 2 分鐘）未更新，下次該觀眾在同頻道呼叫 `StartSession` 時，server 會自動：
+若某 session 的 `last_heartbeat_at` 超過 `staleThreshold`（2 分鐘）未更新，下次該觀眾在同頻道呼叫 `StartSession` 時，server 會自動：
+
 1. 將舊 session 設為 `is_active = false, ended_at = now()`
 2. 建立新 session
 
-**結果：** 即使 client 沒有主動結束，session 最多延遲 `staleThreshold` 才會被關閉。這段時間不會繼續累積秒數（因為沒有 heartbeat 進來）。
+**結果：** 即使 client 沒有主動結束，session 最多延遲 2 分鐘才會被關閉。這段時間不會繼續累積秒數（因為沒有 heartbeat 進來）。
 
 ### 設計取捨
 
 | 考量 | 決策 |
 |---|---|
-| staleThreshold 設多少？ | 目前 2 分鐘，heartbeat 每 30 秒一次，等於允許錯過 4 次 heartbeat |
+| staleThreshold 設多少？ | 2 分鐘（heartbeat 每 30 秒，等於允許錯過 4 次）；Twitch 網路不穩，避免誤判 |
 | 是否需要主動清理任務（cron）？ | MVP 不做，stale 只在下次 StartSession 時觸發 |
 | `ended_at` 精確度 | 非精確值，反映「最後一次 heartbeat 後的關閉時間」 |
 
@@ -143,11 +201,78 @@ Server **無法主動偵測** client 斷線，因此採用兩層機制：
 
 ## 並發安全機制
 
+### Heartbeat — SELECT FOR UPDATE
+
+```go
+tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+    Where("twitch_user_id = ? AND channel_id = ? AND is_active = true", ...).
+    First(&session)
+```
+
+同一個觀眾的並發 heartbeat 會排隊，不會同時讀到相同狀態並重複發點。
+
+### Heartbeat — Atomic Upsert
+
+```sql
+INSERT INTO points_ledgers (id, twitch_user_id, channel_id, ...)
+VALUES (gen_random_uuid(), ?, ?, ...)
+ON CONFLICT (twitch_user_id, channel_id) DO UPDATE SET
+    spendable_balance = points_ledgers.spendable_balance + EXCLUDED.spendable_balance,
+    cumulative_total  = points_ledgers.cumulative_total  + EXCLUDED.cumulative_total,
+    updated_at        = NOW()
+```
+
+讓 DB 做加法，不在 Go 層 read-modify-write，避免餘額被覆蓋。
+
+### StartSession — Savepoint
+
+`StartSession` 在建立新 session 前先設 savepoint，若 `Create` 因 unique index 衝突失敗（另一個 concurrent request 搶先寫入），回滾到 savepoint 再重新查詢，而不是讓整個 transaction 進入 aborted 狀態（PostgreSQL 的行為）。
+
 | 問題 | 解法 |
 |---|---|
 | 兩個 heartbeat 同時進來，double-award | `SELECT FOR UPDATE` 鎖住 session 列 |
 | 兩個 start 同時進來，違反 partial unique index | Transaction + Savepoint + fallback 查詢 |
 | balance 更新衝突 | `INSERT ... ON CONFLICT DO UPDATE` atomic upsert |
+
+---
+
+## Channel Config — 可調發點速率
+
+> **動機：** Demo 與工商時段需要動態調整發點速率，讓經紀公司或實況主可提高觀眾掛台意願。
+
+### 資料模型 — channel_configs
+
+| 欄位 | 型別 | 說明 |
+|---|---|---|
+| `channel_id` | VARCHAR(255) PK | Twitch 頻道 ID |
+| `seconds_per_point` | BIGINT NOT NULL DEFAULT 60 | 幾秒累積 = 1 點（最小值 1） |
+| `updated_at` | TIMESTAMPTZ | 最後更新時間 |
+
+無對應此 channel 的設定時，後端 fallback 至預設值 60。
+
+### Dashboard API
+
+| Method | Path | Auth | Body |
+|---|---|---|---|
+| `PUT` | `/api/v1/dashboard/channels/:channel_id/config` | JWT（Admin 或 Streamer） | `{"seconds_per_point": 10}` |
+
+- 路由掛在 `/api/v1/dashboard/` group，使用既有 `JWTAuth` + 新增 `RequireRole(Admin, Streamer)` middleware
+- upsert 語意（不存在則建立，存在則更新）
+
+### 設計取捨 — Channel Config
+
+| 考量 | 決策 |
+|---|---|
+| `seconds_per_point` 每次 heartbeat 查 DB？ | MVP 直接查（PK lookup 夠快），不加 cache |
+| `staleThreshold` / `maxDelta` 要不要開放設定？ | 不開放，這兩個值是安全機制，不是業務參數 |
+| Streamer 能改其他人的頻道嗎？ | MVP 不做 channel ownership 驗證，依帳號角色授權 |
+
+---
+
+## 已知限制 / 後續待補
+
+- [ ] Stale session 定期清理 cron job（目前只在 `StartSession` 時觸發關閉）
+- [ ] `source` 欄位目前無 CHECK constraint，可視需求補上
 
 ---
 
@@ -158,7 +283,6 @@ Server **無法主動偵測** client 斷線，因此採用兩層機制：
 - `GET /api/v1/points/transactions`：交易記錄
 - Bits 發點整合（`source = "bits"`）
 - Claim 上鏈（`spendable_balance → Soulbound ERC-20 mint`）
-- Stale session 定期清理 cron job（非 MVP）
 
 ---
 
@@ -167,3 +291,5 @@ Server **無法主動偵測** client 斷線，因此採用兩層機制：
 - [Issue #59](https://github.com/nurockplayer/tachigo/issues/59) — watch-to-points MVP 主票
 - [Issue #58](https://github.com/nurockplayer/tachigo/issues/58) — auth_providers 設計討論
 - [PR #52](https://github.com/nurockplayer/tachigo/pull/52) — Phase 1 & 2 實作
+- 實作：[backend/internal/services/watch_service.go](../backend/internal/services/watch_service.go)
+- Migration：[backend/migrations/003_watch_points.sql](../backend/migrations/003_watch_points.sql)

--- a/docs/watch-to-points-design.md
+++ b/docs/watch-to-points-design.md
@@ -1,0 +1,169 @@
+# Watch-to-Points 設計文件
+
+> **狀態：** 實作中（refs #59）
+> **最後更新：** 2026-03-31
+
+---
+
+## 概述
+
+觀眾在 Twitch Extension 觀看直播時定時發送 heartbeat，後端累積觀看秒數，每 60 秒發放 1 點。點數記錄在全平台共用帳本（`points_ledgers`），不區分頻道。
+
+---
+
+## 認證流程
+
+```
+觀眾開啟 Extension
+  → 前端呼叫 POST /api/v1/extension/auth/login（帶 Extension JWT）
+  → 後端 LoginWithExtension：找到或建立 users 記錄，回傳 tachigo JWT
+  → 前端存下 tachigo JWT
+
+觀眾開始觀看
+  → 前端呼叫 POST /api/v1/extension/watch/start（帶 tachigo JWT + channel_id）
+  → 定時呼叫 POST /api/v1/extension/watch/heartbeat（每 30 秒）
+  → 離開時盡力呼叫 POST /api/v1/extension/watch/end（見「Session 結束機制」）
+```
+
+**為什麼先登入才能累積點數：**
+- 使用 `users.id UUID` 作為識別鍵，確保 FK 完整性
+- 點數帳本直接與帳號系統關聯，Phase 2 claim 上鏈不需要額外橋接
+- 避免匿名觀眾累積後無法認領的問題
+
+---
+
+## 資料模型
+
+### watch_sessions
+
+| 欄位 | 型別 | 說明 |
+|---|---|---|
+| `id` | UUID PK | |
+| `user_id` | UUID FK → users.id | 識別觀眾（需已登入） |
+| `channel_id` | VARCHAR(255) | 頻道 ID（來自前端） |
+| `accumulated_seconds` | BIGINT default 0 | 本 session 累積觀看秒數 |
+| `rewarded_seconds` | BIGINT default 0 | 已換算為點數的秒數 |
+| `last_heartbeat_at` | TIMESTAMPTZ NOT NULL default now() | 最後 heartbeat 時間 |
+| `is_active` | BOOLEAN NOT NULL default true | 是否為進行中 session |
+| `ended_at` | TIMESTAMPTZ NULL | session 結束時間 |
+
+**Partial unique index：** `(user_id, channel_id) WHERE is_active = true`
+→ 每個觀眾在每個頻道同時只能有一個活躍 session
+
+**Session lifecycle：**
+```
+active  : is_active = true,  ended_at = NULL
+finished: is_active = false, ended_at = <timestamp>
+```
+
+### points_ledgers
+
+全平台共用帳本，每位觀眾只有一本，不區分頻道。
+
+| 欄位 | 型別 | 說明 |
+|---|---|---|
+| `id` | UUID PK | |
+| `user_id` | UUID UNIQUE FK → users.id | |
+| `cumulative_total` | BIGINT default 0 | 歷史累積點數（只增不減） |
+| `spendable_balance` | BIGINT default 0 | 可消費點數餘額 |
+
+### points_transactions
+
+| 欄位 | 型別 | 說明 |
+|---|---|---|
+| `id` | UUID PK | |
+| `ledger_id` | UUID FK → points_ledgers.id | |
+| `watch_session_id` | UUID NULL | watch_time 來源必填，bits/spend 為 NULL |
+| `source` | VARCHAR(50) | `watch_time` / `bits` / `spend` |
+| `delta` | BIGINT | 變動量（正 = 獲得，負 = 消費） |
+| `balance_after` | BIGINT | 交易後餘額快照 |
+| `note` | TEXT NULL | 備註 |
+
+---
+
+## API 端點
+
+所有 watch 端點使用標準 tachigo JWT（`Authorization: Bearer <tachigo_jwt>`），由 `JWTAuth` middleware 保護。
+
+| Method | Path | 說明 | Body |
+|---|---|---|---|
+| POST | `/api/v1/extension/watch/start` | 開始或取回活躍 session | `{ "channel_id": "..." }` |
+| POST | `/api/v1/extension/watch/heartbeat` | 更新計時，達門檻時發點 | `{ "channel_id": "..." }` |
+| POST | `/api/v1/extension/watch/end` | 主動結束 session（盡力送出） | `{ "channel_id": "..." }` |
+| GET | `/api/v1/extension/watch/balance` | 查詢點數餘額 | — |
+
+---
+
+## 發點邏輯
+
+```
+每次 heartbeat：
+  delta = min(now - last_heartbeat_at, 30s)  ← 上限 30 秒，防止長時間斷線後補算過多
+  accumulated_seconds += delta
+  pending = accumulated_seconds - rewarded_seconds
+  points_to_award = pending / 60             ← 每 60 秒發 1 點
+  rewarded_seconds += points_to_award * 60
+
+若 points_to_award > 0：
+  → Atomic upsert points_ledgers
+  → 寫入 points_transactions（帶 watch_session_id）
+```
+
+---
+
+## Session 結束機制
+
+Server **無法主動偵測** client 斷線，因此採用兩層機制：
+
+### 層一：Client 主動呼叫 EndSession（理想路徑）
+
+前端在以下時機呼叫 `POST /extension/watch/end`：
+- 觀眾關閉 Extension 面板
+- 瀏覽器 `beforeunload` event
+
+**限制：** `beforeunload` 不保證成功送出（例如手機強制關閉、網路中斷），因此這條路徑屬於「盡力送出（best-effort）」。
+
+### 層二：Server 偵測 Stale Session（保底機制）
+
+若某 session 的 `last_heartbeat_at` 超過 `staleThreshold`（目前 2 分鐘）未更新，下次該觀眾在同頻道呼叫 `StartSession` 時，server 會自動：
+1. 將舊 session 設為 `is_active = false, ended_at = now()`
+2. 建立新 session
+
+**結果：** 即使 client 沒有主動結束，session 最多延遲 `staleThreshold` 才會被關閉。這段時間不會繼續累積秒數（因為沒有 heartbeat 進來）。
+
+### 設計取捨
+
+| 考量 | 決策 |
+|---|---|
+| staleThreshold 設多少？ | 目前 2 分鐘，heartbeat 每 30 秒一次，等於允許錯過 4 次 heartbeat |
+| 是否需要主動清理任務（cron）？ | MVP 不做，stale 只在下次 StartSession 時觸發 |
+| `ended_at` 精確度 | 非精確值，反映「最後一次 heartbeat 後的關閉時間」 |
+
+---
+
+## 並發安全機制
+
+| 問題 | 解法 |
+|---|---|
+| 兩個 heartbeat 同時進來，double-award | `SELECT FOR UPDATE` 鎖住 session 列 |
+| 兩個 start 同時進來，違反 partial unique index | Transaction + Savepoint + fallback 查詢 |
+| balance 更新衝突 | `INSERT ... ON CONFLICT DO UPDATE` atomic upsert |
+
+---
+
+## Phase 2 預告
+
+- 前端 Extension UI：顯示餘額、heartbeat 狀態
+- `GET /api/v1/points/balance`：一般帳號查詢端點
+- `GET /api/v1/points/transactions`：交易記錄
+- Bits 發點整合（`source = "bits"`）
+- Claim 上鏈（`spendable_balance → Soulbound ERC-20 mint`）
+- Stale session 定期清理 cron job（非 MVP）
+
+---
+
+## 相關 Issues / PR
+
+- [Issue #59](https://github.com/nurockplayer/tachigo/issues/59) — watch-to-points MVP 主票
+- [Issue #58](https://github.com/nurockplayer/tachigo/issues/58) — auth_providers 設計討論
+- [PR #52](https://github.com/nurockplayer/tachigo/pull/52) — Phase 1 & 2 實作

--- a/docs/watch-to-points-design.md
+++ b/docs/watch-to-points-design.md
@@ -286,6 +286,32 @@ ON CONFLICT (user_id, channel_id) DO UPDATE SET
 
 ---
 
+## 實作計劃備忘
+
+### Issue #61 — UUID v7（隨本次順帶處理）
+
+本次修改以下三個檔案時，同步將 `uuid.New()` 改為 `uuid.New7()`（時序 UUID，避免 B-tree index fragmentation）：
+
+| 檔案 | 改動點 |
+|---|---|
+| `backend/internal/models/points.go` | `PointsLedger.BeforeCreate`、`PointsTransaction.BeforeCreate` |
+| `backend/internal/models/watch_session.go` | `WatchSession.BeforeCreate` |
+| `backend/internal/services/watch_service.go` | `ID: uuid.New()` for WatchSession |
+
+其餘 model（`user.go`、`auth_provider.go`、`address.go`、`refresh_token.go`、`email_auth.go`）與 `extension_service.go` 留給 Issue #61 獨立處理。詳見 [docs/uuid-v7.md](uuid-v7.md)。
+
+### PR #62 重疊分析
+
+PR #62（`users.role` VARCHAR → ENUM）也改動了 `backend/cmd/server/main.go`，本次計劃同樣需要修改此檔案。
+
+| 項目 | PR #62 改動 | 本次計劃改動 |
+|---|---|---|
+| `main.go` | 新增 `CREATE TYPE user_role AS ENUM` block（AutoMigrate 前） | 更新 partial index SQL 欄位名（AutoMigrate 後） |
+
+兩個改動在不同位置，無邏輯衝突。PR #62 merge 後本次 branch 需 rebase 解決 git conflict。
+
+---
+
 ## 架構改動對照
 
 本節記錄設計過程中的關鍵決策轉折，說明舊設計、新設計與原因。

--- a/plans/watch-points-channel-config.md
+++ b/plans/watch-points-channel-config.md
@@ -8,11 +8,12 @@
 
 ## 背景
 
-本次變更涵蓋三個目標：
+本次變更涵蓋四個目標：
 
 1. **points_ledgers 改為 per-channel 帳本** — 原設計為全平台共用，與「頻道點數獨立」需求不符
-2. **Heartbeat 補上 `<20s ignore` 防作弊規則** — 原實作只有 cap 30s，缺少快速重送的擋掉機制
-3. **Channel Config 可調發點速率** — 讓實況主 / 經紀公司可在 Dashboard 動態調整 `seconds_per_point`（例如工商時段加速發點）
+2. **Session 結束機制** — server 無法主動偵測 client 斷線，採兩層機制：client best-effort `EndSession` + server stale session 偵測
+3. **Heartbeat 補上 `<20s ignore` 防作弊規則** — 原實作只有 cap 30s，缺少快速重送的擋掉機制
+4. **Channel Config 可調發點速率** — 讓實況主 / 經紀公司可在 Dashboard 動態調整 `seconds_per_point`（例如工商時段加速發點）
 
 設計細節見 [docs/watch-to-points-design.md](../docs/watch-to-points-design.md)。
 
@@ -22,7 +23,9 @@
 
 | 項目 | 決策 | 理由 |
 |---|---|---|
+| Session 結束偵測 | 兩層：client best-effort `EndSession` + server stale 偵測 | `beforeunload` 不保證送出，server 需保底 |
 | `staleThreshold` | 2 分鐘 | Twitch 網路不穩，4 次錯過才斷線，避免誤判 |
+| Stale 清理時機 | 下次 `StartSession` 時觸發，不做 cron | MVP 降低複雜度 |
 | `maxDeltaPerHeartbeat` | 30 秒 | 斷線後重連不補算過多 |
 | `<20s ignore` | 直接 return，不更新 `last_heartbeat_at` | 正常 30s 間隔不觸發，只擋異常重送 |
 | `seconds_per_point` 每次查 DB | 是，不加 cache | PK lookup 夠快，MVP 不過度設計 |
@@ -32,7 +35,13 @@
 
 ## 待實作項目
 
-### 1. LoginWithExtension 改為 find-only
+### 1. Session 結束機制
+
+- [ ] `backend/internal/services/watch_service.go`
+  - `StartSession()`：偵測 stale session（`last_heartbeat_at > staleThreshold(2 分鐘)`）→ `is_active=false, ended_at=now()`，再建新 session
+  - `EndSession()`：best-effort，冪等（無 active session 視為成功，不回傳錯誤）
+
+### 2. LoginWithExtension 改為 find-only
 
 - [ ] `backend/internal/services/extension_service.go` — 移除 find-or-create 分支，找不到時回傳 `ErrUserNotFound`
 - [ ] `backend/internal/handlers/extension_handler.go` — 判斷 `ErrUserNotFound` → 401，提示先至 tachigo 登入並連結 Twitch
@@ -80,7 +89,9 @@ docker compose run --no-deps --rm app go test ./...
 
 手動流程：
 
-1. 以 Streamer/Admin 帳號登入取得 JWT
+1. 呼叫 `start` 建立 session → 停止送 heartbeat → 等 2 分鐘 → 再次呼叫 `start` → 確認舊 session 被關閉（`is_active=false`），新 session 建立
+2. 呼叫 `start` → 呼叫 `end` → 確認 session `is_active=false`；再呼叫一次 `end` → 確認回傳成功（冪等）
+3. 以 Streamer/Admin 帳號登入取得 JWT
 2. `PUT /api/v1/dashboard/channels/<channel_id>/config` body `{"seconds_per_point": 10}`
 3. 用 Extension JWT 觸發 heartbeat → 確認 30s 內發 3 點
 4. 連送兩次 heartbeat（間隔 <20s）→ 確認第二次 `points_earned: 0`

--- a/plans/watch-points-channel-config.md
+++ b/plans/watch-points-channel-config.md
@@ -1,0 +1,88 @@
+# Watch-to-Points 補強 + Channel Config
+
+> **狀態：** 待實作
+> **關聯 Issue：** refs #59
+> **最後更新：** 2026-04-01
+
+---
+
+## 背景
+
+本次變更涵蓋三個目標：
+
+1. **points_ledgers 改為 per-channel 帳本** — 原設計為全平台共用，與「頻道點數獨立」需求不符
+2. **Heartbeat 補上 `<20s ignore` 防作弊規則** — 原實作只有 cap 30s，缺少快速重送的擋掉機制
+3. **Channel Config 可調發點速率** — 讓實況主 / 經紀公司可在 Dashboard 動態調整 `seconds_per_point`（例如工商時段加速發點）
+
+設計細節見 [docs/watch-to-points-design.md](../docs/watch-to-points-design.md)。
+
+---
+
+## 架構決策
+
+| 項目 | 決策 | 理由 |
+|---|---|---|
+| `staleThreshold` | 2 分鐘 | Twitch 網路不穩，4 次錯過才斷線，避免誤判 |
+| `maxDeltaPerHeartbeat` | 30 秒 | 斷線後重連不補算過多 |
+| `<20s ignore` | 直接 return，不更新 `last_heartbeat_at` | 正常 30s 間隔不觸發，只擋異常重送 |
+| `seconds_per_point` 每次查 DB | 是，不加 cache | PK lookup 夠快，MVP 不過度設計 |
+| Streamer 只能改自己頻道？ | 否，MVP 依角色授權 | 降低複雜度 |
+
+---
+
+## 待實作項目
+
+### 1. LoginWithExtension 改為 find-only
+
+- [ ] `backend/internal/services/extension_service.go` — 移除 find-or-create 分支，找不到時回傳 `ErrUserNotFound`
+- [ ] `backend/internal/handlers/extension_handler.go` — 判斷 `ErrUserNotFound` → 401，提示先至 tachigo 登入並連結 Twitch
+
+### 2. Schema — points_ledgers 改為 per-channel
+
+- [ ] `backend/migrations/003_watch_points.sql` — `points_ledgers` 加入 `channel_id`，unique 改為 `(twitch_user_id, channel_id)`
+- [ ] `backend/internal/models/points.go` — `PointsLedger` struct 加入 `ChannelID`，移除單欄 `UNIQUE` tag
+
+### 3. Service / Handler — per-channel 帳本 + `<20s ignore` + `seconds_per_point`
+
+- [ ] `backend/internal/services/watch_service.go`
+  - `Heartbeat()`：SELECT FOR UPDATE 後加 `< 20s → return` 早退
+  - `Heartbeat()`：SQL upsert 帶入 `channel_id`
+  - `Heartbeat()`：以 `getSecondsPerPoint()` 取代硬編碼 `60`
+  - `GetBalance()`：加入 `channelID` 參數
+  - 新增 `getSecondsPerPoint(db, channelID) int64` helper
+- [ ] `backend/internal/handlers/watch_handler.go` — `GetBalance` 從 Extension JWT claims 取 `ChannelID` 傳入 service
+
+### 4. Migration — channel_configs
+
+- [ ] `backend/migrations/004_channel_config.sql` — 建立 `channel_configs` 表
+- [ ] `backend/internal/models/channel_config.go` — `ChannelConfig` struct
+
+### 5. Dashboard API
+
+- [ ] `backend/internal/middleware/auth.go` — 新增 `RequireRole(roles ...UserRole)`
+- [ ] `backend/internal/handlers/channel_config_handler.go` — `UpdateChannelConfig` handler
+- [ ] `backend/internal/router/router.go` — 新增 `/dashboard/` route group（`JWTAuth` + `RequireRole(Admin, Streamer)`）
+
+### 6. Wiring
+
+- [ ] `backend/cmd/server/main.go`
+  - `AutoMigrate` 加入 `&models.ChannelConfig{}`
+  - 手動建 `idx_points_ledgers_user_channel` unique index
+  - 初始化 `ChannelConfigHandler`，傳入 `router.New()`
+
+---
+
+## 驗證方式
+
+```bash
+docker compose run --no-deps --rm app go test ./...
+```
+
+手動流程：
+
+1. 以 Streamer/Admin 帳號登入取得 JWT
+2. `PUT /api/v1/dashboard/channels/<channel_id>/config` body `{"seconds_per_point": 10}`
+3. 用 Extension JWT 觸發 heartbeat → 確認 30s 內發 3 點
+4. 連送兩次 heartbeat（間隔 <20s）→ 確認第二次 `points_earned: 0`
+5. `GET /extension/watch/balance` → 確認只回傳該頻道餘額
+6. 改回 `seconds_per_point: 60` → 確認回到正常發點


### PR DESCRIPTION
## 功能說明

實作 watch-to-points MVP 的後端核心流程。

---

## 內容總覽

本 PR 包含兩個層級：

| Phase | 範圍 | 說明 |
|------|------|------|
| Phase 1 | Data Layer | 資料表設計與 migration |
| Phase 2 | Backend Flow | watch → points 的業務邏輯與 API |

---

## Phase 1 — Data Layer

**資料表**
- `watch_sessions`
- `points_ledgers`
- `points_transactions`

**重點設計**
- partial unique index  
  `(opaque_user_id, channel_id) WHERE is_active = true`
- points 為 **平台共用（非 per-channel）**

**其他**
- `003_watch_points.sql`
- AutoMigrate + index setup

---

## Phase 2 — Backend Flow

**Auth**
- `ExtJWTAuth` middleware（驗證 Extension JWT）

**Service（核心邏輯）**
- `WatchService`
  - StartSession
  - Heartbeat
  - EndSession
  - GetBalance

**HTTP 層**
- `WatchHandler`
- `/api/v1/extension/watch/*` routes

---

## 關鍵設計

- 使用 **server time** 計算觀看秒數（不信任前端）
- `SELECT FOR UPDATE` 防止 concurrent heartbeat 重複發點
- `points_ledgers` 使用 atomic upsert
- session 透過 partial unique index 保證唯一 active session

---

## 不包含

- 前端 UI
- bits / task / event reward
- anti-abuse / rate limiting（後續補）