### PR TITLE
[frontend] Extension — 點數更新即時反饋

### DIFF
--- a/tachimint/src/App.tsx
+++ b/tachimint/src/App.tsx
@@ -1,9 +1,13 @@
 import { useTwitch } from './hooks/useTwitch'
 import { useBits } from './hooks/useBits'
+import { useHeartbeat } from './hooks/useHeartbeat'
 
 export default function App() {
   const { context, jwt, products, bitsEnabled, authError } = useTwitch()
   const { buyWithBits, status, error } = useBits(jwt)
+  const { balance, gain, isAnimating } = useHeartbeat(jwt, {
+    enabled: context?.role === 'viewer',
+  })
 
   if (!context) {
     return (
@@ -36,6 +40,16 @@ export default function App() {
       </header>
 
       <div className="ext-body">
+        <section className="ext-balance-wrap">
+          <div className={`ext-balance ${isAnimating ? 'ext-balance--bump' : ''}`}>
+            <span className="ext-balance__label">Points</span>
+            <strong className="ext-balance__value">{balance?.toLocaleString() ?? '—'}</strong>
+          </div>
+          {gain !== null && gain > 0 && (
+            <span className="ext-balance-gain">+{gain.toLocaleString()} 點</span>
+          )}
+        </section>
+
         {status === 'success' && (
           <div className="ext-success">
             <span className="ext-success__icon">✓</span>

--- a/tachimint/src/hooks/useHeartbeat.ts
+++ b/tachimint/src/hooks/useHeartbeat.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react'
+import { sendHeartbeat } from '../services/api'
+
+interface UseHeartbeatOptions {
+  enabled?: boolean
+  intervalMs?: number
+}
+
+export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions = {}) {
+  const { enabled = true, intervalMs = 30_000 } = options
+  const [balance, setBalance] = useState<number | null>(null)
+  const [gain, setGain] = useState<number | null>(null)
+  const [isAnimating, setIsAnimating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const lastBalanceRef = useRef<number | null>(null)
+  const stopAnimationTimerRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!enabled || !extensionJwt) return
+
+    let isDisposed = false
+    let heartbeatTimer: number | null = null
+
+    const clearAnimationTimer = () => {
+      if (stopAnimationTimerRef.current !== null) {
+        window.clearTimeout(stopAnimationTimerRef.current)
+        stopAnimationTimerRef.current = null
+      }
+    }
+
+    const runHeartbeat = async () => {
+      try {
+        const data = await sendHeartbeat(extensionJwt)
+        if (isDisposed) return
+
+        const nextBalance = data.balance
+        const prevBalance = lastBalanceRef.current
+        setBalance(nextBalance)
+
+        if (prevBalance !== null && nextBalance > prevBalance) {
+          setGain(nextBalance - prevBalance)
+          setIsAnimating(true)
+          clearAnimationTimer()
+          stopAnimationTimerRef.current = window.setTimeout(() => {
+            setIsAnimating(false)
+            setGain(null)
+          }, 1500)
+        }
+
+        lastBalanceRef.current = nextBalance
+        setError(null)
+      } catch {
+        if (!isDisposed) {
+          setError('Heartbeat failed')
+        }
+      }
+    }
+
+    void runHeartbeat()
+    heartbeatTimer = window.setInterval(() => {
+      void runHeartbeat()
+    }, intervalMs)
+
+    return () => {
+      isDisposed = true
+      if (heartbeatTimer !== null) {
+        window.clearInterval(heartbeatTimer)
+      }
+      clearAnimationTimer()
+    }
+  }, [enabled, extensionJwt, intervalMs])
+
+  return { balance, gain, isAnimating, error }
+}

--- a/tachimint/src/index.css
+++ b/tachimint/src/index.css
@@ -89,6 +89,61 @@ p  { margin: 0; }
   flex: 1;
 }
 
+/* ── Points feedback ────────────────────────────────────────────────────────── */
+.ext-balance-wrap {
+  position: relative;
+  margin-bottom: 12px;
+}
+
+.ext-balance {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.ext-balance--bump {
+  animation: balance-bump 450ms ease;
+}
+
+.ext-balance__label {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.ext-balance__value {
+  font-size: 18px;
+  color: var(--text-h);
+  letter-spacing: -0.2px;
+}
+
+.ext-balance-gain {
+  position: absolute;
+  top: -8px;
+  right: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--success);
+  pointer-events: none;
+  animation: gain-float 1.5s ease forwards;
+}
+
+@keyframes balance-bump {
+  0% { transform: scale(1); }
+  35% { transform: scale(1.06); }
+  100% { transform: scale(1); }
+}
+
+@keyframes gain-float {
+  0% { opacity: 0; transform: translateY(3px); }
+  20% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-10px); }
+}
+
 /* ── Products ───────────────────────────────────────────────────────────────── */
 .ext-products {
   display: flex;

--- a/tachimint/src/services/api.ts
+++ b/tachimint/src/services/api.ts
@@ -37,3 +37,37 @@ export async function loginWithTwitchExtension(extensionJwt: string): Promise<Ta
   })
   return data
 }
+
+interface HeartbeatResponse {
+  balance: number
+}
+
+function parseBalanceFromHeartbeatResponse(payload: unknown): number {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid heartbeat response')
+  }
+
+  // Accept a few common API shapes to keep frontend resilient while backend evolves.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = payload as any
+  const direct = raw.balance
+  const nested = raw.data?.balance
+  const legacy = raw.points_balance
+
+  const value = [direct, nested, legacy].find((candidate) => typeof candidate === 'number')
+  if (typeof value !== 'number') {
+    throw new Error('Heartbeat response missing balance')
+  }
+
+  return value
+}
+
+export async function sendHeartbeat(extensionJwt: string): Promise<HeartbeatResponse> {
+  const { data } = await client.post('/api/v1/extension/heartbeat', {
+    extension_jwt: extensionJwt,
+  })
+
+  return {
+    balance: parseBalanceFromHeartbeatResponse(data),
+  }
+}


### PR DESCRIPTION
## Summary

- 新增 `useHeartbeat` hook，每 30 秒回報 Heartbeat 並追蹤點數餘額變化
- Heartbeat 收到新餘額後，顯示 `+N 點` 浮動提示與數字卡片跳動動畫
- 動畫 1500ms 後自動重置為 idle 狀態

## Test plan

- [ ] 以 viewer 身份載入 extension，確認每 30 秒有 Heartbeat 請求
- [ ] 後端回傳新餘額時，確認數字卡片有跳動動畫
- [ ] 確認 `+N 點` 浮動文字出現後約 1.5 秒自動消失
- [ ] 確認動畫結束後畫面恢復正常（無殘留樣式）

closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)