### PR TITLE
refactor(models): user role varchar → PostgreSQL ENUM

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -33,6 +33,16 @@ func main() {
 
 	db := database.Connect(cfg.Database.DSN)
 
+	// Create custom ENUM types before AutoMigrate (GORM cannot create them automatically).
+	if err := db.Exec(`
+		DO $$ BEGIN
+			CREATE TYPE user_role AS ENUM ('viewer', 'streamer', 'admin');
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$;
+	`).Error; err != nil {
+		log.Fatalf("failed to create user_role enum: %v", err)
+	}
+
 	// Auto-migrate all models
 	if err := db.AutoMigrate(
 		&models.User{},

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -21,7 +21,7 @@ type User struct {
 	Email        *string        `gorm:"type:varchar(255);uniqueIndex"                  json:"email"`
 	PasswordHash *string        `gorm:"type:varchar(255)"                              json:"-"`
 	AvatarURL    *string        `gorm:"type:text"                                      json:"avatar_url"`
-	Role         UserRole       `gorm:"type:varchar(20);default:'viewer'"              json:"role"`
+	Role         UserRole       `gorm:"type:user_role;default:'viewer'"                json:"role"`
 	IsActive      bool           `gorm:"default:true"                                   json:"is_active"`
 	EmailVerified bool           `gorm:"default:false"                                  json:"email_verified"`
 	CreatedAt    time.Time      `                                                      json:"created_at"`

--- a/backend/migrations/001_init.sql
+++ b/backend/migrations/001_init.sql
@@ -4,6 +4,8 @@
 
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
+CREATE TYPE user_role AS ENUM ('viewer', 'streamer', 'admin');
+
 -- Users
 CREATE TABLE IF NOT EXISTS users (
     id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -11,7 +13,7 @@ CREATE TABLE IF NOT EXISTS users (
     email         VARCHAR(255) UNIQUE,
     password_hash VARCHAR(255),
     avatar_url    TEXT,
-    role          VARCHAR(20)  NOT NULL DEFAULT 'viewer',
+    role          user_role    NOT NULL DEFAULT 'viewer',
     is_active     BOOLEAN      NOT NULL DEFAULT TRUE,
     created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),

--- a/docs/uuid-v7.md
+++ b/docs/uuid-v7.md
@@ -1,0 +1,44 @@
+# UUID 版本策略
+
+> **最後更新：** 2026-04-01
+
+---
+
+## 決策
+
+所有 model 的 Primary Key 使用 **UUID v7**，不使用 UUID v4。
+
+---
+
+## 背景
+
+UUID v4（`gen_random_uuid()`）完全隨機，沒有時間順序。用作 Primary Key 時，每筆新資料插入的位置在 B-tree index 裡隨機分散，導致：
+
+- **Page split** — index 頁面頻繁分裂
+- **Index fragmentation** — 讀取效能下降
+- **Write amplification** — 寫入越多越慢
+
+UUID v7 前 48 bits 為毫秒時間戳，後接隨機值。新資料永遠插在 index 末端，行為接近自增 INT，同時保留 UUID 的全域唯一性與無中央協調的優勢。
+
+---
+
+## 實作方式
+
+Go 層在 `BeforeCreate` hook 使用 `uuid.New7()`（`github.com/google/uuid` v1.6+）：
+
+```go
+func (u *User) BeforeCreate(tx *gorm.DB) error {
+    if u.ID == uuid.Nil {
+        u.ID = uuid.New7()
+    }
+    return nil
+}
+```
+
+PostgreSQL 的 `default:gen_random_uuid()` GORM tag 維持不變作為 fallback（Go 層永遠先生成，DB default 不會觸發）。PostgreSQL 17 才有原生 `uuidv7()`，不在此版本做 DB 層改動。
+
+---
+
+## 範圍
+
+所有 model 的 `BeforeCreate` hook，以及 service 層直接賦值 `ID: uuid.New()` 的地方。測試中的 `uuid.New()` 不需更換（測試 ID 無須時序性）。

--- a/plans/uuid-v7-migration.md
+++ b/plans/uuid-v7-migration.md
@@ -1,0 +1,44 @@
+# UUID v7 Migration
+
+> **狀態：** 待實作
+> **關聯 Issue：** refs #61
+> **最後更新：** 2026-04-01
+
+---
+
+## 背景
+
+所有 model 的 PK 目前用 `uuid.New()`（UUID v4，完全隨機），導致 B-tree index 隨機插入、page split。改用 `uuid.New7()`（UUID v7，時序）可解決此問題。詳見 [docs/uuid-v7.md](../docs/uuid-v7.md)。
+
+---
+
+## 待實作項目
+
+### Model BeforeCreate hooks（改 uuid.New7()）
+
+- [ ] `backend/internal/models/user.go`
+- [ ] `backend/internal/models/auth_provider.go`
+- [ ] `backend/internal/models/address.go`
+- [ ] `backend/internal/models/refresh_token.go`
+- [ ] `backend/internal/models/email_auth.go`（EmailVerification、PasswordReset）
+- [ ] `backend/internal/models/points.go`（PointsLedger、PointsTransaction）
+- [ ] `backend/internal/models/watch_session.go`
+
+### Service 層直接賦值（改 uuid.New7()）
+
+- [ ] `backend/internal/services/watch_service.go:62` — `ID: uuid.New()` for WatchSession
+- [ ] `backend/internal/services/extension_service.go:125` — `ID: uuid.New()` for User
+
+### 不需更動
+
+- 測試檔案中的 `uuid.New()` — 測試 ID 無須時序性
+
+---
+
+## 驗證方式
+
+```bash
+docker compose run --no-deps --rm app go test ./...
+```
+
+確認生成的 UUID 為 v7 格式（開頭 8 個 hex chars 反映時間，不是純隨機）。


### PR DESCRIPTION
## Summary

- `users.role` 從 `VARCHAR(20)` 改為 PostgreSQL `user_role` ENUM，讓 DB 層強制驗證合法角色值
- 在 `main.go` 以 idempotent `DO $$` 建立 ENUM type，確保 `AutoMigrate` 可正常執行
- 新增 `docs/uuid-v7.md` 技術決策說明與 `plans/uuid-v7-migration.md` 實作計畫（refs #61）

## Test plan

- [ ] `docker compose run --no-deps --rm app go test ./...`
- [ ] 啟動服務確認 ENUM type 建立正常，寫入非法 role 值時 DB 回傳錯誤

refs #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)