### PR TITLE
[backend] RBAC — RequireRole middleware + role migrations

### DIFF
--- a/backend/internal/handlers/rbac_handler_test.go
+++ b/backend/internal/handlers/rbac_handler_test.go
@@ -1,0 +1,215 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+// rbacEnv wraps testEnv and exposes a router with RBAC-protected routes.
+type rbacEnv struct {
+	*testEnv
+}
+
+func newRBACTestEnv(t *testing.T) *rbacEnv {
+	t.Helper()
+	base := newTestEnv(t)
+
+	// Attach RBAC-protected stubs on top of the existing router.
+	v1 := base.router.Group("/api/v1")
+
+	agencies := v1.Group("/agencies")
+	agencies.Use(middleware.JWTAuth(base.authSvc))
+	{
+		agencies.POST("", middleware.RequireRole(models.RoleAdmin), func(c *gin.Context) {
+			c.JSON(501, gin.H{"error": "not implemented"})
+		})
+		agencies.PUT("/:id/settings",
+			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		agencies.GET("/:id/streamers",
+			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+	}
+
+	events := v1.Group("/events")
+	events.Use(middleware.JWTAuth(base.authSvc))
+	events.Use(middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin))
+	{
+		events.POST("/create", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
+		events.POST("/:id/settle", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
+	}
+
+	admin := v1.Group("/admin")
+	admin.Use(middleware.JWTAuth(base.authSvc))
+	admin.Use(middleware.RequireRole(models.RoleAdmin))
+	{
+		admin.GET("/users", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
+	}
+
+	return &rbacEnv{base}
+}
+
+// tokenForRole registers a user, updates their role in the DB, then logs in to
+// obtain a JWT that carries the requested role in its claims.
+func (e *rbacEnv) tokenForRole(t *testing.T, role models.UserRole) string {
+	t.Helper()
+
+	email := string(role) + "_user@example.com"
+	username := string(role) + "_user"
+	password := "password123"
+
+	user, _, err := e.authSvc.Register(services.RegisterInput{
+		Username: username,
+		Email:    email,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("register(%s): %v", role, err)
+	}
+
+	// Update role directly in DB, then login so the JWT carries the new role.
+	if err := e.db.Model(user).Update("role", role).Error; err != nil {
+		t.Fatalf("set role(%s): %v", role, err)
+	}
+
+	_, tokens, err := e.authSvc.Login(services.LoginInput{
+		Email:    email,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("login(%s): %v", role, err)
+	}
+	return tokens.AccessToken
+}
+
+func doRequest(router *gin.Engine, method, path, token string) int {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	router.ServeHTTP(w, req)
+	return w.Code
+}
+
+// ── GET /admin/users ──────────────────────────────────────────────────────────
+
+// viewer token → 403
+func TestRBAC_AdminUsers_ViewerForbidden(t *testing.T) {
+	env := newRBACTestEnv(t)
+	token := env.tokenForRole(t, models.RoleViewer)
+
+	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", token); got != http.StatusForbidden {
+		t.Errorf("viewer: want 403, got %d", got)
+	}
+}
+
+// streamer token → 403
+func TestRBAC_AdminUsers_StreamerForbidden(t *testing.T) {
+	env := newRBACTestEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+
+	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", token); got != http.StatusForbidden {
+		t.Errorf("streamer: want 403, got %d", got)
+	}
+}
+
+// agency token → 403
+func TestRBAC_AdminUsers_AgencyForbidden(t *testing.T) {
+	env := newRBACTestEnv(t)
+	token := env.tokenForRole(t, models.RoleAgency)
+
+	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", token); got != http.StatusForbidden {
+		t.Errorf("agency: want 403, got %d", got)
+	}
+}
+
+// admin token → 501（handler 尚未實作，但通過授權）
+func TestRBAC_AdminUsers_AdminAllowed(t *testing.T) {
+	env := newRBACTestEnv(t)
+	token := env.tokenForRole(t, models.RoleAdmin)
+
+	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", token); got != http.StatusNotImplemented {
+		t.Errorf("admin: want 501, got %d", got)
+	}
+}
+
+// 無 token → 401
+func TestRBAC_AdminUsers_NoToken(t *testing.T) {
+	env := newRBACTestEnv(t)
+
+	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", ""); got != http.StatusUnauthorized {
+		t.Errorf("no token: want 401, got %d", got)
+	}
+}
+
+// ── POST /agencies ────────────────────────────────────────────────────────────
+
+// 無 token → 401
+func TestRBAC_CreateAgency_NoToken(t *testing.T) {
+	env := newRBACTestEnv(t)
+
+	if got := doRequest(env.router, http.MethodPost, "/api/v1/agencies", ""); got != http.StatusUnauthorized {
+		t.Errorf("no token: want 401, got %d", got)
+	}
+}
+
+// viewer → 403
+func TestRBAC_CreateAgency_ViewerForbidden(t *testing.T) {
+	env := newRBACTestEnv(t)
+	token := env.tokenForRole(t, models.RoleViewer)
+
+	if got := doRequest(env.router, http.MethodPost, "/api/v1/agencies", token); got != http.StatusForbidden {
+		t.Errorf("viewer: want 403, got %d", got)
+	}
+}
+
+// admin → 501（通過授權）
+func TestRBAC_CreateAgency_AdminAllowed(t *testing.T) {
+	env := newRBACTestEnv(t)
+	token := env.tokenForRole(t, models.RoleAdmin)
+
+	if got := doRequest(env.router, http.MethodPost, "/api/v1/agencies", token); got != http.StatusNotImplemented {
+		t.Errorf("admin: want 501, got %d", got)
+	}
+}
+
+// ── POST /events/create ───────────────────────────────────────────────────────
+
+// 無 token → 401
+func TestRBAC_CreateEvent_NoToken(t *testing.T) {
+	env := newRBACTestEnv(t)
+
+	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/create", ""); got != http.StatusUnauthorized {
+		t.Errorf("no token: want 401, got %d", got)
+	}
+}
+
+// viewer → 403
+func TestRBAC_CreateEvent_ViewerForbidden(t *testing.T) {
+	env := newRBACTestEnv(t)
+	token := env.tokenForRole(t, models.RoleViewer)
+
+	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/create", token); got != http.StatusForbidden {
+		t.Errorf("viewer: want 403, got %d", got)
+	}
+}
+
+// streamer → 501（通過授權）
+func TestRBAC_CreateEvent_StreamerAllowed(t *testing.T) {
+	env := newRBACTestEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+
+	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/create", token); got != http.StatusNotImplemented {
+		t.Errorf("streamer: want 501, got %d", got)
+	}
+}

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
 
@@ -36,4 +37,19 @@ func JWTAuth(authSvc *services.AuthService) gin.HandlerFunc {
 func MustClaims(c *gin.Context) *services.Claims {
 	v, _ := c.Get(claimsKey)
 	return v.(*services.Claims)
+}
+
+// RequireRole limits access to the specified roles (OR semantics).
+// Must be used after JWTAuth. Returns 403 Forbidden when role does not match.
+func RequireRole(roles ...models.UserRole) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims := MustClaims(c)
+		for _, r := range roles {
+			if claims.Role == r {
+				c.Next()
+				return
+			}
+		}
+		c.AbortWithStatusJSON(403, gin.H{"success": false, "error": "forbidden"})
+	}
 }

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -1,0 +1,155 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/tachigo/tachigo/internal/config"
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+const testAccessSecret = "test-access-secret-at-least-32-chars!"
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// newAuthSvc returns an AuthService backed by a nil DB.
+// ValidateAccessToken only uses the JWT secret, so no DB is needed for these tests.
+func newAuthSvc() *services.AuthService {
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			AccessSecret:  testAccessSecret,
+			RefreshSecret: "test-refresh-secret",
+			AccessTTL:     15 * time.Minute,
+			RefreshTTL:    30 * 24 * time.Hour,
+		},
+	}
+	return services.NewAuthService(nil, cfg)
+}
+
+// mintToken creates a signed JWT access token for the given role without touching the DB.
+func mintToken(t *testing.T, role models.UserRole) string {
+	t.Helper()
+	claims := services.Claims{
+		UserID: "00000000-0000-0000-0000-000000000001",
+		Role:   role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Subject:   "00000000-0000-0000-0000-000000000001",
+		},
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(testAccessSecret))
+	if err != nil {
+		t.Fatalf("mintToken: %v", err)
+	}
+	return token
+}
+
+// buildRouter creates a minimal gin router with JWTAuth + RequireRole protecting GET /protected.
+func buildRouter(authSvc *services.AuthService, allowed ...models.UserRole) *gin.Engine {
+	r := gin.New()
+	r.Use(gin.Recovery())
+	protected := r.Group("/protected")
+	protected.Use(middleware.JWTAuth(authSvc))
+	protected.Use(middleware.RequireRole(allowed...))
+	protected.GET("", func(c *gin.Context) {
+		c.JSON(200, gin.H{"ok": true})
+	})
+	return r
+}
+
+func doGET(r *gin.Engine, token string) int {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/protected", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+// ── Unit tests: RequireRole ────────────────────────────────────────────────
+
+func TestRequireRole_AllowsMatchingRole(t *testing.T) {
+	authSvc := newAuthSvc()
+	router := buildRouter(authSvc, models.RoleEngineering)
+	token := mintToken(t, models.RoleEngineering)
+
+	if got := doGET(router, token); got != 200 {
+		t.Fatalf("expected 200, got %d", got)
+	}
+}
+
+func TestRequireRole_ForbidsNonMatchingRole(t *testing.T) {
+	authSvc := newAuthSvc()
+	router := buildRouter(authSvc, models.RoleEngineering)
+	token := mintToken(t, models.RoleViewer)
+
+	if got := doGET(router, token); got != 403 {
+		t.Fatalf("expected 403, got %d", got)
+	}
+}
+
+func TestRequireRole_AllowsAnyOfMultipleRoles(t *testing.T) {
+	authSvc := newAuthSvc()
+	router := buildRouter(authSvc, models.RoleAgency, models.RoleEngineering)
+
+	for _, role := range []models.UserRole{models.RoleAgency, models.RoleEngineering} {
+		token := mintToken(t, role)
+		if got := doGET(router, token); got != 200 {
+			t.Fatalf("role %s: expected 200, got %d", role, got)
+		}
+	}
+}
+
+func TestRequireRole_ForbidsOtherRolesWhenMultipleAllowed(t *testing.T) {
+	authSvc := newAuthSvc()
+	router := buildRouter(authSvc, models.RoleAgency, models.RoleEngineering)
+
+	for _, role := range []models.UserRole{models.RoleViewer, models.RoleStreamer} {
+		token := mintToken(t, role)
+		if got := doGET(router, token); got != 403 {
+			t.Fatalf("role %s: expected 403, got %d", role, got)
+		}
+	}
+}
+
+func TestRequireRole_Returns401WithoutToken(t *testing.T) {
+	authSvc := newAuthSvc()
+	router := buildRouter(authSvc, models.RoleEngineering)
+
+	if got := doGET(router, ""); got != 401 {
+		t.Fatalf("expected 401, got %d", got)
+	}
+}
+
+func TestRequireRole_AllRolesCovered(t *testing.T) {
+	// Ensure all four defined roles behave as expected against a single-role gate.
+	authSvc := newAuthSvc()
+	router := buildRouter(authSvc, models.RoleEngineering)
+
+	cases := []struct {
+		role models.UserRole
+		want int
+	}{
+		{models.RoleViewer, 403},
+		{models.RoleStreamer, 403},
+		{models.RoleAgency, 403},
+		{models.RoleEngineering, 200},
+	}
+	for _, tc := range cases {
+		token := mintToken(t, tc.role)
+		if got := doGET(router, token); got != tc.want {
+			t.Errorf("role %s: expected %d, got %d", tc.role, tc.want, got)
+		}
+	}
+}

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -81,8 +81,8 @@ func doGET(r *gin.Engine, token string) int {
 
 func TestRequireRole_AllowsMatchingRole(t *testing.T) {
 	authSvc := newAuthSvc()
-	router := buildRouter(authSvc, models.RoleEngineering)
-	token := mintToken(t, models.RoleEngineering)
+	router := buildRouter(authSvc, models.RoleAdmin)
+	token := mintToken(t, models.RoleAdmin)
 
 	if got := doGET(router, token); got != 200 {
 		t.Fatalf("expected 200, got %d", got)
@@ -91,7 +91,7 @@ func TestRequireRole_AllowsMatchingRole(t *testing.T) {
 
 func TestRequireRole_ForbidsNonMatchingRole(t *testing.T) {
 	authSvc := newAuthSvc()
-	router := buildRouter(authSvc, models.RoleEngineering)
+	router := buildRouter(authSvc, models.RoleAdmin)
 	token := mintToken(t, models.RoleViewer)
 
 	if got := doGET(router, token); got != 403 {
@@ -101,9 +101,9 @@ func TestRequireRole_ForbidsNonMatchingRole(t *testing.T) {
 
 func TestRequireRole_AllowsAnyOfMultipleRoles(t *testing.T) {
 	authSvc := newAuthSvc()
-	router := buildRouter(authSvc, models.RoleAgency, models.RoleEngineering)
+	router := buildRouter(authSvc, models.RoleAgency, models.RoleAdmin)
 
-	for _, role := range []models.UserRole{models.RoleAgency, models.RoleEngineering} {
+	for _, role := range []models.UserRole{models.RoleAgency, models.RoleAdmin} {
 		token := mintToken(t, role)
 		if got := doGET(router, token); got != 200 {
 			t.Fatalf("role %s: expected 200, got %d", role, got)
@@ -113,7 +113,7 @@ func TestRequireRole_AllowsAnyOfMultipleRoles(t *testing.T) {
 
 func TestRequireRole_ForbidsOtherRolesWhenMultipleAllowed(t *testing.T) {
 	authSvc := newAuthSvc()
-	router := buildRouter(authSvc, models.RoleAgency, models.RoleEngineering)
+	router := buildRouter(authSvc, models.RoleAgency, models.RoleAdmin)
 
 	for _, role := range []models.UserRole{models.RoleViewer, models.RoleStreamer} {
 		token := mintToken(t, role)
@@ -125,7 +125,7 @@ func TestRequireRole_ForbidsOtherRolesWhenMultipleAllowed(t *testing.T) {
 
 func TestRequireRole_Returns401WithoutToken(t *testing.T) {
 	authSvc := newAuthSvc()
-	router := buildRouter(authSvc, models.RoleEngineering)
+	router := buildRouter(authSvc, models.RoleAdmin)
 
 	if got := doGET(router, ""); got != 401 {
 		t.Fatalf("expected 401, got %d", got)
@@ -135,7 +135,7 @@ func TestRequireRole_Returns401WithoutToken(t *testing.T) {
 func TestRequireRole_AllRolesCovered(t *testing.T) {
 	// Ensure all four defined roles behave as expected against a single-role gate.
 	authSvc := newAuthSvc()
-	router := buildRouter(authSvc, models.RoleEngineering)
+	router := buildRouter(authSvc, models.RoleAdmin)
 
 	cases := []struct {
 		role models.UserRole
@@ -144,7 +144,7 @@ func TestRequireRole_AllRolesCovered(t *testing.T) {
 		{models.RoleViewer, 403},
 		{models.RoleStreamer, 403},
 		{models.RoleAgency, 403},
-		{models.RoleEngineering, 200},
+		{models.RoleAdmin, 200},
 	}
 	for _, tc := range cases {
 		token := mintToken(t, tc.role)

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -10,9 +10,13 @@ import (
 type UserRole string
 
 const (
-	RoleViewer   UserRole = "viewer"
-	RoleStreamer UserRole = "streamer"
-	RoleAdmin    UserRole = "admin"
+	RoleViewer      UserRole = "viewer"
+	RoleStreamer     UserRole = "streamer"
+	RoleAgency      UserRole = "agency"
+	RoleEngineering UserRole = "engineering"
+
+	// Deprecated: 請改用 RoleEngineering。
+	RoleAdmin UserRole = "admin"
 )
 
 type User struct {

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -10,13 +10,10 @@ import (
 type UserRole string
 
 const (
-	RoleViewer      UserRole = "viewer"
-	RoleStreamer     UserRole = "streamer"
-	RoleAgency      UserRole = "agency"
-	RoleEngineering UserRole = "engineering"
-
-	// Deprecated: 請改用 RoleEngineering。
-	RoleAdmin UserRole = "admin"
+	RoleViewer   UserRole = "viewer"
+	RoleStreamer  UserRole = "streamer"
+	RoleAgency   UserRole = "agency"
+	RoleAdmin    UserRole = "admin"
 )
 
 type User struct {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -108,21 +108,21 @@ func New(
 	}
 
 	// ── Agency management ─────────────────────────────────────────────────
-	// POST /agencies — engineering only
+	// POST /agencies — admin only
 	agencies := v1.Group("/agencies")
 	agencies.Use(middleware.JWTAuth(authSvc))
 	{
-		agencies.POST("", middleware.RequireRole(models.RoleEngineering), func(c *gin.Context) {
+		agencies.POST("", middleware.RequireRole(models.RoleAdmin), func(c *gin.Context) {
 			c.JSON(501, gin.H{"error": "not implemented"})
 		})
-		// PUT /agencies/:id/settings — agency or engineering
+		// PUT /agencies/:id/settings — agency or admin
 		agencies.PUT("/:id/settings",
-			middleware.RequireRole(models.RoleAgency, models.RoleEngineering),
+			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
 			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
 		)
-		// GET /agencies/:id/streamers — agency or engineering
+		// GET /agencies/:id/streamers — agency or admin
 		agencies.GET("/:id/streamers",
-			middleware.RequireRole(models.RoleAgency, models.RoleEngineering),
+			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
 			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
 		)
 	}
@@ -130,16 +130,16 @@ func New(
 	// ── Events ────────────────────────────────────────────────────────────
 	events := v1.Group("/events")
 	events.Use(middleware.JWTAuth(authSvc))
-	events.Use(middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleEngineering))
+	events.Use(middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin))
 	{
 		events.POST("/create", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
 		events.POST("/:id/settle", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
 	}
 
-	// ── Admin (engineering only) ──────────────────────────────────────────
+	// ── Admin (admin only) ──────────────────────────────────────────
 	admin := v1.Group("/admin")
 	admin.Use(middleware.JWTAuth(authSvc))
-	admin.Use(middleware.RequireRole(models.RoleEngineering))
+	admin.Use(middleware.RequireRole(models.RoleAdmin))
 	{
 		admin.GET("/users", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
 	}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
 
@@ -104,6 +105,43 @@ func New(
 			addresses.DELETE("/:id", addrH.Delete)
 			addresses.PUT("/:id/default", addrH.SetDefault)
 		}
+	}
+
+	// ── Agency management ─────────────────────────────────────────────────
+	// POST /agencies — engineering only
+	agencies := v1.Group("/agencies")
+	agencies.Use(middleware.JWTAuth(authSvc))
+	{
+		agencies.POST("", middleware.RequireRole(models.RoleEngineering), func(c *gin.Context) {
+			c.JSON(501, gin.H{"error": "not implemented"})
+		})
+		// PUT /agencies/:id/settings — agency or engineering
+		agencies.PUT("/:id/settings",
+			middleware.RequireRole(models.RoleAgency, models.RoleEngineering),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		// GET /agencies/:id/streamers — agency or engineering
+		agencies.GET("/:id/streamers",
+			middleware.RequireRole(models.RoleAgency, models.RoleEngineering),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+	}
+
+	// ── Events ────────────────────────────────────────────────────────────
+	events := v1.Group("/events")
+	events.Use(middleware.JWTAuth(authSvc))
+	events.Use(middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleEngineering))
+	{
+		events.POST("/create", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
+		events.POST("/:id/settle", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
+	}
+
+	// ── Admin (engineering only) ──────────────────────────────────────────
+	admin := v1.Group("/admin")
+	admin.Use(middleware.JWTAuth(authSvc))
+	admin.Use(middleware.RequireRole(models.RoleEngineering))
+	{
+		admin.GET("/users", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
 	}
 
 	return r

--- a/backend/migrations/004_rbac_roles.sql
+++ b/backend/migrations/004_rbac_roles.sql
@@ -1,0 +1,29 @@
+-- migrations/004_rbac_roles.sql
+-- Add agency / engineering roles; migrate legacy admin → engineering.
+-- Idempotent: safe to run multiple times.
+
+-- 1. Add new enum values (PostgreSQL requires ALTER TYPE; no-op if already exists)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'agency'
+          AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'user_role')
+    ) THEN
+        ALTER TYPE user_role ADD VALUE 'agency';
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'engineering'
+          AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'user_role')
+    ) THEN
+        ALTER TYPE user_role ADD VALUE 'engineering';
+    END IF;
+END$$;
+
+-- 2. Migrate existing admin users to engineering
+UPDATE users SET role = 'engineering' WHERE role = 'admin';

--- a/backend/migrations/004_rbac_roles.sql
+++ b/backend/migrations/004_rbac_roles.sql
@@ -1,8 +1,7 @@
 -- migrations/004_rbac_roles.sql
--- Add agency / engineering roles; migrate legacy admin → engineering.
+-- Add agency role to user_role enum.
 -- Idempotent: safe to run multiple times.
 
--- 1. Add new enum values (PostgreSQL requires ALTER TYPE; no-op if already exists)
 DO $$
 BEGIN
     IF NOT EXISTS (
@@ -13,17 +12,3 @@ BEGIN
         ALTER TYPE user_role ADD VALUE 'agency';
     END IF;
 END$$;
-
-DO $$
-BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_enum
-        WHERE enumlabel = 'engineering'
-          AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'user_role')
-    ) THEN
-        ALTER TYPE user_role ADD VALUE 'engineering';
-    END IF;
-END$$;
-
--- 2. Migrate existing admin users to engineering
-UPDATE users SET role = 'engineering' WHERE role = 'admin';


### PR DESCRIPTION
## 背景

closes #57

實作 RBAC 權限機制，定義四個角色並保護敏感 API 路由。

## 變更內容

- **models/user.go** — 新增 `RoleAgency UserRole = "agency"` 常數
- **migrations/004_rbac_roles.sql** — 冪等 migration：將 `agency` 新增至 PostgreSQL `user_role` enum
- **middleware/auth.go** — 新增 `RequireRole(...UserRole) gin.HandlerFunc`（OR 語意，403 on deny）
- **router/router.go** — 套用權限保護（agencies / events / admin 路由群組）
- **middleware/auth_test.go** — 6 個 unit test，覆蓋所有角色組合與無 token 情境

## 路由權限對應

| 路由 | 允許角色 |
|---|---|
| `POST /agencies` | `admin` |
| `PUT /agencies/:id/settings` | `agency`、`admin` |
| `GET /agencies/:id/streamers` | `agency`、`admin` |
| `POST /events/create` | `streamer`、`agency`、`admin` |
| `POST /events/:id/settle` | `streamer`、`agency`、`admin` |
| `GET /admin/*` | `admin` |

> agencies / events / admin handler 目前回傳 501，待後續功能票實作後替換。

## Test plan

- [ ] `go test ./internal/middleware/...` 全部通過
- [ ] `docker compose run --no-deps --rm app go test ./...` 全部通過
- [ ] 以 viewer/streamer token 打 `GET /admin/users` 確認回傳 403
- [ ] 以無 token 打受保護路由確認回傳 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)