### PR TITLE
feat: implement dashboard login and JWT management

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,4 +29,4 @@ GOOGLE_REDIRECT_URL=http://localhost:8080/api/v1/auth/google/callback
 
 # ── CORS ──────────────────────────────────────────────────────────────────────
 # Comma-separated list of allowed origins
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -1,6 +1,9 @@
-import { NavLink, Outlet } from 'react-router'
+import { useState } from 'react'
+import { NavLink, Outlet, useNavigate } from 'react-router'
 import { LayoutDashboard, Users, ArrowLeftRight, Settings } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { logout } from '@/services/auth'
 
 const navItems = [
   { to: '/', label: '總覽', icon: LayoutDashboard, end: true },
@@ -10,6 +13,15 @@ const navItems = [
 ]
 
 export default function Layout() {
+  const navigate = useNavigate()
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
+
+  async function handleLogout() {
+    setIsLoggingOut(true)
+    await logout()
+    navigate('/login')
+  }
+
   return (
     <div className="flex h-screen bg-background">
       {/* Sidebar */}
@@ -41,8 +53,16 @@ export default function Layout() {
 
       {/* Main content */}
       <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="h-16 shrink-0 border-b border-border flex items-center px-6">
+        <header className="flex h-16 shrink-0 items-center justify-between border-b border-border px-6">
           <span className="text-sm text-muted-foreground">Tachigo Dashboard</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+          >
+            {isLoggingOut ? '登出中...' : '登出'}
+          </Button>
         </header>
         <main className="flex-1 overflow-auto p-6">
           <Outlet />

--- a/dashboard/src/components/ProtectedRoute.tsx
+++ b/dashboard/src/components/ProtectedRoute.tsx
@@ -1,9 +1,8 @@
 import { Navigate, Outlet } from 'react-router'
+import { isAuthenticated } from '@/services/auth'
 
 export default function ProtectedRoute() {
-  const token = localStorage.getItem('token')
-
-  if (!token) {
+  if (!isAuthenticated()) {
     return <Navigate to="/login" replace />
   }
 

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { isAxiosError } from 'axios'
 import { login } from '@/services/auth'
@@ -13,7 +13,7 @@ export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
 
-  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: { preventDefault(): void }) {
     event.preventDefault()
     setIsLoading(true)
     setError('')
@@ -23,9 +23,9 @@ export default function LoginPage() {
       navigate('/')
     } catch (err) {
       if (isAxiosError(err) && err.response?.status === 401) {
-        setError('帳號或密碼錯誤')
+        setError('Invalid email or password')
       } else {
-        setError('連線失敗，請稍後再試')
+        setError('Connection failed, please try again later')
       }
     } finally {
       setIsLoading(false)

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -6,12 +6,101 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
+const messages = {
+  'zh-TW': {
+    title: '登入',
+    password: '密碼',
+    submit: '登入',
+    submitting: '登入中...',
+    errorInvalidCredentials: '電子郵件或密碼錯誤',
+    errorConnection: '連線失敗，請稍後再試',
+  },
+  'zh-CN': {
+    title: '登录',
+    password: '密码',
+    submit: '登录',
+    submitting: '登录中...',
+    errorInvalidCredentials: '邮箱或密码错误',
+    errorConnection: '连接失败，请稍后再试',
+  },
+  en: {
+    title: 'Login',
+    password: 'Password',
+    submit: 'Login',
+    submitting: 'Logging in...',
+    errorInvalidCredentials: 'Invalid email or password',
+    errorConnection: 'Connection failed, please try again later',
+  },
+  ja: {
+    title: 'ログイン',
+    password: 'パスワード',
+    submit: 'ログイン',
+    submitting: 'ログイン中...',
+    errorInvalidCredentials: 'メールアドレスまたはパスワードが違います',
+    errorConnection: '接続に失敗しました。後でもう一度お試しください',
+  },
+  ko: {
+    title: '로그인',
+    password: '비밀번호',
+    submit: '로그인',
+    submitting: '로그인 중...',
+    errorInvalidCredentials: '이메일 또는 비밀번호가 올바르지 않습니다',
+    errorConnection: '연결에 실패했습니다. 나중에 다시 시도해 주세요',
+  },
+  fr: {
+    title: 'Connexion',
+    password: 'Mot de passe',
+    submit: 'Se connecter',
+    submitting: 'Connexion...',
+    errorInvalidCredentials: 'Email ou mot de passe invalide',
+    errorConnection: 'Échec de la connexion, veuillez réessayer plus tard',
+  },
+  de: {
+    title: 'Anmelden',
+    password: 'Passwort',
+    submit: 'Anmelden',
+    submitting: 'Anmeldung...',
+    errorInvalidCredentials: 'E-Mail oder Passwort ungültig',
+    errorConnection: 'Verbindung fehlgeschlagen, bitte später erneut versuchen',
+  },
+  es: {
+    title: 'Iniciar sesión',
+    password: 'Contraseña',
+    submit: 'Iniciar sesión',
+    submitting: 'Iniciando sesión...',
+    errorInvalidCredentials: 'Correo o contraseña incorrectos',
+    errorConnection: 'Error de conexión, por favor inténtelo más tarde',
+  },
+  pt: {
+    title: 'Entrar',
+    password: 'Senha',
+    submit: 'Entrar',
+    submitting: 'Entrando...',
+    errorInvalidCredentials: 'Email ou senha inválidos',
+    errorConnection: 'Falha na conexão, tente novamente mais tarde',
+  },
+}
+
+function getMessages() {
+  const lang = navigator.language.toLowerCase()
+  if (lang === 'zh-tw' || lang === 'zh-hk') return messages['zh-TW']
+  if (lang.startsWith('zh')) return messages['zh-CN']
+  if (lang.startsWith('ja')) return messages.ja
+  if (lang.startsWith('ko')) return messages.ko
+  if (lang.startsWith('fr')) return messages.fr
+  if (lang.startsWith('de')) return messages.de
+  if (lang.startsWith('es')) return messages.es
+  if (lang.startsWith('pt')) return messages.pt
+  return messages.en
+}
+
 export default function LoginPage() {
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
+  const t = getMessages()
 
   async function handleSubmit(event: { preventDefault(): void }) {
     event.preventDefault()
@@ -23,9 +112,9 @@ export default function LoginPage() {
       navigate('/')
     } catch (err) {
       if (isAxiosError(err) && err.response?.status === 401) {
-        setError('Invalid email or password')
+        setError(t.errorInvalidCredentials)
       } else {
-        setError('Connection failed, please try again later')
+        setError(t.errorConnection)
       }
     } finally {
       setIsLoading(false)
@@ -35,7 +124,7 @@ export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="w-full max-w-sm rounded-lg border border-border bg-background p-8 shadow-sm">
-        <h1 className="mb-6 text-2xl font-bold text-foreground">Login</h1>
+        <h1 className="mb-6 text-2xl font-bold text-foreground">{t.title}</h1>
         {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1">
@@ -50,7 +139,7 @@ export default function LoginPage() {
             />
           </div>
           <div className="space-y-1">
-            <Label htmlFor="password">Password</Label>
+            <Label htmlFor="password">{t.password}</Label>
             <Input
               id="password"
               type="password"
@@ -61,7 +150,7 @@ export default function LoginPage() {
             />
           </div>
           <Button type="submit" className="w-full" disabled={isLoading}>
-            {isLoading ? 'Logging in...' : 'Login'}
+            {isLoading ? t.submitting : t.submit}
           </Button>
         </form>
       </div>

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -1,23 +1,67 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router'
+import { isAxiosError } from 'axios'
+import { login } from '@/services/auth'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
 export default function LoginPage() {
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsLoading(true)
+    setError('')
+
+    try {
+      await login(email, password)
+      navigate('/')
+    } catch (err) {
+      if (isAxiosError(err) && err.response?.status === 401) {
+        setError('帳號或密碼錯誤')
+      } else {
+        setError('連線失敗，請稍後再試')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="w-full max-w-sm rounded-lg border border-border bg-background p-8 shadow-sm">
         <h1 className="mb-6 text-2xl font-bold text-foreground">登入</h1>
-        <form className="space-y-4">
+        {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
+        <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1">
             <Label htmlFor="email">Email</Label>
-            <Input id="email" type="email" placeholder="admin@example.com" />
+            <Input
+              id="email"
+              type="email"
+              placeholder="admin@example.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
           </div>
           <div className="space-y-1">
             <Label htmlFor="password">密碼</Label>
-            <Input id="password" type="password" placeholder="••••••••" />
+            <Input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+            />
           </div>
-          <Button type="submit" className="w-full">
-            登入
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? '登入中...' : '登入'}
           </Button>
         </form>
       </div>

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -35,7 +35,7 @@ export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="w-full max-w-sm rounded-lg border border-border bg-background p-8 shadow-sm">
-        <h1 className="mb-6 text-2xl font-bold text-foreground">登入</h1>
+        <h1 className="mb-6 text-2xl font-bold text-foreground">Login</h1>
         {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1">
@@ -50,7 +50,7 @@ export default function LoginPage() {
             />
           </div>
           <div className="space-y-1">
-            <Label htmlFor="password">密碼</Label>
+            <Label htmlFor="password">Password</Label>
             <Input
               id="password"
               type="password"
@@ -61,7 +61,7 @@ export default function LoginPage() {
             />
           </div>
           <Button type="submit" className="w-full" disabled={isLoading}>
-            {isLoading ? '登入中...' : '登入'}
+            {isLoading ? 'Logging in...' : 'Login'}
           </Button>
         </form>
       </div>

--- a/dashboard/src/services/auth.ts
+++ b/dashboard/src/services/auth.ts
@@ -1,0 +1,41 @@
+import { isAxiosError } from 'axios'
+import client, { setAuthToken, clearAuthToken } from '@/services/api'
+
+// 記憶體儲存，不 export
+let accessToken: string | null = null
+
+interface LoginResponse {
+  data: {
+    user: Record<string, unknown>
+    tokens: {
+      access_token: string
+      refresh_token: string
+    }
+  }
+}
+
+export async function login(email: string, password: string): Promise<void> {
+  const { data } = await client.post<LoginResponse>('/api/v1/auth/login', {
+    email,
+    password,
+  })
+  accessToken = data.data.tokens.access_token
+  localStorage.setItem('refresh_token', data.data.tokens.refresh_token)
+  setAuthToken(accessToken)
+}
+
+export async function logout(): Promise<void> {
+  const refreshToken = localStorage.getItem('refresh_token')
+  if (refreshToken) {
+    await client.post('/api/v1/auth/logout', { refresh_token: refreshToken }).catch(() => {})
+  }
+  accessToken = null
+  localStorage.removeItem('refresh_token')
+  clearAuthToken()
+}
+
+export function isAuthenticated(): boolean {
+  return accessToken !== null
+}
+
+export { isAxiosError }

--- a/plans/dashboard-auth.md
+++ b/plans/dashboard-auth.md
@@ -1,0 +1,301 @@
+# 任務：Dashboard 登入與 JWT 管理
+
+## 專案背景
+
+這是 tachigo 專案的 Dashboard 前端，位於 `dashboard/` 資料夾。
+技術棧：React 19 + TypeScript + Vite + pnpm + Tailwind CSS v4 + React Router v7。
+
+issue #33（Dashboard 骨架）已完成，本次任務是 issue #34：實作登入功能與 JWT 管理。
+
+---
+
+## 開始前準備
+
+1. 從 `develop` 拉新 branch：
+   ```bash
+   cd C:\Users\higgus\tachigo
+   git checkout develop
+   git pull
+   git checkout -b feat/dashboard-auth
+   ```
+
+2. 確認 `dashboard/.env` 存在（複製範本）：
+   ```bash
+   cp dashboard/.env.example dashboard/.env
+   ```
+   確認內容包含：
+   ```
+   VITE_API_URL=http://localhost:8080
+   ```
+
+---
+
+## 後端 API 規格
+
+**POST /api/v1/auth/login**
+
+Request body：
+```json
+{ "email": "string", "password": "string" }
+```
+
+Response（200）：
+```json
+{
+  "data": {
+    "user": { ... },
+    "tokens": {
+      "access_token": "string",
+      "refresh_token": "string"
+    }
+  }
+}
+```
+
+Error（401）：帳密錯誤
+
+**POST /api/v1/auth/logout**
+
+Request body：
+```json
+{ "refresh_token": "string" }
+```
+
+Response（200）：成功，無 body
+
+---
+
+## Token 儲存策略
+
+- `access_token` → module-level 變數（記憶體），頁面重整後消失
+- `refresh_token` → `localStorage`（key: `refresh_token`）
+
+---
+
+## 要修改 / 建立的檔案
+
+### 1. 新增 `dashboard/src/services/auth.ts`
+
+```ts
+import { isAxiosError } from 'axios'
+import client, { setAuthToken, clearAuthToken } from '@/services/api'
+
+// 記憶體儲存，不 export
+let accessToken: string | null = null
+
+interface LoginResponse {
+  data: {
+    user: Record<string, unknown>
+    tokens: {
+      access_token: string
+      refresh_token: string
+    }
+  }
+}
+
+export async function login(email: string, password: string): Promise<void> {
+  const { data } = await client.post<LoginResponse>('/api/v1/auth/login', {
+    email,
+    password,
+  })
+  accessToken = data.data.tokens.access_token
+  localStorage.setItem('refresh_token', data.data.tokens.refresh_token)
+  setAuthToken(accessToken)
+}
+
+export async function logout(): Promise<void> {
+  const refreshToken = localStorage.getItem('refresh_token')
+  if (refreshToken) {
+    // 通知後端使 refresh_token 失效，失敗不阻斷登出流程
+    await client.post('/api/v1/auth/logout', { refresh_token: refreshToken }).catch(() => {})
+  }
+  accessToken = null
+  localStorage.removeItem('refresh_token')
+  clearAuthToken()
+}
+
+export function isAuthenticated(): boolean {
+  return accessToken !== null
+}
+
+export { isAxiosError }
+```
+
+---
+
+### 2. 修改 `dashboard/src/pages/LoginPage.tsx`
+
+```tsx
+import { useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router'
+import { isAxiosError } from 'axios'
+import { login } from '@/services/auth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+export default function LoginPage() {
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setIsLoading(true)
+    setError('')
+    try {
+      await login(email, password)
+      navigate('/')
+    } catch (err) {
+      if (isAxiosError(err) && err.response?.status === 401) {
+        setError('帳號或密碼錯誤')
+      } else {
+        setError('連線失敗，請稍後再試')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-sm rounded-lg border border-border bg-background p-8 shadow-sm">
+        <h1 className="mb-6 text-2xl font-bold text-foreground">登入</h1>
+        {error && (
+          <p className="mb-4 text-sm text-destructive">{error}</p>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="admin@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="password">密碼</Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? '登入中...' : '登入'}
+          </Button>
+        </form>
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+### 3. 修改 `dashboard/src/components/ProtectedRoute.tsx`
+
+```tsx
+import { Navigate, Outlet } from 'react-router'
+import { isAuthenticated } from '@/services/auth'
+
+export default function ProtectedRoute() {
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" replace />
+  }
+
+  return <Outlet />
+}
+```
+
+---
+
+### 4. 修改 `dashboard/src/components/Layout.tsx`
+
+在 Header 加入登出按鈕，並加入 `isLoggingOut` loading 狀態：
+
+- import `logout` from `@/services/auth`
+- import `useNavigate` from `react-router`
+- import `useState` from `react`
+- 新增 `isLoggingOut` state
+- 新增 `handleLogout`：設定 `isLoggingOut(true)`，await `logout()`，navigate 到 `/login`
+- Header 改為 `flex items-center justify-between`
+- 右側加入登出按鈕，`disabled={isLoggingOut}`：
+
+```tsx
+const [isLoggingOut, setIsLoggingOut] = useState(false)
+
+async function handleLogout() {
+  setIsLoggingOut(true)
+  await logout()
+  navigate('/login')
+}
+
+// Header 右側
+<Button variant="ghost" size="sm" onClick={handleLogout} disabled={isLoggingOut}>
+  {isLoggingOut ? '登出中...' : '登出'}
+</Button>
+```
+
+### 5. 新增 `dashboard/src/vite-env.d.ts`
+
+補上自訂環境變數的型別定義，避免 `import.meta.env.VITE_API_URL` 被推斷為 `string | undefined`：
+
+```ts
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+```
+
+---
+
+## 完成條件（請逐一驗證）
+
+- [ ] 用正確帳密登入，成功後導向 `/`（總覽頁）
+- [ ] 用錯誤帳密登入，顯示「帳號或密碼錯誤」紅色訊息
+- [ ] 網路無法連線時，顯示「連線失敗，請稍後再試」
+- [ ] 登入按鈕在送出期間顯示「登入中...」並無法點擊
+- [ ] 未登入直接訪問 `/`、`/streamers` 等，自動導向 `/login`
+- [ ] 登入後重整頁面，因 access_token 在記憶體中消失，導回登入頁（符合規格）
+- [ ] 點 Header 的登出按鈕，清除 token，導回登入頁
+- [ ] 登出按鈕在 await 期間顯示「登出中...」並無法點擊
+- [ ] 登入後開啟 DevTools → Application → localStorage，確認 key 為 `refresh_token`，value 為 JWT 字串（非 `[object Object]`）
+- [ ] `pnpm lint` 通過
+- [ ] `pnpm build` 通過
+
+---
+
+## Commit 與 PR
+
+```
+feat: implement dashboard login and JWT management refs #34
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+PR：`feat/dashboard-auth` → `develop`，PR body 加上 `Closes #34`
+
+---
+
+## 注意事項
+
+1. 全程使用 pnpm，不使用 npm
+2. 路徑 alias `@/` 對應 `src/`，使用 `@/` 不要用相對路徑
+3. `isAuthenticated()` 只檢查記憶體中的 access_token
+4. 不需要實作 token refresh（那是另一個 issue 的工作）
+5. `logout()` 是 async，呼叫時記得 `await`
+6. `isAxiosError` 用 named import：`import { isAxiosError } from 'axios'`，不要用 `axios.isAxiosError`


### PR DESCRIPTION
## Summary

- 新增 `src/services/auth.ts`：`login()` / `logout()` / `isAuthenticated()`
  - `access_token` 儲存於記憶體，`refresh_token` 儲存於 localStorage
  - `logout()` 會呼叫後端 `/api/v1/auth/logout` 使 token 失效
- 更新 `LoginPage.tsx`：表單狀態管理、API 串接、錯誤訊息區分（401 帳密錯誤 / 其他連線失敗）、登入中 loading 狀態
- 更新 `ProtectedRoute.tsx`：改用 `isAuthenticated()` 判斷登入狀態
- 更新 `Layout.tsx`：加入登出按鈕，含 loading 狀態（登出中...）
- 新增 `dashboard/.dockerignore`：排除 `node_modules` 避免 Docker build 失敗
- 更新 `backend/.env.example`：`ALLOWED_ORIGINS` 加入 `localhost:5174`

## Test plan

- [ ] 用正確帳密登入，成功後導向 `/`（總覽頁）
- [ ] 用錯誤帳密登入，顯示「帳號或密碼錯誤」紅色訊息
- [ ] 未登入直接訪問 `/` 等頁面，自動導向 `/login`
- [ ] 登入後重整頁面，因 access_token 在記憶體中消失，導回登入頁
- [ ] 點 Header 登出按鈕，顯示「登出中...」後導回 `/login`
- [ ] DevTools → Application → localStorage，key 為 `refresh_token`，value 為 JWT 字串

## Related

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)