### PR TITLE
[backend] PointsService — 雙帳本記帳

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -57,6 +57,8 @@ func main() {
 		&models.PointsLedger{},
 		&models.PointsTransaction{},
 		&models.WatchSession{},
+		&models.WatchTimeStat{},
+		&models.BroadcastTimeStat{},
 	); err != nil {
 		log.Fatalf("migration failed: %v", err)
 	}
@@ -87,6 +89,7 @@ func main() {
 	emailAuthSvc := services.NewEmailAuthService(db, cfg, mailer)
 	watchSvc := services.NewWatchService(db)
 	channelConfigSvc := services.NewChannelConfigService(db)
+	pointsSvc := services.NewPointsService(db, watchSvc)
 
 	// CORS origins from env, default to localhost for dev
 	originsEnv := os.Getenv("ALLOWED_ORIGINS")
@@ -95,7 +98,7 @@ func main() {
 		allowedOrigins = strings.Split(originsEnv, ",")
 	}
 
-	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, watchSvc, channelConfigSvc, allowedOrigins)
+	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, watchSvc, channelConfigSvc, pointsSvc, allowedOrigins)
 
 	addr := ":" + cfg.Server.Port
 	log.Printf("server starting on %s (env=%s)", addr, cfg.Server.Env)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -59,6 +59,7 @@ func main() {
 		&models.WatchSession{},
 		&models.WatchTimeStat{},
 		&models.BroadcastTimeStat{},
+		&models.BroadcastTimeLog{},
 	); err != nil {
 		log.Fatalf("migration failed: %v", err)
 	}

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1560,11 +1560,13 @@ const docTemplate = `{
             "enum": [
                 "viewer",
                 "streamer",
+                "agency",
                 "admin"
             ],
             "x-enum-varnames": [
                 "RoleViewer",
                 "RoleStreamer",
+                "RoleAgency",
                 "RoleAdmin"
             ]
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1553,11 +1553,13 @@
             "enum": [
                 "viewer",
                 "streamer",
+                "agency",
                 "admin"
             ],
             "x-enum-varnames": [
                 "RoleViewer",
                 "RoleStreamer",
+                "RoleAgency",
                 "RoleAdmin"
             ]
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -145,11 +145,13 @@ definitions:
     enum:
     - viewer
     - streamer
+    - agency
     - admin
     type: string
     x-enum-varnames:
     - RoleViewer
     - RoleStreamer
+    - RoleAgency
     - RoleAdmin
   services.AddressInput:
     properties:

--- a/backend/internal/handlers/points_handler.go
+++ b/backend/internal/handlers/points_handler.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+type PointsHandler struct {
+	pointsSvc *services.PointsService
+}
+
+func NewPointsHandler(pointsSvc *services.PointsService) *PointsHandler {
+	return &PointsHandler{pointsSvc: pointsSvc}
+}
+
+// GetBalance handles GET /api/v1/users/me/points?channel_id=...
+func (h *PointsHandler) GetBalance(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	channelID := c.Query("channel_id")
+	if channelID == "" {
+		badRequest(c, "channel_id is required")
+		return
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+
+	balance, err := h.pointsSvc.GetBalance(userID, channelID)
+	if err != nil {
+		internal(c)
+		return
+	}
+	ok(c, balance)
+}

--- a/backend/internal/handlers/watch_handler.go
+++ b/backend/internal/handlers/watch_handler.go
@@ -11,11 +11,12 @@ import (
 )
 
 type WatchHandler struct {
-	watchSvc *services.WatchService
+	watchSvc  *services.WatchService
+	pointsSvc *services.PointsService
 }
 
-func NewWatchHandler(watchSvc *services.WatchService) *WatchHandler {
-	return &WatchHandler{watchSvc: watchSvc}
+func NewWatchHandler(watchSvc *services.WatchService, pointsSvc *services.PointsService) *WatchHandler {
+	return &WatchHandler{watchSvc: watchSvc, pointsSvc: pointsSvc}
 }
 
 type watchBody struct {
@@ -67,6 +68,13 @@ func (h *WatchHandler) Heartbeat(c *gin.Context) {
 		internal(c)
 		return
 	}
+
+	// Accumulate time stats after a valid heartbeat (non-fatal: don't fail the heartbeat if these fail).
+	if result.DeltaSeconds > 0 {
+		_ = h.pointsSvc.AddWatchTime(userID, body.ChannelID, result.DeltaSeconds)
+		_ = h.pointsSvc.AddBroadcastTime(body.ChannelID, result.DeltaSeconds)
+	}
+
 	ok(c, gin.H{
 		"session":       result.Session,
 		"points_earned": result.PointsEarned,

--- a/backend/internal/models/watch_stats.go
+++ b/backend/internal/models/watch_stats.go
@@ -44,3 +44,22 @@ func (b *BroadcastTimeStat) BeforeCreate(tx *gorm.DB) error {
 	}
 	return nil
 }
+
+// BroadcastTimeLog records each heartbeat's broadcast-second increment.
+// Used for time-windowed queries (daily / monthly / yearly).
+// RecordedAt is indexed to support efficient range scans.
+type BroadcastTimeLog struct {
+	ID         uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	StreamerID uuid.UUID `gorm:"type:uuid;not null;index"                       json:"streamer_id"`
+	ChannelID  string    `gorm:"type:varchar(255);not null;index"               json:"channel_id"`
+	Seconds    int64     `gorm:"not null"                                       json:"seconds"`
+	RecordedAt time.Time `gorm:"not null;index"                                 json:"recorded_at"`
+}
+
+func (b *BroadcastTimeLog) BeforeCreate(tx *gorm.DB) error {
+	if b.ID == uuid.Nil {
+		id, _ := uuid.NewV7()
+		b.ID = id
+	}
+	return nil
+}

--- a/backend/internal/models/watch_stats.go
+++ b/backend/internal/models/watch_stats.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// WatchTimeStat accumulates total watch seconds per viewer per channel.
+// Each row is unique on (user_id, channel_id); seconds are upserted atomically.
+type WatchTimeStat struct {
+	ID                uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"              json:"id"`
+	UserID            uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:idx_watch_time_user_channel"  json:"user_id"`
+	ChannelID         string    `gorm:"type:varchar(255);not null;uniqueIndex:idx_watch_time_user_channel" json:"channel_id"`
+	TotalWatchSeconds int64     `gorm:"not null;default:0"                                          json:"total_watch_seconds"`
+	CreatedAt         time.Time `                                                                   json:"created_at"`
+	UpdatedAt         time.Time `                                                                   json:"updated_at"`
+}
+
+func (w *WatchTimeStat) BeforeCreate(tx *gorm.DB) error {
+	if w.ID == uuid.Nil {
+		id, _ := uuid.NewV7()
+		w.ID = id
+	}
+	return nil
+}
+
+// BroadcastTimeStat accumulates total broadcast seconds per streamer per channel.
+// Each row is unique on (streamer_id, channel_id); seconds are upserted atomically.
+type BroadcastTimeStat struct {
+	ID                     uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"                    json:"id"`
+	StreamerID             uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:idx_broadcast_time_streamer_channel" json:"streamer_id"`
+	ChannelID              string    `gorm:"type:varchar(255);not null;uniqueIndex:idx_broadcast_time_streamer_channel" json:"channel_id"`
+	TotalBroadcastSeconds  int64     `gorm:"not null;default:0"                                                json:"total_broadcast_seconds"`
+	CreatedAt              time.Time `                                                                          json:"created_at"`
+	UpdatedAt              time.Time `                                                                          json:"updated_at"`
+}
+
+func (b *BroadcastTimeStat) BeforeCreate(tx *gorm.DB) error {
+	if b.ID == uuid.Nil {
+		id, _ := uuid.NewV7()
+		b.ID = id
+	}
+	return nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -19,6 +19,7 @@ func New(
 	emailAuthSvc *services.EmailAuthService,
 	watchSvc *services.WatchService,
 	channelConfigSvc *services.ChannelConfigService,
+	pointsSvc *services.PointsService,
 	allowedOrigins []string,
 ) *gin.Engine {
 	r := gin.New()
@@ -32,6 +33,7 @@ func New(
 	emailH := handlers.NewEmailAuthHandler(emailAuthSvc)
 	watchH := handlers.NewWatchHandler(watchSvc)
 	channelConfigH := handlers.NewChannelConfigHandler(channelConfigSvc)
+	pointsH := handlers.NewPointsHandler(pointsSvc)
 
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})
@@ -89,6 +91,9 @@ func New(
 	protected := v1.Group("/")
 	protected.Use(middleware.JWTAuth(authSvc))
 	{
+		// Points balance
+		protected.GET("users/me/points", pointsH.GetBalance)
+
 		// User profile
 		protected.GET("users/me", userH.Me)
 		protected.PUT("users/me", userH.UpdateMe)

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -31,7 +31,7 @@ func New(
 	addrH := handlers.NewAddressHandler(addrSvc)
 	extH := handlers.NewExtensionHandler(extSvc)
 	emailH := handlers.NewEmailAuthHandler(emailAuthSvc)
-	watchH := handlers.NewWatchHandler(watchSvc)
+	watchH := handlers.NewWatchHandler(watchSvc, pointsSvc)
 	channelConfigH := handlers.NewChannelConfigHandler(channelConfigSvc)
 	pointsH := handlers.NewPointsHandler(pointsSvc)
 

--- a/backend/internal/services/points_service.go
+++ b/backend/internal/services/points_service.go
@@ -178,23 +178,47 @@ func (s *PointsService) GetWatchStats(userID uuid.UUID, channelID string) (*Watc
 
 // AddBroadcastTime accumulates broadcast seconds for a streamer in a channel.
 // Called on each Heartbeat received, in sync with viewer AddWatchTime.
-func (s *PointsService) AddBroadcastTime(streamerID uuid.UUID, channelID string, seconds int64) error {
+// streamerID is resolved internally from channelID via auth_providers (Twitch provider_id = channelID).
+// If the channelID has no registered streamer, the call is a no-op.
+func (s *PointsService) AddBroadcastTime(channelID string, seconds int64) error {
+	var provider models.AuthProvider
+	if err := s.db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, channelID).
+		First(&provider).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil // streamer not registered yet — skip silently
+		}
+		return err
+	}
+	streamerID := provider.UserID
+
 	now := time.Now()
-	return s.db.Exec(`
+	if err := s.db.Exec(`
 		INSERT INTO broadcast_time_stats (id, streamer_id, channel_id, total_broadcast_seconds, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT (streamer_id, channel_id) DO UPDATE SET
 			total_broadcast_seconds = broadcast_time_stats.total_broadcast_seconds + EXCLUDED.total_broadcast_seconds,
 			updated_at              = ?
-	`, newUUID(), streamerID, channelID, seconds, now, now, now).Error
+	`, newUUID(), streamerID, channelID, seconds, now, now, now).Error; err != nil {
+		return err
+	}
+
+	log := &models.BroadcastTimeLog{
+		StreamerID: streamerID,
+		ChannelID:  channelID,
+		Seconds:    seconds,
+		RecordedAt: now,
+	}
+	return s.db.Create(log).Error
 }
 
 // GetBroadcastStats returns broadcast time across four time windows for a streamer.
+// daily / monthly / yearly are derived from broadcast_time_logs (per-heartbeat increments).
+// current_session_seconds is approximated from active viewer watch_sessions in the channel.
 func (s *PointsService) GetBroadcastStats(streamerID uuid.UUID, channelID string) (*BroadcastStats, error) {
 	now := time.Now()
 
-	// current_session_seconds: accumulated seconds in the current active watch session
-	// used as a proxy for the ongoing broadcast session duration.
+	// current_session_seconds: sum of accumulated_seconds across all active viewer sessions
+	// in the channel — used as a proxy for the ongoing broadcast session duration.
 	var currentSession struct {
 		AccumulatedSeconds int64
 	}
@@ -208,15 +232,16 @@ func (s *PointsService) GetBroadcastStats(streamerID uuid.UUID, channelID string
 	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
 	startOfYear := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
 
-	query := `
-		SELECT COALESCE(SUM(total_broadcast_seconds), 0) AS total
-		FROM broadcast_time_stats
-		WHERE streamer_id = ? AND channel_id = ? AND created_at >= ?
+	// Query broadcast_time_logs for accurate time-windowed totals.
+	logQuery := `
+		SELECT COALESCE(SUM(seconds), 0) AS total
+		FROM broadcast_time_logs
+		WHERE streamer_id = ? AND channel_id = ? AND recorded_at >= ?
 	`
 
 	fetch := func(since time.Time) int64 {
 		var r struct{ Total int64 }
-		s.db.Raw(query, streamerID, channelID, since).Scan(&r)
+		s.db.Raw(logQuery, streamerID, channelID, since).Scan(&r)
 		return r.Total
 	}
 

--- a/backend/internal/services/points_service.go
+++ b/backend/internal/services/points_service.go
@@ -1,0 +1,229 @@
+package services
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+var (
+	ErrInsufficientBalance = errors.New("insufficient spendable balance")
+	ErrLedgerNotFound      = errors.New("points ledger not found")
+)
+
+// PointsBalance holds both balance views for a viewer in a channel.
+type PointsBalance struct {
+	CumulativeTotal  int64 `json:"cumulative_total"`
+	SpendableBalance int64 `json:"spendable_balance"`
+}
+
+// WatchStats holds a viewer's accumulated watch time in a channel.
+type WatchStats struct {
+	TotalWatchSeconds int64 `json:"total_watch_seconds"`
+}
+
+// BroadcastStats holds a streamer's broadcast time across four time windows.
+type BroadcastStats struct {
+	CurrentSessionSeconds int64 `json:"current_session_seconds"`
+	DailySeconds          int64 `json:"daily_seconds"`
+	MonthlySeconds        int64 `json:"monthly_seconds"`
+	YearlySeconds         int64 `json:"yearly_seconds"`
+}
+
+type PointsService struct {
+	db       *gorm.DB
+	watchSvc *WatchService
+}
+
+func NewPointsService(db *gorm.DB, watchSvc *WatchService) *PointsService {
+	return &PointsService{db: db, watchSvc: watchSvc}
+}
+
+// GetBalance wraps WatchService.GetBalance and returns a PointsBalance struct.
+// Returns zeroed balance if no ledger exists yet.
+func (s *PointsService) GetBalance(userID uuid.UUID, channelID string) (*PointsBalance, error) {
+	spendable, cumulative, err := s.watchSvc.GetBalance(userID, channelID)
+	if err != nil {
+		return nil, err
+	}
+	return &PointsBalance{
+		CumulativeTotal:  cumulative,
+		SpendableBalance: spendable,
+	}, nil
+}
+
+// ListTransactions returns the most recent 50 transactions for a viewer in a channel.
+func (s *PointsService) ListTransactions(userID uuid.UUID, channelID string) ([]models.PointsTransaction, error) {
+	var ledger models.PointsLedger
+	if err := s.db.Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return []models.PointsTransaction{}, nil
+		}
+		return nil, err
+	}
+
+	var txs []models.PointsTransaction
+	err := s.db.Where("ledger_id = ?", ledger.ID).
+		Order("created_at DESC").
+		Limit(50).
+		Find(&txs).Error
+	return txs, err
+}
+
+// DeductPoints subtracts amount from spendable_balance only.
+// cumulative_total is never modified by a deduction.
+// Returns ErrInsufficientBalance if the current spendable balance is too low.
+func (s *PointsService) DeductPoints(userID uuid.UUID, channelID string, amount int64, note string) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		var ledger models.PointsLedger
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("user_id = ? AND channel_id = ?", userID, channelID).
+			First(&ledger).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrInsufficientBalance
+			}
+			return err
+		}
+
+		if ledger.SpendableBalance < amount {
+			return ErrInsufficientBalance
+		}
+
+		newBalance := ledger.SpendableBalance - amount
+		if err := tx.Model(&ledger).Updates(map[string]interface{}{
+			"spendable_balance": newBalance,
+			"updated_at":        time.Now(),
+		}).Error; err != nil {
+			return err
+		}
+
+		notePtr := &note
+		txRecord := &models.PointsTransaction{
+			LedgerID:     ledger.ID,
+			Source:       models.TxSourceSpend,
+			Delta:        -amount,
+			BalanceAfter: newBalance,
+			Note:         notePtr,
+		}
+		return tx.Create(txRecord).Error
+	})
+}
+
+// AddPoints adds amount to both spendable_balance and cumulative_total.
+// Intended for use by AirdropService — Heartbeat points are handled by WatchService.Heartbeat.
+func (s *PointsService) AddPoints(userID uuid.UUID, channelID string, source models.TxSource, amount int64) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		ledgerID := newUUID()
+		now := time.Now()
+
+		if err := tx.Exec(`
+			INSERT INTO points_ledgers (id, user_id, channel_id, spendable_balance, cumulative_total, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT (user_id, channel_id) DO UPDATE SET
+				spendable_balance = points_ledgers.spendable_balance + EXCLUDED.spendable_balance,
+				cumulative_total  = points_ledgers.cumulative_total  + EXCLUDED.cumulative_total,
+				updated_at        = ?
+		`, ledgerID, userID, channelID, amount, amount, now, now, now).Error; err != nil {
+			return err
+		}
+
+		var ledger models.PointsLedger
+		if err := tx.Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
+			return err
+		}
+
+		txRecord := &models.PointsTransaction{
+			LedgerID:     ledger.ID,
+			Source:       source,
+			Delta:        amount,
+			BalanceAfter: ledger.SpendableBalance,
+		}
+		return tx.Create(txRecord).Error
+	})
+}
+
+// AddWatchTime accumulates observed seconds for a viewer in a channel.
+// Called after each successful Heartbeat.
+func (s *PointsService) AddWatchTime(userID uuid.UUID, channelID string, seconds int64) error {
+	now := time.Now()
+	return s.db.Exec(`
+		INSERT INTO watch_time_stats (id, user_id, channel_id, total_watch_seconds, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT (user_id, channel_id) DO UPDATE SET
+			total_watch_seconds = watch_time_stats.total_watch_seconds + EXCLUDED.total_watch_seconds,
+			updated_at          = ?
+	`, newUUID(), userID, channelID, seconds, now, now, now).Error
+}
+
+// GetWatchStats returns the total accumulated watch seconds for a viewer in a channel.
+func (s *PointsService) GetWatchStats(userID uuid.UUID, channelID string) (*WatchStats, error) {
+	var result struct {
+		TotalWatchSeconds int64
+	}
+	err := s.db.Raw(`
+		SELECT COALESCE(total_watch_seconds, 0) AS total_watch_seconds
+		FROM watch_time_stats
+		WHERE user_id = ? AND channel_id = ?
+	`, userID, channelID).Scan(&result).Error
+	if err != nil {
+		return nil, err
+	}
+	return &WatchStats{TotalWatchSeconds: result.TotalWatchSeconds}, nil
+}
+
+// AddBroadcastTime accumulates broadcast seconds for a streamer in a channel.
+// Called on each Heartbeat received, in sync with viewer AddWatchTime.
+func (s *PointsService) AddBroadcastTime(streamerID uuid.UUID, channelID string, seconds int64) error {
+	now := time.Now()
+	return s.db.Exec(`
+		INSERT INTO broadcast_time_stats (id, streamer_id, channel_id, total_broadcast_seconds, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT (streamer_id, channel_id) DO UPDATE SET
+			total_broadcast_seconds = broadcast_time_stats.total_broadcast_seconds + EXCLUDED.total_broadcast_seconds,
+			updated_at              = ?
+	`, newUUID(), streamerID, channelID, seconds, now, now, now).Error
+}
+
+// GetBroadcastStats returns broadcast time across four time windows for a streamer.
+func (s *PointsService) GetBroadcastStats(streamerID uuid.UUID, channelID string) (*BroadcastStats, error) {
+	now := time.Now()
+
+	// current_session_seconds: accumulated seconds in the current active watch session
+	// used as a proxy for the ongoing broadcast session duration.
+	var currentSession struct {
+		AccumulatedSeconds int64
+	}
+	s.db.Raw(`
+		SELECT COALESCE(SUM(accumulated_seconds), 0) AS accumulated_seconds
+		FROM watch_sessions
+		WHERE channel_id = ? AND is_active = true
+	`, channelID).Scan(&currentSession)
+
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfYear := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
+
+	query := `
+		SELECT COALESCE(SUM(total_broadcast_seconds), 0) AS total
+		FROM broadcast_time_stats
+		WHERE streamer_id = ? AND channel_id = ? AND created_at >= ?
+	`
+
+	fetch := func(since time.Time) int64 {
+		var r struct{ Total int64 }
+		s.db.Raw(query, streamerID, channelID, since).Scan(&r)
+		return r.Total
+	}
+
+	return &BroadcastStats{
+		CurrentSessionSeconds: currentSession.AccumulatedSeconds,
+		DailySeconds:          fetch(startOfDay),
+		MonthlySeconds:        fetch(startOfMonth),
+		YearlySeconds:         fetch(startOfYear),
+	}, nil
+}

--- a/backend/internal/services/points_service_test.go
+++ b/backend/internal/services/points_service_test.go
@@ -1,0 +1,290 @@
+package services
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+// newPointsSvc creates a PointsService backed by an in-memory SQLite test DB.
+func newPointsSvc(t *testing.T) (*PointsService, *WatchService) {
+	t.Helper()
+	db := newTestDB(t)
+	watchSvc := NewWatchService(db)
+	pointsSvc := NewPointsService(db, watchSvc)
+	return pointsSvc, watchSvc
+}
+
+// seedViewer inserts a viewer user and returns their UUID.
+func seedViewer(t *testing.T, svc *PointsService) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := svc.db.Exec(
+		`INSERT INTO users (id, role, is_active, email_verified, created_at, updated_at)
+		 VALUES (?, 'viewer', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, id,
+	).Error; err != nil {
+		t.Fatalf("seed viewer: %v", err)
+	}
+	return id
+}
+
+// seedStreamer inserts a streamer user linked to a Twitch channel and returns their UUID.
+func seedStreamer(t *testing.T, svc *PointsService, channelID string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := svc.db.Exec(
+		`INSERT INTO users (id, role, is_active, email_verified, created_at, updated_at)
+		 VALUES (?, 'streamer', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, id,
+	).Error; err != nil {
+		t.Fatalf("seed streamer user: %v", err)
+	}
+	providerID := uuid.New()
+	if err := svc.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		 VALUES (?, ?, 'twitch', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		providerID, id, channelID,
+	).Error; err != nil {
+		t.Fatalf("seed streamer auth_provider: %v", err)
+	}
+	return id
+}
+
+// ─── GetBalance ──────────────────────────────────────────────────────────────
+
+func TestPointsService_GetBalance_NoLedger(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	bal, err := svc.GetBalance(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bal.SpendableBalance != 0 || bal.CumulativeTotal != 0 {
+		t.Errorf("want (0,0), got (%d,%d)", bal.SpendableBalance, bal.CumulativeTotal)
+	}
+}
+
+func TestPointsService_GetBalance_AfterEarning(t *testing.T) {
+	svc, watchSvc := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	// Earn 1 point via WatchService (3 × 25 s heartbeats = 75 s → 1 pt)
+	s, _ := watchSvc.StartSession(userID, "ch_abc")
+	for i := 0; i < 3; i++ {
+		s = reloadSession(t, watchSvc, s.ID)
+		backdateHeartbeat(t, watchSvc, s.ID, 25*time.Second)
+		watchSvc.Heartbeat(userID, "ch_abc")
+	}
+
+	bal, err := svc.GetBalance(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bal.SpendableBalance != 1 || bal.CumulativeTotal != 1 {
+		t.Errorf("want (1,1), got (%d,%d)", bal.SpendableBalance, bal.CumulativeTotal)
+	}
+}
+
+// ─── DeductPoints ────────────────────────────────────────────────────────────
+
+func TestPointsService_DeductPoints_InsufficientBalance(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	err := svc.DeductPoints(userID, "ch_abc", 100, "test spend")
+	if !errors.Is(err, ErrInsufficientBalance) {
+		t.Errorf("want ErrInsufficientBalance, got %v", err)
+	}
+}
+
+func TestPointsService_DeductPoints_Success(t *testing.T) {
+	svc, watchSvc := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	// Earn 2 points first
+	s, _ := watchSvc.StartSession(userID, "ch_abc")
+	for i := 0; i < 5; i++ {
+		s = reloadSession(t, watchSvc, s.ID)
+		backdateHeartbeat(t, watchSvc, s.ID, 25*time.Second)
+		watchSvc.Heartbeat(userID, "ch_abc")
+	}
+
+	if err := svc.DeductPoints(userID, "ch_abc", 1, "redeem"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	bal, _ := svc.GetBalance(userID, "ch_abc")
+	if bal.SpendableBalance != 1 {
+		t.Errorf("spendable: want 1, got %d", bal.SpendableBalance)
+	}
+	// cumulative_total must not change
+	if bal.CumulativeTotal != 2 {
+		t.Errorf("cumulative: want 2 (unchanged), got %d", bal.CumulativeTotal)
+	}
+}
+
+// ─── AddPoints ───────────────────────────────────────────────────────────────
+
+func TestPointsService_AddPoints_IncreasesBothBalances(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceBits, 500); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	bal, _ := svc.GetBalance(userID, "ch_abc")
+	if bal.SpendableBalance != 500 || bal.CumulativeTotal != 500 {
+		t.Errorf("want (500,500), got (%d,%d)", bal.SpendableBalance, bal.CumulativeTotal)
+	}
+}
+
+// ─── ListTransactions ────────────────────────────────────────────────────────
+
+func TestPointsService_ListTransactions_EmptyWhenNoLedger(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	txs, err := svc.ListTransactions(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txs) != 0 {
+		t.Errorf("want 0 transactions, got %d", len(txs))
+	}
+}
+
+func TestPointsService_ListTransactions_RecordsDeduction(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	svc.AddPoints(userID, "ch_abc", models.TxSourceBits, 100)
+	svc.DeductPoints(userID, "ch_abc", 30, "spend test")
+
+	txs, err := svc.ListTransactions(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txs) != 2 {
+		t.Errorf("want 2 transactions, got %d", len(txs))
+	}
+}
+
+// ─── AddWatchTime / GetWatchStats ────────────────────────────────────────────
+
+func TestPointsService_AddWatchTime_Accumulates(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	svc.AddWatchTime(userID, "ch_abc", 30)
+	svc.AddWatchTime(userID, "ch_abc", 45)
+
+	stats, err := svc.GetWatchStats(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalWatchSeconds != 75 {
+		t.Errorf("want 75 s, got %d", stats.TotalWatchSeconds)
+	}
+}
+
+func TestPointsService_GetWatchStats_ZeroWhenNone(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+
+	stats, err := svc.GetWatchStats(userID, "ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalWatchSeconds != 0 {
+		t.Errorf("want 0 s, got %d", stats.TotalWatchSeconds)
+	}
+}
+
+// ─── AddBroadcastTime ────────────────────────────────────────────────────────
+
+func TestPointsService_AddBroadcastTime_NoOpWhenStreamerNotRegistered(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+
+	// No auth_provider for this channelID — should silently return nil
+	err := svc.AddBroadcastTime("ch_no_streamer", 30)
+	if err != nil {
+		t.Errorf("expected no error for unregistered channel, got %v", err)
+	}
+
+	var count int64
+	svc.db.Raw("SELECT COUNT(*) FROM broadcast_time_logs").Scan(&count)
+	if count != 0 {
+		t.Errorf("expected 0 log entries, got %d", count)
+	}
+}
+
+func TestPointsService_AddBroadcastTime_WritesLogAndStat(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	channelID := "ch_with_streamer"
+	streamerID := seedStreamer(t, svc, channelID)
+
+	if err := svc.AddBroadcastTime(channelID, 30); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := svc.AddBroadcastTime(channelID, 45); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// broadcast_time_stats should have lifetime total
+	var total int64
+	svc.db.Raw("SELECT total_broadcast_seconds FROM broadcast_time_stats WHERE streamer_id = ?", streamerID).Scan(&total)
+	if total != 75 {
+		t.Errorf("broadcast_time_stats: want 75 s, got %d", total)
+	}
+
+	// broadcast_time_logs should have 2 entries
+	var count int64
+	svc.db.Raw("SELECT COUNT(*) FROM broadcast_time_logs WHERE streamer_id = ?", streamerID).Scan(&count)
+	if count != 2 {
+		t.Errorf("broadcast_time_logs: want 2 entries, got %d", count)
+	}
+}
+
+// ─── GetBroadcastStats ───────────────────────────────────────────────────────
+
+func TestPointsService_GetBroadcastStats_TimeWindows(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	channelID := "ch_stats"
+	streamerID := seedStreamer(t, svc, channelID)
+
+	// Insert log entries directly with controlled recorded_at timestamps
+	now := time.Now()
+	entries := []struct {
+		seconds    int64
+		recordedAt time.Time
+	}{
+		{60, now.Add(-10 * time.Minute)},                    // today
+		{120, now.Add(-25 * time.Hour)},                     // yesterday (outside daily, inside monthly)
+		{180, now.AddDate(0, -1, -1)},                       // last month (outside monthly, inside yearly)
+	}
+	for _, e := range entries {
+		svc.db.Exec(
+			`INSERT INTO broadcast_time_logs (id, streamer_id, channel_id, seconds, recorded_at) VALUES (?, ?, ?, ?, ?)`,
+			uuid.New(), streamerID, channelID, e.seconds, e.recordedAt,
+		)
+	}
+
+	stats, err := svc.GetBroadcastStats(streamerID, channelID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.DailySeconds != 60 {
+		t.Errorf("daily: want 60, got %d", stats.DailySeconds)
+	}
+	if stats.MonthlySeconds != 60+120 {
+		t.Errorf("monthly: want 180, got %d", stats.MonthlySeconds)
+	}
+	if stats.YearlySeconds != 60+120+180 {
+		t.Errorf("yearly: want 360, got %d", stats.YearlySeconds)
+	}
+}

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -143,6 +143,33 @@ func migrateTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at DATETIME
 		)`,
+		`CREATE TABLE IF NOT EXISTS watch_time_stats (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			total_watch_seconds INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_time_user_channel
+			ON watch_time_stats (user_id, channel_id)`,
+		`CREATE TABLE IF NOT EXISTS broadcast_time_stats (
+			id TEXT PRIMARY KEY,
+			streamer_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			total_broadcast_seconds INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_broadcast_time_streamer_channel
+			ON broadcast_time_stats (streamer_id, channel_id)`,
+		`CREATE TABLE IF NOT EXISTS broadcast_time_logs (
+			id TEXT PRIMARY KEY,
+			streamer_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			seconds INTEGER NOT NULL,
+			recorded_at DATETIME NOT NULL
+		)`,
 	}
 	for _, s := range stmts {
 		if err := db.Exec(s).Error; err != nil {

--- a/backend/internal/services/watch_service.go
+++ b/backend/internal/services/watch_service.go
@@ -105,6 +105,7 @@ func (s *WatchService) StartSession(userID uuid.UUID, channelID string) (*models
 type HeartbeatResult struct {
 	Session      *models.WatchSession
 	PointsEarned int64
+	DeltaSeconds int64
 }
 
 // Heartbeat advances the session timer and awards points if a full minute has accumulated.
@@ -135,7 +136,7 @@ func (s *WatchService) Heartbeat(userID uuid.UUID, channelID string) (*Heartbeat
 		// Ignore heartbeats that arrive too quickly — likely a client retry.
 		// Normal cadence is 30 s; anything under 20 s is anomalous.
 		if delta < 20*time.Second {
-			result = HeartbeatResult{Session: &session, PointsEarned: 0}
+			result = HeartbeatResult{Session: &session, PointsEarned: 0, DeltaSeconds: 0}
 			return nil
 		}
 
@@ -201,7 +202,7 @@ func (s *WatchService) Heartbeat(userID uuid.UUID, channelID string) (*Heartbeat
 			}
 		}
 
-		result = HeartbeatResult{Session: &session, PointsEarned: pointsToAward}
+		result = HeartbeatResult{Session: &session, PointsEarned: pointsToAward, DeltaSeconds: deltaSeconds}
 		return nil
 	})
 


### PR DESCRIPTION
## Summary

- 實作 `PointsService` 完整雙帳本架構，補齊 `WatchService` 未覆蓋的點數與時數功能
- 新增時數統計三張表（`watch_time_stats`、`broadcast_time_stats`、`broadcast_time_logs`）
- 修正廣播時數時間窗口查詢設計，改用 log 表支援 daily / monthly / yearly
- 串接 `WatchHandler.Heartbeat`，每次心跳後同步累計觀眾與實況主時數
- 暴露 `GET /api/v1/users/me/points?channel_id=` 供前端查詢餘額

## Changes

**新增檔案**
- `backend/internal/services/points_service.go` — `PointsService` 完整實作（8 個方法）
- `backend/internal/models/watch_stats.go` — `WatchTimeStat`、`BroadcastTimeStat`、`BroadcastTimeLog` model
- `backend/internal/handlers/points_handler.go` — `GET /api/v1/users/me/points`

**修改檔案**
- `watch_service.go` — `HeartbeatResult` 補 `DeltaSeconds`
- `watch_handler.go` — 持有 `pointsSvc`，Heartbeat 後呼叫 `AddWatchTime` / `AddBroadcastTime`
- `router.go` — 加入 `pointsSvc` 參數、`users/me/points` 路由
- `main.go` — AutoMigrate 加三張新表、wire `PointsService`

## Test plan

- [x] `go build ./...` 通過
- [x] `go test ./internal/services/...` 通過
- [x] 本機驗證 `GET /api/v1/users/me/points?channel_id=` 回傳正確餘額（`cumulative_total: 1, spendable_balance: 1`）
- [x] 驗證 Heartbeat 後 `watch_time_stats` 有新增紀錄（60 秒累計正確）
- [x] 驗證 `broadcast_time_logs` 於無對應 Twitch streamer 時靜默跳過（符合設計）

closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)