### PR TITLE
[backend/frontend] Click Boost — 挖礦角色點擊增益

### DIFF
--- a/backend/internal/handlers/watch_handler.go
+++ b/backend/internal/handlers/watch_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -100,6 +101,44 @@ func (h *WatchHandler) EndSession(c *gin.Context) {
 		return
 	}
 	ok(c, gin.H{"ended": true})
+}
+
+// Click handles POST /extension/watch/click
+func (h *WatchHandler) Click(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	var body watchBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+
+	result, err := h.watchSvc.RecordClick(userID, body.ChannelID)
+	if err != nil {
+		if errors.Is(err, services.ErrNoActiveSession) {
+			badRequest(c, "no active session")
+			return
+		}
+		var cooldownErr services.ErrClickOnCooldown
+		if errors.As(err, &cooldownErr) {
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"success":        false,
+				"error":          "on_cooldown",
+				"retry_after_ms": cooldownErr.RetryAfterMs,
+			})
+			return
+		}
+		internal(c)
+		return
+	}
+	ok(c, gin.H{
+		"balance": result.BalanceAfter,
+		"delta":   result.Delta,
+	})
 }
 
 // GetBalance handles GET /extension/watch/balance?channel_id=...

--- a/backend/internal/models/points.go
+++ b/backend/internal/models/points.go
@@ -13,6 +13,7 @@ type TxSource string
 const (
 	TxSourceBits      TxSource = "bits"
 	TxSourceWatchTime TxSource = "watch_time"
+	TxSourceClick     TxSource = "click"
 	TxSourceSpend     TxSource = "spend"
 )
 

--- a/backend/internal/models/watch_session.go
+++ b/backend/internal/models/watch_session.go
@@ -23,6 +23,9 @@ type WatchSession struct {
 	AccumulatedSeconds int64      `gorm:"not null;default:0"                             json:"accumulated_seconds"`
 	RewardedSeconds    int64      `gorm:"not null;default:0"                             json:"rewarded_seconds"`
 	LastHeartbeatAt    time.Time  `gorm:"not null;default:now()"                         json:"last_heartbeat_at"`
+	// ClickCooldownUntil tracks when the viewer may next click.
+	// Defaults to the epoch so the first click is always allowed.
+	ClickCooldownUntil time.Time  `gorm:"not null;default:'1970-01-01 00:00:00+00'"      json:"-"`
 	IsActive           bool       `gorm:"not null;default:true;index"                    json:"is_active"`
 	EndedAt            *time.Time `                                                      json:"ended_at"`
 	CreatedAt          time.Time  `                                                      json:"created_at"`

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -82,6 +82,7 @@ func New(
 		{
 			watch.POST("/start", watchH.StartSession)
 			watch.POST("/heartbeat", watchH.Heartbeat)
+			watch.POST("/click", watchH.Click)
 			watch.POST("/end", watchH.EndSession)
 			watch.GET("/balance", watchH.GetBalance)
 		}

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -108,6 +108,7 @@ func migrateTestDB(db *gorm.DB) error {
 			accumulated_seconds INTEGER NOT NULL DEFAULT 0,
 			rewarded_seconds INTEGER NOT NULL DEFAULT 0,
 			last_heartbeat_at DATETIME NOT NULL,
+			click_cooldown_until DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00',
 			is_active INTEGER NOT NULL DEFAULT 1,
 			ended_at DATETIME,
 			created_at DATETIME,

--- a/backend/internal/services/watch_service.go
+++ b/backend/internal/services/watch_service.go
@@ -14,6 +14,12 @@ import (
 // staleThreshold is how long without a heartbeat before a session is considered stale.
 const staleThreshold = 2 * time.Minute
 
+// clickCooldown is how long a viewer must wait between clicks.
+const clickCooldown = 5 * time.Second
+
+// clickPointsPerClick is the fixed reward per click (MVP; configurable in future).
+const clickPointsPerClick = int64(1)
+
 // newUUID generates a time-ordered UUID v7. Falls back to random v4 on failure.
 func newUUID() uuid.UUID {
 	id, err := uuid.NewV7()
@@ -24,6 +30,13 @@ func newUUID() uuid.UUID {
 }
 
 var ErrNoActiveSession = errors.New("no active session")
+
+// ErrClickOnCooldown is returned when a viewer clicks before their cooldown expires.
+type ErrClickOnCooldown struct {
+	RetryAfterMs int64
+}
+
+func (e ErrClickOnCooldown) Error() string { return "click on cooldown" }
 
 type WatchService struct {
 	db *gorm.DB
@@ -222,6 +235,82 @@ func (s *WatchService) EndSession(userID uuid.UUID, channelID string) error {
 			"is_active": false,
 			"ended_at":  now,
 		}).Error
+}
+
+// ClickResult contains the outcome of a single click event.
+type ClickResult struct {
+	BalanceAfter int64
+	Delta        int64
+}
+
+// RecordClick awards points for a viewer clicking the mining character.
+//
+// Rules:
+//   - The viewer must have an active watch session.
+//   - A per-viewer cooldown (clickCooldown) prevents click spam.
+//   - On success, clickPointsPerClick is added to the viewer's ledger.
+//
+// Concurrency: SELECT FOR UPDATE on the session row serialises concurrent clicks.
+func (s *WatchService) RecordClick(userID uuid.UUID, channelID string) (*ClickResult, error) {
+	var result ClickResult
+
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var session models.WatchSession
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
+			First(&session).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNoActiveSession
+			}
+			return err
+		}
+
+		if time.Now().Before(session.ClickCooldownUntil) {
+			remaining := time.Until(session.ClickCooldownUntil)
+			return ErrClickOnCooldown{RetryAfterMs: remaining.Milliseconds()}
+		}
+
+		if err := tx.Model(&session).Update("click_cooldown_until", time.Now().Add(clickCooldown)).Error; err != nil {
+			return err
+		}
+
+		ledgerID := newUUID()
+		upsertTime := time.Now()
+		if err := tx.Exec(`
+			INSERT INTO points_ledgers (id, user_id, channel_id, spendable_balance, cumulative_total, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT (user_id, channel_id) DO UPDATE SET
+				spendable_balance = points_ledgers.spendable_balance + EXCLUDED.spendable_balance,
+				cumulative_total  = points_ledgers.cumulative_total  + EXCLUDED.cumulative_total,
+				updated_at        = ?
+		`, ledgerID, userID, channelID, clickPointsPerClick, clickPointsPerClick, upsertTime, upsertTime, upsertTime).Error; err != nil {
+			return err
+		}
+
+		var ledger models.PointsLedger
+		if err := tx.Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
+			return err
+		}
+
+		txRecord := &models.PointsTransaction{
+			LedgerID:       ledger.ID,
+			WatchSessionID: &session.ID,
+			Source:         models.TxSourceClick,
+			Delta:          clickPointsPerClick,
+			BalanceAfter:   ledger.SpendableBalance,
+		}
+		if err := tx.Create(txRecord).Error; err != nil {
+			return err
+		}
+
+		result = ClickResult{BalanceAfter: ledger.SpendableBalance, Delta: clickPointsPerClick}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // GetBalance returns the viewer's current spendable balance and cumulative total

--- a/backend/internal/services/watch_service_test.go
+++ b/backend/internal/services/watch_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -248,6 +249,96 @@ func TestEndSession_Idempotent(t *testing.T) {
 	svc.EndSession(userID, "ch_abc")
 	if err := svc.EndSession(userID, "ch_abc"); err != nil {
 		t.Errorf("unexpected error on second EndSession: %v", err)
+	}
+}
+
+// ─── GetBalance ──────────────────────────────────────────────────────────────
+
+// ─── RecordClick ─────────────────────────────────────────────────────────────
+
+func TestRecordClick_NoActiveSession(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	_, err := svc.RecordClick(userID, "ch_abc")
+	if err != ErrNoActiveSession {
+		t.Errorf("want ErrNoActiveSession, got %v", err)
+	}
+}
+
+func TestRecordClick_AwardsPoint(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	channelID := "ch_abc"
+
+	svc.StartSession(userID, channelID)
+
+	result, err := svc.RecordClick(userID, channelID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Delta != 1 {
+		t.Errorf("want delta=1, got %d", result.Delta)
+	}
+	if result.BalanceAfter != 1 {
+		t.Errorf("want balance=1, got %d", result.BalanceAfter)
+	}
+
+	spendable, cumulative, _ := svc.GetBalance(userID, channelID)
+	if spendable != 1 || cumulative != 1 {
+		t.Errorf("balance: want (1,1), got (%d,%d)", spendable, cumulative)
+	}
+}
+
+func TestRecordClick_OnCooldown(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+
+	svc.StartSession(userID, "ch_abc")
+
+	// First click should succeed.
+	if _, err := svc.RecordClick(userID, "ch_abc"); err != nil {
+		t.Fatalf("first click: %v", err)
+	}
+
+	// Immediate second click must be rejected with ErrClickOnCooldown.
+	_, err := svc.RecordClick(userID, "ch_abc")
+	var cooldownErr ErrClickOnCooldown
+	if !errors.As(err, &cooldownErr) {
+		t.Errorf("want ErrClickOnCooldown, got %v", err)
+	}
+	if cooldownErr.RetryAfterMs <= 0 {
+		t.Errorf("expected RetryAfterMs > 0, got %d", cooldownErr.RetryAfterMs)
+	}
+}
+
+func TestRecordClick_LedgerAccumulates(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	channelID := "ch_abc"
+
+	svc.StartSession(userID, channelID)
+
+	// Backdate cooldown to simulate passing time between clicks.
+	backdateCooldown := func() {
+		t.Helper()
+		if err := svc.db.Model(&models.WatchSession{}).
+			Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
+			Update("click_cooldown_until", "1970-01-01 00:00:00").Error; err != nil {
+			t.Fatalf("backdate cooldown: %v", err)
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		backdateCooldown()
+		if _, err := svc.RecordClick(userID, channelID); err != nil {
+			t.Fatalf("click %d: %v", i+1, err)
+		}
+	}
+
+	spendable, cumulative, _ := svc.GetBalance(userID, channelID)
+	if spendable != 3 || cumulative != 3 {
+		t.Errorf("want (3,3) after 3 clicks, got (%d,%d)", spendable, cumulative)
 	}
 }
 

--- a/backend/migrations/005_click_boost.sql
+++ b/backend/migrations/005_click_boost.sql
@@ -1,0 +1,7 @@
+-- migrations/005_click_boost.sql
+-- Adds click-boost cooldown tracking to watch_sessions.
+-- GORM AutoMigrate handles this automatically in dev.
+-- Use this for manual DB setup or production migrations.
+
+ALTER TABLE watch_sessions
+  ADD COLUMN IF NOT EXISTS click_cooldown_until TIMESTAMPTZ NOT NULL DEFAULT '1970-01-01 00:00:00+00';

--- a/backend/migrations/006_click_boost.sql
+++ b/backend/migrations/006_click_boost.sql
@@ -1,4 +1,4 @@
--- migrations/005_click_boost.sql
+-- migrations/006_click_boost.sql
 -- Adds click-boost cooldown tracking to watch_sessions.
 -- GORM AutoMigrate handles this automatically in dev.
 -- Use this for manual DB setup or production migrations.

--- a/plans/click-boost.md
+++ b/plans/click-boost.md
@@ -1,0 +1,216 @@
+# 挖礦角色點擊增益（Click Boost）
+
+> **狀態：** 待實作
+> **關聯 Issue：** refs #77
+> **最後更新：** 2026-04-04
+
+---
+
+## 背景
+
+目前觀看點數完全被動（heartbeat 每 60 秒 +1 點），互動性不足。
+此功能讓觀眾可以點擊 Extension 中的挖礦角色，觸發即時點數增益，
+體驗類似忠誠點數互動，同時透過冷卻機制防止刷點。
+
+依賴基礎設施：
+- 雙帳本系統（`PointsLedger` + `PointsTransaction`）— PR #74 已合併
+- Watch session 管理（`WatchSession`）— PR #52 已合併
+- Extension JWT 認證中間件（`ext_auth.go`）
+
+---
+
+## 架構決策
+
+| 項目 | 決策 | 理由 |
+|---|---|---|
+| 冷卻儲存位置 | 在 `watch_sessions` 新增 `click_cooldown_until` 欄位 | 不新增表，與現有 session 鎖定機制共用 `SELECT FOR UPDATE` |
+| 預設冷卻時間 | 5 秒 / 觀眾 | 體感即時但防止 macro 暴力點擊 |
+| 每次點擊獎勵 | 固定 1 點（MVP），後續可接 ChannelConfig | 先驗證流程，再做可調參數 |
+| 速率拒絕行為 | 回傳 `429`，附帶 `retry_after_ms` | 前端可據此控制 UI 冷卻倒數 |
+| TxSource | 新增 `"click"` 值 | 帳本可區分 watch_time / bits / click / spend 來源 |
+| 前端冷卻控制 | 樂觀 UI：點擊後立即灰掉按鈕並倒數，不等 API 回應 | 降低延遲感，API 429 時重置倒數即可 |
+| 視覺反饋 | 浮字（+1）+ CSS keyframe 動畫，不引入新套件 | 與現有 `isAnimating` 模式一致 |
+
+---
+
+## 資料庫變更
+
+### Migration：新增 click_cooldown_until
+
+```sql
+-- migrations/XXXXXX_add_click_cooldown_to_watch_sessions.sql
+ALTER TABLE watch_sessions
+  ADD COLUMN click_cooldown_until TIMESTAMPTZ NOT NULL DEFAULT '1970-01-01';
+```
+
+無需索引，每次查詢都走 session 的 `(user_id, channel_id, is_active)` 索引。
+
+---
+
+## 後端實作
+
+### 1. Model 變更
+
+**`backend/internal/models/points.go`**
+
+```go
+const (
+    TxSourceWatchTime TxSource = "watch_time"
+    TxSourceBits      TxSource = "bits"
+    TxSourceClick     TxSource = "click"   // 新增
+    TxSourceSpend     TxSource = "spend"
+)
+```
+
+**`backend/internal/models/watch_session.go`**
+
+```go
+type WatchSession struct {
+    // ... 現有欄位 ...
+    ClickCooldownUntil time.Time `gorm:"not null;default:'1970-01-01'" json:"-"`
+}
+```
+
+### 2. Service 新方法
+
+**`backend/internal/services/watch_service.go`**
+
+新增常數：
+
+```go
+const (
+    clickCooldown      = 5 * time.Second
+    clickPointsPerClick = int64(1)
+)
+```
+
+新增方法 `RecordClick(userID, channelID uuid.UUID) (balanceAfter int64, err error)`：
+
+```
+1. BEGIN TRANSACTION
+2. SELECT session WHERE user_id=? AND channel_id=? AND is_active=true FOR UPDATE
+   → 無活躍 session：回傳 ErrNoActiveSession（前端顯示「請先開始觀看」）
+3. 檢查 click_cooldown_until > NOW()
+   → 若是：回傳 ErrClickOnCooldown{RetryAfterMs: ...}
+4. UPDATE watch_sessions SET click_cooldown_until = NOW() + 5s
+5. UPSERT points_ledgers（+1 spendable, +1 cumulative）
+6. INSERT points_transactions（source="click", delta=1, session_id=session.ID）
+7. COMMIT
+8. 回傳 balanceAfter
+```
+
+### 3. Handler 新方法
+
+**`backend/internal/handlers/watch_handler.go`**
+
+```go
+// POST /api/v1/extension/watch/click
+func (h *WatchHandler) Click(c *gin.Context) {
+    userID  := // 從 JWT 取
+    var req struct {
+        ChannelID string `json:"channel_id" binding:"required"`
+    }
+    // binding...
+    balance, err := h.watchSvc.RecordClick(userID, channelID)
+    switch {
+    case errors.Is(err, services.ErrNoActiveSession):
+        c.JSON(400, gin.H{"error": "no_active_session"})
+    case errors.As(err, &cooldownErr):
+        c.JSON(429, gin.H{"error": "on_cooldown", "retry_after_ms": cooldownErr.RetryAfterMs})
+    case err != nil:
+        c.JSON(500, gin.H{"error": "internal"})
+    default:
+        c.JSON(200, gin.H{"balance": balance, "delta": 1})
+    }
+}
+```
+
+### 4. 路由
+
+**`backend/internal/router/router.go`**
+
+在 `extension` 受保護路由組新增（與 heartbeat 同層）：
+
+```go
+protected.POST("/watch/click", watchHandler.Click)
+```
+
+---
+
+## 前端實作
+
+### 1. API 函式
+
+**`tachimint/src/services/api.ts`**
+
+```typescript
+export async function sendClick(channelId: string): Promise<{
+  balance: number
+  delta: number
+} | { error: string; retry_after_ms?: number }> {
+  const res = await apiClient.post('/api/v1/extension/watch/click', {
+    channel_id: channelId,
+  })
+  return res.data
+}
+```
+
+### 2. useClickBoost Hook
+
+**`tachimint/src/hooks/useClickBoost.ts`**（新增檔案）
+
+```typescript
+interface UseClickBoostResult {
+  handleClick: () => void
+  cooldownMs: number          // 0 = 可點擊
+  isAnimating: boolean        // 浮字動畫開關
+  gain: number | null         // 本次獲得點數
+  balance: number | null      // 更新後餘額（供外層同步）
+}
+```
+
+狀態機：
+- `idle` → 點擊 → `pending`（樂觀 UI 立即啟動冷卻倒數）
+- `pending` → API 回 200 → `animating`（顯示浮字 1500ms）→ `idle`
+- `pending` → API 回 429 → 以 `retry_after_ms` 重設倒數
+
+### 3. App.tsx 整合
+
+在 Viewer 視圖中：
+- 引入 `useClickBoost`，將 `balance` 同步給現有餘額顯示
+- 在挖礦角色圖案上綁定 `onClick={handleClick}`
+- `cooldownMs > 0` 時對圖案套用灰階 + `cursor: not-allowed`
+- `isAnimating` 時顯示 `+{gain}` 浮字（絕對定位，CSS keyframe 向上淡出）
+
+---
+
+## 待實作 Checklist
+
+### 後端
+
+- [ ] Migration：`watch_sessions.click_cooldown_until`
+- [ ] `models/points.go`：新增 `TxSourceClick`
+- [ ] `models/watch_session.go`：新增 `ClickCooldownUntil` 欄位
+- [ ] `services/watch_service.go`：實作 `RecordClick()`
+- [ ] `handlers/watch_handler.go`：實作 `Click()` handler
+- [ ] `router/router.go`：掛載 `POST /watch/click`
+- [ ] 單元測試：`RecordClick` 正常 / 無 session / 冷卻中
+- [ ] 整合測試：`POST /watch/click` 200 / 400 / 429
+
+### 前端
+
+- [ ] `services/api.ts`：新增 `sendClick()`
+- [ ] `hooks/useClickBoost.ts`：實作 hook（含樂觀 UI 冷卻倒數）
+- [ ] `App.tsx`：整合 `useClickBoost`，綁定點擊事件
+- [ ] 視覺反饋：浮字動畫（`+1`）+ 冷卻灰階效果
+- [ ] 冷卻倒數進度條（選做）
+
+---
+
+## 驗證方式
+
+1. **正常點擊**：觀眾點擊 → 餘額 +1，浮字顯示 +1，5 秒內按鈕灰掉
+2. **冷卻中**：5 秒內再點 → API 回 429，UI 倒數不重置（從剩餘時間繼續）
+3. **無 session**：未開始觀看時點擊 → 回 400，UI 顯示提示
+4. **帳本一致性**：`PointsTransaction` source="click" 有正確記錄，`PointsLedger` 餘額正確累加
+5. **並發**：兩個 tab 同時點擊 → 只有一個成功（DB 鎖保護）

--- a/tachimint/src/App.tsx
+++ b/tachimint/src/App.tsx
@@ -1,13 +1,25 @@
 import { useTwitch } from './hooks/useTwitch'
 import { useBits } from './hooks/useBits'
 import { useHeartbeat } from './hooks/useHeartbeat'
+import { useClickBoost } from './hooks/useClickBoost'
 
 export default function App() {
   const { context, jwt, products, bitsEnabled, authError } = useTwitch()
   const { buyWithBits, status, error } = useBits(jwt)
-  const { balance, gain, isAnimating } = useHeartbeat(jwt, {
-    enabled: context?.role === 'viewer',
+  const isViewer = context?.role === 'viewer'
+  const { balance: heartbeatBalance, gain, isAnimating } = useHeartbeat(jwt, {
+    enabled: isViewer,
   })
+  const {
+    handleClick,
+    cooldownMs,
+    isAnimating: clickAnimating,
+    gain: clickGain,
+    balance: clickBalance,
+  } = useClickBoost(context?.channelId, isViewer)
+
+  // Show the most recently updated balance (click response is more recent than heartbeat).
+  const balance = clickBalance ?? heartbeatBalance
 
   if (!context) {
     return (
@@ -47,6 +59,27 @@ export default function App() {
           </div>
           {gain !== null && gain > 0 && (
             <span className="ext-balance-gain">+{gain.toLocaleString()} 點</span>
+          )}
+        </section>
+
+        <section className="ext-mine">
+          <div className="ext-mine__wrap">
+            <button
+              className={`ext-mine__btn${cooldownMs > 0 ? ' ext-mine__btn--cooldown' : ''}`}
+              onClick={handleClick}
+              disabled={cooldownMs > 0}
+              aria-label="Click to mine points"
+            >
+              ⛏
+            </button>
+            {clickGain !== null && clickGain > 0 && (
+              <span className={`ext-mine__gain${clickAnimating ? '' : ' ext-mine__gain--hidden'}`}>
+                +{clickGain}
+              </span>
+            )}
+          </div>
+          {cooldownMs > 0 && (
+            <span className="ext-mine__cooldown">{(cooldownMs / 1000).toFixed(1)}s</span>
           )}
         </section>
 

--- a/tachimint/src/App.tsx
+++ b/tachimint/src/App.tsx
@@ -7,7 +7,7 @@ export default function App() {
   const { context, jwt, products, bitsEnabled, authError } = useTwitch()
   const { buyWithBits, status, error } = useBits(jwt)
   const isViewer = context?.role === 'viewer'
-  const { balance: heartbeatBalance, gain, isAnimating } = useHeartbeat(jwt, {
+  const { balance, gain, isAnimating, syncBalance } = useHeartbeat(jwt, {
     enabled: isViewer,
   })
   const {
@@ -15,11 +15,7 @@ export default function App() {
     cooldownMs,
     isAnimating: clickAnimating,
     gain: clickGain,
-    balance: clickBalance,
-  } = useClickBoost(context?.channelId, isViewer)
-
-  // Show the most recently updated balance (click response is more recent than heartbeat).
-  const balance = clickBalance ?? heartbeatBalance
+  } = useClickBoost(context?.channelId, isViewer, syncBalance)
 
   if (!context) {
     return (

--- a/tachimint/src/hooks/useClickBoost.ts
+++ b/tachimint/src/hooks/useClickBoost.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { sendClick } from '../services/api'
+
+const OPTIMISTIC_COOLDOWN_MS = 5_000
+const ANIM_DURATION_MS = 1_500
+const COUNTDOWN_INTERVAL_MS = 100
+
+export function useClickBoost(channelId: string | undefined, enabled: boolean) {
+  const [cooldownMs, setCooldownMs] = useState(0)
+  const [isAnimating, setIsAnimating] = useState(false)
+  const [gain, setGain] = useState<number | null>(null)
+  const [balance, setBalance] = useState<number | null>(null)
+
+  const onCooldownRef = useRef(false)
+  const cooldownTimerRef = useRef<number | null>(null)
+  const animTimerRef = useRef<number | null>(null)
+
+  const stopCooldown = useCallback(() => {
+    if (cooldownTimerRef.current !== null) {
+      clearInterval(cooldownTimerRef.current)
+      cooldownTimerRef.current = null
+    }
+    onCooldownRef.current = false
+    setCooldownMs(0)
+  }, [])
+
+  const startCooldown = useCallback(
+    (ms: number) => {
+      stopCooldown()
+      onCooldownRef.current = true
+      const endAt = Date.now() + ms
+      setCooldownMs(ms)
+      cooldownTimerRef.current = window.setInterval(() => {
+        const remaining = endAt - Date.now()
+        if (remaining <= 0) {
+          stopCooldown()
+        } else {
+          setCooldownMs(remaining)
+        }
+      }, COUNTDOWN_INTERVAL_MS)
+    },
+    [stopCooldown],
+  )
+
+  const handleClick = useCallback(async () => {
+    if (!channelId || !enabled || onCooldownRef.current) return
+
+    // Optimistic: lock UI immediately, don't wait for API round-trip.
+    startCooldown(OPTIMISTIC_COOLDOWN_MS)
+
+    try {
+      const result = await sendClick(channelId)
+      setBalance(result.balance)
+      setGain(result.delta)
+      setIsAnimating(true)
+      if (animTimerRef.current !== null) clearTimeout(animTimerRef.current)
+      animTimerRef.current = window.setTimeout(() => {
+        setIsAnimating(false)
+        setGain(null)
+      }, ANIM_DURATION_MS)
+    } catch (err: unknown) {
+      // If the server returns a precise retry-after, honour it.
+      const retryAfterMs = (
+        err as { response?: { data?: { retry_after_ms?: number } } }
+      )?.response?.data?.retry_after_ms
+
+      if (typeof retryAfterMs === 'number' && retryAfterMs > 0) {
+        startCooldown(retryAfterMs)
+      } else {
+        // Unexpected error — unblock so the viewer can try again.
+        stopCooldown()
+      }
+    }
+  }, [channelId, enabled, startCooldown, stopCooldown])
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current !== null) clearInterval(cooldownTimerRef.current)
+      if (animTimerRef.current !== null) clearTimeout(animTimerRef.current)
+    }
+  }, [])
+
+  return { handleClick, cooldownMs, isAnimating, gain, balance }
+}

--- a/tachimint/src/hooks/useClickBoost.ts
+++ b/tachimint/src/hooks/useClickBoost.ts
@@ -5,11 +5,14 @@ const OPTIMISTIC_COOLDOWN_MS = 5_000
 const ANIM_DURATION_MS = 1_500
 const COUNTDOWN_INTERVAL_MS = 100
 
-export function useClickBoost(channelId: string | undefined, enabled: boolean) {
+export function useClickBoost(
+  channelId: string | undefined,
+  enabled: boolean,
+  onBalanceUpdate: (balance: number) => void,
+) {
   const [cooldownMs, setCooldownMs] = useState(0)
   const [isAnimating, setIsAnimating] = useState(false)
   const [gain, setGain] = useState<number | null>(null)
-  const [balance, setBalance] = useState<number | null>(null)
 
   const onCooldownRef = useRef(false)
   const cooldownTimerRef = useRef<number | null>(null)
@@ -50,7 +53,7 @@ export function useClickBoost(channelId: string | undefined, enabled: boolean) {
 
     try {
       const result = await sendClick(channelId)
-      setBalance(result.balance)
+      onBalanceUpdate(result.balance)
       setGain(result.delta)
       setIsAnimating(true)
       if (animTimerRef.current !== null) clearTimeout(animTimerRef.current)
@@ -81,5 +84,5 @@ export function useClickBoost(channelId: string | undefined, enabled: boolean) {
     }
   }, [])
 
-  return { handleClick, cooldownMs, isAnimating, gain, balance }
+  return { handleClick, cooldownMs, isAnimating, gain }
 }

--- a/tachimint/src/hooks/useClickBoost.ts
+++ b/tachimint/src/hooks/useClickBoost.ts
@@ -74,7 +74,7 @@ export function useClickBoost(
         stopCooldown()
       }
     }
-  }, [channelId, enabled, startCooldown, stopCooldown])
+  }, [channelId, enabled, onBalanceUpdate, startCooldown, stopCooldown])
 
   // Cleanup on unmount.
   useEffect(() => {

--- a/tachimint/src/hooks/useHeartbeat.ts
+++ b/tachimint/src/hooks/useHeartbeat.ts
@@ -70,5 +70,12 @@ export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions 
     }
   }, [enabled, extensionJwt, intervalMs])
 
-  return { balance, gain, isAnimating, error }
+  // Allow external callers (e.g. click boost) to sync the baseline so the
+  // next heartbeat gain animation doesn't double-count already-awarded points.
+  const syncBalance = (newBalance: number) => {
+    lastBalanceRef.current = newBalance
+    setBalance(newBalance)
+  }
+
+  return { balance, gain, isAnimating, error, syncBalance }
 }

--- a/tachimint/src/hooks/useHeartbeat.ts
+++ b/tachimint/src/hooks/useHeartbeat.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { sendHeartbeat } from '../services/api'
 
 interface UseHeartbeatOptions {
@@ -72,10 +72,10 @@ export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions 
 
   // Allow external callers (e.g. click boost) to sync the baseline so the
   // next heartbeat gain animation doesn't double-count already-awarded points.
-  const syncBalance = (newBalance: number) => {
+  const syncBalance = useCallback((newBalance: number) => {
     lastBalanceRef.current = newBalance
     setBalance(newBalance)
-  }
+  }, [])
 
   return { balance, gain, isAnimating, error, syncBalance }
 }

--- a/tachimint/src/index.css
+++ b/tachimint/src/index.css
@@ -144,6 +144,71 @@ p  { margin: 0; }
   100% { opacity: 0; transform: translateY(-10px); }
 }
 
+/* ── Mining character ───────────────────────────────────────────────────────── */
+.ext-mine {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.ext-mine__wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.ext-mine__btn {
+  width: 64px;
+  height: 64px;
+  font-size: 32px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: transform 0.1s, background 0.15s, opacity 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.ext-mine__btn:hover:not(:disabled) {
+  background: #222228;
+  transform: scale(1.08);
+}
+
+.ext-mine__btn:active:not(:disabled) {
+  transform: scale(0.94);
+}
+
+.ext-mine__btn--cooldown {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ext-mine__gain {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--success);
+  pointer-events: none;
+  animation: gain-float 1.5s ease forwards;
+}
+
+.ext-mine__gain--hidden {
+  display: none;
+}
+
+.ext-mine__cooldown {
+  font-size: 11px;
+  color: var(--text);
+  min-width: 32px;
+  text-align: center;
+}
+
 /* ── Products ───────────────────────────────────────────────────────────────── */
 .ext-products {
   display: flex;

--- a/tachimint/src/services/api.ts
+++ b/tachimint/src/services/api.ts
@@ -62,6 +62,19 @@ function parseBalanceFromHeartbeatResponse(payload: unknown): number {
   return value
 }
 
+interface ClickResponse {
+  balance: number
+  delta: number
+}
+
+export async function sendClick(channelId: string): Promise<ClickResponse> {
+  const { data } = await client.post<{ success: boolean; data: ClickResponse }>(
+    '/api/v1/extension/watch/click',
+    { channel_id: channelId },
+  )
+  return data.data
+}
+
 export async function sendHeartbeat(extensionJwt: string): Promise<HeartbeatResponse> {
   const { data } = await client.post('/api/v1/extension/heartbeat', {
     extension_jwt: extensionJwt,


### PR DESCRIPTION
## Summary

- 新增 `POST /api/v1/extension/watch/click` 端點，觀眾點擊挖礦角色可獲得 +1 點
- 每位觀眾 5 秒冷卻，防止刷點（DB 層 `SELECT FOR UPDATE` 並發保護）
- 新增 `TxSourceClick = "click"` 帳本來源，完整記錄於 `points_transactions`
- 前端新增 `useClickBoost` hook（樂觀 UI 冷卻倒數）與挖礦角色按鈕區塊

## Changes

**Backend**
- `migrations/005_click_boost.sql` — `watch_sessions` 新增 `click_cooldown_until`
- `models/points.go` — `TxSourceClick`
- `models/watch_session.go` — `ClickCooldownUntil` 欄位
- `services/watch_service.go` — `ErrClickOnCooldown`、`RecordClick()`
- `handlers/watch_handler.go` — `Click()` handler
- `router/router.go` — `POST /watch/click`
- 新增 4 個 service 測試：正常點擊 / 無 session / 冷卻中 / 累積帳本

**Frontend**
- `services/api.ts` — `sendClick()`
- `hooks/useClickBoost.ts` — 新 hook（樂觀冷卻 + 浮字動畫）
- `App.tsx` — 挖礦角色按鈕區塊整合
- `index.css` — `.ext-mine` 系列樣式

## Test plan

- [x] `docker compose run --no-deps --rm app go test ./...` 全綠
- [ ] 點擊挖礦角色 → 餘額 +1，浮字顯示，5 秒按鈕灰掉
- [x] 5 秒內再點 → API 回 429，倒數不重置
- [x] 未開始觀看時點擊 → 回 400
- [x] `points_transactions` 有 `source="click"` 記錄

closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)