### PR TITLE
[backend] StreamerService — 實況主管理與數據統計

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -54,6 +54,7 @@ func main() {
 		&models.PasswordReset{},
 		// Points & watch-time
 		&models.ChannelConfig{},
+		&models.Streamer{},
 		&models.PointsLedger{},
 		&models.PointsTransaction{},
 		&models.WatchSession{},
@@ -80,6 +81,12 @@ func main() {
 	`).Error; err != nil {
 		log.Fatalf("failed to create points ledger index: %v", err)
 	}
+	if err := db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
+		ON streamers (user_id, channel_id)
+	`).Error; err != nil {
+		log.Fatalf("failed to create streamer index: %v", err)
+	}
 
 	// Wire services
 	authSvc := services.NewAuthService(db, cfg)
@@ -91,6 +98,7 @@ func main() {
 	watchSvc := services.NewWatchService(db)
 	channelConfigSvc := services.NewChannelConfigService(db)
 	pointsSvc := services.NewPointsService(db, watchSvc)
+	streamerSvc := services.NewStreamerService(db, pointsSvc)
 
 	// CORS origins from env, default to localhost for dev
 	originsEnv := os.Getenv("ALLOWED_ORIGINS")
@@ -99,7 +107,7 @@ func main() {
 		allowedOrigins = strings.Split(originsEnv, ",")
 	}
 
-	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, watchSvc, channelConfigSvc, pointsSvc, allowedOrigins)
+	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, watchSvc, channelConfigSvc, pointsSvc, streamerSvc, allowedOrigins)
 
 	addr := ":" + cfg.Server.Port
 	log.Printf("server starting on %s (env=%s)", addr, cfg.Server.Env)

--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -2,11 +2,13 @@ package handlers
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
 	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
 
@@ -37,6 +39,10 @@ func (h *StreamerHandler) Register(c *gin.Context) {
 
 	streamer, err := h.streamerSvc.Register(userID, body.ChannelID, body.DisplayName)
 	if err != nil {
+		if errors.Is(err, services.ErrChannelNotOwned) {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "channel_id does not match your Twitch account"})
+			return
+		}
 		internal(c)
 		return
 	}
@@ -66,6 +72,24 @@ func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
 	if channelID == "" {
 		badRequest(c, "channel_id is required")
 		return
+	}
+
+	claims := middleware.MustClaims(c)
+	if claims.Role != models.RoleAdmin {
+		userID, err := uuid.Parse(claims.UserID)
+		if err != nil {
+			badRequest(c, "invalid user id")
+			return
+		}
+		owns, err := h.streamerSvc.OwnsChannel(userID, channelID)
+		if err != nil {
+			internal(c)
+			return
+		}
+		if !owns {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return
+		}
 	}
 
 	stats, err := h.streamerSvc.GetChannelStats(channelID)

--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+type StreamerHandler struct {
+	streamerSvc *services.StreamerService
+}
+
+func NewStreamerHandler(svc *services.StreamerService) *StreamerHandler {
+	return &StreamerHandler{streamerSvc: svc}
+}
+
+func (h *StreamerHandler) Register(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+
+	var body struct {
+		ChannelID   string `json:"channel_id" binding:"required"`
+		DisplayName string `json:"display_name"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+
+	streamer, err := h.streamerSvc.Register(userID, body.ChannelID, body.DisplayName)
+	if err != nil {
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"streamer": streamer})
+}
+
+func (h *StreamerHandler) ListChannels(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+
+	channels, err := h.streamerSvc.ListChannels(userID)
+	if err != nil {
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"channels": channels})
+}
+
+func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
+	channelID := c.Param("channel_id")
+	if channelID == "" {
+		badRequest(c, "channel_id is required")
+		return
+	}
+
+	stats, err := h.streamerSvc.GetChannelStats(channelID)
+	if err != nil {
+		if errors.Is(err, services.ErrStreamerNotFound) {
+			notFound(c, "streamer not found")
+			return
+		}
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"stats": stats})
+}

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -1,0 +1,131 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/handlers"
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+func newStreamerDashboardEnv(t *testing.T) *dashboardEnv {
+	t.Helper()
+
+	base := newTestEnv(t)
+	watchSvc := services.NewWatchService(base.db)
+	pointsSvc := services.NewPointsService(base.db, watchSvc)
+	streamerSvc := services.NewStreamerService(base.db, pointsSvc)
+	streamerH := handlers.NewStreamerHandler(streamerSvc)
+	configSvc := services.NewChannelConfigService(base.db)
+	configH := handlers.NewChannelConfigHandler(configSvc)
+
+	v1 := base.router.Group("/api/v1")
+	dashboard := v1.Group("/dashboard")
+	dashboard.Use(middleware.JWTAuth(base.authSvc))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	{
+		dashboard.POST("/streamers/register", streamerH.Register)
+		dashboard.GET("/streamers/channels", streamerH.ListChannels)
+		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
+		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
+	}
+
+	return &dashboardEnv{testEnv: base}
+}
+
+func dashboardRequest(t *testing.T, router *gin.Engine, method, path, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestStreamerRegister_AndListChannels(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers/register", token, `{"channel_id":"ch_123","display_name":"測試實況主"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("register want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/channels", token, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("list want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data, _ := resp["data"].(map[string]interface{})
+	channels, _ := data["channels"].([]interface{})
+	if len(channels) != 1 {
+		t.Fatalf("want 1 channel, got %d", len(channels))
+	}
+	channel, _ := channels[0].(map[string]interface{})
+	if channel["channel_id"] != "ch_123" {
+		t.Fatalf("channel_id: want ch_123, got %v", channel["channel_id"])
+	}
+}
+
+func TestStreamerStats_ForbiddenForViewer(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	token := env.tokenForRole(t, models.RoleViewer)
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_123/stats", token, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestStreamerStats_OK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+
+	var streamer models.User
+	if err := env.db.Where("email = ?", "streamer_dashboard@example.com").First(&streamer).Error; err != nil {
+		t.Fatalf("load streamer: %v", err)
+	}
+	if err := env.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		uuid.New(), streamer.ID, models.ProviderTwitch, "ch_123",
+	).Error; err != nil {
+		t.Fatalf("seed auth provider: %v", err)
+	}
+	if err := env.db.Create(&models.BroadcastTimeLog{
+		StreamerID: streamer.ID,
+		ChannelID:  "ch_123",
+		Seconds:    33,
+		RecordedAt: time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_123/stats", token, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data, _ := resp["data"].(map[string]interface{})
+	stats, _ := data["stats"].(map[string]interface{})
+	if stats["daily_seconds"] != float64(33) {
+		t.Fatalf("daily_seconds: want 33, got %v", stats["daily_seconds"])
+	}
+}

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -57,9 +57,25 @@ func dashboardRequest(t *testing.T, router *gin.Engine, method, path, token, bod
 	return w
 }
 
+func seedTwitchProvider(t *testing.T, env *dashboardEnv, email, channelID string) {
+	t.Helper()
+	var user models.User
+	if err := env.db.Where("email = ?", email).First(&user).Error; err != nil {
+		t.Fatalf("load user: %v", err)
+	}
+	if err := env.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		uuid.New(), user.ID, models.ProviderTwitch, channelID,
+	).Error; err != nil {
+		t.Fatalf("seed auth provider: %v", err)
+	}
+}
+
 func TestStreamerRegister_AndListChannels(t *testing.T) {
 	env := newStreamerDashboardEnv(t)
 	token := env.tokenForRole(t, models.RoleStreamer)
+	seedTwitchProvider(t, env, "streamer_dashboard@example.com", "ch_123")
 
 	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers/register", token, `{"channel_id":"ch_123","display_name":"測試實況主"}`)
 	if w.Code != http.StatusOK {
@@ -80,6 +96,17 @@ func TestStreamerRegister_AndListChannels(t *testing.T) {
 	channel, _ := channels[0].(map[string]interface{})
 	if channel["channel_id"] != "ch_123" {
 		t.Fatalf("channel_id: want ch_123, got %v", channel["channel_id"])
+	}
+}
+
+func TestRegister_RejectsUnownedChannel(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+	// No auth_provider seeded — channel does not belong to this user.
+
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers/register", token, `{"channel_id":"ch_someone_else","display_name":""}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -108,6 +135,13 @@ func TestStreamerStats_OK(t *testing.T) {
 	).Error; err != nil {
 		t.Fatalf("seed auth provider: %v", err)
 	}
+	// Register ownership so GetChannelStats ownership check passes.
+	if err := env.db.Create(&models.Streamer{
+		UserID:    streamer.ID,
+		ChannelID: "ch_123",
+	}).Error; err != nil {
+		t.Fatalf("seed streamer: %v", err)
+	}
 	if err := env.db.Create(&models.BroadcastTimeLog{
 		StreamerID: streamer.ID,
 		ChannelID:  "ch_123",
@@ -127,5 +161,31 @@ func TestStreamerStats_OK(t *testing.T) {
 	stats, _ := data["stats"].(map[string]interface{})
 	if stats["daily_seconds"] != float64(33) {
 		t.Fatalf("daily_seconds: want 33, got %v", stats["daily_seconds"])
+	}
+}
+
+func TestGetChannelStats_ForbiddenForOtherStreamer(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+
+	// Streamer A registers ch_A.
+	tokenA := env.tokenForRole(t, models.RoleStreamer)
+	seedTwitchProvider(t, env, "streamer_dashboard@example.com", "ch_A")
+	dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers/register", tokenA, `{"channel_id":"ch_A"}`)
+
+	// Streamer B — registered with a different email.
+	_, tokenB := env.registerUser(t, "streamer_b", "streamer_b@example.com", "password123")
+	if err := env.db.Exec(`UPDATE users SET role = 'streamer' WHERE email = 'streamer_b@example.com'`).Error; err != nil {
+		t.Fatalf("set role: %v", err)
+	}
+	// Re-login to get a token with updated role.
+	_, tokens, err := env.authSvc.Login(services.LoginInput{Email: "streamer_b@example.com", Password: "password123"})
+	if err != nil {
+		t.Fatalf("login streamer_b: %v", err)
+	}
+	tokenB = tokens.AccessToken
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_A/stats", tokenB, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -94,6 +94,38 @@ func migrateTestDB(db *gorm.DB) error {
 			created_at DATETIME,
 			updated_at DATETIME
 		)`,
+		`CREATE TABLE IF NOT EXISTS streamers (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			channel_id TEXT NOT NULL,
+			display_name TEXT,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
+			ON streamers (user_id, channel_id)`,
+		`CREATE TABLE IF NOT EXISTS watch_sessions (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			accumulated_seconds INTEGER NOT NULL DEFAULT 0,
+			rewarded_seconds INTEGER NOT NULL DEFAULT 0,
+			last_heartbeat_at DATETIME NOT NULL,
+			is_active INTEGER NOT NULL DEFAULT 1,
+			ended_at DATETIME,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
+			ON watch_sessions (user_id, channel_id)
+			WHERE is_active = 1`,
+		`CREATE TABLE IF NOT EXISTS broadcast_time_logs (
+			id TEXT PRIMARY KEY,
+			streamer_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			seconds INTEGER NOT NULL,
+			recorded_at DATETIME NOT NULL
+		)`,
 	}
 	for _, s := range stmts {
 		if err := db.Exec(s).Error; err != nil {

--- a/backend/internal/models/streamer.go
+++ b/backend/internal/models/streamer.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type Streamer struct {
+	ID          uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	UserID      uuid.UUID `gorm:"type:uuid;not null;index;uniqueIndex:idx_streamers_user_channel" json:"user_id"`
+	ChannelID   string    `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_streamers_user_channel" json:"channel_id"`
+	DisplayName string    `gorm:"type:varchar(255)"                              json:"display_name"`
+	CreatedAt   time.Time `                                                      json:"created_at"`
+	UpdatedAt   time.Time `                                                      json:"updated_at"`
+}
+
+func (s *Streamer) BeforeCreate(tx *gorm.DB) error {
+	if s.ID == uuid.Nil {
+		id, _ := uuid.NewV7()
+		s.ID = id
+	}
+	return nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -20,6 +20,7 @@ func New(
 	watchSvc *services.WatchService,
 	channelConfigSvc *services.ChannelConfigService,
 	pointsSvc *services.PointsService,
+	streamerSvc *services.StreamerService,
 	allowedOrigins []string,
 ) *gin.Engine {
 	r := gin.New()
@@ -34,6 +35,7 @@ func New(
 	watchH := handlers.NewWatchHandler(watchSvc, pointsSvc)
 	channelConfigH := handlers.NewChannelConfigHandler(channelConfigSvc)
 	pointsH := handlers.NewPointsHandler(pointsSvc)
+	streamerH := handlers.NewStreamerHandler(streamerSvc)
 
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})
@@ -118,6 +120,9 @@ func New(
 	dashboard.Use(middleware.JWTAuth(authSvc))
 	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
 	{
+		dashboard.POST("/streamers/register", streamerH.Register)
+		dashboard.GET("/streamers/channels", streamerH.ListChannels)
+		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
 		dashboard.PUT("/channels/:channel_id/config", channelConfigH.UpdateChannelConfig)
 	}
 

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"errors"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+var ErrStreamerNotFound = errors.New("streamer not found")
+
+type StreamerService struct {
+	db        *gorm.DB
+	pointsSvc *PointsService
+}
+
+func NewStreamerService(db *gorm.DB, pointsSvc *PointsService) *StreamerService {
+	return &StreamerService{db: db, pointsSvc: pointsSvc}
+}
+
+func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName string) (*models.Streamer, error) {
+	streamer := &models.Streamer{
+		UserID:      userID,
+		ChannelID:   channelID,
+		DisplayName: displayName,
+	}
+
+	if err := s.db.
+		Where("user_id = ? AND channel_id = ?", userID, channelID).
+		Assign(models.Streamer{DisplayName: displayName}).
+		FirstOrCreate(streamer).Error; err != nil {
+		return nil, err
+	}
+
+	return streamer, nil
+}
+
+func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, error) {
+	var streamers []models.Streamer
+	if err := s.db.
+		Where("user_id = ?", userID).
+		Order("created_at ASC").
+		Find(&streamers).Error; err != nil {
+		return nil, err
+	}
+	if streamers == nil {
+		return []models.Streamer{}, nil
+	}
+	return streamers, nil
+}
+
+func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, error) {
+	var provider models.AuthProvider
+	if err := s.db.
+		Where("provider = ? AND provider_id = ?", models.ProviderTwitch, channelID).
+		First(&provider).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStreamerNotFound
+		}
+		return nil, err
+	}
+
+	return s.pointsSvc.GetBroadcastStats(provider.UserID, channelID)
+}

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -9,7 +9,10 @@ import (
 	"github.com/tachigo/tachigo/internal/models"
 )
 
-var ErrStreamerNotFound = errors.New("streamer not found")
+var (
+	ErrStreamerNotFound = errors.New("streamer not found")
+	ErrChannelNotOwned  = errors.New("channel not owned by user")
+)
 
 type StreamerService struct {
 	db        *gorm.DB
@@ -21,6 +24,17 @@ func NewStreamerService(db *gorm.DB, pointsSvc *PointsService) *StreamerService 
 }
 
 func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName string) (*models.Streamer, error) {
+	// Verify the channelID matches the user's Twitch auth_provider entry.
+	var count int64
+	if err := s.db.Model(&models.AuthProvider{}).
+		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderTwitch, channelID).
+		Count(&count).Error; err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, ErrChannelNotOwned
+	}
+
 	streamer := &models.Streamer{
 		UserID:      userID,
 		ChannelID:   channelID,
@@ -35,6 +49,16 @@ func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName stri
 	}
 
 	return streamer, nil
+}
+
+func (s *StreamerService) OwnsChannel(userID uuid.UUID, channelID string) (bool, error) {
+	var count int64
+	if err := s.db.Model(&models.Streamer{}).
+		Where("user_id = ? AND channel_id = ?", userID, channelID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, error) {

--- a/backend/internal/services/streamer_service_test.go
+++ b/backend/internal/services/streamer_service_test.go
@@ -1,0 +1,171 @@
+package services
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+func seedStreamerUserRow(t *testing.T, db *gorm.DB, role models.UserRole) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := db.Exec(
+		`INSERT INTO users (id, role, is_active, email_verified, created_at, updated_at)
+		 VALUES (?, ?, 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		id, role,
+	).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+func TestRegister_OK(t *testing.T) {
+	db := newTestDB(t)
+	watchSvc := NewWatchService(db)
+	pointsSvc := NewPointsService(db, watchSvc)
+	svc := NewStreamerService(db, pointsSvc)
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+
+	streamer, err := svc.Register(userID, "ch_abc", "Alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if streamer.UserID != userID || streamer.ChannelID != "ch_abc" {
+		t.Fatalf("unexpected streamer: %+v", streamer)
+	}
+
+	streamer2, err := svc.Register(userID, "ch_abc", "Alice")
+	if err != nil {
+		t.Fatalf("unexpected error on second register: %v", err)
+	}
+	if streamer2.ID != streamer.ID {
+		t.Fatalf("expected upsert to reuse row, got %s vs %s", streamer2.ID, streamer.ID)
+	}
+}
+
+func TestRegister_UpdateDisplayName(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+
+	if _, err := svc.Register(userID, "ch_abc", "Old"); err != nil {
+		t.Fatalf("register old: %v", err)
+	}
+	streamer, err := svc.Register(userID, "ch_abc", "New")
+	if err != nil {
+		t.Fatalf("register new: %v", err)
+	}
+	if streamer.DisplayName != "New" {
+		t.Fatalf("display_name: want New, got %q", streamer.DisplayName)
+	}
+}
+
+func TestListChannels_Empty(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+
+	channels, err := svc.ListChannels(userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(channels) != 0 {
+		t.Fatalf("want empty slice, got %d items", len(channels))
+	}
+}
+
+func TestListChannels_MultipleChannels(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+
+	if _, err := svc.Register(userID, "ch_A", "Alpha"); err != nil {
+		t.Fatalf("register ch_A: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if _, err := svc.Register(userID, "ch_B", "Beta"); err != nil {
+		t.Fatalf("register ch_B: %v", err)
+	}
+
+	channels, err := svc.ListChannels(userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(channels) != 2 {
+		t.Fatalf("want 2 channels, got %d", len(channels))
+	}
+}
+
+func TestGetChannelStats_NoStreamer(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+
+	_, err := svc.GetChannelStats("missing_channel")
+	if !errors.Is(err, ErrStreamerNotFound) {
+		t.Fatalf("want ErrStreamerNotFound, got %v", err)
+	}
+}
+
+func TestGetChannelStats_OK(t *testing.T) {
+	db := newTestDB(t)
+	watchSvc := NewWatchService(db)
+	pointsSvc := NewPointsService(db, watchSvc)
+	svc := NewStreamerService(db, pointsSvc)
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+
+	if err := db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		uuid.New(), userID, models.ProviderTwitch, "ch_stats",
+	).Error; err != nil {
+		t.Fatalf("seed auth provider: %v", err)
+	}
+
+	now := time.Now()
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 1, 0, 0, 0, now.Location())
+	startOfMonth := time.Date(now.Year(), now.Month(), 2, 0, 0, 0, 0, now.Location())
+	startOfYear := time.Date(now.Year(), 2, 1, 0, 0, 0, 0, now.Location())
+
+	for _, recordedAt := range []time.Time{startOfDay, startOfMonth, startOfYear} {
+		if err := db.Create(&models.BroadcastTimeLog{
+			StreamerID: userID,
+			ChannelID:  "ch_stats",
+			Seconds:    30,
+			RecordedAt: recordedAt,
+		}).Error; err != nil {
+			t.Fatalf("seed broadcast log: %v", err)
+		}
+	}
+
+	viewerID := seedStreamerUserRow(t, db, models.RoleViewer)
+	if _, err := watchSvc.StartSession(viewerID, "ch_stats"); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := db.Model(&models.WatchSession{}).
+		Where("user_id = ? AND channel_id = ?", viewerID, "ch_stats").
+		Update("accumulated_seconds", 45).Error; err != nil {
+		t.Fatalf("seed active session seconds: %v", err)
+	}
+
+	stats, err := svc.GetChannelStats("ch_stats")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.CurrentSessionSeconds != 45 {
+		t.Fatalf("current_session_seconds: want 45, got %d", stats.CurrentSessionSeconds)
+	}
+	if stats.DailySeconds != 30 {
+		t.Fatalf("daily_seconds: want 30, got %d", stats.DailySeconds)
+	}
+	if stats.MonthlySeconds != 60 {
+		t.Fatalf("monthly_seconds: want 60, got %d", stats.MonthlySeconds)
+	}
+	if stats.YearlySeconds != 90 {
+		t.Fatalf("yearly_seconds: want 90, got %d", stats.YearlySeconds)
+	}
+}

--- a/backend/internal/services/streamer_service_test.go
+++ b/backend/internal/services/streamer_service_test.go
@@ -24,12 +24,24 @@ func seedStreamerUserRow(t *testing.T, db *gorm.DB, role models.UserRole) uuid.U
 	return id
 }
 
+func seedTwitchAuthProvider(t *testing.T, db *gorm.DB, userID uuid.UUID, channelID string) {
+	t.Helper()
+	if err := db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		uuid.New(), userID, models.ProviderTwitch, channelID,
+	).Error; err != nil {
+		t.Fatalf("seed auth provider: %v", err)
+	}
+}
+
 func TestRegister_OK(t *testing.T) {
 	db := newTestDB(t)
 	watchSvc := NewWatchService(db)
 	pointsSvc := NewPointsService(db, watchSvc)
 	svc := NewStreamerService(db, pointsSvc)
 	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedTwitchAuthProvider(t, db, userID, "ch_abc")
 
 	streamer, err := svc.Register(userID, "ch_abc", "Alice")
 	if err != nil {
@@ -52,6 +64,7 @@ func TestRegister_UpdateDisplayName(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
 	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedTwitchAuthProvider(t, db, userID, "ch_abc")
 
 	if _, err := svc.Register(userID, "ch_abc", "Old"); err != nil {
 		t.Fatalf("register old: %v", err)
@@ -83,6 +96,8 @@ func TestListChannels_MultipleChannels(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
 	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedTwitchAuthProvider(t, db, userID, "ch_A")
+	seedTwitchAuthProvider(t, db, userID, "ch_B")
 
 	if _, err := svc.Register(userID, "ch_A", "Alpha"); err != nil {
 		t.Fatalf("register ch_A: %v", err)

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -122,6 +122,16 @@ func migrateTestDB(db *gorm.DB) error {
 			created_at DATETIME,
 			updated_at DATETIME
 		)`,
+		`CREATE TABLE IF NOT EXISTS streamers (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			channel_id TEXT NOT NULL,
+			display_name TEXT,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
+			ON streamers (user_id, channel_id)`,
 		`CREATE TABLE IF NOT EXISTS points_ledgers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL,

--- a/backend/migrations/005_streamers.sql
+++ b/backend/migrations/005_streamers.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS streamers (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    channel_id   VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, channel_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_streamers_channel_id ON streamers(channel_id);

--- a/plans/streamer-service.md
+++ b/plans/streamer-service.md
@@ -1,0 +1,200 @@
+# StreamerService — 實況主管理與數據統計
+
+> **狀態：** 進行中
+> **關聯 Issue：** refs #28
+> **最後更新：** 2026-04-04
+
+---
+
+## 背景
+
+#27（PointsService 雙帳本）已完成，`broadcast_time_stats` 與 `broadcast_time_logs` 的寫入邏輯（`AddBroadcastTime`）和查詢邏輯（`GetBroadcastStats`）已就位。#68（ChannelConfig / dashboard routes）已建立 `/api/v1/dashboard/` route group，並以 `RequireRole(Admin, Streamer)` 保護。
+
+本次任務目標：
+
+1. 建立 `streamers` 表作為「用戶—頻道」管理映射，補充 `auth_providers` 的隱式關係
+2. 實作 `StreamerService`：封裝頻道管理與統計查詢
+3. 新增 Dashboard API：讓實況主可查詢自己的頻道播出統計與觀眾數據
+4. 前述 `PointsService.GetBroadcastStats` 已有完整實作，`StreamerHandler` 呼叫即可
+
+設計細節見 [docs/architecture.md](../docs/architecture.md)。
+
+---
+
+## 架構決策
+
+| 項目 | 決策 | 理由 |
+|---|---|---|
+| Migration 編號 | `005_streamers.sql` | `004_channel_config.sql` 與 `004_rbac_roles.sql` 均已存在，下一個為 005 |
+| `streamers` 表設計 | `(user_id, channel_id)` unique pair，channel_id 為 Twitch channel ID string | 一位 user 可管理多個頻道；與 auth_providers.provider_id 對應 |
+| GetStats 的 streamerID 查找 | 由 `channelID → auth_providers WHERE provider='twitch' AND provider_id=channelID` 取得 streamerID | 與 `PointsService.AddBroadcastTime` 相同模式，保持一致 |
+| Dashboard 路由前綴 | `/api/v1/dashboard/` | 與現有 `PUT /dashboard/channels/:channel_id/config` 一致 |
+| 經紀公司權限邊界 | Agency 可查詢旗下頻道，但不可查詢其他 agency 的頻道（MVP 以 role 區分，不做細粒度 ownership check） | 降低實作複雜度 |
+| `GetBroadcastStats` | 直接呼叫 `PointsService.GetBroadcastStats(streamerID, channelID)` | 邏輯已在 #27 完整實作，無需重複 |
+
+---
+
+## 待實作 Checklist
+
+### 1. Migration
+
+- [ ] `backend/migrations/005_streamers.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS streamers (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    channel_id  VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, channel_id)
+);
+
+CREATE INDEX idx_streamers_channel_id ON streamers(channel_id);
+```
+
+### 2. Model
+
+- [ ] `backend/internal/models/streamer.go`
+
+```go
+package models
+
+import (
+    "time"
+    "github.com/google/uuid"
+)
+
+type Streamer struct {
+    ID          uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+    UserID      uuid.UUID `gorm:"type:uuid;not null;index"`
+    ChannelID   string    `gorm:"type:varchar(255);not null;index"`
+    DisplayName string    `gorm:"type:varchar(255)"`
+    CreatedAt   time.Time
+    UpdatedAt   time.Time
+}
+```
+
+`BeforeCreate` hook 參考其他 models，呼叫 `newUUID()` 產生 UUID。
+
+### 3. StreamerService
+
+- [ ] `backend/internal/services/streamer_service.go`
+
+```go
+type StreamerService struct {
+    db        *gorm.DB
+    pointsSvc *PointsService
+}
+
+func NewStreamerService(db *gorm.DB, pointsSvc *PointsService) *StreamerService
+
+// Register 將 user 與 channelID 綁定為 streamer（upsert）。
+// channelID 必須與 auth_providers.provider_id 對應的 Twitch channel 一致。
+func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName string) (*models.Streamer, error)
+
+// ListChannels 回傳 user 管理的所有頻道。
+func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, error)
+
+// GetChannelStats 查詢指定頻道的播出統計。
+// 內部從 auth_providers 解析 streamerID，再呼叫 PointsService.GetBroadcastStats。
+func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, error)
+```
+
+`GetChannelStats` 查找流程：
+1. `SELECT user_id FROM auth_providers WHERE provider='twitch' AND provider_id=channelID`
+2. 若找不到 → 回傳 `ErrStreamerNotFound`
+3. 呼叫 `s.pointsSvc.GetBroadcastStats(streamerID, channelID)`
+
+### 4. Handler
+
+- [ ] `backend/internal/handlers/streamer_handler.go`
+
+```go
+type StreamerHandler struct {
+    streamerSvc *services.StreamerService
+}
+
+func NewStreamerHandler(svc *services.StreamerService) *StreamerHandler
+
+// POST /dashboard/streamers/register
+// Body: { "channel_id": "...", "display_name": "..." }
+func (h *StreamerHandler) Register(c *gin.Context)
+
+// GET /dashboard/streamers/channels
+// 回傳當前登入 user 管理的所有頻道
+func (h *StreamerHandler) ListChannels(c *gin.Context)
+
+// GET /dashboard/channels/:channel_id/stats
+// 回傳頻道播出統計（current session / daily / monthly / yearly）
+func (h *StreamerHandler) GetChannelStats(c *gin.Context)
+```
+
+### 5. Router
+
+- [ ] `backend/internal/router/router.go`
+  - `New()` 加入 `streamerSvc *services.StreamerService` 參數
+  - 在 `dashboard` group 新增路由：
+
+```go
+streamerH := handlers.NewStreamerHandler(streamerSvc)
+
+dashboard.POST("/streamers/register", streamerH.Register)
+dashboard.GET("/streamers/channels", streamerH.ListChannels)
+dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
+```
+
+### 6. Main.go
+
+- [ ] `backend/cmd/server/main.go`
+  - `AutoMigrate` 加入 `&models.Streamer{}`
+  - 初始化：`streamerSvc := services.NewStreamerService(db, pointsSvc)`
+  - 傳入 `router.New()`
+
+### 7. Test DB Util
+
+- [ ] `backend/internal/services/testutil_test.go` — 在 `migrateTestDB` 加入 `streamers` 表 DDL：
+
+```sql
+CREATE TABLE IF NOT EXISTS streamers (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    channel_id TEXT NOT NULL,
+    display_name TEXT,
+    created_at DATETIME,
+    updated_at DATETIME
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
+    ON streamers (user_id, channel_id);
+```
+
+### 8. 測試
+
+- [ ] `backend/internal/services/streamer_service_test.go`
+
+| 測試案例 | 描述 |
+|---|---|
+| `TestRegister_OK` | 正常建立 streamer，可重複呼叫（upsert） |
+| `TestRegister_UpdateDisplayName` | 同一 (user, channel) 再次 Register 更新 display_name |
+| `TestListChannels_Empty` | 尚未綁定頻道時回傳空 slice |
+| `TestListChannels_MultipleChannels` | 一個 user 綁定多個頻道 |
+| `TestGetChannelStats_NoStreamer` | channelID 無對應 auth_providers 時回傳 ErrStreamerNotFound |
+| `TestGetChannelStats_OK` | 正常查詢，委派給 PointsService.GetBroadcastStats |
+
+---
+
+## 驗證方式
+
+```bash
+docker compose run --no-deps --rm app go test ./...
+```
+
+手動流程：
+
+1. 以 Streamer 帳號登入取得 JWT
+2. `POST /api/v1/dashboard/streamers/register` body `{"channel_id": "<twitch_channel_id>", "display_name": "測試實況主"}`
+3. `GET /api/v1/dashboard/streamers/channels` → 確認回傳剛綁定的頻道
+4. 以 Viewer 帳號觸發 heartbeat，累積播出時間
+5. `GET /api/v1/dashboard/channels/<channel_id>/stats` → 確認 `daily_seconds` 有數值
+6. 以非 Streamer/Admin 帳號呼叫任一 `/dashboard/` endpoint → 確認回傳 403


### PR DESCRIPTION
## 背景

closes #28

#27（PointsService 雙帳本）已完成，`broadcast_time_stats` / `broadcast_time_logs` 寫入與查詢邏輯已就位。本 PR 在此基礎上新增實況主管理層，讓 Streamer 帳號可綁定頻道並查詢播出統計。

## 變更內容

- `backend/migrations/005_streamers.sql` — 新增 `streamers` 表（user_id + channel_id unique）
- `backend/internal/models/streamer.go` — Streamer model，BeforeCreate UUID hook
- `backend/internal/services/streamer_service.go` — Register（upsert）、ListChannels、GetChannelStats（透過 auth_providers 解析 streamerID，委派 PointsService.GetBroadcastStats）、OwnsChannel
- `backend/internal/handlers/streamer_handler.go` — 三個 dashboard endpoint，補上授權驗證
- `backend/internal/router/router.go` — dashboard group 新增路由
- `backend/cmd/server/main.go` — AutoMigrate + 手動建 unique index

## 新增 API

| Method | Path | 權限 |
|---|---|---|
| POST | `/api/v1/dashboard/streamers/register` | Streamer / Admin |
| GET | `/api/v1/dashboard/streamers/channels` | Streamer / Admin |
| GET | `/api/v1/dashboard/channels/:channel_id/stats` | Streamer / Admin |

## Test plan

- [x] `go test ./...` 全部通過
- [x] `streamer_service_test.go` — 6 tests（Register upsert、ListChannels、GetChannelStats）
- [x] `streamer_handler_test.go` — 5 tests（register + list、Viewer 403、stats OK）
- [x] `TestRegister_RejectsUnownedChannel` — channel_id 不屬於自己的 Twitch 帳號時 Register 回 403
- [x] `TestGetChannelStats_ForbiddenForOtherStreamer` — streamer B 查 streamer A 的 channel stats 回 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)