### PR TITLE
[backend] #68 Channel 挖礦倍率設定

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -53,8 +53,8 @@ func main() {
 		&models.EmailVerification{},
 		&models.PasswordReset{},
 		// Points & watch-time
-		&models.ChannelConfig{},
 		&models.Streamer{},
+		&models.ChannelConfig{},
 		&models.PointsLedger{},
 		&models.PointsTransaction{},
 		&models.WatchSession{},

--- a/backend/internal/handlers/channel_config_handler.go
+++ b/backend/internal/handlers/channel_config_handler.go
@@ -51,6 +51,10 @@ func (h *ChannelConfigHandler) UpdateChannelConfig(c *gin.Context) {
 		badRequest(c, err.Error())
 		return
 	}
+	if body.SecondsPerPoint == 0 && body.Multiplier == 0 {
+		badRequest(c, "at least one field must be a positive value")
+		return
+	}
 
 	channelID, allowed := h.authorizeChannelAccess(c)
 	if !allowed {

--- a/backend/internal/handlers/channel_config_handler.go
+++ b/backend/internal/handlers/channel_config_handler.go
@@ -1,39 +1,103 @@
 package handlers
 
 import (
-	"github.com/gin-gonic/gin"
+	"net/http"
 
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
 
 type ChannelConfigHandler struct {
-	configSvc *services.ChannelConfigService
+	configSvc   *services.ChannelConfigService
+	streamerSvc *services.StreamerService
 }
 
-func NewChannelConfigHandler(configSvc *services.ChannelConfigService) *ChannelConfigHandler {
-	return &ChannelConfigHandler{configSvc: configSvc}
+func NewChannelConfigHandler(configSvc *services.ChannelConfigService, streamerSvc *services.StreamerService) *ChannelConfigHandler {
+	return &ChannelConfigHandler{configSvc: configSvc, streamerSvc: streamerSvc}
+}
+
+func (h *ChannelConfigHandler) GetChannelConfig(c *gin.Context) {
+	channelID, allowed := h.authorizeChannelAccess(c)
+	if !allowed {
+		return
+	}
+
+	cfg, err := h.configSvc.Get(channelID)
+	if err != nil {
+		internal(c)
+		return
+	}
+	if cfg == nil {
+		cfg = &models.ChannelConfig{
+			ChannelID:       channelID,
+			SecondsPerPoint: services.DefaultSecondsPerPoint,
+			Multiplier:      1,
+		}
+	}
+
+	ok(c, gin.H{"config": cfg})
 }
 
 func (h *ChannelConfigHandler) UpdateChannelConfig(c *gin.Context) {
 	var body struct {
-		SecondsPerPoint int64 `json:"seconds_per_point" binding:"required,min=1"`
+		SecondsPerPoint int64 `json:"seconds_per_point" binding:"min=0"`
+		Multiplier      int64 `json:"multiplier" binding:"min=0"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		badRequest(c, err.Error())
 		return
 	}
 
-	channelID := c.Param("channel_id")
-	if channelID == "" {
-		badRequest(c, "channel_id is required")
+	channelID, allowed := h.authorizeChannelAccess(c)
+	if !allowed {
 		return
 	}
 
-	cfg, err := h.configSvc.UpdateChannelConfig(channelID, body.SecondsPerPoint)
+	cfg, err := h.configSvc.UpdateChannelConfig(channelID, body.SecondsPerPoint, body.Multiplier)
 	if err != nil {
 		internal(c)
 		return
 	}
 
 	ok(c, gin.H{"config": cfg})
+}
+
+func (h *ChannelConfigHandler) authorizeChannelAccess(c *gin.Context) (string, bool) {
+	channelID := c.Param("channel_id")
+	if channelID == "" {
+		badRequest(c, "channel_id is required")
+		return "", false
+	}
+
+	claims := middleware.MustClaims(c)
+	switch claims.Role {
+	case models.RoleAdmin:
+		return channelID, true
+	case models.RoleAgency:
+		c.JSON(http.StatusNotImplemented, Response{Success: false, Error: "agency channel config not implemented"})
+		return "", false
+	case models.RoleStreamer:
+		userID, err := uuid.Parse(claims.UserID)
+		if err != nil {
+			badRequest(c, "invalid user id")
+			return "", false
+		}
+		owns, err := h.streamerSvc.OwnsChannel(userID, channelID)
+		if err != nil {
+			internal(c)
+			return "", false
+		}
+		if !owns {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return "", false
+		}
+		return channelID, true
+	default:
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return "", false
+	}
 }

--- a/backend/internal/handlers/channel_config_handler_test.go
+++ b/backend/internal/handlers/channel_config_handler_test.go
@@ -22,14 +22,18 @@ func newDashboardTestEnv(t *testing.T) *dashboardEnv {
 	t.Helper()
 
 	base := newTestEnv(t)
+	watchSvc := services.NewWatchService(base.db)
+	pointsSvc := services.NewPointsService(base.db, watchSvc)
 	configSvc := services.NewChannelConfigService(base.db)
-	configH := handlers.NewChannelConfigHandler(configSvc)
+	streamerSvc := services.NewStreamerService(base.db, pointsSvc)
+	configH := handlers.NewChannelConfigHandler(configSvc, streamerSvc)
 
 	v1 := base.router.Group("/api/v1")
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(base.authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
+		dashboard.GET("/channels/:channel_id/config", configH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
 	}
 
@@ -81,6 +85,35 @@ func updateChannelConfig(t *testing.T, router *gin.Engine, token, channelID, bod
 	return w
 }
 
+func getChannelConfig(t *testing.T, router *gin.Engine, token, channelID string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard/channels/"+channelID+"/config", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func seedOwnedStreamerChannel(t *testing.T, env *dashboardEnv, email, channelID string) {
+	t.Helper()
+
+	var user models.User
+	if err := env.db.Where("email = ?", email).First(&user).Error; err != nil {
+		t.Fatalf("load user by email: %v", err)
+	}
+	if err := env.db.Create(&models.Streamer{
+		UserID:      user.ID,
+		ChannelID:   channelID,
+		DisplayName: "Owned channel",
+	}).Error; err != nil {
+		t.Fatalf("seed streamer ownership: %v", err)
+	}
+}
+
 func TestUpdateChannelConfig_NoToken(t *testing.T) {
 	env := newDashboardTestEnv(t)
 
@@ -102,36 +135,89 @@ func TestUpdateChannelConfig_ViewerForbidden(t *testing.T) {
 	}
 }
 
-func TestUpdateChannelConfig_StreamerAllowed(t *testing.T) {
+func TestGetChannelConfig_OK(t *testing.T) {
 	env := newDashboardTestEnv(t)
-	token := env.tokenForRole(t, models.RoleStreamer)
+	token := env.tokenForRole(t, models.RoleAdmin)
 
-	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":45}`)
+	if err := env.db.Create(&models.ChannelConfig{
+		ChannelID:       "channel_123",
+		SecondsPerPoint: 60,
+		Multiplier:      3,
+	}).Error; err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
 
+	w := getChannelConfig(t, env.router, token, "channel_123")
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
+}
 
-	resp := parseBody(t, w.Body.Bytes())
-	if resp["success"] != true {
-		t.Fatalf("expected success=true, got %#v", resp["success"])
-	}
+func TestGetChannelConfig_StreamerOwned(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+	seedOwnedStreamerChannel(t, env, "streamer_dashboard@example.com", "channel_owned")
 
-	data, _ := resp["data"].(map[string]interface{})
-	config, _ := data["config"].(map[string]interface{})
-	if config["channel_id"] != "channel_123" {
-		t.Fatalf("channel_id: want channel_123, got %v", config["channel_id"])
+	w := getChannelConfig(t, env.router, token, "channel_owned")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
-	if config["seconds_per_point"] != float64(45) {
-		t.Fatalf("seconds_per_point: want 45, got %v", config["seconds_per_point"])
+}
+
+func TestGetChannelConfig_StreamerForbidden(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+
+	w := getChannelConfig(t, env.router, token, "channel_other")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateChannelConfig_WithMultiplier(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleAdmin)
+
+	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":60,"multiplier":3}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 
 	var saved models.ChannelConfig
 	if err := env.db.First(&saved, "channel_id = ?", "channel_123").Error; err != nil {
 		t.Fatalf("load saved config: %v", err)
 	}
-	if saved.SecondsPerPoint != 45 {
-		t.Fatalf("saved seconds_per_point: want 45, got %d", saved.SecondsPerPoint)
+	if saved.SecondsPerPoint != 60 || saved.Multiplier != 3 {
+		t.Fatalf("unexpected saved config: %+v", saved)
+	}
+}
+
+func TestUpdateChannelConfig_StreamerForbidden(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+
+	w := updateChannelConfig(t, env.router, token, "channel_other", `{"seconds_per_point":60,"multiplier":2}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateChannelConfig_StreamerAllowed(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleStreamer)
+	seedOwnedStreamerChannel(t, env, "streamer_dashboard@example.com", "channel_123")
+
+	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":45}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var saved models.ChannelConfig
+	if err := env.db.First(&saved, "channel_id = ?", "channel_123").Error; err != nil {
+		t.Fatalf("load saved config: %v", err)
+	}
+	if saved.SecondsPerPoint != 45 || saved.Multiplier != 1 {
+		t.Fatalf("unexpected saved config: %+v", saved)
 	}
 }
 
@@ -142,12 +228,12 @@ func TestUpdateChannelConfig_AdminCanUpdateExistingConfig(t *testing.T) {
 	if err := env.db.Create(&models.ChannelConfig{
 		ChannelID:       "channel_123",
 		SecondsPerPoint: 60,
+		Multiplier:      1,
 	}).Error; err != nil {
 		t.Fatalf("seed config: %v", err)
 	}
 
 	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":90}`)
-
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -165,8 +251,7 @@ func TestUpdateChannelConfig_RejectsInvalidBody(t *testing.T) {
 	env := newDashboardTestEnv(t)
 	token := env.tokenForRole(t, models.RoleAdmin)
 
-	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":0}`)
-
+	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":-1}`)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
 	}

--- a/backend/internal/handlers/channel_config_handler_test.go
+++ b/backend/internal/handlers/channel_config_handler_test.go
@@ -31,7 +31,7 @@ func newDashboardTestEnv(t *testing.T) *dashboardEnv {
 	v1 := base.router.Group("/api/v1")
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(base.authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
 	{
 		dashboard.GET("/channels/:channel_id/config", configH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
@@ -127,6 +127,17 @@ func TestUpdateChannelConfig_NoToken(t *testing.T) {
 func TestUpdateChannelConfig_ViewerForbidden(t *testing.T) {
 	env := newDashboardTestEnv(t)
 	token := env.tokenForRole(t, models.RoleViewer)
+
+	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":45}`)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateChannelConfig_AgencyForbidden(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleAgency)
 
 	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":45}`)
 
@@ -254,5 +265,27 @@ func TestUpdateChannelConfig_RejectsInvalidBody(t *testing.T) {
 	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":-1}`)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateChannelConfig_RejectsEmptyValues(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleAdmin)
+
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{name: "empty object", body: `{}`},
+		{name: "zero values", body: `{"seconds_per_point":0,"multiplier":0}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := updateChannelConfig(t, env.router, token, "channel_123", tc.body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
 	}
 }

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -25,7 +25,7 @@ func newStreamerDashboardEnv(t *testing.T) *dashboardEnv {
 	streamerSvc := services.NewStreamerService(base.db, pointsSvc)
 	streamerH := handlers.NewStreamerHandler(streamerSvc)
 	configSvc := services.NewChannelConfigService(base.db)
-	configH := handlers.NewChannelConfigHandler(configSvc)
+	configH := handlers.NewChannelConfigHandler(configSvc, streamerSvc)
 
 	v1 := base.router.Group("/api/v1")
 	dashboard := v1.Group("/dashboard")

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -91,6 +91,7 @@ func migrateTestDB(db *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS channel_configs (
 			channel_id TEXT PRIMARY KEY,
 			seconds_per_point INTEGER NOT NULL DEFAULT 60,
+			multiplier INTEGER NOT NULL DEFAULT 1,
 			created_at DATETIME,
 			updated_at DATETIME
 		)`,

--- a/backend/internal/models/channel_config.go
+++ b/backend/internal/models/channel_config.go
@@ -7,6 +7,7 @@ import "time"
 type ChannelConfig struct {
 	ChannelID       string    `gorm:"type:varchar(255);primaryKey" json:"channel_id"`
 	SecondsPerPoint int64     `gorm:"not null;default:60"         json:"seconds_per_point"`
+	Multiplier      int64     `gorm:"not null;default:1"          json:"multiplier"`
 	CreatedAt       time.Time `                                   json:"created_at"`
 	UpdatedAt       time.Time `                                   json:"updated_at"`
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -119,7 +119,7 @@ func New(
 
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
 	{
 		dashboard.POST("/streamers/register", streamerH.Register)
 		dashboard.GET("/streamers/channels", streamerH.ListChannels)

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -33,7 +33,7 @@ func New(
 	extH := handlers.NewExtensionHandler(extSvc)
 	emailH := handlers.NewEmailAuthHandler(emailAuthSvc)
 	watchH := handlers.NewWatchHandler(watchSvc, pointsSvc)
-	channelConfigH := handlers.NewChannelConfigHandler(channelConfigSvc)
+	channelConfigH := handlers.NewChannelConfigHandler(channelConfigSvc, streamerSvc)
 	pointsH := handlers.NewPointsHandler(pointsSvc)
 	streamerH := handlers.NewStreamerHandler(streamerSvc)
 
@@ -119,11 +119,12 @@ func New(
 
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
 		dashboard.POST("/streamers/register", streamerH.Register)
 		dashboard.GET("/streamers/channels", streamerH.ListChannels)
 		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
+		dashboard.GET("/channels/:channel_id/config", channelConfigH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", channelConfigH.UpdateChannelConfig)
 	}
 

--- a/backend/internal/services/channel_config_service.go
+++ b/backend/internal/services/channel_config_service.go
@@ -15,15 +15,53 @@ func NewChannelConfigService(db *gorm.DB) *ChannelConfigService {
 	return &ChannelConfigService{db: db}
 }
 
-func (s *ChannelConfigService) UpdateChannelConfig(channelID string, secondsPerPoint int64) (*models.ChannelConfig, error) {
-	cfg := &models.ChannelConfig{
-		ChannelID:       channelID,
-		SecondsPerPoint: secondsPerPoint,
+func (s *ChannelConfigService) Get(channelID string) (*models.ChannelConfig, error) {
+	var cfg models.ChannelConfig
+	if err := s.db.Where("channel_id = ?", channelID).First(&cfg).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (s *ChannelConfigService) EffectiveMultiplier(channelID string) (int64, error) {
+	cfg, err := s.Get(channelID)
+	if err != nil {
+		return 0, err
+	}
+	if cfg == nil || cfg.Multiplier <= 0 {
+		return 1, nil
+	}
+	return cfg.Multiplier, nil
+}
+
+func (s *ChannelConfigService) UpdateChannelConfig(channelID string, secondsPerPoint, multiplier int64) (*models.ChannelConfig, error) {
+	cfg, err := s.Get(channelID)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		cfg = &models.ChannelConfig{
+			ChannelID:       channelID,
+			SecondsPerPoint: DefaultSecondsPerPoint,
+			Multiplier:      1,
+		}
+	}
+	if secondsPerPoint > 0 {
+		cfg.SecondsPerPoint = secondsPerPoint
+	}
+	if multiplier > 0 {
+		cfg.Multiplier = multiplier
 	}
 
 	if err := s.db.
 		Where("channel_id = ?", channelID).
-		Assign(models.ChannelConfig{SecondsPerPoint: secondsPerPoint}).
+		Assign(models.ChannelConfig{
+			SecondsPerPoint: cfg.SecondsPerPoint,
+			Multiplier:      cfg.Multiplier,
+		}).
 		FirstOrCreate(cfg).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/services/channel_config_service_test.go
+++ b/backend/internal/services/channel_config_service_test.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+func TestGet_NoConfig(t *testing.T) {
+	svc := NewChannelConfigService(newTestDB(t))
+
+	cfg, err := svc.Get("ch_missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("want nil config, got %+v", cfg)
+	}
+}
+
+func TestGet_OK(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewChannelConfigService(db)
+	if err := db.Create(&models.ChannelConfig{
+		ChannelID:       "ch_abc",
+		SecondsPerPoint: 45,
+		Multiplier:      3,
+	}).Error; err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cfg, err := svc.Get("ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil || cfg.SecondsPerPoint != 45 || cfg.Multiplier != 3 {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestEffectiveMultiplier_Default(t *testing.T) {
+	svc := NewChannelConfigService(newTestDB(t))
+
+	multiplier, err := svc.EffectiveMultiplier("ch_missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if multiplier != 1 {
+		t.Fatalf("want 1, got %d", multiplier)
+	}
+}
+
+func TestEffectiveMultiplier_OK(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewChannelConfigService(db)
+	if err := db.Create(&models.ChannelConfig{
+		ChannelID:       "ch_abc",
+		SecondsPerPoint: 60,
+		Multiplier:      4,
+	}).Error; err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	multiplier, err := svc.EffectiveMultiplier("ch_abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if multiplier != 4 {
+		t.Fatalf("want 4, got %d", multiplier)
+	}
+}
+
+func TestUpdateChannelConfig_MultiplierOnly(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewChannelConfigService(db)
+	if err := db.Create(&models.ChannelConfig{
+		ChannelID:       "ch_abc",
+		SecondsPerPoint: 90,
+		Multiplier:      1,
+	}).Error; err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cfg, err := svc.UpdateChannelConfig("ch_abc", 0, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SecondsPerPoint != 90 || cfg.Multiplier != 5 {
+		t.Fatalf("unexpected config after update: %+v", cfg)
+	}
+}
+
+func TestUpdateChannelConfig_BothFields(t *testing.T) {
+	svc := NewChannelConfigService(newTestDB(t))
+
+	cfg, err := svc.UpdateChannelConfig("ch_abc", 30, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SecondsPerPoint != 30 || cfg.Multiplier != 2 {
+		t.Fatalf("unexpected config after update: %+v", cfg)
+	}
+}

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -120,6 +120,7 @@ func migrateTestDB(db *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS channel_configs (
 			channel_id TEXT PRIMARY KEY,
 			seconds_per_point INTEGER NOT NULL DEFAULT 60,
+			multiplier INTEGER NOT NULL DEFAULT 1,
 			created_at DATETIME,
 			updated_at DATETIME
 		)`,

--- a/backend/internal/services/watch_service.go
+++ b/backend/internal/services/watch_service.go
@@ -159,15 +159,18 @@ func (s *WatchService) Heartbeat(userID uuid.UUID, channelID string) (*Heartbeat
 		// Use integer division on the duration to avoid float truncation issues
 		// (e.g. 29.9s should count as 29s, not silently floor via float cast).
 		deltaSeconds := int64(delta / time.Second)
-		secondsPerPoint, err := s.getSecondsPerPoint(tx, channelID)
+		cfg, err := s.getChannelConfig(tx, channelID)
 		if err != nil {
 			return err
 		}
+		secondsPerPoint := cfg.SecondsPerPoint
+		multiplier := cfg.Multiplier
 
 		newAccumulated := session.AccumulatedSeconds + deltaSeconds
 		pendingSeconds := newAccumulated - session.RewardedSeconds
-		pointsToAward := pendingSeconds / secondsPerPoint
-		newRewarded := session.RewardedSeconds + pointsToAward*secondsPerPoint
+		basePoints := pendingSeconds / secondsPerPoint
+		pointsToAward := basePoints * multiplier
+		newRewarded := session.RewardedSeconds + basePoints*secondsPerPoint
 
 		if err := tx.Model(&session).Updates(map[string]interface{}{
 			"accumulated_seconds": newAccumulated,
@@ -326,16 +329,23 @@ func (s *WatchService) GetBalance(userID uuid.UUID, channelID string) (spendable
 	return ledger.SpendableBalance, ledger.CumulativeTotal, nil
 }
 
-func (s *WatchService) getSecondsPerPoint(db *gorm.DB, channelID string) (int64, error) {
+func (s *WatchService) getChannelConfig(db *gorm.DB, channelID string) (*models.ChannelConfig, error) {
 	var cfg models.ChannelConfig
 	if err := db.Where("channel_id = ?", channelID).First(&cfg).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return DefaultSecondsPerPoint, nil
+			return &models.ChannelConfig{
+				ChannelID:       channelID,
+				SecondsPerPoint: DefaultSecondsPerPoint,
+				Multiplier:      1,
+			}, nil
 		}
-		return 0, err
+		return nil, err
 	}
 	if cfg.SecondsPerPoint <= 0 {
-		return DefaultSecondsPerPoint, nil
+		cfg.SecondsPerPoint = DefaultSecondsPerPoint
 	}
-	return cfg.SecondsPerPoint, nil
+	if cfg.Multiplier <= 0 {
+		cfg.Multiplier = 1
+	}
+	return &cfg, nil
 }

--- a/backend/internal/services/watch_service_test.go
+++ b/backend/internal/services/watch_service_test.go
@@ -215,6 +215,60 @@ func TestHeartbeat_CapsLargeGapAt30Seconds(t *testing.T) {
 	}
 }
 
+func TestHeartbeat_MultiplierApplied(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	channelID := "ch_multi"
+
+	if err := svc.db.Create(&models.ChannelConfig{
+		ChannelID:       channelID,
+		SecondsPerPoint: 60,
+		Multiplier:      3,
+	}).Error; err != nil {
+		t.Fatalf("seed channel config: %v", err)
+	}
+
+	s, _ := svc.StartSession(userID, channelID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+	svc.Heartbeat(userID, channelID)
+	s = reloadSession(t, svc, s.ID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+	svc.Heartbeat(userID, channelID)
+	s = reloadSession(t, svc, s.ID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+
+	result, err := svc.Heartbeat(userID, channelID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PointsEarned != 3 {
+		t.Fatalf("want 3 points, got %d", result.PointsEarned)
+	}
+}
+
+func TestHeartbeat_DefaultMultiplier(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	channelID := "ch_default_multi"
+
+	s, _ := svc.StartSession(userID, channelID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+	svc.Heartbeat(userID, channelID)
+	s = reloadSession(t, svc, s.ID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+	svc.Heartbeat(userID, channelID)
+	s = reloadSession(t, svc, s.ID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+
+	result, err := svc.Heartbeat(userID, channelID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PointsEarned != 1 {
+		t.Fatalf("want 1 point, got %d", result.PointsEarned)
+	}
+}
+
 // ─── EndSession ──────────────────────────────────────────────────────────────
 
 func TestEndSession_ClosesActiveSession(t *testing.T) {

--- a/backend/migrations/007_channel_config_multiplier.sql
+++ b/backend/migrations/007_channel_config_multiplier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE channel_configs ADD COLUMN IF NOT EXISTS multiplier INT NOT NULL DEFAULT 1;

--- a/plans/channel-config-multiplier.md
+++ b/plans/channel-config-multiplier.md
@@ -1,0 +1,60 @@
+# channel-config-multiplier 實作計畫
+
+狀態：已完成
+
+refs #68
+
+## 背景
+
+`WatchService.Heartbeat` 以 `seconds_per_point` 控制發點速率（預設 60 秒 1 點），已在 #59 完成。`ChannelConfigService` 基礎實作已在 #73 完成。
+
+本 PR 在現有基礎上新增 `multiplier` 欄位，讓 Streamer / Admin 可針對各頻道調整挖礦倍率，同時新增 `GET /dashboard/channels/:channel_id/config` 端點與完整的 ownership 驗證。
+
+## 架構決策
+
+### 發點公式
+
+```
+basePoints    = floor(delta_seconds / seconds_per_point)
+pointsToAward = basePoints * multiplier
+newRewarded   = basePoints * seconds_per_point   // 記錄 raw seconds，不受 multiplier 影響
+```
+
+`newRewarded` 故意不乘 multiplier，原因：若之後 config 被修改，不會造成下次 heartbeat 的 pending seconds 計算錯誤（drift）。
+
+### ownership 驗證（authorizeChannelAccess）
+
+- Admin → 直接通過
+- Agency → 501（MVP 暫不實作）
+- Streamer → 查 `streamers` 表 `OwnsChannel(userID, channelID)`，不擁有 → 403
+- 其他 → 403
+
+`streamers` 表只能透過 `Register`（已驗 auth_provider Twitch 對應）寫入，確保授權鏈完整。
+
+### UpdateChannelConfig upsert 語意
+
+`seconds_per_point=0` 或 `multiplier=0` 表示「保留舊值」，service 層做值保護，避免誤傳 0 清空設定。
+
+## 待實作 checklist
+
+- [x] `backend/migrations/007_channel_config_multiplier.sql` — ALTER TABLE 加 `multiplier` 欄位
+- [x] `models.ChannelConfig` 加 `Multiplier int64` 欄位
+- [x] `ChannelConfigService.Get` — 取得單筆 config
+- [x] `ChannelConfigService.EffectiveMultiplier` — fallback 1
+- [x] `ChannelConfigService.UpdateChannelConfig` — 支援同時更新 `seconds_per_point` + `multiplier`
+- [x] `WatchService.Heartbeat` — 套用 multiplier 公式，`getSecondsPerPoint` 改為 `getChannelConfig`
+- [x] `ChannelConfigHandler.GetChannelConfig` — 新增 GET endpoint
+- [x] `ChannelConfigHandler.UpdateChannelConfig` — 支援 multiplier
+- [x] `ChannelConfigHandler.authorizeChannelAccess` — Streamer ownership 驗證
+- [x] Router — dashboard group 新增 GET `/channels/:channel_id/config`
+
+## 驗證方式
+
+```bash
+docker compose run --no-deps --rm app go test ./internal/...
+```
+
+測試涵蓋：
+- `channel_config_service_test.go` — Get、EffectiveMultiplier（default/override）、UpdateChannelConfig
+- `watch_service_test.go` — MultiplierApplied（3x → 3 points）、DefaultMultiplier（1x → 1 point）
+- `channel_config_handler_test.go` — Admin/Streamer GET/PUT、ownership 邊界（forbidden/allowed）


### PR DESCRIPTION
## 背景

closes #68

\`WatchService.Heartbeat\` 已在 #59 完成 \`seconds_per_point\` 發點控制，\`ChannelConfigService\` 基礎實作已在 #73 完成。本 PR 在現有基礎上新增 \`multiplier\` 倍率欄位，並補上 \`GET /dashboard/channels/:channel_id/config\` 端點與完整的頻道 ownership 驗證。

## 變更內容

- \`backend/migrations/007_channel_config_multiplier.sql\` — ALTER TABLE 加 \`multiplier INT DEFAULT 1\`
- \`backend/internal/models/channel_config.go\` — 新增 \`Multiplier int64\` 欄位
- \`backend/internal/services/channel_config_service.go\` — 新增 \`Get\`、\`EffectiveMultiplier\`；\`UpdateChannelConfig\` 支援 multiplier
- \`backend/internal/services/watch_service.go\` — \`Heartbeat\` 發點套用 \`multiplier\`（\`basePoints * multiplier\`）；\`newRewarded\` 記錄 raw seconds 避免 config 修改後 drift
- \`backend/internal/handlers/channel_config_handler.go\` — 新增 \`GetChannelConfig\`；\`authorizeChannelAccess\` 加 Streamer ownership 驗證
- \`backend/internal/router/router.go\` — dashboard group 新增 \`GET /channels/:channel_id/config\`

## 新增 / 修改 API

| Method | Path | 權限 |
|---|---|---|
| GET | \`/api/v1/dashboard/channels/:channel_id/config\` | Streamer（限自己頻道） / Admin |
| PUT | \`/api/v1/dashboard/channels/:channel_id/config\` | Streamer（限自己頻道） / Admin |

**權限邊界：**
- Streamer 操作非自己頻道（查 \`streamers\` 表）→ 403
- Agency → 403（group-level RequireRole 擋下；config 內部為 501 佔位）
- Admin 不受限制

## Test plan

- [x] \`go test ./...\` 全部通過
- [x] \`channel_config_service_test.go\` — Get（noConfig / OK）、EffectiveMultiplier（default / override）、UpdateChannelConfig（multiplierOnly / bothFields）
- [x] \`watch_service_test.go\` — MultiplierApplied（3x → 75s 得 3 點）、DefaultMultiplier（無設定 → 1 點）
- [x] \`channel_config_handler_test.go\` — Admin GET/PUT OK、Streamer owned/forbidden、RejectsInvalidBody
- [x] \`channel_config_handler_test.go\` — Agency PUT → 403（group-level gate）
- [x] \`channel_config_handler_test.go\` — PUT \`{}\` / \`{"seconds_per_point":0,"multiplier":0}\` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 頻道配置新增「multiplier」倍率，可調整點數倍數
  * 新增查詢頻道配置的 API（可取得預設值當無設定時）
  * 儀表板頻道設定路由對更多角色可見（含 Agency）

* **改進**
  * 點數計算更新：先計算 basePoints，再乘以 multiplier 發放點數
  * 更新請求驗證：至少需提供 seconds_per_point 或 multiplier 中正值之一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->