### PR TITLE
[backend] StreamerService — 建立、管理與數據統計

### DIFF
--- a/backend/internal/handlers/channel_config_handler.go
+++ b/backend/internal/handlers/channel_config_handler.go
@@ -81,9 +81,6 @@ func (h *ChannelConfigHandler) authorizeChannelAccess(c *gin.Context) (string, b
 	switch claims.Role {
 	case models.RoleAdmin:
 		return channelID, true
-	case models.RoleAgency:
-		c.JSON(http.StatusNotImplemented, Response{Success: false, Error: "agency channel config not implemented"})
-		return "", false
 	case models.RoleStreamer:
 		userID, err := uuid.Parse(claims.UserID)
 		if err != nil {

--- a/backend/internal/handlers/channel_config_handler_test.go
+++ b/backend/internal/handlers/channel_config_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 
 	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/middleware"
@@ -105,12 +106,12 @@ func seedOwnedStreamerChannel(t *testing.T, env *dashboardEnv, email, channelID 
 	if err := env.db.Where("email = ?", email).First(&user).Error; err != nil {
 		t.Fatalf("load user by email: %v", err)
 	}
-	if err := env.db.Create(&models.Streamer{
-		UserID:      user.ID,
-		ChannelID:   channelID,
-		DisplayName: "Owned channel",
-	}).Error; err != nil {
-		t.Fatalf("seed streamer ownership: %v", err)
+	if err := env.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		uuid.New(), user.ID, models.ProviderTwitch, channelID,
+	).Error; err != nil {
+		t.Fatalf("seed channel ownership: %v", err)
 	}
 }
 

--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -20,27 +20,37 @@ func NewStreamerHandler(svc *services.StreamerService) *StreamerHandler {
 	return &StreamerHandler{streamerSvc: svc}
 }
 
-func (h *StreamerHandler) Register(c *gin.Context) {
-	claims := middleware.MustClaims(c)
-	userID, err := uuid.Parse(claims.UserID)
-	if err != nil {
-		badRequest(c, "invalid user id")
-		return
-	}
-
+func (h *StreamerHandler) Create(c *gin.Context) {
 	var body struct {
-		ChannelID   string `json:"channel_id" binding:"required"`
-		DisplayName string `json:"display_name"`
+		UserID       string  `json:"user_id" binding:"required"`
+		AgencyUserID *string `json:"agency_user_id"`
+		TwitchLogin  string  `json:"twitch_login" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		badRequest(c, err.Error())
 		return
 	}
 
-	streamer, err := h.streamerSvc.Register(userID, body.ChannelID, body.DisplayName)
+	userID, err := uuid.Parse(body.UserID)
+	if err != nil {
+		badRequest(c, "invalid user_id")
+		return
+	}
+
+	var agencyUserID *uuid.UUID
+	if body.AgencyUserID != nil {
+		aid, err := uuid.Parse(*body.AgencyUserID)
+		if err != nil {
+			badRequest(c, "invalid agency_user_id")
+			return
+		}
+		agencyUserID = &aid
+	}
+
+	streamer, err := h.streamerSvc.Create(userID, agencyUserID, body.TwitchLogin)
 	if err != nil {
 		if errors.Is(err, services.ErrChannelNotOwned) {
-			c.JSON(http.StatusForbidden, Response{Success: false, Error: "channel_id does not match your Twitch account"})
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "twitch_login does not match user's Twitch account"})
 			return
 		}
 		internal(c)
@@ -50,38 +60,67 @@ func (h *StreamerHandler) Register(c *gin.Context) {
 	ok(c, gin.H{"streamer": streamer})
 }
 
-func (h *StreamerHandler) ListChannels(c *gin.Context) {
+func (h *StreamerHandler) List(c *gin.Context) {
 	claims := middleware.MustClaims(c)
-	userID, err := uuid.Parse(claims.UserID)
-	if err != nil {
-		badRequest(c, "invalid user id")
-		return
-	}
 
-	channels, err := h.streamerSvc.ListChannels(userID)
-	if err != nil {
-		internal(c)
-		return
-	}
-
-	ok(c, gin.H{"channels": channels})
-}
-
-func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
-	channelID := c.Param("channel_id")
-	if channelID == "" {
-		badRequest(c, "channel_id is required")
-		return
-	}
-
-	claims := middleware.MustClaims(c)
-	if claims.Role != models.RoleAdmin {
-		userID, err := uuid.Parse(claims.UserID)
+	var (
+		streamers []models.Streamer
+		listErr   error
+	)
+	switch claims.Role {
+	case models.RoleAdmin:
+		streamers, listErr = h.streamerSvc.ListAll()
+	case models.RoleAgency:
+		agencyUserID, err := uuid.Parse(claims.UserID)
 		if err != nil {
 			badRequest(c, "invalid user id")
 			return
 		}
-		owns, err := h.streamerSvc.OwnsChannel(userID, channelID)
+		streamers, listErr = h.streamerSvc.ListByAgencyUserID(agencyUserID)
+	default:
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return
+	}
+
+	if listErr != nil {
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"streamers": streamers})
+}
+
+func (h *StreamerHandler) GetStats(c *gin.Context) {
+	streamerID, err := uuid.Parse(c.Param("streamer_id"))
+	if err != nil {
+		badRequest(c, "invalid streamer_id")
+		return
+	}
+
+	streamer, err := h.streamerSvc.GetByID(streamerID)
+	if err != nil {
+		if errors.Is(err, services.ErrStreamerNotFound) {
+			notFound(c, "streamer not found")
+			return
+		}
+		internal(c)
+		return
+	}
+
+	claims := middleware.MustClaims(c)
+	switch claims.Role {
+	case models.RoleStreamer:
+		if claims.UserID != streamer.UserID.String() {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return
+		}
+	case models.RoleAgency:
+		agencyUserID, err := uuid.Parse(claims.UserID)
+		if err != nil {
+			badRequest(c, "invalid user id")
+			return
+		}
+		owns, err := h.streamerSvc.OwnsStreamer(agencyUserID, streamerID)
 		if err != nil {
 			internal(c)
 			return
@@ -90,9 +129,13 @@ func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
 			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
 			return
 		}
+	case models.RoleAdmin:
+	default:
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return
 	}
 
-	stats, err := h.streamerSvc.GetChannelStats(channelID)
+	stats, err := h.streamerSvc.GetStats(streamer.UserID)
 	if err != nil {
 		if errors.Is(err, services.ErrStreamerNotFound) {
 			notFound(c, "streamer not found")

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -24,18 +23,17 @@ func newStreamerDashboardEnv(t *testing.T) *dashboardEnv {
 	pointsSvc := services.NewPointsService(base.db, watchSvc)
 	streamerSvc := services.NewStreamerService(base.db, pointsSvc)
 	streamerH := handlers.NewStreamerHandler(streamerSvc)
-	configSvc := services.NewChannelConfigService(base.db)
-	configH := handlers.NewChannelConfigHandler(configSvc, streamerSvc)
 
 	v1 := base.router.Group("/api/v1")
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(base.authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
-		dashboard.POST("/streamers/register", streamerH.Register)
-		dashboard.GET("/streamers/channels", streamerH.ListChannels)
-		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
-		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
+		dashboard.POST("/streamers", middleware.RequireRole(models.RoleAdmin), streamerH.Create)
+		dashboard.GET("/streamers", middleware.RequireRole(models.RoleAgency, models.RoleAdmin), streamerH.List)
+		dashboard.GET("/streamers/:streamer_id/stats",
+			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
+			streamerH.GetStats)
 	}
 
 	return &dashboardEnv{testEnv: base}
@@ -57,135 +55,235 @@ func dashboardRequest(t *testing.T, router *gin.Engine, method, path, token, bod
 	return w
 }
 
-func seedTwitchProvider(t *testing.T, env *dashboardEnv, email, channelID string) {
+func createDashboardUser(t *testing.T, env *dashboardEnv, role models.UserRole, prefix string) (models.User, string) {
 	t.Helper()
-	var user models.User
-	if err := env.db.Where("email = ?", email).First(&user).Error; err != nil {
-		t.Fatalf("load user: %v", err)
+
+	email := prefix + "@example.com"
+	username := prefix
+	password := "password123"
+
+	user, _, err := env.authSvc.Register(services.RegisterInput{
+		Username: username,
+		Email:    email,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("register %s: %v", prefix, err)
 	}
+	if err := env.db.Model(user).Update("role", role).Error; err != nil {
+		t.Fatalf("set role %s: %v", prefix, err)
+	}
+
+	_, tokens, err := env.authSvc.Login(services.LoginInput{Email: email, Password: password})
+	if err != nil {
+		t.Fatalf("login %s: %v", prefix, err)
+	}
+	return *user, tokens.AccessToken
+}
+
+func seedTwitchProviderForUser(t *testing.T, env *dashboardEnv, userID uuid.UUID, twitchLogin string) {
+	t.Helper()
 	if err := env.db.Exec(
 		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-		uuid.New(), user.ID, models.ProviderTwitch, channelID,
+		uuid.New(), userID, models.ProviderTwitch, twitchLogin,
 	).Error; err != nil {
 		t.Fatalf("seed auth provider: %v", err)
 	}
 }
 
-func TestStreamerRegister_AndListChannels(t *testing.T) {
-	env := newStreamerDashboardEnv(t)
-	token := env.tokenForRole(t, models.RoleStreamer)
-	seedTwitchProvider(t, env, "streamer_dashboard@example.com", "ch_123")
-
-	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers/register", token, `{"channel_id":"ch_123","display_name":"測試實況主"}`)
-	if w.Code != http.StatusOK {
-		t.Fatalf("register want 200, got %d: %s", w.Code, w.Body.String())
+func seedStreamerRow(t *testing.T, env *dashboardEnv, userID uuid.UUID, agencyUserID *uuid.UUID, twitchLogin string) *models.Streamer {
+	t.Helper()
+	streamer := &models.Streamer{
+		UserID:       userID,
+		AgencyUserID: agencyUserID,
+		TwitchLogin:  twitchLogin,
 	}
-
-	w = dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/channels", token, "")
-	if w.Code != http.StatusOK {
-		t.Fatalf("list want 200, got %d: %s", w.Code, w.Body.String())
-	}
-
-	resp := parseBody(t, w.Body.Bytes())
-	data, _ := resp["data"].(map[string]interface{})
-	channels, _ := data["channels"].([]interface{})
-	if len(channels) != 1 {
-		t.Fatalf("want 1 channel, got %d", len(channels))
-	}
-	channel, _ := channels[0].(map[string]interface{})
-	if channel["channel_id"] != "ch_123" {
-		t.Fatalf("channel_id: want ch_123, got %v", channel["channel_id"])
-	}
-}
-
-func TestRegister_RejectsUnownedChannel(t *testing.T) {
-	env := newStreamerDashboardEnv(t)
-	token := env.tokenForRole(t, models.RoleStreamer)
-	// No auth_provider seeded — channel does not belong to this user.
-
-	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers/register", token, `{"channel_id":"ch_someone_else","display_name":""}`)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
-	}
-}
-
-func TestStreamerStats_ForbiddenForViewer(t *testing.T) {
-	env := newStreamerDashboardEnv(t)
-	token := env.tokenForRole(t, models.RoleViewer)
-
-	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_123/stats", token, "")
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
-	}
-}
-
-func TestStreamerStats_OK(t *testing.T) {
-	env := newStreamerDashboardEnv(t)
-	token := env.tokenForRole(t, models.RoleStreamer)
-
-	var streamer models.User
-	if err := env.db.Where("email = ?", "streamer_dashboard@example.com").First(&streamer).Error; err != nil {
-		t.Fatalf("load streamer: %v", err)
-	}
-	if err := env.db.Exec(
-		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-		uuid.New(), streamer.ID, models.ProviderTwitch, "ch_123",
-	).Error; err != nil {
-		t.Fatalf("seed auth provider: %v", err)
-	}
-	// Register ownership so GetChannelStats ownership check passes.
-	if err := env.db.Create(&models.Streamer{
-		UserID:    streamer.ID,
-		ChannelID: "ch_123",
-	}).Error; err != nil {
+	if err := env.db.Create(streamer).Error; err != nil {
 		t.Fatalf("seed streamer: %v", err)
 	}
-	if err := env.db.Create(&models.BroadcastTimeLog{
-		StreamerID: streamer.ID,
-		ChannelID:  "ch_123",
-		Seconds:    33,
-		RecordedAt: time.Now(),
-	}).Error; err != nil {
-		t.Fatalf("seed log: %v", err)
-	}
+	return streamer
+}
 
-	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_123/stats", token, "")
+func TestCreate_AdminOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "streamer_admin")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target")
+	agencyUser, _ := createDashboardUser(t, env, models.RoleAgency, "agency_target")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_login")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","agency_user_id":"` + agencyUser.ID.String() + `","twitch_login":"target_login"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", adminToken, body)
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 
 	resp := parseBody(t, w.Body.Bytes())
-	data, _ := resp["data"].(map[string]interface{})
-	stats, _ := data["stats"].(map[string]interface{})
-	if stats["daily_seconds"] != float64(33) {
-		t.Fatalf("daily_seconds: want 33, got %v", stats["daily_seconds"])
+	data := resp["data"].(map[string]interface{})
+	streamer := data["streamer"].(map[string]interface{})
+	if streamer["user_id"] != streamerUser.ID.String() {
+		t.Fatalf("user_id mismatch: %v", streamer["user_id"])
+	}
+	if streamer["agency_user_id"] != agencyUser.ID.String() {
+		t.Fatalf("agency_user_id mismatch: %v", streamer["agency_user_id"])
+	}
+	if streamer["twitch_login"] != "target_login" {
+		t.Fatalf("twitch_login mismatch: %v", streamer["twitch_login"])
 	}
 }
 
-func TestGetChannelStats_ForbiddenForOtherStreamer(t *testing.T) {
+func TestCreate_StreamerForbidden(t *testing.T) {
 	env := newStreamerDashboardEnv(t)
+	_, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "forbidden_streamer")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target_s")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_login")
 
-	// Streamer A registers ch_A.
-	tokenA := env.tokenForRole(t, models.RoleStreamer)
-	seedTwitchProvider(t, env, "streamer_dashboard@example.com", "ch_A")
-	dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers/register", tokenA, `{"channel_id":"ch_A"}`)
-
-	// Streamer B — registered with a different email.
-	_, tokenB := env.registerUser(t, "streamer_b", "streamer_b@example.com", "password123")
-	if err := env.db.Exec(`UPDATE users SET role = 'streamer' WHERE email = 'streamer_b@example.com'`).Error; err != nil {
-		t.Fatalf("set role: %v", err)
-	}
-	// Re-login to get a token with updated role.
-	_, tokens, err := env.authSvc.Login(services.LoginInput{Email: "streamer_b@example.com", Password: "password123"})
-	if err != nil {
-		t.Fatalf("login streamer_b: %v", err)
-	}
-	tokenB = tokens.AccessToken
-
-	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_A/stats", tokenB, "")
+	body := `{"user_id":"` + streamerUser.ID.String() + `","twitch_login":"target_login"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", streamerToken, body)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_AgencyForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, agencyToken := createDashboardUser(t, env, models.RoleAgency, "forbidden_agency")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target_a")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_login")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","twitch_login":"target_login"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", agencyToken, body)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestList_AgencySeesOwnOnly(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	agencyA, agencyToken := createDashboardUser(t, env, models.RoleAgency, "agency_a")
+	agencyB, _ := createDashboardUser(t, env, models.RoleAgency, "agency_b")
+	streamerA1, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_a_streamer1")
+	streamerA2, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_a_streamer2")
+	streamerB1, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_b_streamer1")
+
+	seedStreamerRow(t, env, streamerA1.ID, &agencyA.ID, "a1_login")
+	seedStreamerRow(t, env, streamerA2.ID, &agencyA.ID, "a2_login")
+	seedStreamerRow(t, env, streamerB1.ID, &agencyB.ID, "b1_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", agencyToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != 2 {
+		t.Fatalf("want 2 streamers, got %d", len(streamers))
+	}
+	for _, item := range streamers {
+		streamer := item.(map[string]interface{})
+		if streamer["agency_user_id"] != agencyA.ID.String() {
+			t.Fatalf("unexpected agency_user_id: %v", streamer["agency_user_id"])
+		}
+	}
+}
+
+func TestList_AdminSeesAll(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "list_admin")
+	agencyA, _ := createDashboardUser(t, env, models.RoleAgency, "list_agency_a")
+	agencyB, _ := createDashboardUser(t, env, models.RoleAgency, "list_agency_b")
+	streamerA, _ := createDashboardUser(t, env, models.RoleStreamer, "list_streamer_a")
+	streamerB, _ := createDashboardUser(t, env, models.RoleStreamer, "list_streamer_b")
+
+	seedStreamerRow(t, env, streamerA.ID, &agencyA.ID, "admin_a_login")
+	seedStreamerRow(t, env, streamerB.ID, &agencyB.ID, "admin_b_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", adminToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != 2 {
+		t.Fatalf("want 2 streamers, got %d", len(streamers))
+	}
+}
+
+func TestGetStats_StreamerOwnOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	streamerUser, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_self")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "self_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, nil, "self_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", streamerToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_StreamerOtherForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	otherStreamer, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_other")
+	seedTwitchProviderForUser(t, env, otherStreamer.ID, "other_login")
+	streamer := seedStreamerRow(t, env, otherStreamer.ID, nil, "other_login")
+	_, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_requester")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", streamerToken, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AgencyOwnOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	agency, agencyToken := createDashboardUser(t, env, models.RoleAgency, "stats_agency_self")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_agency_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "agency_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, &agency.ID, "agency_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", agencyToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AgencyOtherForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	otherAgency, _ := createDashboardUser(t, env, models.RoleAgency, "stats_agency_other")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_agency_other_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "other_agency_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, &otherAgency.ID, "other_agency_login")
+	_, agencyToken := createDashboardUser(t, env, models.RoleAgency, "stats_agency_requester")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", agencyToken, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AdminAllOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "stats_admin")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_admin_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "admin_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, nil, "admin_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", adminToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_NotFound(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "stats_not_found_admin")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+uuid.New().String()+"/stats", adminToken, "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -98,13 +98,16 @@ func migrateTestDB(db *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS streamers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
-			channel_id TEXT NOT NULL,
+			agency_user_id TEXT REFERENCES users(id),
+			twitch_login TEXT NOT NULL,
 			display_name TEXT,
 			created_at DATETIME,
 			updated_at DATETIME
 		)`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
-			ON streamers (user_id, channel_id)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_twitch_login
+			ON streamers (twitch_login)`,
+		`CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id
+			ON streamers (agency_user_id)`,
 		`CREATE TABLE IF NOT EXISTS watch_sessions (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),

--- a/backend/internal/models/streamer.go
+++ b/backend/internal/models/streamer.go
@@ -8,12 +8,13 @@ import (
 )
 
 type Streamer struct {
-	ID          uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	UserID      uuid.UUID `gorm:"type:uuid;not null;index;uniqueIndex:idx_streamers_user_channel" json:"user_id"`
-	ChannelID   string    `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_streamers_user_channel" json:"channel_id"`
-	DisplayName string    `gorm:"type:varchar(255)"                              json:"display_name"`
-	CreatedAt   time.Time `                                                      json:"created_at"`
-	UpdatedAt   time.Time `                                                      json:"updated_at"`
+	ID           uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	UserID       uuid.UUID  `gorm:"type:uuid;not null"                              json:"user_id"`
+	AgencyUserID *uuid.UUID `gorm:"type:uuid"                                       json:"agency_user_id"`
+	TwitchLogin  string     `gorm:"type:varchar(50);not null;uniqueIndex"           json:"twitch_login"`
+	DisplayName  string     `gorm:"type:varchar(100)"                               json:"display_name"`
+	CreatedAt    time.Time  `                                                        json:"created_at"`
+	UpdatedAt    time.Time  `                                                        json:"updated_at"`
 }
 
 func (s *Streamer) BeforeCreate(tx *gorm.DB) error {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -120,11 +120,13 @@ func New(
 
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
-		dashboard.POST("/streamers/register", streamerH.Register)
-		dashboard.GET("/streamers/channels", streamerH.ListChannels)
-		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
+		dashboard.POST("/streamers", middleware.RequireRole(models.RoleAdmin), streamerH.Create)
+		dashboard.GET("/streamers", middleware.RequireRole(models.RoleAgency, models.RoleAdmin), streamerH.List)
+		dashboard.GET("/streamers/:streamer_id/stats",
+			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
+			streamerH.GetStats)
 		dashboard.GET("/channels/:channel_id/config", channelConfigH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", channelConfigH.UpdateChannelConfig)
 	}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -127,8 +127,12 @@ func New(
 		dashboard.GET("/streamers/:streamer_id/stats",
 			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
 			streamerH.GetStats)
-		dashboard.GET("/channels/:channel_id/config", channelConfigH.GetChannelConfig)
-		dashboard.PUT("/channels/:channel_id/config", channelConfigH.UpdateChannelConfig)
+		dashboard.GET("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
+			channelConfigH.GetChannelConfig)
+		dashboard.PUT("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
+			channelConfigH.UpdateChannelConfig)
 	}
 
 	// ── Agency management ─────────────────────────────────────────────────

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -101,9 +101,6 @@ func (s *StreamerService) ListByAgencyUserID(agencyUserID uuid.UUID) ([]models.S
 		Find(&streamers).Error; err != nil {
 		return nil, err
 	}
-	if streamers == nil {
-		return []models.Streamer{}, nil
-	}
 	return streamers, nil
 }
 
@@ -111,9 +108,6 @@ func (s *StreamerService) ListAll() ([]models.Streamer, error) {
 	var streamers []models.Streamer
 	if err := s.db.Order("created_at ASC").Find(&streamers).Error; err != nil {
 		return nil, err
-	}
-	if streamers == nil {
-		return []models.Streamer{}, nil
 	}
 	return streamers, nil
 }

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -14,6 +14,17 @@ var (
 	ErrChannelNotOwned  = errors.New("channel not owned by user")
 )
 
+type StreamerStats struct {
+	CurrentSessionSeconds  int64   `json:"current_session_seconds"`
+	DailySeconds           int64   `json:"daily_seconds"`
+	MonthlySeconds         int64   `json:"monthly_seconds"`
+	YearlySeconds          int64   `json:"yearly_seconds"`
+	UniqueMiners           int64   `json:"unique_miners"`
+	AvgSessionSeconds      float64 `json:"avg_session_seconds"`
+	TotalTokenMinted       int64   `json:"total_token_minted"`
+	SpendableInCirculation int64   `json:"spendable_in_circulation"`
+}
+
 type StreamerService struct {
 	db        *gorm.DB
 	pointsSvc *PointsService
@@ -23,11 +34,10 @@ func NewStreamerService(db *gorm.DB, pointsSvc *PointsService) *StreamerService 
 	return &StreamerService{db: db, pointsSvc: pointsSvc}
 }
 
-func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName string) (*models.Streamer, error) {
-	// Verify the channelID matches the user's Twitch auth_provider entry.
+func (s *StreamerService) Create(userID uuid.UUID, agencyUserID *uuid.UUID, twitchLogin string) (*models.Streamer, error) {
 	var count int64
 	if err := s.db.Model(&models.AuthProvider{}).
-		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderTwitch, channelID).
+		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderTwitch, twitchLogin).
 		Count(&count).Error; err != nil {
 		return nil, err
 	}
@@ -36,14 +46,14 @@ func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName stri
 	}
 
 	streamer := &models.Streamer{
-		UserID:      userID,
-		ChannelID:   channelID,
-		DisplayName: displayName,
+		UserID:       userID,
+		AgencyUserID: agencyUserID,
+		TwitchLogin:  twitchLogin,
 	}
 
 	if err := s.db.
-		Where("user_id = ? AND channel_id = ?", userID, channelID).
-		Assign(models.Streamer{DisplayName: displayName}).
+		Where("user_id = ? AND twitch_login = ?", userID, twitchLogin).
+		Assign(models.Streamer{AgencyUserID: agencyUserID}).
 		FirstOrCreate(streamer).Error; err != nil {
 		return nil, err
 	}
@@ -53,18 +63,40 @@ func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName stri
 
 func (s *StreamerService) OwnsChannel(userID uuid.UUID, channelID string) (bool, error) {
 	var count int64
-	if err := s.db.Model(&models.Streamer{}).
-		Where("user_id = ? AND channel_id = ?", userID, channelID).
+	if err := s.db.Model(&models.AuthProvider{}).
+		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderTwitch, channelID).
 		Count(&count).Error; err != nil {
 		return false, err
 	}
 	return count > 0, nil
 }
 
-func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, error) {
+func (s *StreamerService) GetByID(id uuid.UUID) (*models.Streamer, error) {
+	var streamer models.Streamer
+	if err := s.db.Where("id = ?", id).First(&streamer).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStreamerNotFound
+		}
+		return nil, err
+	}
+	return &streamer, nil
+}
+
+func (s *StreamerService) GetByUserID(userID uuid.UUID) (*models.Streamer, error) {
+	var streamer models.Streamer
+	if err := s.db.Where("user_id = ?", userID).First(&streamer).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStreamerNotFound
+		}
+		return nil, err
+	}
+	return &streamer, nil
+}
+
+func (s *StreamerService) ListByAgencyUserID(agencyUserID uuid.UUID) ([]models.Streamer, error) {
 	var streamers []models.Streamer
 	if err := s.db.
-		Where("user_id = ?", userID).
+		Where("agency_user_id = ?", agencyUserID).
 		Order("created_at ASC").
 		Find(&streamers).Error; err != nil {
 		return nil, err
@@ -75,16 +107,80 @@ func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, err
 	return streamers, nil
 }
 
-func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, error) {
+func (s *StreamerService) ListAll() ([]models.Streamer, error) {
+	var streamers []models.Streamer
+	if err := s.db.Order("created_at ASC").Find(&streamers).Error; err != nil {
+		return nil, err
+	}
+	if streamers == nil {
+		return []models.Streamer{}, nil
+	}
+	return streamers, nil
+}
+
+func (s *StreamerService) OwnsStreamer(agencyUserID uuid.UUID, streamerID uuid.UUID) (bool, error) {
+	var count int64
+	if err := s.db.Model(&models.Streamer{}).
+		Where("id = ? AND agency_user_id = ?", streamerID, agencyUserID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (s *StreamerService) GetStats(streamerID uuid.UUID) (*StreamerStats, error) {
 	var provider models.AuthProvider
 	if err := s.db.
-		Where("provider = ? AND provider_id = ?", models.ProviderTwitch, channelID).
+		Where("user_id = ? AND provider = ?", streamerID, models.ProviderTwitch).
 		First(&provider).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrStreamerNotFound
 		}
 		return nil, err
 	}
+	channelID := provider.ProviderID
 
-	return s.pointsSvc.GetBroadcastStats(provider.UserID, channelID)
+	broadcast, err := s.pointsSvc.GetBroadcastStats(streamerID, channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	var traffic struct {
+		UniqueMiners      int64   `gorm:"column:unique_miners"`
+		AvgSessionSeconds float64 `gorm:"column:avg_session_seconds"`
+	}
+	if err := s.db.Raw(`
+		SELECT
+			COUNT(DISTINCT user_id)               AS unique_miners,
+			COALESCE(AVG(accumulated_seconds), 0) AS avg_session_seconds
+		FROM watch_sessions
+		WHERE channel_id = ?
+	`, channelID).Scan(&traffic).Error; err != nil {
+		return nil, err
+	}
+
+	var economy struct {
+		TotalTokenMinted       int64 `gorm:"column:total_token_minted"`
+		SpendableInCirculation int64 `gorm:"column:spendable_in_circulation"`
+	}
+	if err := s.db.Raw(`
+		SELECT
+			COALESCE(SUM(cumulative_total), 0)  AS total_token_minted,
+			COALESCE(SUM(spendable_balance), 0) AS spendable_in_circulation
+		FROM points_ledgers
+		WHERE channel_id = ?
+	`, channelID).Scan(&economy).Error; err != nil {
+		return nil, err
+	}
+
+	return &StreamerStats{
+		CurrentSessionSeconds:  broadcast.CurrentSessionSeconds,
+		DailySeconds:           broadcast.DailySeconds,
+		MonthlySeconds:         broadcast.MonthlySeconds,
+		YearlySeconds:          broadcast.YearlySeconds,
+		UniqueMiners:           traffic.UniqueMiners,
+		AvgSessionSeconds:      traffic.AvgSessionSeconds,
+		TotalTokenMinted:       economy.TotalTokenMinted,
+		SpendableInCirculation: economy.SpendableInCirculation,
+	}, nil
 }

--- a/backend/internal/services/streamer_service_test.go
+++ b/backend/internal/services/streamer_service_test.go
@@ -35,152 +35,309 @@ func seedTwitchAuthProvider(t *testing.T, db *gorm.DB, userID uuid.UUID, channel
 	}
 }
 
-func TestRegister_OK(t *testing.T) {
+func seedStreamerRecord(t *testing.T, db *gorm.DB, userID uuid.UUID, agencyUserID *uuid.UUID, twitchLogin string) *models.Streamer {
+	t.Helper()
+	streamer := &models.Streamer{
+		UserID:       userID,
+		AgencyUserID: agencyUserID,
+		TwitchLogin:  twitchLogin,
+	}
+	if err := db.Create(streamer).Error; err != nil {
+		t.Fatalf("seed streamer: %v", err)
+	}
+	return streamer
+}
+
+func newStreamerService(t *testing.T) (*gorm.DB, *StreamerService, *WatchService) {
+	t.Helper()
 	db := newTestDB(t)
 	watchSvc := NewWatchService(db)
 	pointsSvc := NewPointsService(db, watchSvc)
-	svc := NewStreamerService(db, pointsSvc)
-	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
-	seedTwitchAuthProvider(t, db, userID, "ch_abc")
+	return db, NewStreamerService(db, pointsSvc), watchSvc
+}
 
-	streamer, err := svc.Register(userID, "ch_abc", "Alice")
+func TestCreate_OK(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	agencyUserID := seedStreamerUserRow(t, db, models.RoleAgency)
+	seedTwitchAuthProvider(t, db, userID, "alice_login")
+
+	streamer, err := svc.Create(userID, &agencyUserID, "alice_login")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if streamer.UserID != userID || streamer.ChannelID != "ch_abc" {
-		t.Fatalf("unexpected streamer: %+v", streamer)
+	if streamer.UserID != userID {
+		t.Fatalf("user_id: want %s, got %s", userID, streamer.UserID)
+	}
+	if streamer.AgencyUserID == nil || *streamer.AgencyUserID != agencyUserID {
+		t.Fatalf("agency_user_id mismatch: %+v", streamer.AgencyUserID)
+	}
+	if streamer.TwitchLogin != "alice_login" {
+		t.Fatalf("twitch_login: want alice_login, got %q", streamer.TwitchLogin)
 	}
 
-	streamer2, err := svc.Register(userID, "ch_abc", "Alice")
-	if err != nil {
-		t.Fatalf("unexpected error on second register: %v", err)
-	}
-	if streamer2.ID != streamer.ID {
-		t.Fatalf("expected upsert to reuse row, got %s vs %s", streamer2.ID, streamer.ID)
+	var saved models.Streamer
+	if err := db.Where("id = ?", streamer.ID).First(&saved).Error; err != nil {
+		t.Fatalf("load streamer: %v", err)
 	}
 }
 
-func TestRegister_UpdateDisplayName(t *testing.T) {
-	db := newTestDB(t)
-	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+func TestCreate_ChannelNotOwned(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
 	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
-	seedTwitchAuthProvider(t, db, userID, "ch_abc")
 
-	if _, err := svc.Register(userID, "ch_abc", "Old"); err != nil {
-		t.Fatalf("register old: %v", err)
-	}
-	streamer, err := svc.Register(userID, "ch_abc", "New")
-	if err != nil {
-		t.Fatalf("register new: %v", err)
-	}
-	if streamer.DisplayName != "New" {
-		t.Fatalf("display_name: want New, got %q", streamer.DisplayName)
+	_, err := svc.Create(userID, nil, "missing_login")
+	if !errors.Is(err, ErrChannelNotOwned) {
+		t.Fatalf("want ErrChannelNotOwned, got %v", err)
 	}
 }
 
-func TestListChannels_Empty(t *testing.T) {
-	db := newTestDB(t)
-	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+func TestCreate_Idempotent(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
 	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	agencyA := seedStreamerUserRow(t, db, models.RoleAgency)
+	agencyB := seedStreamerUserRow(t, db, models.RoleAgency)
+	seedTwitchAuthProvider(t, db, userID, "alice_login")
 
-	channels, err := svc.ListChannels(userID)
+	first, err := svc.Create(userID, &agencyA, "alice_login")
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	second, err := svc.Create(userID, &agencyB, "alice_login")
+	if err != nil {
+		t.Fatalf("second create: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("expected same id, got %s vs %s", first.ID, second.ID)
+	}
+	if second.AgencyUserID == nil || *second.AgencyUserID != agencyB {
+		t.Fatalf("expected agency_user_id updated to %s, got %+v", agencyB, second.AgencyUserID)
+	}
+}
+
+func TestStreamerGetByID_Found(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	streamer := seedStreamerRecord(t, db, userID, nil, "alice_login")
+
+	got, err := svc.GetByID(streamer.ID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(channels) != 0 {
-		t.Fatalf("want empty slice, got %d items", len(channels))
+	if got.ID != streamer.ID || got.UserID != userID || got.TwitchLogin != "alice_login" {
+		t.Fatalf("unexpected streamer: %+v", got)
 	}
 }
 
-func TestListChannels_MultipleChannels(t *testing.T) {
-	db := newTestDB(t)
-	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
-	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
-	seedTwitchAuthProvider(t, db, userID, "ch_A")
-	seedTwitchAuthProvider(t, db, userID, "ch_B")
+func TestStreamerGetByID_NotFound(t *testing.T) {
+	_, svc, _ := newStreamerService(t)
 
-	if _, err := svc.Register(userID, "ch_A", "Alpha"); err != nil {
-		t.Fatalf("register ch_A: %v", err)
-	}
-	time.Sleep(time.Millisecond)
-	if _, err := svc.Register(userID, "ch_B", "Beta"); err != nil {
-		t.Fatalf("register ch_B: %v", err)
-	}
-
-	channels, err := svc.ListChannels(userID)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(channels) != 2 {
-		t.Fatalf("want 2 channels, got %d", len(channels))
-	}
-}
-
-func TestGetChannelStats_NoStreamer(t *testing.T) {
-	db := newTestDB(t)
-	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
-
-	_, err := svc.GetChannelStats("missing_channel")
+	_, err := svc.GetByID(uuid.New())
 	if !errors.Is(err, ErrStreamerNotFound) {
 		t.Fatalf("want ErrStreamerNotFound, got %v", err)
 	}
 }
 
-func TestGetChannelStats_OK(t *testing.T) {
-	db := newTestDB(t)
-	watchSvc := NewWatchService(db)
-	pointsSvc := NewPointsService(db, watchSvc)
-	svc := NewStreamerService(db, pointsSvc)
+func TestGetByUserID_Found(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedStreamerRecord(t, db, userID, nil, "alice_login")
+
+	got, err := svc.GetByUserID(userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.UserID != userID || got.TwitchLogin != "alice_login" {
+		t.Fatalf("unexpected streamer: %+v", got)
+	}
+}
+
+func TestGetByUserID_NotFound(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
 	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
 
-	if err := db.Exec(
-		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-		uuid.New(), userID, models.ProviderTwitch, "ch_stats",
-	).Error; err != nil {
-		t.Fatalf("seed auth provider: %v", err)
+	_, err := svc.GetByUserID(userID)
+	if !errors.Is(err, ErrStreamerNotFound) {
+		t.Fatalf("want ErrStreamerNotFound, got %v", err)
 	}
+}
+
+func TestListByAgencyUserID_FiltersCorrectly(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
+	agencyA := seedStreamerUserRow(t, db, models.RoleAgency)
+	agencyB := seedStreamerUserRow(t, db, models.RoleAgency)
+	streamerA1 := seedStreamerUserRow(t, db, models.RoleStreamer)
+	streamerA2 := seedStreamerUserRow(t, db, models.RoleStreamer)
+	streamerB1 := seedStreamerUserRow(t, db, models.RoleStreamer)
+
+	seedStreamerRecord(t, db, streamerA1, &agencyA, "a1_login")
+	seedStreamerRecord(t, db, streamerA2, &agencyA, "a2_login")
+	seedStreamerRecord(t, db, streamerB1, &agencyB, "b1_login")
+
+	streamers, err := svc.ListByAgencyUserID(agencyA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(streamers) != 2 {
+		t.Fatalf("want 2 streamers, got %d", len(streamers))
+	}
+	for _, streamer := range streamers {
+		if streamer.AgencyUserID == nil || *streamer.AgencyUserID != agencyA {
+			t.Fatalf("unexpected agency_user_id: %+v", streamer)
+		}
+	}
+}
+
+func TestListByAgencyUserID_Empty(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
+	agencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+
+	streamers, err := svc.ListByAgencyUserID(agencyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if streamers == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
+	if len(streamers) != 0 {
+		t.Fatalf("want empty slice, got %d items", len(streamers))
+	}
+}
+
+func TestOwnsStreamer_True(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
+	agencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+	streamerUserID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	streamer := seedStreamerRecord(t, db, streamerUserID, &agencyID, "owned_login")
+
+	owns, err := svc.OwnsStreamer(agencyID, streamer.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !owns {
+		t.Fatal("expected owns=true")
+	}
+}
+
+func TestOwnsStreamer_False(t *testing.T) {
+	db, svc, _ := newStreamerService(t)
+	agencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+	otherAgencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+	streamerUserID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	streamer := seedStreamerRecord(t, db, streamerUserID, &otherAgencyID, "other_login")
+
+	owns, err := svc.OwnsStreamer(agencyID, streamer.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owns {
+		t.Fatal("expected owns=false")
+	}
+}
+
+func TestGetStats_AllEightMetrics(t *testing.T) {
+	db, svc, watchSvc := newStreamerService(t)
+	streamerUserID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedTwitchAuthProvider(t, db, streamerUserID, "streamer_login")
 
 	now := time.Now()
-	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 1, 0, 0, 0, now.Location())
-	startOfMonth := time.Date(now.Year(), now.Month(), 2, 0, 0, 0, 0, now.Location())
-	startOfYear := time.Date(now.Year(), 2, 1, 0, 0, 0, 0, now.Location())
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfYear := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
 
-	for _, recordedAt := range []time.Time{startOfDay, startOfMonth, startOfYear} {
+	logTimes := []time.Time{
+		now,
+		startOfDay.Add(-24 * time.Hour),
+		startOfMonth.Add(-24 * time.Hour),
+	}
+	if !logTimes[1].Before(startOfMonth) {
+		logTimes[1] = startOfMonth.Add(2 * time.Hour)
+	}
+	if !logTimes[2].Before(startOfYear) {
+		logTimes[2] = startOfYear.Add(2 * time.Hour)
+	}
+
+	seconds := []int64{30, 30, 30}
+	for i, recordedAt := range logTimes {
 		if err := db.Create(&models.BroadcastTimeLog{
-			StreamerID: userID,
-			ChannelID:  "ch_stats",
-			Seconds:    30,
+			StreamerID: streamerUserID,
+			ChannelID:  "streamer_login",
+			Seconds:    seconds[i],
 			RecordedAt: recordedAt,
 		}).Error; err != nil {
-			t.Fatalf("seed broadcast log: %v", err)
+			t.Fatalf("seed broadcast log %d: %v", i, err)
 		}
 	}
 
 	viewerID := seedStreamerUserRow(t, db, models.RoleViewer)
-	if _, err := watchSvc.StartSession(viewerID, "ch_stats"); err != nil {
+	if _, err := watchSvc.StartSession(viewerID, "streamer_login"); err != nil {
 		t.Fatalf("start session: %v", err)
 	}
 	if err := db.Model(&models.WatchSession{}).
-		Where("user_id = ? AND channel_id = ?", viewerID, "ch_stats").
+		Where("user_id = ? AND channel_id = ?", viewerID, "streamer_login").
 		Update("accumulated_seconds", 45).Error; err != nil {
-		t.Fatalf("seed active session seconds: %v", err)
+		t.Fatalf("seed watch session: %v", err)
 	}
 
-	stats, err := svc.GetChannelStats("ch_stats")
+	if err := db.Create(&models.PointsLedger{
+		UserID:           viewerID,
+		ChannelID:        "streamer_login",
+		CumulativeTotal:  100,
+		SpendableBalance: 60,
+	}).Error; err != nil {
+		t.Fatalf("seed ledger: %v", err)
+	}
+
+	expectedDaily := int64(0)
+	expectedMonthly := int64(0)
+	expectedYearly := int64(0)
+	for i, recordedAt := range logTimes {
+		if !recordedAt.Before(startOfDay) {
+			expectedDaily += seconds[i]
+		}
+		if !recordedAt.Before(startOfMonth) {
+			expectedMonthly += seconds[i]
+		}
+		if !recordedAt.Before(startOfYear) {
+			expectedYearly += seconds[i]
+		}
+	}
+
+	stats, err := svc.GetStats(streamerUserID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if stats.CurrentSessionSeconds != 45 {
 		t.Fatalf("current_session_seconds: want 45, got %d", stats.CurrentSessionSeconds)
 	}
-	if stats.DailySeconds != 30 {
-		t.Fatalf("daily_seconds: want 30, got %d", stats.DailySeconds)
+	if stats.DailySeconds != expectedDaily {
+		t.Fatalf("daily_seconds: want %d, got %d", expectedDaily, stats.DailySeconds)
 	}
-	if stats.MonthlySeconds != 60 {
-		t.Fatalf("monthly_seconds: want 60, got %d", stats.MonthlySeconds)
+	if stats.MonthlySeconds != expectedMonthly {
+		t.Fatalf("monthly_seconds: want %d, got %d", expectedMonthly, stats.MonthlySeconds)
 	}
-	if stats.YearlySeconds != 90 {
-		t.Fatalf("yearly_seconds: want 90, got %d", stats.YearlySeconds)
+	if stats.YearlySeconds != expectedYearly {
+		t.Fatalf("yearly_seconds: want %d, got %d", expectedYearly, stats.YearlySeconds)
+	}
+	if stats.UniqueMiners != 1 {
+		t.Fatalf("unique_miners: want 1, got %d", stats.UniqueMiners)
+	}
+	if stats.AvgSessionSeconds != 45 {
+		t.Fatalf("avg_session_seconds: want 45, got %v", stats.AvgSessionSeconds)
+	}
+	if stats.TotalTokenMinted != 100 {
+		t.Fatalf("total_token_minted: want 100, got %d", stats.TotalTokenMinted)
+	}
+	if stats.SpendableInCirculation != 60 {
+		t.Fatalf("spendable_in_circulation: want 60, got %d", stats.SpendableInCirculation)
+	}
+}
+
+func TestGetStats_NoStreamer(t *testing.T) {
+	_, svc, _ := newStreamerService(t)
+
+	_, err := svc.GetStats(uuid.New())
+	if !errors.Is(err, ErrStreamerNotFound) {
+		t.Fatalf("want ErrStreamerNotFound, got %v", err)
 	}
 }

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -127,13 +127,16 @@ func migrateTestDB(db *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS streamers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
-			channel_id TEXT NOT NULL,
+			agency_user_id TEXT REFERENCES users(id),
+			twitch_login TEXT NOT NULL,
 			display_name TEXT,
 			created_at DATETIME,
 			updated_at DATETIME
 		)`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
-			ON streamers (user_id, channel_id)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_twitch_login
+			ON streamers (twitch_login)`,
+		`CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id
+			ON streamers (agency_user_id)`,
 		`CREATE TABLE IF NOT EXISTS points_ledgers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL,

--- a/backend/migrations/005_streamers.sql
+++ b/backend/migrations/005_streamers.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS streamers (
-    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    channel_id   VARCHAR(255) NOT NULL,
-    display_name VARCHAR(255),
-    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE (user_id, channel_id)
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agency_user_id  UUID        REFERENCES users(id),
+    twitch_login    VARCHAR(50) NOT NULL UNIQUE,
+    display_name    VARCHAR(100),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS idx_streamers_channel_id ON streamers(channel_id);
+CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);


### PR DESCRIPTION
## 背景

實作 issue #28 規格：`streamers` 資料表、StreamerService、以及 Agency 後台管理 API。

## 變更內容

**Migration**
- `005_streamers.sql`：建立 `streamers` 資料表（`twitch_login` unique、`agency_user_id` FK）

**Model**
- `models.Streamer`：對應 DB 欄位

**StreamerService**
- `Create` — Admin 建立 streamer，驗證 `twitch_login` 與 auth_providers 一致，idempotent
- `GetByID` / `GetByUserID` — 查詢單筆
- `ListByAgencyUserID` / `ListAll` — Agency 查旗下 / Admin 查全部
- `OwnsStreamer` / `OwnsChannel` — 權限邊界驗證
- `GetStats` — 8 項統計指標（4 個開台時數維度、unique miners、平均停留秒數、總產出點數、可用點數）

**Handler / Router**
- `POST /api/v1/dashboard/streamers`（Admin only）
- `GET /api/v1/dashboard/streamers`（Agency 看旗下 / Admin 看全部）
- `GET /api/v1/dashboard/streamers/:streamer_id/stats`（Streamer 查自己 / Agency 查旗下 / Admin 無限制）
- channel config 路由加上獨立 `RequireRole(RoleAdmin, RoleStreamer)`，Agency 呼叫回傳 403

## Test plan

- [x] `docker compose run --no-deps --rm app go test ./...` 全綠
- [x] `TestListByAgencyUserID_FiltersCorrectly` — Agency 只看到旗下 streamer
- [x] `TestGetStats_AllEightMetrics` — 8 個統計指標皆正確
- [x] `TestGetStats_StreamerOtherForbidden` — Streamer 查他人 → 403
- [x] `TestGetStats_AgencyOtherForbidden` — Agency 查非旗下 → 403
- [x] `TestCreate_AdminOK` / `TestCreate_StreamerForbidden` / `TestCreate_AgencyForbidden`
- [x] `TestList_AgencySeesOwnOnly` / `TestList_AdminSeesAll`

closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)