### PR TITLE
docs: add tachimint frontend design planning

### DIFF
--- a/docs/dashboard-auth-state-inventory.md
+++ b/docs/dashboard-auth-state-inventory.md
@@ -1,0 +1,291 @@
+# Dashboard Auth State Inventory
+
+## 目標
+
+定義 `dashboard` 在登入、token restore、route guard 與權限判斷時的完整狀態。
+
+這份文件優先處理：
+
+- login page
+- app 啟動後的 auth restore
+- protected routes
+- `401` / `403` 的 UI 行為
+
+不處理：
+
+- 單一業務頁面的資料 state
+- channel config / stats / transactions 自身的資料狀態
+
+---
+
+## 使用者
+
+- streamer
+- agency
+- admin
+
+---
+
+## 主要任務
+
+1. 已有帳號的使用者可以登入 `dashboard`
+2. 已登入使用者重新整理後，session 能被正確 restore
+3. 未登入使用者不能進 protected routes
+4. 已登入但權限不足的使用者，看到明確的 `forbidden` UI，而不是被誤導成 logout
+
+---
+
+## 依賴資料
+
+- `POST /api/v1/auth/login`
+- `POST /api/v1/auth/refresh`
+- `GET /api/v1/users/me`
+- access token
+- refresh token
+- user role
+
+---
+
+## Source of Truth
+
+### Auth state
+
+單一來源，建議集中在 auth provider / auth store。
+
+建議欄位：
+
+- `authState: 'booting' | 'anonymous' | 'authenticating' | 'authenticated' | 'refreshing' | 'forbidden' | 'error'`
+- `user: User | null`
+- `accessTokenReady: boolean`
+- `refreshTokenPresent: boolean`
+
+### Route state
+
+由 router / protected route 從 auth state 推導，不自行重複保存。
+
+建議 derived state：
+
+- `canEnterProtectedRoute`
+- `shouldRedirectToLogin`
+- `shouldShowForbidden`
+
+### UI-only state
+
+- login form values
+- form validation errors
+- submit pending
+
+---
+
+## 狀態表
+
+| State | 觸發條件 | UI 表現 | 是否可操作 | API / 資料來源 |
+|-------|----------|---------|------------|----------------|
+| `booting` | App 啟動，尚未檢查 token / session | 全頁 loading 或 app shell skeleton | 否 | local token + restore flow |
+| `anonymous` | 沒有有效登入資訊 | 顯示 login page | 是 | local auth state |
+| `authenticating` | 使用者送出 login form | login button pending、表單 disable | 否 | `POST /auth/login` |
+| `authenticated` | login / refresh / restore 成功，且 `GET /users/me` 成功 | 可進入 protected app | 是 | access token + user profile |
+| `refreshing` | access token 過期，正在 refresh | 保留原頁面或全域 loading overlay | 建議局部禁止敏感操作 | `POST /auth/refresh` |
+| `forbidden` | 已登入，但 user role 不符頁面要求 | 顯示 forbidden state，不直接 logout | 否 | `403` 或 role gating |
+| `error` | auth restore / login / refresh 發生不可恢復錯誤 | 顯示錯誤訊息與 retry / 返回登入 | 視情況 | network / `5xx` / invalid state |
+
+---
+
+## 狀態轉移
+
+### App 啟動
+
+1. 進入 `booting`
+2. 檢查是否有 refresh token / session restore 資訊
+3. 若沒有：
+   - 轉成 `anonymous`
+4. 若有：
+   - 嘗試 refresh / restore
+   - 成功後進 `authenticated`
+   - 失敗後依錯誤類型進 `anonymous` 或 `error`
+
+### 使用者登入
+
+1. `anonymous`
+2. 使用者送出表單
+3. 進入 `authenticating`
+4. 成功：
+   - 儲存 token
+   - 取得 user profile
+   - 進入 `authenticated`
+5. 失敗：
+   - 回到 `anonymous`
+   - 顯示表單錯誤或全域錯誤
+
+### Access token 過期
+
+1. `authenticated`
+2. 某 API 回 `401`
+3. 若 refresh token 存在且可嘗試 refresh：
+   - 進 `refreshing`
+   - 成功回 `authenticated`
+   - 失敗依類型：
+     - refresh token 無效 / session 已失效 → `anonymous`
+     - 暫時性故障 → `error` 或保留頁面並提示 retry
+
+### 權限不足
+
+1. `authenticated`
+2. 使用者進入不符合 role 的頁面，或 API 回 `403`
+3. 進入 `forbidden`
+4. 不應直接 logout
+
+---
+
+## 各狀態設計要求
+
+## `booting`
+
+### 必須有
+
+- 明確的載入中畫面
+- 不應閃出 login page 再跳回 app
+
+### 不應有
+
+- 尚未完成 restore 就先 render protected content
+
+---
+
+## `anonymous`
+
+### 必須有
+
+- login form
+- 清楚的登入錯誤訊息區域
+
+### 不應有
+
+- 看起來像系統壞掉的空白畫面
+
+---
+
+## `authenticating`
+
+### 必須有
+
+- submit pending
+- 防止重複送出
+
+### 不應有
+
+- 一次點兩次造成雙重登入請求
+
+---
+
+## `authenticated`
+
+### 必須有
+
+- user 基本識別資訊
+- app shell 正常渲染
+- token refresh 不應破壞目前頁面
+
+---
+
+## `refreshing`
+
+### 必須有
+
+- 對使用者來說是可理解的短暫中間狀態
+- 若 refresh 成功，應盡可能無感恢復
+
+### 特別注意
+
+- refresh 暫時失敗不應一律當成 logout
+- queued requests 不應因 refresh race condition 全部壞掉
+
+---
+
+## `forbidden`
+
+### 必須有
+
+- 明確文字說明沒有權限
+- 若有必要，可提供返回安全頁面的 CTA
+
+### 不應有
+
+- 把 `403` 誤導成 `401`
+- 直接清 session / 直接踢回 login
+
+---
+
+## `error`
+
+### 必須有
+
+- 錯誤訊息
+- retry 或返回登入的選項
+
+### 建議區分
+
+- network / backend unavailable
+- restore failed
+- unknown auth state
+
+---
+
+## Route Guard 規則
+
+### ProtectedRoute
+
+應只根據 auth source of truth 做判斷：
+
+- `booting` → render loading
+- `anonymous` → redirect login
+- `authenticating` / `refreshing` → render pending state
+- `authenticated` → render route
+- `forbidden` → render forbidden page
+- `error` → render error page 或 fallback
+
+### 角色型路由
+
+如果頁面要求特定 role：
+
+- 先確認是否 `authenticated`
+- 再做 role 檢查
+- role 不符應顯示 `forbidden`
+- 不應直接 logout
+
+---
+
+## API 錯誤映射建議
+
+| HTTP / 狀況 | dashboard auth 狀態 | UI 建議 |
+|-------------|---------------------|---------|
+| `400` login validation error | `anonymous` | 顯示表單錯誤 |
+| `401` login failed | `anonymous` | 顯示帳密錯誤 |
+| `401` access token expired + refresh success | `authenticated` | 無感恢復 |
+| `401` refresh token invalid | `anonymous` | 回 login |
+| `403` role mismatch | `forbidden` | 顯示 forbidden page |
+| network / `5xx` during restore | `error` | 顯示暫時不可用與 retry |
+
+---
+
+## 驗收清單
+
+1. 重整頁面後不應先看到 login 再跳回 app
+2. refresh 成功時，使用者不應無故被登出
+3. refresh 暫時失敗時，不應一律清 session
+4. `403` 頁面應顯示為 forbidden，而不是 logout
+5. login form 至少有：
+   - idle
+   - pending
+   - validation error
+   - credential error
+   - backend unavailable
+
+---
+
+## 後續可接文件
+
+建議接著補：
+
+1. `dashboard-channel-config-state-inventory.md`
+2. `docs/tachimint/home-state-inventory.md`

--- a/docs/frontend-roadmap.md
+++ b/docs/frontend-roadmap.md
@@ -1,0 +1,358 @@
+# 前端 Roadmap
+
+## 目標
+
+為 `tachigo` 建立一份可執行的前端演進路線，避免後續開發同時混雜：
+
+- `dashboard` 的管理後台需求
+- `tachimint` 的 Twitch Extension / GameFi 體驗需求
+- 共用設計規則、元件與資料狀態管理方式
+
+這份 roadmap 的目的不是一次決定所有視覺細節，而是先回答：
+
+1. 先做哪一個前端產品
+2. 每個階段要交付什麼
+3. 什麼算完成
+4. 哪些事情現在先不要做
+
+---
+
+## 產品切面
+
+### 1. Dashboard
+
+使用者：
+
+- streamer
+- agency
+- admin
+
+核心目的：
+
+- 查看頻道資料與統計
+- 管理頻道設定
+- 後續承接 agency / event / 營運型流程
+
+前端特性：
+
+- 任務導向
+- 資訊密度高
+- 權限與錯誤狀態必須清楚
+- 穩定性與可維護性優先於花俏視覺
+
+### 2. Tachimint
+
+使用者：
+
+- viewer
+- broadcaster / moderator / external 只需極簡提示畫面
+
+核心目的：
+
+- 讓觀眾在 Twitch Extension 內完成 watch-to-earn / idle-game 體驗
+- 建立 click、heartbeat、bits、任務與成長感的前端骨架
+
+前端特性：
+
+- Twitch-native first，GameFi flavor second
+- 狀態感與回饋感優先
+- 需要嚴格對齊 Twitch / JWT / watch session lifecycle
+- 高風險點在資料同步、session 狀態與 UI state ownership
+
+### 3. 共用前端基礎
+
+核心目的：
+
+- 讓不同前端產品共享一致的設計語言與工程規則
+
+包含內容：
+
+- design tokens
+- 共用狀態呈現模式
+- API contract 對齊方式
+- 錯誤處理與 loading/empty/forbidden 規則
+
+---
+
+## 總體策略
+
+### 原則 1：先穩定狀態，再強化視覺
+
+`tachigo` 目前更容易出錯的地方，不是「畫面不夠漂亮」，而是：
+
+- auth flow 與 route guard 不一致
+- balance / session / heartbeat 有多份 state
+- 前端 request contract 與後端實作不一致
+- role-based UI 邊界不清楚
+
+因此 roadmap 採：
+
+1. 先收斂 state inventory 與 API contract
+2. 再完成可用 UI 骨架
+3. 最後做視覺升級與 GameFi 氛圍
+
+### 原則 2：Dashboard 與 Extension 分開規劃
+
+這兩個產品的使用情境完全不同：
+
+- `dashboard` 要的是穩定管理流
+- `tachimint` 要的是互動與節奏
+
+不能共用同一套頁面思維，也不該共用同一份 roadmap phase。
+
+### 原則 3：每個畫面先有 state inventory
+
+每個頁面在進入視覺稿前，都應先列出：
+
+- loading
+- success
+- empty
+- partial data
+- forbidden
+- error
+- retry / cooldown / unavailable
+
+如果 state inventory 不完整，就不要先做高保真設計。
+
+---
+
+## 分階段規劃
+
+## Phase 1：共用基礎與規則收斂
+
+### 目標
+
+建立所有前端工作共用的設計與工程基準。
+
+### 產出物
+
+- 前端設計原則文件
+- `tachimint` 視覺原則文件
+- state inventory 模板
+- API contract checklist
+- design tokens 初版
+- 共用 UI primitives 規格
+
+### 建議元件
+
+- `PageHeader`
+- `SectionCard`
+- `StatCard`
+- `StatusBadge`
+- `EmptyState`
+- `LoadingState`
+- `ErrorState`
+- `ForbiddenState`
+- `ConfirmDialog`
+
+### 驗收標準
+
+- 新頁面不再各自發明 loading / error / empty 樣式
+- PR review 可以用同一組 state / contract 標準檢查
+- `dashboard` 與 `tachimint` 都能引用同一份基礎規則
+
+### 現階段不要做
+
+- 大量高保真設計稿
+- 先做完整設計系統網站
+- 過度抽象的 component library
+
+---
+
+## Phase 2：Dashboard MVP
+
+### 目標
+
+讓 `dashboard` 先成為可穩定操作的管理後台。
+
+### 優先頁面
+
+- login / auth restore
+- channels list
+- channel stats
+- channel config
+- 基本 settings
+
+### 核心工作
+
+- token persistence / refresh flow
+- route guard 與 `authProvider` 收斂
+- role-based UI gating
+- list / form / detail 頁面結構固定化
+- 與後端 dashboard API contract 對齊
+
+### 工程重點
+
+- 單一 auth state source of truth
+- 明確區分 `401`、`403`、`404`、`500`
+- 建立表單成功 / 失敗 / 驗證錯誤模式
+- 明確處理 streamer / agency / admin 差異
+
+### 驗收標準
+
+- 重整頁面後 auth 不會掉
+- 主要 dashboard 頁面可完整走通
+- 不同角色看不到不該看的操作
+- 空資料與 forbidden 狀態都有清楚 UI
+
+### 現階段不要做
+
+- 複雜資料視覺化 dashboard
+- 過度客製的 table infra
+- 高複雜營運流程頁面
+
+---
+
+## Phase 3：Tachimint MVP
+
+### 目標
+
+把 `tachimint` 從「功能分散的 extension 原型」整理成穩定的 viewer app shell。
+
+### 優先面板
+
+- Home
+- Missions
+- Equipment
+- Shop
+
+### 核心工作
+
+- 整理 hook ownership：
+  - `useTwitch`
+  - `useWatchSession`
+  - `useHeartbeat`
+  - `useBalance`
+  - `useClickBoost`
+  - `useBits`
+- 明確 viewer / non-viewer 流程
+- 修正 session start / heartbeat / end lifecycle
+- 讓 balance、cooldown、bits 狀態來源單一化
+- 建立直式 app shell 與 bottom nav
+
+### UI 重點
+
+- loading / auth failed / backend unavailable
+- session starting
+- balance ready / animating
+- click ready / cooldown / gain / error
+- bits idle / pending / success / error
+- missions / equipment / shop 先用 placeholder，但結構正確
+
+### 驗收標準
+
+- viewer 流程能從 auth → session → heartbeat → balance → click 正常走通
+- broadcaster / moderator / external 不會誤走 viewer 流程
+- click 與 balance 不再各持一份不同步 state
+- bits flow 至少有明確 pending / success / error UI
+
+### 現階段不要做
+
+- 真正的 BOSS 任務後端串接
+- wallet connect / NFT claim flow
+- 大量動畫 prototype
+
+---
+
+## Phase 4：Tachimint 視覺與互動升級
+
+### 目標
+
+在 MVP 穩定後，把 `tachimint` 提升成有辨識度、但仍像 Twitch Extension 的互動體驗。
+
+### 核心工作
+
+- 強化 Home 主舞台
+- gain 動畫與 cooldown ring
+- resource bar 視覺階層
+- missions / equipment / shop 的一致視覺語言
+- compact Twitch panel 響應壓縮規則
+
+### 設計重點
+
+- 直式 extension panel，而不是手機 app mockup
+- 優先讓顏色、密度、語氣與元件感受貼近 Twitch 生態中合理存在的 extension
+- 高資訊密度，但仍可快速掃描
+- 有遊戲感，但只作為點綴，不做成獨立遊戲 launcher
+- 不做成錢包 popup
+- 不做成外部 SaaS dashboard
+
+### 驗收標準
+
+- Home 畫面具備明確主視覺焦點
+- 所有互動關鍵狀態都有對應視覺反饋
+- 360x720 與 318x500 都能閱讀與操作
+- 第一眼仍應被理解為 Twitch 內的 extension，而不是獨立 app
+
+### 現階段不要做
+
+- 過度複雜的動效系統
+- 先做完整角色養成與裝備 inventory
+
+---
+
+## Phase 5：進階能力接入
+
+### 目標
+
+把先前留為 placeholder 的功能，逐步接成真實產品能力。
+
+### 可能範圍
+
+- agency 專屬 dashboard 流程
+- Angela Gate / BOSS 任務 API 串接
+- equipment / buff / NFT teaser 到真實流程
+- events / campaign / season UX
+
+### 驗收標準
+
+- placeholder 被真資料替換時，不需要重做整個畫面骨架
+- 權限與資料流能沿用前面 phase 的既有模式
+
+---
+
+## 優先順序建議
+
+### 建議順序
+
+1. `Phase 1` 共用規則
+2. `Phase 2` Dashboard MVP
+3. `Phase 3` Tachimint MVP
+4. `Phase 4` Tachimint 視覺升級
+5. `Phase 5` 進階能力接入
+
+### 為什麼這樣排
+
+- `dashboard` 比較適合先把 auth、權限、資料契約打穩
+- `tachimint` 的互動性高，若在 state ownership 混亂時就直接疊視覺，返工成本會更高
+- 共用規則先建立後，後面兩條產品線的 review 成本都會下降
+
+---
+
+## 近期可執行清單
+
+### 建議先做
+
+1. 補一份 `dashboard` state inventory 文件
+2. 補一份 `tachimint` state inventory 文件
+3. 補一份 `tachimint` 視覺原則文件
+4. 定義前端共用 design tokens 初版
+5. 確認 `dashboard` 是否正式採 `Refine.dev`
+6. 把 `tachimint` 六支 hook 的 ownership 文件化
+
+### 建議暫緩
+
+- 做完整高保真 Figma 大全套
+- 做完整 NFT / wallet UX
+- 提前擴張到大量營運頁面
+
+---
+
+## 成功標準
+
+這份 roadmap 若執行順利，應該帶來以下結果：
+
+- 前端任務能更清楚分辨是 `dashboard` 還是 `tachimint`
+- PR review 有共同標準，不再每次重講一次 scope
+- `dashboard` 與 `tachimint` 都能先把資料與權限邏輯走穩
+- 視覺升級建立在穩定的 state 與 API contract 上，而不是反覆返工

--- a/docs/frontend-state-inventory.md
+++ b/docs/frontend-state-inventory.md
@@ -1,0 +1,233 @@
+# 前端 State Inventory
+
+## 目的
+
+這份文件用來統一 `tachigo` 前端在設計與實作前的狀態盤點方式。
+
+目標是避免：
+
+- UI 只有 happy path，沒有 error / empty / forbidden
+- 同一份資料被多個 hook 或頁面各自持有
+- 畫面設計與 API contract 脫鉤
+- PR review 每次重新討論一次「這個狀態到底要怎麼顯示」
+
+---
+
+## 使用方式
+
+每做一個新頁面、新 panel 或新流程，至少先列出以下狀態：
+
+1. `loading`
+2. `success`
+3. `empty`
+4. `partial`
+5. `forbidden`
+6. `error`
+7. `retry / cooldown / unavailable`
+
+如果某個狀態「理論上不會發生」，也要明寫原因，不要省略。
+
+---
+
+## State 定義
+
+### `loading`
+
+資料尚未取得或流程尚未初始化完成。
+
+要回答：
+
+- 這時候顯示 skeleton、spinner 還是整頁 loading？
+- 使用者能不能操作？
+- 哪個條件代表 loading 結束？
+
+### `success`
+
+資料完整、流程正常、主要操作可進行。
+
+要回答：
+
+- 畫面最主要資訊是什麼？
+- 成功後有沒有次狀態，例如 animating / synced / stale？
+
+### `empty`
+
+不是錯誤，但目前沒有資料。
+
+要回答：
+
+- 為什麼是空的？
+- 是否需要 CTA？
+- 是第一次使用的空，還是篩選後的空？
+
+### `partial`
+
+主要流程可用，但有部分資料缺失、延遲或 placeholder。
+
+要回答：
+
+- 哪些資料是真的？
+- 哪些是 mock / placeholder？
+- 使用者是否需要知道「這塊尚未開放」？
+
+### `forbidden`
+
+使用者已登入，但沒有權限看或做某件事。
+
+要回答：
+
+- 這是 `401` 還是 `403`？
+- 顯示方式是整頁擋下，還是局部禁用？
+- 是否需要提示使用者該找誰或該去哪裡？
+
+### `error`
+
+系統或請求失敗，使用者目前無法完成目標。
+
+要回答：
+
+- 是整頁錯誤還是局部錯誤？
+- 可不可以重試？
+- 是否需要保留原本畫面資料？
+
+### `retry / cooldown / unavailable`
+
+這類不是傳統 error，但也不是正常 success。
+
+常見於：
+
+- click cooldown
+- bits pending
+- backend unavailable
+- refresh / reconnect
+
+要回答：
+
+- 這是短暫中間狀態，還是明確失敗？
+- 使用者現在能做什麼？
+- 是否要顯示倒數、重試鈕或 disabled 說明？
+
+---
+
+## State Inventory 模板
+
+可直接複製以下區塊到新文件或 issue：
+
+```md
+# <頁面 / 流程名稱>
+
+## 目標
+
+- 使用者：
+- 主要任務：
+- 依賴資料：
+
+## Source of Truth
+
+- Auth state:
+- Session state:
+- Primary data state:
+- UI-only state:
+
+## States
+
+| State | 觸發條件 | UI 表現 | 是否可操作 | API / 資料來源 |
+|-------|----------|---------|------------|----------------|
+| loading |  |  |  |  |
+| success |  |  |  |  |
+| empty |  |  |  |  |
+| partial |  |  |  |  |
+| forbidden |  |  |  |  |
+| error |  |  |  |  |
+| retry/cooldown/unavailable |  |  |  |  |
+
+## Transitions
+
+- 從 loading 到 success：
+- 從 loading 到 error：
+- 從 success 到 cooldown / pending：
+- 從 error 到 retry：
+
+## Notes
+
+- 哪些資料是 placeholder：
+- 哪些狀態需要動畫：
+- 哪些狀態需要 telemetry / logging：
+```
+
+---
+
+## Dashboard 範例
+
+### `Channel Config` 頁
+
+| State | 觸發條件 | UI 表現 | 是否可操作 | API / 資料來源 |
+|-------|----------|---------|------------|----------------|
+| loading | 首次進頁，設定尚未載入 | 表單 skeleton | 否 | `GET /dashboard/channels/:channel_id/config` |
+| success | config 成功取得 | 顯示表單與儲存按鈕 | 是 | config payload |
+| empty | channel 尚未有設定，回預設值 | 顯示預設值與提示文案 | 是 | 預設 config |
+| forbidden | 使用者不是該 channel owner | 整頁 forbidden state | 否 | `403` |
+| error | API 失敗 | 錯誤訊息 + retry | 視情況 | `500` / network error |
+
+---
+
+## Tachimint 範例
+
+### `Home / Mining` panel
+
+| State | 觸發條件 | UI 表現 | 是否可操作 | API / 資料來源 |
+|-------|----------|---------|------------|----------------|
+| loading | Twitch context / auth 尚未完成 | 全畫面 loading | 否 | `useTwitch` |
+| success | auth ready + session ready + balance ready | 主舞台、resource bar、mine button | 是 | `useWatchSession` + `useBalance` |
+| partial | missions / buffs / equipment 尚未接真 API | 顯示 placeholder 區塊 | 部分可操作 | local placeholder |
+| forbidden | non-viewer role | 顯示 broadcaster / non-viewer 提示 | 否 | `context.role` |
+| error | backend unavailable / heartbeat error | 顯示錯誤 banner 或 fallback state | 視情況 | API error |
+| cooldown | click 後等待下一次可點擊 | button disabled + countdown ring | 否 | `useClickBoost` |
+
+---
+
+## Source of Truth 原則
+
+狀態盤點時，務必額外標註每個畫面的 source of truth。
+
+### 建議分類
+
+- `server state`
+  來自 API / query cache，例如 config、balance、transactions
+
+- `session state`
+  與 auth、JWT、watch session 生命週期相關
+
+- `ui state`
+  純畫面狀態，例如 active tab、dialog open、hover、animation
+
+- `derived state`
+  從其他 state 推導出來，例如 `canClick`、`showEmptyState`
+
+### 禁忌
+
+- 同一份 server data 由多個 hook 各自維護
+- 用 UI state 偷偷覆蓋 server truth，卻沒有校準策略
+- 在 component tree 多處各自判斷 role / auth / forbidden
+
+---
+
+## Review Checklist
+
+做前端 PR review 時，可以直接檢查：
+
+1. 這個頁面有沒有列出完整 state inventory？
+2. `401`、`403`、`404`、`500` 的 UI 是否被區分？
+3. empty state 是否和 error state 分開？
+4. source of truth 是否只有一份？
+5. placeholder / mock data 是否有被明確標示？
+6. 非 happy path 是否有對應測試或至少有設計說明？
+
+---
+
+## 建議下一步
+
+可以優先為以下兩塊補正式 state inventory：
+
+1. `dashboard` 的 `auth + protected routes + channel config`
+2. `tachimint` 的 `viewer home / mining flow`

--- a/docs/tachimint/component-contract.md
+++ b/docs/tachimint/component-contract.md
@@ -1,0 +1,738 @@
+# Tachimint Component Contract
+
+## 目標
+
+定義 `tachimint` 第一版前端的 component tree 與 component contract，作為後續：
+
+- React 切版
+- state 下放 / props 設計
+- UI 重構
+
+的基準文件。
+
+這份文件承接：
+
+- [home-wireframe-contract.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/home-wireframe-contract.md)
+- [secondary-panels-wireframe-contract.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/secondary-panels-wireframe-contract.md)
+- [target-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/target-state-inventory.md)
+- [design-tokens.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/design-tokens.md)
+
+---
+
+## 原則
+
+### 1. Layout component 不應擁有業務 state
+
+像：
+
+- `AppShell`
+- `TopStatusBar`
+- `BottomTabBar`
+- `PanelHeader`
+
+這類元件應該只接收 props，不自己發 request、不自己推導 auth / heartbeat / balance。
+
+### 2. State 應由 hook 擁有，component 只做表達
+
+目標對齊：
+
+- `useTwitch`
+- `useWatchSession`
+- `useHeartbeat`
+- `useBalance`
+- `useClickBoost`
+- `useBits`
+
+component 只負責：
+
+- render
+- event callback
+- variant 切換
+
+### 3. Home 與 Secondary Panels 共用基礎元件
+
+不要每個 tab 都各自重新發明：
+
+- header
+- status banner
+- card
+- badge
+- placeholder
+- bottom nav
+
+---
+
+## 目標 Component Tree
+
+```text
+TachimintApp
+└─ AppShell
+   ├─ TopStatusBar
+   ├─ StatusBannerHost
+   ├─ ActivePanel
+   │  ├─ HomePanel
+   │  │  ├─ MiningStage
+   │  │  │  ├─ MiningVisual
+   │  │  │  ├─ PointsDisplay
+   │  │  │  ├─ MineAction
+   │  │  │  └─ GainLayer
+   │  │  ├─ ResourceRow
+   │  │  │  ├─ ResourceCard
+   │  │  │  ├─ ResourceCard
+   │  │  │  └─ HeartbeatCard
+   │  │  └─ BitsStrip
+   │  │     └─ BitsProductCard
+   │  ├─ MissionsPanel
+   │  │  ├─ PanelHeader
+   │  │  ├─ FeatureCard
+   │  │  ├─ MissionCard[]
+   │  │  └─ FooterHint
+   │  ├─ EquipmentPanel
+   │  │  ├─ PanelHeader
+   │  │  ├─ LoadoutCard
+   │  │  ├─ EquipmentSlot[]
+   │  │  ├─ ItemPreviewCard[]
+   │  │  └─ FooterHint
+   │  └─ ShopPanel
+   │     ├─ PanelHeader
+   │     ├─ FeatureCard
+   │     ├─ ShopItemCard[]
+   │     └─ FooterHint
+   └─ BottomTabBar
+```
+
+---
+
+## Root Layer
+
+## `TachimintApp`
+
+### 責任
+
+- 組合各支 hook
+- 根據 `role / auth / activeTab` 決定 render 路徑
+- 把 state 映射成 UI props
+
+### 不應負責
+
+- 直接寫大量 JSX 結構
+- 在 component tree 內直接散落 API 呼叫
+
+### 建議輸出給 `AppShell`
+
+- `statusBarProps`
+- `bannerProps`
+- `activeTab`
+- `panelProps`
+- `tabBarProps`
+
+---
+
+## `AppShell`
+
+### 責任
+
+- 提供固定 layout 骨架
+- 排出：
+  - header
+  - banner slot
+  - active panel
+  - bottom nav
+
+### Props 建議
+
+- `header`
+- `banner`
+- `children`
+- `tabBar`
+
+### 不應負責
+
+- 自己判斷 auth state
+- 自己判斷哪個 panel 顯示什麼
+
+---
+
+## Home Panel Components
+
+## `HomePanel`
+
+### 責任
+
+組合首頁各區塊：
+
+- `MiningStage`
+- `ResourceRow`
+- `BitsStrip`
+
+### Props 建議
+
+- `miningStage`
+- `resources`
+- `bits`
+
+### 不應負責
+
+- 自己發 heartbeat
+- 自己管理 click cooldown
+
+---
+
+## `MiningStage`
+
+### 責任
+
+承載首頁主焦點：
+
+- capybara miner
+- 主數字
+- CTA
+- cooldown / gain layer
+
+### 子元件
+
+- `MiningVisual`
+- `PointsDisplay`
+- `MineAction`
+- `GainLayer`
+
+### Props 建議
+
+- `primaryValue`
+- `secondaryLabel`
+- `cta`
+- `cooldown`
+- `gain`
+- `visualVariant`
+
+### 狀態變體
+
+- `loading`
+- `ready`
+- `cooldown`
+- `disabled`
+- `error-hint`
+
+---
+
+## `MiningVisual`
+
+### 責任
+
+- 顯示 capybara miner
+- 顯示輕量背景氛圍
+
+### 不應負責
+
+- 顯示主數字
+- 直接顯示 request 狀態文案
+
+---
+
+## `PointsDisplay`
+
+### 責任
+
+- 顯示主數字
+- 顯示 label / subtext
+- 支援 skeleton / error / animating
+
+### Props 建議
+
+- `value`
+- `label`
+- `subtext`
+- `state`
+
+### 狀態變體
+
+- `loading`
+- `ready`
+- `animating`
+- `error`
+
+---
+
+## `MineAction`
+
+### 責任
+
+- 顯示主 CTA
+- 顯示 cooldown / pending / disabled 文案
+- 接收 `onPress`
+
+### Props 建議
+
+- `state`
+- `cooldownMs`
+- `disabledReason`
+- `onPress`
+
+### 狀態變體
+
+- `ready`
+- `cooldown`
+- `pending`
+- `disabled`
+
+### 不應負責
+
+- 計算 cooldown
+- 發 click request
+
+---
+
+## `GainLayer`
+
+### 責任
+
+- 顯示 gain 浮字
+- 顯示 cooldown ring
+- 顯示短期 bump / glow
+
+### Props 建議
+
+- `gain`
+- `isAnimating`
+- `cooldownMs`
+
+### 原則
+
+- 永遠是覆蓋層
+- 不應成為主要內容承載者
+
+---
+
+## `ResourceRow`
+
+### 責任
+
+- 排列資源與狀態小卡
+
+### 子元件
+
+- `ResourceCard`
+- `HeartbeatCard`
+
+### Props 建議
+
+- `items`
+
+---
+
+## `ResourceCard`
+
+### 用途
+
+顯示：
+
+- `Spendable`
+- `Cumulative`
+
+### Props 建議
+
+- `label`
+- `value`
+- `state`
+- `trend`
+
+### 狀態變體
+
+- `loading`
+- `ready`
+- `error`
+
+---
+
+## `HeartbeatCard`
+
+### 用途
+
+顯示 heartbeat / session 的摘要狀態。
+
+### Props 建議
+
+- `state`
+- `caption`
+
+### 狀態變體
+
+- `running`
+- `error`
+- `idle`
+
+---
+
+## `BitsStrip`
+
+### 責任
+
+- 顯示首頁 bits 模組
+- 保持它是次要功能，不主導頁面
+
+### Props 建議
+
+- `state`
+- `products`
+- `featuredProduct`
+- `onBuy`
+
+### 狀態變體
+
+- `unavailable`
+- `idle`
+- `pending`
+- `success`
+- `error`
+
+---
+
+## `BitsProductCard`
+
+### 責任
+
+- 顯示單一 bits 商品
+- 處理 label / price / CTA 的 render
+
+### 不應負責
+
+- 直接發 purchase request
+
+---
+
+## Shared Secondary Panel Components
+
+## `PanelHeader`
+
+### 責任
+
+- 顯示 panel title
+- 顯示 helper text
+- 保持各 tab header 一致
+
+### Props 建議
+
+- `title`
+- `subtitle`
+- `statusHint`
+
+---
+
+## `FeatureCard`
+
+### 用途
+
+承載每個 panel 最上方的重點區塊：
+
+- featured mission
+- loadout block
+- featured offer
+
+### Props 建議
+
+- `title`
+- `description`
+- `meta`
+- `state`
+- `children`
+
+---
+
+## `FooterHint`
+
+### 用途
+
+- 補充 placeholder / future note
+
+### Props 建議
+
+- `text`
+- `tone`
+
+---
+
+## Missions Components
+
+## `MissionsPanel`
+
+### 責任
+
+- 組合任務頁的 header、featured mission、mission list、footer
+
+### 子元件
+
+- `PanelHeader`
+- `FeatureCard`
+- `MissionCard`
+- `FooterHint`
+
+### Props 建議
+
+- `featuredMission`
+- `missions`
+- `state`
+
+---
+
+## `MissionCard`
+
+### Props 建議
+
+- `title`
+- `description`
+- `status`
+- `progress`
+- `reward`
+- `locked`
+
+### 狀態變體
+
+- `preview`
+- `locked`
+- `active`
+- `upcoming`
+
+---
+
+## Equipment Components
+
+## `EquipmentPanel`
+
+### 子元件
+
+- `PanelHeader`
+- `LoadoutCard`
+- `EquipmentSlot`
+- `ItemPreviewCard`
+- `FooterHint`
+
+### Props 建議
+
+- `loadout`
+- `slots`
+- `items`
+- `state`
+
+---
+
+## `LoadoutCard`
+
+### 責任
+
+- 顯示 capybara / miner mini view
+- 顯示 slot summary
+
+### Props 建議
+
+- `visual`
+- `slots`
+- `state`
+
+---
+
+## `EquipmentSlot`
+
+### Props 建議
+
+- `slotName`
+- `filled`
+- `locked`
+- `itemName`
+
+---
+
+## `ItemPreviewCard`
+
+### Props 建議
+
+- `name`
+- `type`
+- `rarity`
+- `effectText`
+- `state`
+
+### 狀態變體
+
+- `preview`
+- `locked`
+- `equipped`
+
+---
+
+## Shop Components
+
+## `ShopPanel`
+
+### 子元件
+
+- `PanelHeader`
+- `FeatureCard`
+- `ShopItemCard`
+- `FooterHint`
+
+### Props 建議
+
+- `featuredOffer`
+- `items`
+- `state`
+
+---
+
+## `ShopItemCard`
+
+### Props 建議
+
+- `name`
+- `type`
+- `description`
+- `priceLabel`
+- `state`
+- `onPress`
+
+### 狀態變體
+
+- `available`
+- `pending`
+- `preview`
+- `unavailable`
+- `locked`
+
+---
+
+## Global Components
+
+## `TopStatusBar`
+
+### 責任
+
+- 顯示當前 tab 的全局狀態摘要
+
+### Props 建議
+
+- `title`
+- `contextLabel`
+- `statusDots`
+- `rightChip`
+
+---
+
+## `StatusBannerHost`
+
+### 責任
+
+- 接收優先順序最高的一條 banner
+- 確保只渲染一條主 banner
+
+### Props 建議
+
+- `banner`
+
+---
+
+## `BottomTabBar`
+
+### 責任
+
+- 顯示四個主 tab
+- 處理 active tab 切換
+
+### Props 建議
+
+- `tabs`
+- `activeTab`
+- `onTabChange`
+
+---
+
+## Component 與 State Ownership 對應
+
+### `useTwitch`
+
+主要餵給：
+
+- `TopStatusBar`
+- `StatusBannerHost`
+- `BitsStrip`
+- role gate / non-viewer branch
+
+### `useWatchSession`
+
+主要餵給：
+
+- `StatusBannerHost`
+- `MineAction`
+- `HeartbeatCard`
+
+### `useHeartbeat`
+
+主要餵給：
+
+- `HeartbeatCard`
+- `StatusBannerHost`
+
+### `useBalance`
+
+主要餵給：
+
+- `PointsDisplay`
+- `ResourceCard`
+- `GainLayer`
+
+### `useClickBoost`
+
+主要餵給：
+
+- `MineAction`
+- `GainLayer`
+
+### `useBits`
+
+主要餵給：
+
+- `BitsStrip`
+- `BitsProductCard`
+
+---
+
+## 第一階段實作切分建議
+
+### Step 1
+
+先做 layout 與 shared UI：
+
+- `AppShell`
+- `TopStatusBar`
+- `StatusBannerHost`
+- `BottomTabBar`
+- `PanelHeader`
+- `FeatureCard`
+- `FooterHint`
+
+### Step 2
+
+做 Home 核心：
+
+- `HomePanel`
+- `MiningStage`
+- `PointsDisplay`
+- `MineAction`
+- `ResourceRow`
+- `BitsStrip`
+
+### Step 3
+
+做 secondary panels 的 placeholder 版：
+
+- `MissionsPanel`
+- `EquipmentPanel`
+- `ShopPanel`
+
+---
+
+## 驗收清單
+
+1. `App.tsx` 不再直接承載大段首頁 JSX
+2. 每個 component 的責任可以用一句話說清楚
+3. state 來源與 component 顯示關係一致
+4. shared UI 不會在四個 tab 各複製一份
+5. component tree 足以支撐第一階段實作，不需要邊做邊重想結構

--- a/docs/tachimint/design-draft.md
+++ b/docs/tachimint/design-draft.md
@@ -1,0 +1,424 @@
+# Tachimint Design Draft
+
+## 目標
+
+提供 `tachimint` 第一版前端設計草案，作為後續：
+
+- Figma wireframe
+- component 設計
+- 前端實作切版
+
+的共同基準。
+
+這份草案不是最終高保真設計稿，而是偏向：
+
+- 結構先行
+- 視覺方向明確
+- state 可落地
+- placeholder 誠實
+
+---
+
+## 設計前提
+
+這份草案建立在以下原則上：
+
+- `Twitch-native first`
+- `GameFi flavor second`
+- 小面積 panel 可讀性優先
+- 真實 API 與 placeholder 必須分清楚
+
+參考文件：
+
+- [visual-principles.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/visual-principles.md)
+- [home-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/home-state-inventory.md)
+- [target-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/target-state-inventory.md)
+
+---
+
+## 版型總覽
+
+### Form Factor
+
+目標尺寸優先考慮：
+
+- `360 x 720`
+- `318 x 500`
+
+整體應是一個直式 Twitch Extension panel，而不是手機 app mockup。
+
+### 畫面骨架
+
+建議固定為四段：
+
+1. Top status bar
+2. Home / panel content
+3. Secondary utility strip
+4. Bottom navigation
+
+說明：
+
+- Top status bar 負責身份、狀態、資源摘要
+- Home / panel content 放主要互動
+- Secondary utility strip 放補充資訊或輕量 CTA
+- Bottom nav 切換主面板
+
+---
+
+## 首頁 Home / Mining
+
+### 目標
+
+使用者一進來必須在幾秒內看懂：
+
+- 現在是不是 viewer
+- auth / session 是否正常
+- 可不可以挖
+- 現在有多少 points
+- 是否有 bits boost 可以買
+
+### 結構草案
+
+#### 1. Header
+
+內容：
+
+- `Tachimint` 小標
+- 頻道或目前所在 context 摘要
+- 右上角 status cluster
+
+status cluster 可包含：
+
+- auth degraded dot
+- bits availability dot
+- session / heartbeat 小狀態
+
+風格：
+
+- 高度低
+- 緊湊
+- 不做大型 hero
+
+#### 2. Main Mining Stage
+
+內容：
+
+- capybara miner 主視覺
+- 主 points 數字
+- 次要 points 說明
+- 主 CTA：`Mine`
+- cooldown / gain feedback
+
+設計要點：
+
+- capybara 是辨識點，但不是插畫展板
+- points 數字要比角色更容易掃到
+- CTA 永遠在首屏中央區域
+
+#### 3. Resource Row
+
+建議在主舞台下方放一列 2~3 個小卡：
+
+- `Spendable`
+- `Cumulative`
+- `Heartbeat`
+
+用途：
+
+- 把核心數值拆出來
+- 避免所有資訊都壓在主舞台上
+
+#### 4. Bits Strip
+
+形式：
+
+- 單列卡片或橫向小模組
+
+內容：
+
+- 最主要的 bits boost 商品
+- pending / unavailable / success 狀態
+
+目的：
+
+- 讓 bits 是「可見的次要功能」
+- 但不搶首頁主要焦點
+
+#### 5. Bottom Nav
+
+固定四個 tab：
+
+- `Home`
+- `Missions`
+- `Equipment`
+- `Shop`
+
+風格：
+
+- 簡潔 icon + label
+- active tab 清楚
+- 不做過重遊戲快捷欄
+
+---
+
+## Home 狀態草圖
+
+### A. Context Loading
+
+畫面：
+
+- 中央 loading
+- 簡短文案：`Connecting to Twitch…`
+
+不要：
+
+- 顯示完整主 UI skeleton 太久
+
+### B. Viewer Ready
+
+畫面：
+
+- 完整 Home 結構
+- `Mine` 可操作
+- points 與 bits 區塊可見
+
+### C. Non-viewer View
+
+適用：
+
+- broadcaster
+- moderator
+- external
+
+畫面：
+
+- 簡潔提示卡
+- 說明此 extension 主要提供 viewer 使用
+
+不要：
+
+- 落回 viewer 主畫面
+
+### D. Auth Degraded
+
+畫面：
+
+- Header 有 degraded indicator
+- Home 內有一塊明確 banner / inline notice
+
+原則：
+
+- 不再只靠紅點
+- 要讓使用者知道是暫時性問題還是未綁定問題
+
+### E. Session Starting
+
+畫面：
+
+- `Mine` disabled
+- 顯示 `Preparing session…`
+
+### F. Click Cooldown
+
+畫面：
+
+- `Mine` 按鈕 disabled
+- 明確顯示秒數
+- 可用 ring 或文字倒數
+
+### G. Heartbeat Error
+
+畫面：
+
+- Home 保持可讀
+- 顯示一條 degraded banner 或 small card
+
+不要：
+
+- 完全無提示
+
+### H. Bits Pending / Success / Error
+
+bits strip 應有 3 種狀態切換：
+
+- `pending`
+- `success`
+- `error`
+
+且不應把整個首頁切成交易完成畫面。
+
+---
+
+## Missions Panel 草案
+
+### 目標
+
+在 API 尚未完全接好前，先讓這個 panel 有清楚結構與誠實 placeholder。
+
+### 結構
+
+1. panel title
+2. active mission card
+3. upcoming / locked mission list
+
+### 視覺方向
+
+- 比 Home 更資訊型
+- 仍保留遊戲化卡片語言
+- 但不要變成完整 quest journal
+
+### Placeholder 規則
+
+若尚未接真 API：
+
+- 標示 `Planned`
+- 標示 `Locked`
+- 標示 `Coming soon`
+
+不要假裝 countdown、reward、progress 都是真的。
+
+---
+
+## Equipment Panel 草案
+
+### 目標
+
+先建立「裝備感」而不是先做完整 inventory 系統。
+
+### 結構
+
+1. character / miner mini view
+2. equipment slots
+3. item preview cards
+
+### 視覺方向
+
+- 可借用 RPG slot 語法
+- 但要壓低厚重 fantasy 味
+
+比較接近：
+
+- 輕量 avatar upgrade panel
+
+而不是：
+
+- Diablo 背包
+- MMO 紙娃娃系統
+
+### Placeholder 規則
+
+- 直接標 `Not connected`
+- 或 `Equipment preview`
+
+---
+
+## Shop Panel 草案
+
+### 目標
+
+讓商城是清楚、可信的補充功能，不變成首頁第二主角。
+
+### 結構
+
+1. featured boost
+2. product list
+3. unavailable / coming soon items
+
+### 視覺方向
+
+- 比 missions / equipment 更接近 Twitch extension 交易模組
+- 保持乾淨、可掃描
+
+### 不要做成
+
+- Web3 NFT marketplace
+- 金融商品列表
+- 重型 fantasy 商人 UI
+
+---
+
+## 元件清單
+
+這份草案建議至少先定以下元件：
+
+- `TopStatusBar`
+- `StatusDot`
+- `StatusBanner`
+- `MiningStage`
+- `PointsDisplay`
+- `MineButton`
+- `CooldownRing`
+- `GainFloat`
+- `ResourceMiniCard`
+- `BitsStrip`
+- `BitsProductCard`
+- `PanelHeader`
+- `PlaceholderCard`
+- `BottomTabBar`
+
+---
+
+## 視覺層級
+
+### 首要層級
+
+- main points
+- main CTA
+- session / cooldown 狀態
+
+### 次要層級
+
+- cumulative / spendable breakdown
+- bits boost
+- panel nav
+
+### 第三級
+
+- 裝飾性背景
+- 額外小圖示
+- flavor 文案
+
+原則：
+
+- 遊戲 flavor 永遠不能蓋過首要層級
+
+---
+
+## 文案草案
+
+### 可直接拿來試的短文案
+
+- `Mine`
+- `Cooldown`
+- `Preparing session`
+- `Bits boost`
+- `Mission preview`
+- `Equipment preview`
+- `Shop preview`
+- `Viewer only`
+- `Temporarily unavailable`
+
+### 文案原則
+
+- 儘量短
+- 先可理解，再談 flavor
+- extension 內避免長段敘事
+
+---
+
+## 設計驗收清單
+
+1. 首頁一屏內看得懂核心互動
+2. 非 viewer 不會誤進主挖礦畫面
+3. auth / heartbeat / cooldown 狀態有可見 UI
+4. missions / equipment / shop 的 placeholder 不會誤導
+5. 整體像 Twitch extension，不像獨立產品
+6. 遊戲感存在，但沒有壓過資訊可讀性
+
+---
+
+## 後續建議
+
+1. 補一份 `design-tokens.md`
+2. 依這份草案畫 `Home / Mining` wireframe
+3. 再做一次 `Home` 的 component contract 拆解

--- a/docs/tachimint/design-tokens.md
+++ b/docs/tachimint/design-tokens.md
@@ -1,0 +1,464 @@
+# Tachimint Design Tokens
+
+## 目標
+
+定義 `tachimint` 第一版設計 tokens，作為：
+
+- Figma styles
+- CSS variables
+- React component styling
+
+的共同基準。
+
+這份文件的目標不是一次做出完整 design system，而是先固定最重要的視覺骨架，避免後續：
+
+- 每個畫面自己挑色
+- 間距與圓角風格飄移
+- 狀態色不一致
+- extension panel 在不同頁面像不同產品
+
+參考文件：
+
+- [visual-principles.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/visual-principles.md)
+- [design-draft.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/design-draft.md)
+
+---
+
+## Token 使用原則
+
+### 1. 先服務可讀性
+
+所有 token 都要先服務：
+
+- 小面積可讀性
+- 狀態辨識
+- Twitch 深色環境相容性
+
+### 2. 紫色是系統語言，不是裝飾洪水
+
+`tachimint` 可以使用 Twitch-compatible purple，但應作為：
+
+- active
+- focus
+- selection
+- key CTA
+
+而不是整片背景都變亮紫。
+
+### 3. 金色只作為獎勵點綴
+
+gold / amber 只能用在：
+
+- gain
+- reward
+- highlight accent
+
+不要把所有卡片都做成金邊 fantasy 卡。
+
+---
+
+## 色彩 Tokens
+
+### Core Surface
+
+```text
+--tm-color-bg-app:        #0E0E13
+--tm-color-bg-panel:      #15151D
+--tm-color-bg-elevated:   #1D1D2A
+--tm-color-bg-muted:      #242437
+--tm-color-bg-overlay:    rgba(8, 8, 12, 0.72)
+```
+
+用途：
+
+- `bg-app`: 最外層背景
+- `bg-panel`: 主 panel / card
+- `bg-elevated`: hover / active surface
+- `bg-muted`: 次要區塊、placeholder
+
+### Border / Divider
+
+```text
+--tm-color-border-soft:   rgba(255, 255, 255, 0.08)
+--tm-color-border-strong: rgba(255, 255, 255, 0.16)
+--tm-color-divider:       rgba(255, 255, 255, 0.06)
+```
+
+原則：
+
+- 優先用透明白做邊界
+- 不用太亮的實線框
+
+### Text
+
+```text
+--tm-color-text-primary:   #F6F7FB
+--tm-color-text-secondary: #B7B8C9
+--tm-color-text-muted:     #8A8CA4
+--tm-color-text-disabled:  #66687D
+--tm-color-text-inverse:   #0E0E13
+```
+
+用途：
+
+- `primary`: 主數字、標題、CTA 文字
+- `secondary`: 說明、次要數值
+- `muted`: placeholder / 備註
+
+### Brand / Accent
+
+```text
+--tm-color-brand-500:     #9147FF
+--tm-color-brand-400:     #A970FF
+--tm-color-brand-300:     #BF94FF
+--tm-color-brand-soft:    rgba(145, 71, 255, 0.18)
+```
+
+說明：
+
+- `brand-500` 為主 CTA、active tab、focus accent
+- `brand-soft` 用於 selected surface 或 glow 的輕量底色
+
+### Reward / Mining Accent
+
+```text
+--tm-color-reward-500:    #F4C86A
+--tm-color-reward-400:    #FFD98E
+--tm-color-reward-soft:   rgba(244, 200, 106, 0.16)
+```
+
+用途：
+
+- gain 浮字
+- reward highlight
+- mining 主舞台的小面積點綴
+
+### System Status
+
+```text
+--tm-color-success-500:   #3DD6A0
+--tm-color-success-soft:  rgba(61, 214, 160, 0.16)
+
+--tm-color-info-500:      #53B7F7
+--tm-color-info-soft:     rgba(83, 183, 247, 0.16)
+
+--tm-color-warning-500:   #FFB84D
+--tm-color-warning-soft:  rgba(255, 184, 77, 0.16)
+
+--tm-color-error-500:     #FF6B81
+--tm-color-error-soft:    rgba(255, 107, 129, 0.16)
+
+--tm-color-cooldown-500:  #8FA2FF
+--tm-color-cooldown-soft: rgba(143, 162, 255, 0.16)
+```
+
+建議對應：
+
+- `success`: bits 完成、可用狀態
+- `info`: session / heartbeat running
+- `warning`: unavailable / planned / coming soon
+- `error`: auth degraded / request fail
+- `cooldown`: click cooldown ring 與數字
+
+---
+
+## 字體 Tokens
+
+### Font Family
+
+建議先以高可讀無襯線為主：
+
+```text
+--tm-font-sans: "Inter", "Segoe UI", sans-serif
+--tm-font-display: "Inter", "Segoe UI", sans-serif
+--tm-font-mono: "JetBrains Mono", "SFMono-Regular", monospace
+```
+
+說明：
+
+- 不建議上來就用重 fantasy display font
+- `display` 仍用同一家族，靠字重與 spacing 做辨識
+
+### Font Size
+
+```text
+--tm-font-size-10: 10px
+--tm-font-size-12: 12px
+--tm-font-size-14: 14px
+--tm-font-size-16: 16px
+--tm-font-size-18: 18px
+--tm-font-size-20: 20px
+--tm-font-size-24: 24px
+--tm-font-size-32: 32px
+```
+
+### Font Weight
+
+```text
+--tm-font-weight-regular: 400
+--tm-font-weight-medium:  500
+--tm-font-weight-semibold: 600
+--tm-font-weight-bold:    700
+```
+
+### Line Height
+
+```text
+--tm-line-height-tight:   1.15
+--tm-line-height-snug:    1.3
+--tm-line-height-normal:  1.5
+```
+
+### Typography Roles
+
+```text
+--tm-type-title-lg:   700 24px/1.15 var(--tm-font-display)
+--tm-type-title-md:   700 20px/1.15 var(--tm-font-display)
+--tm-type-title-sm:   600 16px/1.3  var(--tm-font-display)
+
+--tm-type-body-md:    400 14px/1.5  var(--tm-font-sans)
+--tm-type-body-sm:    400 12px/1.5  var(--tm-font-sans)
+
+--tm-type-label-md:   600 12px/1.3  var(--tm-font-sans)
+--tm-type-label-sm:   600 10px/1.3  var(--tm-font-sans)
+
+--tm-type-number-xl:  700 32px/1.0  var(--tm-font-display)
+--tm-type-number-lg:  700 24px/1.0  var(--tm-font-display)
+--tm-type-number-md:  700 18px/1.0  var(--tm-font-display)
+```
+
+---
+
+## Spacing Tokens
+
+### Space Scale
+
+```text
+--tm-space-2:   2px
+--tm-space-4:   4px
+--tm-space-6:   6px
+--tm-space-8:   8px
+--tm-space-10:  10px
+--tm-space-12:  12px
+--tm-space-16:  16px
+--tm-space-20:  20px
+--tm-space-24:  24px
+--tm-space-32:  32px
+```
+
+### 用法建議
+
+- 微小圖示 / dot 間距：`4-6`
+- card 內 padding：`12-16`
+- section 間距：`16-20`
+- panel 主要段落間距：`20-24`
+
+---
+
+## Radius Tokens
+
+```text
+--tm-radius-sm:  8px
+--tm-radius-md:  12px
+--tm-radius-lg:  16px
+--tm-radius-xl:  20px
+--tm-radius-pill: 999px
+```
+
+原則：
+
+- 小型 chips / status dot container：`sm`
+- 一般 card / button：`md`
+- mining stage / major panel：`lg`
+
+不要：
+
+- 每個元件都圓到像手機 app 卡片
+
+---
+
+## Shadow Tokens
+
+```text
+--tm-shadow-sm:  0 2px 8px rgba(0, 0, 0, 0.18)
+--tm-shadow-md:  0 8px 24px rgba(0, 0, 0, 0.24)
+--tm-shadow-lg:  0 16px 40px rgba(0, 0, 0, 0.32)
+
+--tm-glow-brand: 0 0 0 1px rgba(145, 71, 255, 0.18), 0 8px 24px rgba(145, 71, 255, 0.16)
+--tm-glow-reward: 0 0 0 1px rgba(244, 200, 106, 0.18), 0 8px 24px rgba(244, 200, 106, 0.14)
+```
+
+原則：
+
+- 陰影要偏柔，不要像浮空 modal
+- glow 只給 CTA、active 狀態、小面積 reward accent
+
+---
+
+## Motion Tokens
+
+```text
+--tm-motion-fast:   120ms
+--tm-motion-base:   180ms
+--tm-motion-slow:   260ms
+
+--tm-ease-standard: cubic-bezier(0.2, 0.0, 0, 1)
+--tm-ease-emphasis: cubic-bezier(0.2, 0.8, 0.2, 1)
+```
+
+用途：
+
+- hover / press：`fast`
+- tab / card transition：`base`
+- gain bump / stage emphasis：`slow`
+
+---
+
+## Layout Tokens
+
+```text
+--tm-panel-max-width:   360px
+--tm-panel-min-width:   318px
+--tm-header-height:     48px
+--tm-bottom-nav-height: 60px
+--tm-mining-stage-min-height: 220px
+```
+
+---
+
+## Component Tokens
+
+### Top Status Bar
+
+```text
+--tm-header-bg:           rgba(21, 21, 29, 0.88)
+--tm-header-border:       var(--tm-color-border-soft)
+--tm-header-padding-x:    var(--tm-space-12)
+--tm-header-padding-y:    var(--tm-space-10)
+```
+
+### Main CTA
+
+```text
+--tm-button-primary-bg:         linear-gradient(180deg, #A970FF 0%, #9147FF 100%)
+--tm-button-primary-text:       #FFFFFF
+--tm-button-primary-radius:     var(--tm-radius-lg)
+--tm-button-primary-shadow:     var(--tm-glow-brand)
+--tm-button-primary-padding-x:  18px
+--tm-button-primary-padding-y:  12px
+```
+
+### Cooldown CTA
+
+```text
+--tm-button-cooldown-bg:        #2B2D42
+--tm-button-cooldown-text:      var(--tm-color-cooldown-500)
+--tm-button-cooldown-ring:      var(--tm-color-cooldown-500)
+```
+
+### Resource Card
+
+```text
+--tm-card-bg:              var(--tm-color-bg-panel)
+--tm-card-border:          var(--tm-color-border-soft)
+--tm-card-radius:          var(--tm-radius-md)
+--tm-card-padding:         var(--tm-space-12)
+--tm-card-shadow:          var(--tm-shadow-sm)
+```
+
+### Status Banner
+
+```text
+--tm-banner-radius:        var(--tm-radius-md)
+--tm-banner-padding-x:     var(--tm-space-12)
+--tm-banner-padding-y:     var(--tm-space-10)
+```
+
+Banner variants：
+
+- success：`success-soft + success-500`
+- error：`error-soft + error-500`
+- warning：`warning-soft + warning-500`
+- info：`info-soft + info-500`
+
+### Bottom Nav
+
+```text
+--tm-tabbar-bg:            rgba(17, 17, 24, 0.94)
+--tm-tabbar-border:        var(--tm-color-border-soft)
+--tm-tabbar-active-bg:     var(--tm-color-brand-soft)
+--tm-tabbar-active-text:   var(--tm-color-text-primary)
+--tm-tabbar-inactive-text: var(--tm-color-text-muted)
+```
+
+---
+
+## 狀態對應建議
+
+### Auth Degraded
+
+- 背景：`error-soft`
+- 圖示 / dot：`error-500`
+- 文字：`text-primary`
+
+### Session Starting
+
+- 背景：`info-soft`
+- 圖示：`info-500`
+
+### Heartbeat Running
+
+- 小狀態文字：`info-500`
+- 不需要整塊大面積上色
+
+### Click Gain
+
+- 浮字：`reward-400`
+- 微弱 glow：`glow-reward`
+
+### Bits Success
+
+- 成功狀態：`success-soft + success-500`
+
+### Placeholder / Planned
+
+- 背景：`bg-muted`
+- 文字：`text-secondary`
+- 標籤：`warning-soft + warning-500`
+
+---
+
+## CSS Variable 導入建議
+
+若之後實作，可先從：
+
+```css
+:root {
+  --tm-color-bg-app: #0E0E13;
+  --tm-color-bg-panel: #15151D;
+  --tm-color-brand-500: #9147FF;
+  --tm-color-text-primary: #F6F7FB;
+  --tm-space-12: 12px;
+  --tm-radius-md: 12px;
+}
+```
+
+開始，再依 panel / component 擴充。
+
+---
+
+## 驗收清單
+
+1. 同一個頁面內不會出現三套不同紫色
+2. CTA、status、placeholder 都能靠 token 命名一致管理
+3. `Home / Missions / Equipment / Shop` 看起來屬於同一個產品
+4. 色彩與陰影不會讓畫面滑向 launcher / wallet / SaaS 風格
+5. tokens 足以支撐第一版 Figma 與切版，不需要每次重新定義基礎樣式
+
+---
+
+## 後續建議
+
+1. 把這份 token 映射成 Figma color styles / text styles
+2. 依 token 補 `Home / Mining` wireframe contract
+3. 之後再視需要抽出 shared frontend tokens 與 `dashboard` 共用層

--- a/docs/tachimint/home-state-inventory.md
+++ b/docs/tachimint/home-state-inventory.md
@@ -1,0 +1,300 @@
+# Tachimint Home / Mining State Inventory
+
+## 目標
+
+定義 `tachimint` 目前首頁 `Home / Mining` 畫面的真實 state，作為後續重構：
+
+- `useTwitch`
+- `useHeartbeat`
+- `useClickBoost`
+- `useBits`
+
+的基準文件。
+
+這份文件描述的是**現況**，不是目標中的六支 hook 架構，也不是未來 GameFi 完整設計稿。
+
+---
+
+## 使用者
+
+- viewer
+- broadcaster
+- moderator（目前未明確處理）
+- external（目前未明確處理）
+
+---
+
+## 主要任務
+
+1. 等待 Twitch Extension context 與 authorization 就緒
+2. viewer 進入首頁後看到 points、挖礦按鈕與 Bits 商品
+3. heartbeat 定時同步點數
+4. click 觸發點數增益與 cooldown
+5. Bits 交易可進入 pending / success / error 流程
+
+---
+
+## 依賴資料
+
+- `window.Twitch.ext.onContext`
+- `window.Twitch.ext.onAuthorized`
+- `window.Twitch.ext.bits.getProducts`
+- `window.Twitch.ext.bits.useBits`
+- `POST /api/v1/extension/auth/login`
+- heartbeat API（目前前端 contract 與後端預期不一致）
+- click API
+- bits complete API
+
+---
+
+## Source of Truth
+
+### `useTwitch`
+
+持有：
+
+- `context`
+- `jwt`
+- `products`
+- `bitsEnabled`
+- `authError`
+
+說明：
+
+- `context` 決定 viewer / broadcaster 分支
+- `jwt` 目前同時被 `useBits` 與 `useHeartbeat` 使用
+- backend login 失敗時只留下 `authError`，UI 目前只顯示紅點
+
+### `useHeartbeat`
+
+持有：
+
+- `balance`
+- `gain`
+- `isAnimating`
+- `error`
+- `syncBalance()`
+
+說明：
+
+- 目前同時擁有 balance state 與 gain animation ownership
+- `syncBalance()` 被 `useClickBoost` 用來避免下一次 heartbeat 動畫重複計算
+
+### `useClickBoost`
+
+持有：
+
+- `cooldownMs`
+- `isAnimating`
+- `gain`
+
+說明：
+
+- click 成功後會呼叫 `onBalanceUpdate(result.balance)`，目前實際是把 heartbeat hook 裡的 balance 同步掉
+
+### `useBits`
+
+持有：
+
+- `status`
+- `error`
+
+`status` 目前只有四種：
+
+- `idle`
+- `pending`
+- `success`
+- `error`
+
+---
+
+## 狀態表
+
+| State | 觸發條件 | UI 表現 | 是否可操作 | API / 資料來源 |
+|-------|----------|---------|------------|----------------|
+| `context loading` | `context === null` | 全畫面 loading spinner，文字 `Connecting…` | 否 | `useTwitch.context` |
+| `viewer ready` | `context.role === 'viewer'` 且進入主面板 | 顯示 points、mine button、products | 是 | `App.tsx` viewer 分支 |
+| `broadcaster view` | `context.role === 'broadcaster'` | 顯示 broadcaster 專用簡單提示畫面 | 否 | `App.tsx` broadcaster 分支 |
+| `moderator/external undefined` | `context` 存在但 role 非 `viewer` / `broadcaster` | 目前會落回 viewer 主畫面結構，未明確分支 | 部分可操作，但語意不清楚 | `App.tsx` 現況 |
+| `auth degraded` | backend login 失敗，`authError !== null` | header 右上角顯示紅點，title 為錯誤訊息 | 仍可部分操作 | `useTwitch.authError` |
+| `balance unknown` | `balance === null` | points 顯示 `—` | click 可操作與否取決於 viewer/cooldown，不取決於 balance | `useHeartbeat.balance` |
+| `heartbeat success` | `sendHeartbeat()` 成功 | 若有新點數則 balance 更新、顯示 `+N 點` 與 bump 動畫 | 是 | `useHeartbeat` |
+| `heartbeat error` | `sendHeartbeat()` 丟錯 | 畫面沒有獨立錯誤區，只是 hook 內有 `error` state | 是 | `useHeartbeat.error` |
+| `click ready` | `channelId` 存在、`enabled === true`、`cooldownMs === 0` | mine button 可點擊 | 是 | `useClickBoost` |
+| `click cooldown` | `cooldownMs > 0` | mine button disabled，顯示秒數倒數 | 否 | `useClickBoost.cooldownMs` |
+| `click gain` | click 成功後 `gain !== null` | 顯示 `+delta` 浮字 1.5s | 否，通常同時在 cooldown 中 | `useClickBoost.gain` |
+| `click unexpected error` | click 非 429 失敗 | UI 會解除 cooldown，但沒有獨立錯誤訊息 | 會重新可操作 | `useClickBoost` catch 分支 |
+| `bits unavailable` | `bitsEnabled === false` | 顯示 `Bits not available.` | 否 | `useTwitch.bitsEnabled` |
+| `bits idle` | `status === 'idle'` | 顯示商品列表與購買按鈕 | 是 | `useBits.status` |
+| `bits pending` | `status === 'pending'` | 購買按鈕 disabled，文案變 `…` | 否 | `useBits.status` |
+| `bits success` | `status === 'success'` | 顯示 success 區塊與 reload button | 否 | `useBits.status` |
+| `bits error` | `status === 'error'` | 顯示錯誤文字，商品列表仍保留 | 是 | `useBits.error` |
+
+---
+
+## 狀態轉移
+
+### 1. Loading → viewer / broadcaster
+
+1. 初始進入 `context loading`
+2. `window.Twitch.ext.onContext()` 回來後設定 `context`
+3. 若 `context.role === 'broadcaster'`
+   - 進入 `broadcaster view`
+4. 其他情況
+   - 進入主面板
+   - 若 `role === 'viewer'`，heartbeat 會被啟用
+   - 若 `role !== 'viewer'` 且不是 broadcaster，目前沒有明確分支，會落進 viewer 主面板結構
+
+### 2. Viewer → auth degraded
+
+1. `onAuthorized()` 取得 extension JWT
+2. 前端嘗試呼叫 backend login
+3. 若成功：
+   - `setAuthToken(tokens.access_token)`
+   - UI 沒有明確 success state，只是正常運作
+4. 若失敗：
+   - `authError = 'Backend unavailable'`
+   - Header 顯示紅點
+   - Bits 仍可能照常初始化並可用
+
+### 3. Ready → heartbeat success / error
+
+1. `useHeartbeat(enabled: isViewer)` 啟動
+2. 若 heartbeat 成功：
+   - 更新 `balance`
+   - 若新 balance 大於前一筆，顯示 gain 與 bump 動畫
+3. 若 heartbeat 失敗：
+   - hook 內設定 `error = 'Heartbeat failed'`
+   - App 目前沒有把這個 error render 出來
+
+### 4. Ready → click cooldown / gain / error
+
+1. 點擊 mine button
+2. 立即進入 optimistic `click cooldown`
+3. 若 click 成功：
+   - 更新 balance baseline
+   - 顯示 `click gain`
+4. 若 server 回 `retry_after_ms`
+   - cooldown 改用 server 指定秒數
+5. 若非預期錯誤：
+   - cooldown 解除
+   - 沒有獨立錯誤 UI
+
+### 5. Bits idle → pending / success / error
+
+1. 使用者點商品按鈕
+2. 進入 `bits pending`
+3. 若 `onTransactionComplete` + backend 驗證成功：
+   - 進 `bits success`
+4. 若 backend 驗證失敗：
+   - 進 `bits error`
+5. 若 `onTransactionCancelled`
+   - 回 `bits idle`
+
+---
+
+## 已知問題 / 與目標架構落差
+
+### 1. `useHeartbeat` 同時擁有 balance 與 gain animation
+
+現況：
+
+- `useHeartbeat` 既是 heartbeat scheduler，又持有 `balance`、`gain`、`isAnimating`
+
+落差：
+
+- 和後續拆成 `useHeartbeat` + `useBalance` 的方向不一致
+
+### 2. `useTwitch` 目前任何 role 都會嘗試 backend login
+
+現況：
+
+- `onAuthorized()` 後直接 login backend，沒有先看 role
+
+落差：
+
+- 後續目標架構預期應先分 viewer / non-viewer，再決定是否需要 tachigo auth
+
+### 3. auth 失敗只顯示紅點
+
+現況：
+
+- backend login 失敗時只有 `authError` 紅點
+
+落差：
+
+- 後續應拆成可理解的 auth state 與對應畫面，而不是只靠 header indicator
+
+### 4. `moderator / external` 目前沒有明確 UI 分支
+
+現況：
+
+- `App.tsx` 只特判 `broadcaster`
+- 其他非 viewer 角色目前會落回主面板
+
+落差：
+
+- 後續應明確定義 non-viewer policy，至少不要誤用 viewer UI
+
+### 5. heartbeat 目前以 `extensionJwt` 為輸入
+
+現況：
+
+- `useHeartbeat(extensionJwt, { enabled: isViewer })`
+
+落差：
+
+- 後端 watch API 的目標契約應該以 tachigo JWT + `channel_id` 為主，不應由 extension JWT 直接驅動 heartbeat request
+
+### 6. click enabled 條件過寬
+
+現況：
+
+- 只要 `isViewer` 且沒有 cooldown，就可能可點
+
+落差：
+
+- 後續應至少依賴 session ready 與 balance ready，而不是只看 viewer role
+
+### 7. heartbeat error 目前沒有實際 render
+
+現況：
+
+- `useHeartbeat.error` 存在，但 `App.tsx` 沒有顯示
+
+落差：
+
+- 使用者目前看不到 heartbeat 是否失敗，也沒有 retry / degraded UI
+
+---
+
+## 驗收清單
+
+1. 文件中的每個 state 都能對應到目前程式碼裡的真實條件
+2. 至少覆蓋以下情境：
+   - `window.Twitch.ext` 尚未提供 context
+   - `viewer` 正常進首頁
+   - `broadcaster` 顯示非 viewer 畫面
+   - backend login 失敗但 bits 仍可用
+   - heartbeat 失敗
+   - click cooldown
+   - bits pending / success / error
+3. 看完文件後，另一位工程師應能快速知道：
+   - 現在 Home / Mining 的真實 state
+   - 每份 state 現在由哪支 hook 持有
+   - 哪些地方是後續重構的優先缺口
+
+---
+
+## 後續建議
+
+這份文件之後最自然可接兩個方向：
+
+1. 補一份 `target-state-inventory.md`
+   以目標六支 hook 架構重新定義理想 state
+
+2. 依照這份現況文件，開始拆：
+   - `useBalance`
+   - `useWatchSession`
+   - `authState`
+   - non-viewer 分流

--- a/docs/tachimint/home-wireframe-contract.md
+++ b/docs/tachimint/home-wireframe-contract.md
@@ -1,0 +1,504 @@
+# Tachimint Home Wireframe Contract
+
+## 目標
+
+定義 `tachimint` 首頁 `Home / Mining` 的 wireframe contract，讓後續：
+
+- Figma wireframe
+- UI implementation
+- component 切分
+
+都能依照同一套版面與 state 規則進行。
+
+這份文件不追求高保真視覺細節，而是先固定：
+
+- 區塊順序
+- 視覺層級
+- 各 state 進來時要替換哪個區塊
+- 哪些內容必須永遠在首屏內可見
+
+參考文件：
+
+- [design-draft.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/design-draft.md)
+- [design-tokens.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/design-tokens.md)
+- [target-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/target-state-inventory.md)
+
+---
+
+## Wireframe 原則
+
+### 1. 首屏必須看懂核心互動
+
+使用者不應該需要捲動才知道：
+
+- 目前是否可挖
+- 現在有多少 points
+- cooldown 是否存在
+- session / auth 是否異常
+
+### 2. 區塊替換優於整頁切換
+
+除了 `context loading` 與 `non-viewer view` 之外，大部分 state 不應該整頁重畫，而是局部替換：
+
+- header 狀態
+- mining stage CTA
+- banner
+- bits strip
+
+### 3. 主要互動永遠在中段
+
+`Mine` 按鈕、主數字、capybara miner 這三個元素要構成明確中心，不應被 secondary card 或裝飾打散。
+
+---
+
+## 畫面骨架
+
+### 固定骨架
+
+```text
++--------------------------------------------------+
+| Top Status Bar                                   |
++--------------------------------------------------+
+| Optional Inline Banner                           |
++--------------------------------------------------+
+| Main Mining Stage                                |
+| - Capybara / main focus                          |
+| - Primary points                                 |
+| - CTA / cooldown                                 |
++--------------------------------------------------+
+| Resource Row                                     |
+| - Spendable | Cumulative | Heartbeat             |
++--------------------------------------------------+
+| Bits Strip                                       |
++--------------------------------------------------+
+| Bottom Navigation                                |
++--------------------------------------------------+
+```
+
+### 區塊優先順序
+
+1. `Top Status Bar`
+2. `Optional Inline Banner`
+3. `Main Mining Stage`
+4. `Resource Row`
+5. `Bits Strip`
+6. `Bottom Navigation`
+
+---
+
+## 區塊規格
+
+## 1. Top Status Bar
+
+### 目的
+
+承載最小但必要的全局資訊：
+
+- 當前面板標題
+- channel / role context
+- auth / session / bits 小狀態
+
+### 內容
+
+左側：
+
+- `Tachimint`
+- 次要小字：
+  - channel name
+  - 或 `Viewer mode`
+
+右側：
+
+- auth status dot
+- bits status dot
+- heartbeat / session small chip
+
+### 高度建議
+
+- `44px - 52px`
+
+### 不應承載
+
+- 大型標語
+- 大 hero 圖
+- 大量數字資訊
+
+---
+
+## 2. Optional Inline Banner
+
+### 目的
+
+承載重要但不該遮蔽首頁操作的狀態。
+
+### 可出現的 state
+
+- `auth degraded`
+- `heartbeat error`
+- `session starting`
+- `session error`
+
+### 規則
+
+- 一次只顯示一條主 banner
+- 優先顯示最影響操作的狀態
+
+優先順序建議：
+
+1. `session error`
+2. `auth account unlinked`
+3. `auth backend unavailable`
+4. `heartbeat error`
+5. `session starting`
+
+### 畫面形式
+
+- 橫向卡片
+- icon + 1 行標題 + 1 行短說明
+- 可有 secondary action，例如 `Retry`
+
+---
+
+## 3. Main Mining Stage
+
+### 目的
+
+作為首頁主焦點，集中呈現：
+
+- 挖礦角色
+- 主數字
+- 主要 CTA
+- cooldown / gain 回饋
+
+### 區塊拆分
+
+#### A. Focus Visual
+
+內容：
+
+- capybara miner
+- 輕量背景紋理或氛圍層
+
+規則：
+
+- 角色圖不能壓過數字與 CTA
+- 只作為辨識點，不做大型插畫展示
+
+#### B. Primary Points
+
+內容：
+
+- 主數字：建議優先顯示 `spendable`
+- 次要標示：`Points` 或 `Mining balance`
+- 視需要補一行 `+gain`
+
+規則：
+
+- 數字是這一區最重要元素
+- `balance loading` 時用 skeleton 或 placeholder，不能空白
+
+#### C. Main CTA
+
+按鈕文案建議：
+
+- `Mine`
+
+狀態替換：
+
+- `click ready`：主 CTA 可點
+- `click cooldown`：disabled + countdown
+- `session starting`：disabled + `Preparing…`
+- `click error`：恢復 CTA，並透過 banner 或 small text 提示
+
+#### D. Cooldown / Gain Layer
+
+表現方式：
+
+- cooldown ring
+- 數字倒數
+- gain 浮字
+
+規則：
+
+- 這層是輔助層，不可遮住主數字
+- gain 動畫停留短，不影響下一次讀取
+
+### 高度建議
+
+- `220px - 280px`
+
+---
+
+## 4. Resource Row
+
+### 目的
+
+把主舞台之外的核心數值拆出來，提升可掃描性。
+
+### 建議欄位
+
+卡片 1：
+
+- `Spendable`
+
+卡片 2：
+
+- `Cumulative`
+
+卡片 3：
+
+- `Heartbeat`
+
+### 規則
+
+- 固定 3 欄或 2+1 欄
+- 小卡內容只能放 1 個主值 + 1 個 label
+- heartbeat 卡偏狀態型，不要塞太多細節
+
+### 狀態對應
+
+- `balance loading`：前兩張卡 skeleton
+- `balance error`：前兩張卡顯示 error fallback
+- `heartbeat running`：第三張卡顯示 `Synced`
+- `heartbeat error`：第三張卡顯示 degraded 狀態
+
+---
+
+## 5. Bits Strip
+
+### 目的
+
+以低干擾方式呈現首頁內可見的 monetization / boost 模組。
+
+### 結構
+
+左側：
+
+- 商品名稱
+- 小型說明
+
+右側：
+
+- price / CTA
+- pending / success / unavailable 狀態
+
+### 規則
+
+- 只顯示一個 featured product 或最簡化列表
+- 不展開成完整商城
+- `bits unavailable` 時保留區塊，但轉成 disabled / empty 狀態
+
+### 狀態替換
+
+- `bits idle`：可點商品
+- `bits pending`：CTA disabled
+- `bits success`：顯示成功提示，但不整頁 takeover
+- `bits error`：顯示 inline error
+- `bits unavailable`：顯示 `Not available in this channel`
+
+---
+
+## 6. Bottom Navigation
+
+### 目的
+
+在固定版型下提供主面板切換。
+
+### 結構
+
+四個 tab：
+
+- `Home`
+- `Missions`
+- `Equipment`
+- `Shop`
+
+### 規則
+
+- 固定在底部
+- icon + 短 label
+- active state 要比 hover state 更明確
+
+### 不應做成
+
+- 遊戲技能快捷欄
+- 重型 fantasy 金屬按鈕列
+
+---
+
+## 主要 State 替換規則
+
+## A. `context loading`
+
+整頁替換為 loading state。
+
+保留：
+
+- 無
+
+隱藏：
+
+- 所有主 UI 區塊
+
+## B. `non-viewer view`
+
+整頁替換為 non-viewer 提示。
+
+可保留：
+
+- 簡化 header
+
+隱藏：
+
+- mining stage
+- resource row
+- bits strip
+- bottom nav
+
+## C. `auth loading`
+
+保留骨架：
+
+- header
+- main mining stage
+- resource row
+- bits strip
+- bottom nav
+
+替換內容：
+
+- banner 顯示 `Authorizing…`
+- `Mine` disabled
+- points 先不顯示真值
+
+## D. `auth ready`
+
+完整顯示正常 Home。
+
+## E. `auth account unlinked`
+
+保留：
+
+- header
+- banner
+- main stage
+
+替換：
+
+- `Mine` disabled
+- main stage 顯示引導文案
+- bits strip 可視產品決定是否保留
+
+## F. `auth backend unavailable`
+
+保留：
+
+- header
+- banner
+- main stage
+
+替換：
+
+- 主操作停用
+- 明確顯示暫時不可用
+
+## G. `session starting`
+
+保留完整頁面。
+
+替換：
+
+- CTA disabled
+- banner 或 CTA 附近顯示 `Preparing session…`
+
+## H. `session ready`
+
+完整正常狀態。
+
+## I. `heartbeat error`
+
+不整頁替換。
+
+只改：
+
+- banner 顯示 degraded
+- resource row 的 heartbeat card 變成 error 變體
+
+## J. `click cooldown`
+
+只改 main stage：
+
+- CTA disabled
+- 顯示倒數
+- 可持續顯示主數字
+
+## K. `bits pending / success / error`
+
+只改 bits strip。
+
+不要影響：
+
+- mining stage
+- resource row
+- bottom nav
+
+---
+
+## 首屏最低資訊要求
+
+在 `360 x 720` 與 `318 x 500` 內，首屏至少要同時看見：
+
+1. `Tachimint` / context header
+2. 主 points 數字
+3. `Mine` 按鈕
+4. 至少一個狀態提示位置
+5. bottom nav
+
+若空間不足，優先壓縮：
+
+- bits strip 高度
+- decorative space
+- resource row 文案長度
+
+不要壓縮掉：
+
+- 主數字
+- CTA
+- status 提示位
+
+---
+
+## Wireframe 註記規則
+
+在 Figma / wireframe 上，建議每個區塊都標註：
+
+- `real`
+- `placeholder`
+- `state-driven`
+- `optional`
+
+例如：
+
+- `Top Status Bar`：`real`
+- `Bits Strip`：`real`
+- `Missions Tab Content`：`placeholder`
+- `Auth Banner`：`state-driven`
+
+---
+
+## 驗收清單
+
+1. `Mine`、主 points、capybara 三者形成明確中心
+2. 重要 state 優先以區塊替換，而不是整頁重畫
+3. `context loading` 與 `non-viewer view` 是唯二整頁替換情境
+4. `bits` 狀態只影響 bits strip，不搶首頁控制權
+5. 小尺寸下仍能一眼看懂是否可挖
+6. wireframe 可直接交給設計或前端做下一步，不需要再重講版型規則
+
+---
+
+## 後續建議
+
+1. 依這份 contract 畫 `Home / Mining` 低保真 wireframe
+2. 再補 `Missions / Equipment / Shop` 的 wireframe contract
+3. 若開始實作，將各區塊直接映射成 component tree

--- a/docs/tachimint/implementation-checklist.md
+++ b/docs/tachimint/implementation-checklist.md
@@ -1,0 +1,336 @@
+# Tachimint Implementation Checklist
+
+## 目標
+
+把目前 `tachimint` 設計討論文件，整理成可直接拆成 issue / phase 的實作清單。
+
+這份文件不取代：
+
+- [frontend-roadmap.md](/Users/tachikoma/Documents/Web3/tachigo/docs/frontend-roadmap.md)
+- [target-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/target-state-inventory.md)
+- [component-contract.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/component-contract.md)
+
+而是把它們變成「接下來真的要做什麼」。
+
+---
+
+## 範圍原則
+
+### 這一輪要做的
+
+- 收斂 `Home / Mining` 的 state ownership
+- 建立 `AppShell` 與四個 tab 的基本骨架
+- 讓 `viewer / non-viewer` 流程明確
+- 讓 auth / session / heartbeat / click / bits 都有對應 UI state
+- 先把 `Missions / Equipment / Shop` 做成誠實 placeholder
+
+### 這一輪先不要做的
+
+- BOSS 任務真 API 串接
+- 裝備系統真資料與 equip / unequip 流程
+- 完整商城與複雜價格邏輯
+- wallet / NFT / mint flow
+- 大量高保真特效
+
+---
+
+## 建議拆分
+
+## Phase A：Layout 與共用元件骨架
+
+### A1. 建立 `AppShell`
+
+目標：
+
+- 把 `tachimint` 畫面從單一頁面結構拆成固定骨架
+
+包含：
+
+- `TopStatusBar`
+- `StatusBannerHost`
+- active panel slot
+- `BottomTabBar`
+
+完成標準：
+
+- `App.tsx` 不再直接承載大段 layout JSX
+- 四個 tab 有統一外框
+
+### A2. 建立共用 UI primitives
+
+目標：
+
+- 先做四個 tab 都會重用的 UI 元件
+
+建議元件：
+
+- `PanelHeader`
+- `FeatureCard`
+- `StatusBadge`
+- `PlaceholderCard`
+- `FooterHint`
+
+完成標準：
+
+- `Home / Missions / Equipment / Shop` 不再各自發明卡片結構
+
+### A3. 導入第一版 tokens
+
+目標：
+
+- 把 [design-tokens.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/design-tokens.md) 映射成實際 CSS variables 或 styling constants
+
+完成標準：
+
+- 至少色彩、字體、間距、圓角、狀態色有統一來源
+
+---
+
+## Phase B：Home 核心重構
+
+### B1. 建立 `HomePanel`
+
+目標：
+
+- 把首頁拆成：
+  - `MiningStage`
+  - `ResourceRow`
+  - `BitsStrip`
+
+完成標準：
+
+- 首頁主要區塊有清楚 component 邊界
+
+### B2. 把 balance source of truth 收斂到 `useBalance`
+
+目標：
+
+- 不再讓 heartbeat / click 各自持有不同 balance state
+
+完成標準：
+
+- 主數字與 gain animation 都由同一支 hook 驅動
+- click 後不再靠跨 hook 同步 patch 修 UI
+
+### B3. 把 heartbeat 收斂成純同步 hook
+
+目標：
+
+- `useHeartbeat` 只負責 timer 與 refetch trigger
+
+完成標準：
+
+- `useHeartbeat` 不再直接持有 balance / gain / animation
+
+### B4. 重構 click flow
+
+目標：
+
+- 讓 `MineAction` 只負責 render，真正的 cooldown / request / optimistic update 由 `useClickBoost` 控制
+
+完成標準：
+
+- 有明確 `ready / cooldown / pending / error` 狀態
+- `retry_after_ms` 能正確驅動 UI
+
+### B5. 把 bits 模組收成 `BitsStrip`
+
+目標：
+
+- bits 在首頁作為次要功能，不再散在主畫面各處
+
+完成標準：
+
+- 有 `idle / pending / success / error / unavailable` UI
+- bits 狀態不會整頁 takeover
+
+---
+
+## Phase C：Auth / Role / Session 狀態收斂
+
+### C1. 明確 viewer / non-viewer gate
+
+目標：
+
+- `broadcaster / moderator / external` 不再落進 viewer 主畫面
+
+完成標準：
+
+- 只有 `viewer` 會進入 `Home / Mining` 主流程
+- 其他角色有獨立提示畫面
+
+### C2. 把 `authError` 升級成真正 `authState`
+
+目標：
+
+- 不再只靠 header 紅點表達 auth 問題
+
+建議狀態：
+
+- `loading`
+- `ready`
+- `account_unlinked`
+- `backend_unavailable`
+
+完成標準：
+
+- auth 問題有對應 banner / fallback
+
+### C3. 把 `sessionStarting / sessionReady / sessionError` 顯性化
+
+目標：
+
+- start / end flow 不再是隱性行為
+
+完成標準：
+
+- `Mine` 是否可操作明確依賴 session state
+- session error 有實際 UI
+
+---
+
+## Phase D：Secondary Panels Placeholder
+
+### D1. 建立 `MissionsPanel`
+
+目標：
+
+- 先實作 preview / locked 版本
+
+完成標準：
+
+- featured mission + mission list + footer hint 到位
+- 不誤導成真任務系統
+
+### D2. 建立 `EquipmentPanel`
+
+目標：
+
+- 先實作 slot-based preview
+
+完成標準：
+
+- `LoadoutCard`
+- `EquipmentSlot`
+- `ItemPreviewCard`
+
+都能正常顯示 placeholder 狀態
+
+### D3. 建立 `ShopPanel`
+
+目標：
+
+- 先實作輕量 shop / boost panel
+
+完成標準：
+
+- 有 featured offer
+- 有產品卡
+- `preview / unavailable / available` 狀態可切換
+
+---
+
+## Phase E：視覺與互動收斂
+
+### E1. 對齊 Twitch-native 視覺方向
+
+目標：
+
+- 確保畫面不像 launcher / wallet / SaaS dashboard
+
+完成標準：
+
+- `Home` 與三個 secondary panels 在同一套產品語言內
+
+### E2. 補首頁必要動效
+
+目標：
+
+- 補足對狀態有幫助的最小動效
+
+建議範圍：
+
+- gain float
+- cooldown ring
+- CTA press feedback
+- tab 切換過渡
+
+完成標準：
+
+- 動效幫助理解，不干擾閱讀
+
+---
+
+## 建議開票順序
+
+### 第一批
+
+1. `AppShell + BottomTabBar + TopStatusBar`
+2. `HomePanel` 切分
+3. `useBalance / useHeartbeat / useClickBoost` ownership 重構
+4. `viewer / non-viewer gate`
+
+### 第二批
+
+5. `authState` 顯性化
+6. `BitsStrip` 收斂
+7. `MissionsPanel` placeholder
+8. `EquipmentPanel` placeholder
+9. `ShopPanel` placeholder
+
+### 第三批
+
+10. tokens 導入與視覺收斂
+11. 最小動效補強
+
+---
+
+## 每張 Issue 建議模板
+
+### 目標
+
+- 這張票要解什麼 UI / state 問題
+
+### 範圍
+
+- 會改哪些 component / hook / page
+
+### 不包含
+
+- 明確列出這張票先不碰的功能
+
+### 驗收標準
+
+- 列出對應 state
+- 列出是否需要 viewer / non-viewer / error flow 驗證
+
+### 參考文件
+
+- 直接鏈到對應的：
+  - state inventory
+  - wireframe contract
+  - component contract
+
+---
+
+## 最小可上線切片
+
+如果想用最小切片往前推，建議最先完成的是：
+
+1. `AppShell`
+2. `HomePanel`
+3. `useBalance` 作為唯一 points source of truth
+4. `MineAction` 正確 cooldown / pending / error
+5. non-viewer gate
+6. bits strip 的基本狀態
+
+做到這裡，`tachimint` 就會從「原型頁面」進化成比較穩定的 extension UI 基礎。
+
+---
+
+## 驗收清單
+
+1. 可以直接從這份文件拆出 5-10 張 issue
+2. 每張 issue 都能找到對應設計文件
+3. 順序上先解 state ownership，再補視覺細節
+4. 不會在 placeholder 階段誤做過多後端未完成功能

--- a/docs/tachimint/secondary-panels-wireframe-contract.md
+++ b/docs/tachimint/secondary-panels-wireframe-contract.md
@@ -1,0 +1,399 @@
+# Tachimint Secondary Panels Wireframe Contract
+
+## 目標
+
+定義 `tachimint` 次要三個主 tab 的 wireframe contract：
+
+- `Missions`
+- `Equipment`
+- `Shop`
+
+這份文件的目的，是讓這三個 panel 在 API 尚未完整接好前，也能先有：
+
+- 一致的版型
+- 誠實的 placeholder
+- 可延續到正式功能的結構
+
+參考文件：
+
+- [design-draft.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/design-draft.md)
+- [design-tokens.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/design-tokens.md)
+- [target-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/target-state-inventory.md)
+- [home-wireframe-contract.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/home-wireframe-contract.md)
+
+---
+
+## 共用原則
+
+### 1. 次要 panel 不能比 Home 更重
+
+`Home / Mining` 永遠是主舞台。
+
+所以 `Missions / Equipment / Shop` 應該：
+
+- 清楚
+- 可讀
+- 有結構
+
+但不應：
+
+- 比 Home 更像完整遊戲介面
+- 用更重的裝飾搶主角
+
+### 2. Placeholder 要誠實
+
+在真 API 尚未接好前，這三個 panel 可以存在，但必須明確標示：
+
+- `Preview`
+- `Planned`
+- `Locked`
+- `Not connected`
+
+不要假裝成：
+
+- 可真的領取獎勵
+- 可真的裝備
+- 可真的購買完整商城內容
+
+### 3. Panel 版型要共用
+
+三個 panel 應沿用同一組結構語言：
+
+1. panel header
+2. featured block
+3. list / slots / products
+4. optional footer note
+
+---
+
+## 共用畫面骨架
+
+```text
++--------------------------------------------------+
+| Top Status Bar                                   |
++--------------------------------------------------+
+| Panel Header                                     |
+| - Title                                          |
+| - Short status / helper text                     |
++--------------------------------------------------+
+| Featured Block                                   |
++--------------------------------------------------+
+| Main Content List / Slots / Products             |
++--------------------------------------------------+
+| Optional Footer Note / Placeholder Hint          |
++--------------------------------------------------+
+| Bottom Navigation                                |
++--------------------------------------------------+
+```
+
+### 與 Home 的差異
+
+- 不需要 `Optional Inline Banner` 常駐位
+- 不需要大型主 CTA 置中
+- 內容可偏列表型
+
+但仍要保留：
+
+- top status continuity
+- bottom nav continuity
+- 一致的 panel padding / card 語言
+
+---
+
+## Missions Panel
+
+## 目標
+
+提供任務與進度的概念入口，但在後端尚未完成前，不把它畫成完整 quest system。
+
+## 區塊規格
+
+### 1. Panel Header
+
+內容：
+
+- `Missions`
+- 短 helper text，例如：
+  - `Watch and progress`
+  - `Mission preview`
+
+### 2. Featured Mission Block
+
+內容：
+
+- 主要 mission title
+- 簡短說明
+- progress area
+- reward preview
+
+規則：
+
+- 只放 1 張 featured mission
+- 若尚未接 API，progress 要明示為 preview
+
+### 3. Mission List
+
+建議 2~4 張卡：
+
+- `Active`
+- `Upcoming`
+- `Locked`
+
+每張卡可包含：
+
+- title
+- short description
+- status badge
+- optional progress line
+
+### 4. Footer Note
+
+可顯示：
+
+- `More mission types coming soon`
+
+## 狀態替換
+
+### `missions preview only`
+
+- Featured block 顯示 preview 標示
+- list 中至少一張卡標成 `Locked`
+
+### `missions unavailable`
+
+- panel 不消失
+- 轉成 placeholder card + 說明
+
+### `missions real`
+
+- progress 條、reward、status badge 才能改為真資料語氣
+
+## 不應做成
+
+- RPG 任務日誌
+- 大量敘事文本
+- 滿版世界觀說明
+
+---
+
+## Equipment Panel
+
+## 目標
+
+建立裝備概念與 slot-based 結構，但先不要把它畫成完整 inventory game。
+
+## 區塊規格
+
+### 1. Panel Header
+
+內容：
+
+- `Equipment`
+- helper text，例如：
+  - `Upgrade preview`
+  - `Loadout preview`
+
+### 2. Miner Loadout Block
+
+內容：
+
+- capybara / miner mini portrait
+- 2~4 個主要裝備 slot
+
+slot 建議：
+
+- `Tool`
+- `Charm`
+- `Boost`
+- `Skin`
+
+### 3. Item Preview List
+
+每張卡可包含：
+
+- item name
+- rarity / type badge
+- short effect text
+- `Preview` 或 `Locked`
+
+### 4. Footer Note
+
+可顯示：
+
+- `Equipment system not connected yet`
+
+## 狀態替換
+
+### `equipment preview only`
+
+- slot 可見
+- item card 可見
+- 所有 action 皆 disabled
+
+### `equipment locked`
+
+- slot 顯示 lock icon
+- item card 顯示 unlock hint
+
+### `equipment real`
+
+- 才允許顯示 equip / unequip action
+
+## 不應做成
+
+- Diablo 背包
+- MMORPG 紙娃娃
+- 滿格 inventory grid
+
+---
+
+## Shop Panel
+
+## 目標
+
+提供商城與 boost 的統一入口，但保持 Twitch extension 的輕量交易感。
+
+## 區塊規格
+
+### 1. Panel Header
+
+內容：
+
+- `Shop`
+- helper text，例如：
+  - `Boost and upgrades`
+  - `Support with Bits`
+
+### 2. Featured Offer Block
+
+內容：
+
+- 主要 boost / featured item
+- 1 行說明
+- price / availability
+
+規則：
+
+- 這張卡比 list 稍大
+- 但不能做成滿版商城首頁
+
+### 3. Product List
+
+建議 2~4 張產品卡：
+
+- Bits-supported item
+- planned boost
+- locked future item
+
+每張卡可包含：
+
+- item name
+- item type
+- short effect
+- state badge
+- CTA / disabled CTA
+
+### 4. Footer Note
+
+可顯示：
+
+- `Some items are preview only`
+
+## 狀態替換
+
+### `shop available`
+
+- featured offer 與至少一張商品卡可互動
+
+### `bits unavailable`
+
+- 保留 panel
+- item 改成 unavailable 樣式
+- 說明當前頻道無法使用 Bits
+
+### `shop preview only`
+
+- CTA 全部 disabled
+- badge 清楚寫 `Preview`
+
+## 不應做成
+
+- NFT marketplace
+- 財務產品頁
+- 複雜價格表與比較表
+
+---
+
+## 共用元件建議
+
+這三個 panel 可共用：
+
+- `PanelHeader`
+- `FeatureCard`
+- `StatusBadge`
+- `PlaceholderCard`
+- `LockStateCard`
+- `MiniProgress`
+- `ItemPreviewCard`
+- `FooterHint`
+
+---
+
+## 首屏資訊要求
+
+在較小尺寸下，這三個 panel 的首屏至少要看見：
+
+1. panel title
+2. 1 個 featured block
+3. 至少 1 個 list item / slot 區
+4. bottom nav
+
+若空間不足，優先壓縮：
+
+- helper text 長度
+- item 說明文字
+- footer note
+
+不要優先壓縮：
+
+- panel title
+- featured block
+- current tab indication
+
+---
+
+## Wireframe 註記規則
+
+在 Figma / wireframe 上，建議每個區塊標記：
+
+- `real`
+- `preview`
+- `locked`
+- `not connected`
+
+例如：
+
+- featured mission：`preview`
+- equipment slots：`preview`
+- bits offer：`real` 或 `preview`
+
+---
+
+## 驗收清單
+
+1. 三個 panel 看起來屬於同一個產品
+2. 結構與 Home 一致，但不搶主舞台
+3. placeholder 語意清楚，不誤導為已完成功能
+4. `Missions` 偏進度與任務
+5. `Equipment` 偏 slot 與 upgrade 概念
+6. `Shop` 偏 boost / item 入口，而不是大型商城
+
+---
+
+## 後續建議
+
+1. 若要繼續深化，可分別補：
+   - `missions-state-inventory.md`
+   - `equipment-state-inventory.md`
+   - `shop-state-inventory.md`
+2. 或直接依這份 contract 畫三個 panel 的低保真 wireframe

--- a/docs/tachimint/target-state-inventory.md
+++ b/docs/tachimint/target-state-inventory.md
@@ -1,0 +1,443 @@
+# Tachimint Target State Inventory
+
+## 目標
+
+定義 `tachimint` 在目標架構下的理想 state ownership 與畫面狀態。
+
+這份文件承接：
+
+- [frontend-roadmap.md](/Users/tachikoma/Documents/Web3/tachigo/docs/frontend-roadmap.md)
+- [frontend-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/frontend-state-inventory.md)
+- [home-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/home-state-inventory.md)
+
+重點不是描述現在怎麼運作，而是定義後續重構後：
+
+- 每份 state 應該由哪支 hook 擁有
+- 哪些狀態應該被畫出來
+- 哪些狀態轉移應該被固定
+- 哪些視覺原則必須讓它看起來像 Twitch 內的 extension，而不是獨立 app
+
+---
+
+## 目標架構
+
+首頁 `Home / Mining` 目標拆成六支 hook：
+
+- `useTwitch`
+- `useWatchSession`
+- `useHeartbeat`
+- `useBalance`
+- `useClickBoost`
+- `useBits`
+
+其中：
+
+- `useTwitch` 處理 Twitch context、extension auth、Bits 商品初始化、viewer / non-viewer 分流
+- `useWatchSession` 處理 start / end 與 session readiness
+- `useHeartbeat` 只負責 heartbeat timer 與成功後通知 refetch
+- `useBalance` 持有 `spendable` / `cumulative` / gain animation
+- `useClickBoost` 只處理 click、cooldown、optimistic update
+- `useBits` 只處理交易狀態與 receipt 驗證
+
+---
+
+## 使用者
+
+- viewer
+- broadcaster
+- moderator
+- external
+
+---
+
+## 主要任務
+
+1. 非 viewer 不進 viewer 遊戲流程
+2. viewer 完成 auth 後啟動 watch session
+3. session ready 後取得 balance
+4. heartbeat 只做定時同步，不自行持有 balance source of truth
+5. click 走 cooldown + optimistic balance update
+6. Bits 交易與首頁其他 state 不互相污染
+
+---
+
+## 依賴資料
+
+- `window.Twitch.ext.onContext`
+- `window.Twitch.ext.onAuthorized`
+- `window.Twitch.ext.bits.getProducts`
+- `POST /api/v1/extension/auth/login`
+- `POST /api/v1/extension/watch/start`
+- `POST /api/v1/extension/watch/heartbeat`
+- `POST /api/v1/extension/watch/click`
+- `POST /api/v1/extension/watch/end`
+- `GET /api/v1/extension/watch/balance`
+- `POST /api/v1/extension/bits/complete`
+
+---
+
+## Source of Truth
+
+### `useTwitch`
+
+擁有：
+
+- `context`
+- `extensionJwt`
+- `products`
+- `bitsEnabled`
+- `authState`
+- `tachigoAuthReady`
+
+建議 `authState`：
+
+- `loading`
+- `ready`
+- `account_unlinked`
+- `backend_unavailable`
+
+不應再持有：
+
+- balance
+- heartbeat error
+- click cooldown
+
+---
+
+### `useWatchSession`
+
+擁有：
+
+- `sessionReady`
+- `sessionStarting`
+- `sessionError`
+
+責任：
+
+- auth ready + viewer + channelId 存在時，呼叫 `start`
+- `beforeunload` best-effort `end`
+
+不應再持有：
+
+- balance
+- click state
+
+---
+
+### `useHeartbeat`
+
+擁有：
+
+- `heartbeatState`
+- `heartbeatError`
+
+建議 `heartbeatState`：
+
+- `idle`
+- `running`
+- `error`
+
+責任：
+
+- 定時呼叫 heartbeat
+- 成功後觸發 `onSuccess()` / `refetch()`
+
+不應再持有：
+
+- `balance`
+- `gain`
+- `isAnimating`
+- `syncBalance`
+
+---
+
+### `useBalance`
+
+擁有：
+
+- `spendable`
+- `cumulative`
+- `balanceState`
+- `gain`
+- `isAnimating`
+
+建議 `balanceState`：
+
+- `idle`
+- `loading`
+- `ready`
+- `error`
+
+責任：
+
+- session ready 後拉 `GET /watch/balance`
+- heartbeat 成功後 refetch
+- click 成功後做 optimistic update
+
+這裡應該成為 points 顯示的單一 source of truth。
+
+---
+
+### `useClickBoost`
+
+擁有：
+
+- `cooldownState`
+- `cooldownMs`
+- `clickState`
+- `gain`
+- `isAnimating`
+
+建議：
+
+- `clickState: 'idle' | 'pending' | 'success' | 'error'`
+- `cooldownState: 'ready' | 'cooldown'`
+
+責任：
+
+- 發 click request
+- 處理 optimistic cooldown
+- 收到 `retry_after_ms` 時校準 cooldown
+- 成功後呼叫 `optimisticClickUpdate()`
+
+不應直接持有：
+
+- 真實 balance
+
+---
+
+### `useBits`
+
+擁有：
+
+- `status`
+- `error`
+
+建議 `status`：
+
+- `idle`
+- `pending`
+- `success`
+- `error`
+- `unavailable`
+
+責任：
+
+- 啟動 Twitch Bits flow
+- receipt complete 後呼叫 backend 驗證
+
+---
+
+## 狀態表
+
+| State | 觸發條件 | UI 表現 | 是否可操作 | Source of Truth |
+|-------|----------|---------|------------|-----------------|
+| `context loading` | `context === null` | 全畫面 loading | 否 | `useTwitch` |
+| `non-viewer view` | `context.role !== 'viewer'` | 顯示 broadcaster / moderator / external 提示頁 | 否 | `useTwitch` + App role gate |
+| `auth loading` | viewer 且 `authState === 'loading'` | 驗證中畫面 | 否 | `useTwitch` |
+| `auth ready` | viewer 且 `authState === 'ready'` | 可進入 app shell | 是 | `useTwitch` |
+| `auth account unlinked` | viewer login 401 且對應帳號未建立 | 顯示前往 tachigo.io 指引 | 否 | `useTwitch` |
+| `auth backend unavailable` | viewer login 5xx / network / 其他不可恢復錯誤 | 顯示暫時不可用畫面 | 否 | `useTwitch` |
+| `session starting` | `useWatchSession` 正在 start | 首頁主內容可顯示，但主要 CTA disabled | 否 | `useWatchSession` |
+| `session ready` | start 成功 | heartbeat / click / balance 流程可啟用 | 是 | `useWatchSession` |
+| `session error` | start 失敗 | 顯示 session error / retry | 否 | `useWatchSession` |
+| `balance loading` | session ready 後首次抓 balance | points 區塊顯示 skeleton 或 placeholder | 否 | `useBalance` |
+| `balance ready` | spendable / cumulative 取得成功 | 顯示兩個數字 | 是 | `useBalance` |
+| `balance animating` | refetch 後 spendable 增加 | bump + gain 動畫 | 是 | `useBalance` |
+| `balance error` | balance refetch 失敗 | 顯示局部錯誤 / retry | 視情況 | `useBalance` |
+| `heartbeat running` | viewer + session ready | 顯示掛台同步狀態 | 是 | `useHeartbeat` |
+| `heartbeat error` | heartbeat request 失敗 | 顯示 degraded banner | 是，但需提示 | `useHeartbeat` |
+| `click ready` | `sessionReady && balance ready && cooldownMs === 0` | mine button 可點 | 是 | `useClickBoost` + derived gating |
+| `click cooldown` | `cooldownMs > 0` | button disabled + countdown | 否 | `useClickBoost` |
+| `click gain` | click 成功 | 顯示浮字與局部動效 | 否，通常在 cooldown 中 | `useClickBoost` |
+| `click error` | click 非預期失敗 | 顯示局部錯誤並解除 lock | 是，可重試 | `useClickBoost` |
+| `bits unavailable` | `bitsEnabled === false` 或商品不可用 | 顯示 unavailable / empty 區塊 | 否 | `useTwitch` + `useBits` |
+| `bits idle` | `status === 'idle'` | 顯示可購買商品卡 | 是 | `useBits` |
+| `bits pending` | `status === 'pending'` | 商品按鈕 disabled | 否 | `useBits` |
+| `bits success` | `status === 'success'` | 顯示成功狀態 | 視產品決策 | `useBits` |
+| `bits error` | `status === 'error'` | 顯示錯誤訊息 | 是，可重試 | `useBits` |
+
+---
+
+## 狀態轉移
+
+### 1. Loading → non-viewer / auth
+
+1. `context loading`
+2. `onContext()` 回來
+3. 若 `role !== 'viewer'`
+   - 進 `non-viewer view`
+4. 若 `role === 'viewer'`
+   - 進 `auth loading`
+   - 等待 backend login 完成
+
+### 2. Auth → session
+
+1. `auth ready`
+2. `useWatchSession` 啟動
+3. 進 `session starting`
+4. 成功 → `session ready`
+5. 失敗 → `session error`
+
+### 3. Session → balance / heartbeat
+
+1. `session ready`
+2. `useBalance` 首次抓資料 → `balance loading`
+3. 成功 → `balance ready`
+4. 同時 `useHeartbeat` 進 `heartbeat running`
+5. heartbeat 成功後只觸發 `useBalance.refetch()`
+
+### 4. Ready → click
+
+1. `session ready` + `balance ready`
+2. `click ready`
+3. 點擊後：
+   - 立刻進 `click cooldown`
+   - 成功時顯示 `click gain`
+   - 同步做 optimistic balance update
+4. 非預期錯誤：
+   - `click error`
+   - 解除 cooldown
+
+### 5. Ready → bits
+
+1. `bits idle`
+2. 使用者購買 → `bits pending`
+3. 成功 → `bits success`
+4. 驗證失敗 → `bits error`
+5. 若平台不支援或無商品 → `bits unavailable`
+
+---
+
+## 目標設計要求
+
+### 視覺方向
+
+- Twitch-native first，GameFi flavor second
+- 可以保留 capybara miner、gain feedback、missions / equipment / shop 等遊戲化元素
+- 但整體 form factor、資訊密度、層級與語氣應優先像 Twitch extension
+
+### 不應偏移成
+
+- 獨立遊戲 launcher
+- 錢包 popup
+- 外部 SaaS dashboard
+
+## 非 viewer 分流
+
+### 必須有
+
+- `broadcaster`
+- `moderator`
+- `external`
+
+三者至少要共用一個明確 non-viewer 畫面，不可再誤落 viewer 主面板。
+
+---
+
+## Auth 狀態
+
+### 必須有
+
+- `loading`
+- `ready`
+- `account_unlinked`
+- `backend_unavailable`
+
+### 不應有
+
+- 只用 header 紅點表達 auth 問題
+
+---
+
+## Balance 狀態
+
+### 必須有
+
+- 單一 source of truth
+- loading / ready / error
+- gain animation 與數字來源同一支 hook
+
+### 不應有
+
+- heartbeat 與 click 各自持有不同 balance state
+
+---
+
+## Click 狀態
+
+### 必須有
+
+- button enabled 條件綁定 `sessionReady && balance ready`
+- cooldown 與 server `retry_after_ms` 可對齊
+- unexpected error 可恢復
+
+---
+
+## Heartbeat 狀態
+
+### 必須有
+
+- running / error 可見
+- heartbeat 失敗不應讓使用者完全無感
+
+### 不應有
+
+- 用 heartbeat response 直接當成 balance source of truth
+
+---
+
+## 已知與現況差異
+
+### 1. 目標中 `useHeartbeat` 不再持有 balance
+
+這和目前現況文件最大的差異之一，也是重構優先順序最高的地方。
+
+### 2. 目標中非 viewer 一律先被 role gate 擋下
+
+這用來修正現在 `moderator / external` 會落進 viewer 主畫面的問題。
+
+### 3. 目標中 `authError` 會變成可理解的 authState
+
+這用來修正現在只有紅點、沒有真正 fallback 畫面的問題。
+
+### 4. 目標中 click / balance / heartbeat 三者責任被重新切乾淨
+
+這用來避免後續再出現：
+
+- 雙重 source of truth
+- gain animation 重複計算
+- click 與 heartbeat 互相污染
+
+---
+
+## 驗收清單
+
+1. 每個重要畫面 state 都有對應的 source of truth
+2. `useHeartbeat` 不再持有 balance
+3. `useBalance` 成為 points 顯示唯一真實來源
+4. non-viewer roles 不再落入 viewer 主畫面
+5. auth failure 至少能區分：
+   - account unlinked
+   - backend unavailable
+6. click enabled 條件至少依賴：
+   - viewer
+   - auth ready
+   - session ready
+   - balance ready
+7. 看完文件後，另一位工程師應能直接開始拆 hook 與重構 UI state
+
+---
+
+## 後續建議
+
+最自然的下一步有兩種：
+
+1. 依這份文件開一組重構 issue
+   - auth state
+   - watch session lifecycle
+   - useBalance extraction
+   - non-viewer split
+
+2. 補一份 `tachimint-hook-ownership.md`
+   直接把六支 hook 的輸入、輸出、責任與互動方式文件化

--- a/docs/tachimint/visual-principles.md
+++ b/docs/tachimint/visual-principles.md
@@ -1,0 +1,366 @@
+# Tachimint Visual Principles
+
+## 目標
+
+定義 `tachimint` 的前端視覺方向，讓後續 Figma、元件設計與實作都能沿用同一組原則。
+
+這份文件回答的不是：
+
+- API 怎麼串
+- state 怎麼切
+- hook 怎麼拆
+
+而是回答：
+
+- `tachimint` 應該看起來像什麼
+- 不應該看起來像什麼
+- 在 Twitch Extension 的限制下，哪些視覺決策是優先原則
+
+這份文件承接：
+
+- [frontend-roadmap.md](/Users/tachikoma/Documents/Web3/tachigo/docs/frontend-roadmap.md)
+- [home-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/home-state-inventory.md)
+- [target-state-inventory.md](/Users/tachikoma/Documents/Web3/tachigo/docs/tachimint/target-state-inventory.md)
+
+---
+
+## 核心原則
+
+### 1. Twitch-native first
+
+`tachimint` 必須讓使用者第一眼就覺得：
+
+- 這是 Twitch 內合理存在的 extension
+- 不是外部網站嵌進來
+- 不是另一個獨立產品
+
+因此整體 form factor、資訊密度、語氣與互動方式，都要優先貼近 Twitch 生態。
+
+### 2. GameFi flavor second
+
+`tachimint` 可以有遊戲感，但遊戲感只能是加味，不應主導整體結構。
+
+可以保留：
+
+- capybara miner 主視覺
+- gain feedback
+- missions / equipment / shop
+- 輕量 fantasy / mining 氛圍
+
+但不應讓畫面看起來像：
+
+- RPG 背包 UI
+- MMORPG HUD
+- 獨立遊戲 launcher
+
+### 3. Small-panel readability is a feature
+
+Twitch Extension 不是大畫面 dashboard，也不是手機 app。
+
+設計時要先假設：
+
+- 空間窄
+- 高度有限
+- 使用者注意力短
+- 需要在幾秒內看懂目前狀態
+
+因此可讀性本身是第一級需求，不是最後才補的細節。
+
+---
+
+## 不應偏移成
+
+### 不要做成 Twitch 官方介面的複製品
+
+目標是「相容」而不是「仿製」。
+
+不需要硬拷貝 Twitch 官方元件，但要保留：
+
+- 深色基底
+- 清楚層級
+- 合理的紫色使用
+- extension 內可接受的資訊密度
+
+### 不要做成獨立遊戲 launcher
+
+避免：
+
+- 過重的世界觀背景
+- 充滿特效的首頁
+- 大型金屬框、厚重裝飾邊框、滿版 fantasy 材質
+- 讓任務 / 裝備 / 商城像另一個完整遊戲系統
+
+### 不要做成錢包 popup
+
+避免：
+
+- 過度像 MetaMask 或 wallet approval modal 的卡片結構
+- 強烈金融產品語氣
+- 以資產列表與交易狀態作為主要視覺節奏
+
+### 不要做成 SaaS dashboard
+
+避免：
+
+- 純後台式 stat cards 排列
+- 太白、太淺、太乾的資料介面
+- 一眼看起來像 admin panel
+
+---
+
+## 視覺語氣
+
+### 情緒
+
+應該是：
+
+- 神秘但清楚
+- 遊戲化但不幼稚
+- Twitch 原生感強
+- 節奏感明確
+
+不應該是：
+
+- 中世紀 cosplay
+- 科幻戰艦控制台
+- Web3 錢包面板
+
+### 文案語氣
+
+應偏向：
+
+- 短句
+- 明確
+- 行動導向
+- 像 extension 提示，而不是 RPG 敘事文本
+
+例如：
+
+- `Mining`
+- `Cooldown`
+- `Watch to earn`
+- `Bits boost`
+
+而不是過長的世界觀敘述。
+
+---
+
+## 色彩方向
+
+### 基底
+
+建議以深色為主，但不要做成純黑。
+
+方向應偏向：
+
+- charcoal
+- deep violet
+- muted navy
+
+目的：
+
+- 與 Twitch 深色環境相容
+- 讓紫色與高亮狀態色有空間發揮
+
+### 強調色
+
+優先順序：
+
+1. Twitch-compatible purple
+2. 少量 mint / cyan 作為系統或成功狀態
+3. 少量 gold / amber 作為成長或獎勵點綴
+
+注意：
+
+- 紫色應該是系統語言的一部分，不要整片發光紫
+- 金色只能點綴，不要整套 dark fantasy 金邊卡片
+
+### 狀態色
+
+至少需要清楚區分：
+
+- success
+- pending
+- error
+- unavailable
+- cooldown
+
+這些狀態色要優先服務可讀性，而不是追求華麗。
+
+---
+
+## 排版與密度
+
+### 版型
+
+首頁應該是一個直式 extension panel，不是手機 mockup。
+
+建議結構：
+
+1. top status / header
+2. primary mining stage
+3. secondary status blocks
+4. bottom nav
+
+### 密度
+
+原則：
+
+- 資訊密度可以高
+- 但視線路徑必須短
+- 一屏內要先看懂「能不能挖、現在多少、下一步做什麼」
+
+避免：
+
+- 首頁同時塞太多裝飾與數值
+- secondary feature 和 primary CTA 搶焦點
+
+### 字體
+
+優先使用易讀的無襯線字體，不走重 fantasy display font。
+
+可以在標題或數字局部使用較有辨識度的字重或字形，但不要讓整個 extension 變成海報。
+
+---
+
+## 元件方向
+
+### Header
+
+應該承載：
+
+- 頻道 / viewer context
+- auth / degraded 狀態
+- 主要資源摘要
+
+應該是緊湊、實用的，而不是大型 hero header。
+
+### Mining Stage
+
+首頁主舞台要有角色或主視覺焦點，但必須服務操作。
+
+應該包含：
+
+- capybara miner
+- 目前挖礦主狀態
+- 主要 CTA
+- gain / cooldown feedback
+
+不應該包含：
+
+- 過重背景劇情
+- 需要捲動才看得到的主操作
+
+### Stat / Resource Cards
+
+應該偏小、明確、可掃描。
+
+用途：
+
+- 顯示 spendable / cumulative
+- 顯示 heartbeat / session 狀態
+- 顯示 bits / boost 摘要
+
+設計上應該像 extension info module，不要像 dashboard analytics card。
+
+### Bottom Navigation
+
+固定底部 tab bar 是合理方向，但必須保持：
+
+- 可單手理解
+- icon + 短標籤
+- 當前 tab 強調清楚
+- 不要過度擬真遊戲快捷欄
+
+### Placeholder Panels
+
+`Missions`、`Equipment`、`Shop` 在 API 尚未完成前，可以有 teaser / locked / placeholder。
+
+但樣式要誠實表達：
+
+- 已規劃
+- 尚未開放
+- 或功能預覽
+
+不要假裝成已可操作的完整系統。
+
+---
+
+## 動效方向
+
+### 可以有的動效
+
+- gain 浮字
+- cooldown 環
+- 按鈕按下回饋
+- 資源數字 bump
+- tab 切換的輕微過渡
+
+### 不應過度
+
+避免：
+
+- 滿版粒子
+- 長時間發光
+- 影響資訊辨識的背景動畫
+- 每個元件都各自晃動
+
+原則是：
+
+- 動效幫助理解狀態
+- 不是為了炫技
+
+---
+
+## Figma 實作準則
+
+### 應先畫的東西
+
+1. `Home / Mining`
+2. `non-viewer view`
+3. `auth degraded`
+4. `session starting`
+5. `click cooldown`
+6. `bits pending / success / error`
+7. `Missions / Equipment / Shop` placeholder
+
+### 每個畫面都要對齊
+
+- state inventory
+- source of truth
+- 真實 API 可接程度
+- 是否為 placeholder
+
+### 在 Figma 上要直接標記
+
+- `real`
+- `placeholder`
+- `locked`
+- `not connected yet`
+
+避免設計稿看起來像所有功能都已完成。
+
+---
+
+## 驗收清單
+
+1. 第一眼應該像 Twitch 內的 extension，不像獨立 app
+2. viewer 能在數秒內看懂：
+   - 目前是否可挖
+   - 目前點數狀態
+   - 是否在 cooldown
+   - 是否有 bits 可買
+3. `capybara miner` 可以成為辨識點，但不能壓過可讀性
+4. `Missions / Equipment / Shop` 就算是 placeholder，也不會誤導成已可完整使用
+5. 視覺風格不會滑向：
+   - 遊戲 launcher
+   - 錢包 popup
+   - SaaS dashboard
+
+---
+
+## 後續建議
+
+1. 補一份 `tachimint` design tokens 草案
+2. 補一份 `Home / Mining` wireframe contract
+3. 把 `Missions / Equipment / Shop` 的 placeholder contract 明文化


### PR DESCRIPTION
## Summary

- 新增 Tachimint 前端規劃與設計文件
- 收斂 Twitch-native first / GameFi flavor second 的視覺方向
- 補齊 state inventory、visual principles、design draft、design tokens 與 Home wireframe contract

## Notes

- 這個 PR 先作為前端設計討論稿
- 目的是先收斂方向與文件結構，不一定要直接 merge
- 後續可再依討論結果調整內容或拆分文件
