### PR TITLE
[backend] Agency 建立 — POST /agencies（admin only）

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -15,12 +15,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/joho/godotenv"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/joho/godotenv"
 
 	_ "github.com/tachigo/tachigo/docs"
 	"github.com/tachigo/tachigo/internal/config"
 	"github.com/tachigo/tachigo/internal/database"
+	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/router"
 	"github.com/tachigo/tachigo/internal/services"
@@ -116,6 +117,8 @@ func main() {
 	pointsSvc := services.NewPointsService(db, watchSvc)
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	claimSvc := services.NewClaimService(db)
+	agencySvc := services.NewAgencyService(db)
+	agencyH := handlers.NewAgencyHandler(agencySvc)
 
 	// CORS origins from env, default to localhost for dev
 	originsEnv := os.Getenv("ALLOWED_ORIGINS")
@@ -124,7 +127,7 @@ func main() {
 		allowedOrigins = strings.Split(originsEnv, ",")
 	}
 
-	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, watchSvc, channelConfigSvc, pointsSvc, streamerSvc, claimSvc, allowedOrigins)
+	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, watchSvc, channelConfigSvc, pointsSvc, streamerSvc, claimSvc, agencyH, allowedOrigins)
 
 	addr := ":" + cfg.Server.Port
 	log.Printf("server starting on %s (env=%s)", addr, cfg.Server.Env)

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -45,6 +45,10 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 			conflict(c, err.Error())
 			return
 		}
+		if errors.Is(err, services.ErrAgencyNameTooLong) {
+			badRequest(c, err.Error())
+			return
+		}
 		log.Printf("agency create: unexpected error: %v", err)
 		internal(c)
 		return

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+type AgencyHandler struct {
+	agencySvc *services.AgencyService
+}
+
+func NewAgencyHandler(agencySvc *services.AgencyService) *AgencyHandler {
+	return &AgencyHandler{agencySvc: agencySvc}
+}
+
+type createAgencyRequest struct {
+	Name  string `json:"name" binding:"required"`
+	Email string `json:"email" binding:"required,email"`
+}
+
+type createAgencyResponse struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+func (h *AgencyHandler) Create(c *gin.Context) {
+	var req createAgencyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+
+	user, err := h.agencySvc.Create(req.Name, req.Email)
+	if err != nil {
+		if errors.Is(err, services.ErrAgencyEmailTaken) {
+			conflict(c, "email already registered")
+			return
+		}
+		internal(c)
+		return
+	}
+
+	created(c, createAgencyResponse{
+		ID:   user.ID,
+		Name: req.Name,
+	})
+}

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"log"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -37,9 +38,14 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 	user, err := h.agencySvc.Create(req.Name, req.Email)
 	if err != nil {
 		if errors.Is(err, services.ErrAgencyEmailTaken) {
-			conflict(c, "email already registered")
+			conflict(c, err.Error())
 			return
 		}
+		if errors.Is(err, services.ErrAgencyNameTaken) {
+			conflict(c, err.Error())
+			return
+		}
+		log.Printf("agency create: unexpected error: %v", err)
 		internal(c)
 		return
 	}

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -1,0 +1,156 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/handlers"
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+const agencyTestAccessSecret = "test-access-secret-at-least-32-chars!"
+
+func newAgencyTestEnv(t *testing.T) (*testEnv, http.Handler) {
+	t.Helper()
+
+	env := newTestEnv(t)
+	agencySvc := services.NewAgencyService(env.db)
+	agencyH := handlers.NewAgencyHandler(agencySvc)
+
+	r := env.router
+	v1 := r.Group("/api/v1")
+	agencies := v1.Group("/agencies")
+	agencies.Use(middleware.JWTAuth(env.authSvc))
+	agencies.POST("", middleware.RequireRole(models.RoleAdmin), agencyH.Create)
+
+	return env, r
+}
+
+func makeAccessToken(t *testing.T, role models.UserRole) string {
+	t.Helper()
+
+	subject := uuid.NewString()
+	claims := services.Claims{
+		UserID: uuid.NewString(),
+		Role:   role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Subject:   subject,
+		},
+	}
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(agencyTestAccessSecret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	return token
+}
+
+func TestAgencyHandler_Create_Success(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"name":  "agency-one",
+		"email": "agency-one@example.com",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/agencies", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	if data["id"] == nil || data["id"] == "" {
+		t.Fatalf("expected non-empty id, got %v", data["id"])
+	}
+	if data["name"] != "agency-one" {
+		t.Fatalf("expected name agency-one, got %v", data["name"])
+	}
+}
+
+func TestAgencyHandler_Create_DuplicateEmail(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	firstBody, _ := json.Marshal(map[string]string{
+		"name":  "agency-dup",
+		"email": "agency-dup@example.com",
+	})
+	secondBody, _ := json.Marshal(map[string]string{
+		"name":  "agency-dup-2",
+		"email": "agency-dup@example.com",
+	})
+
+	first := httptest.NewRecorder()
+	firstReq, _ := http.NewRequest("POST", "/api/v1/agencies", bytes.NewBuffer(firstBody))
+	firstReq.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	firstReq.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(first, firstReq)
+
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first create expected 201, got %d: %s", first.Code, first.Body.String())
+	}
+
+	second := httptest.NewRecorder()
+	secondReq, _ := http.NewRequest("POST", "/api/v1/agencies", bytes.NewBuffer(secondBody))
+	secondReq.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	secondReq.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(second, secondReq)
+
+	if second.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", second.Code, second.Body.String())
+	}
+}
+
+func TestAgencyHandler_Create_InvalidBody(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"name": "agency-invalid",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/agencies", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_Create_RequiresAdmin(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"name":  "agency-viewer",
+		"email": "agency-viewer@example.com",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/agencies", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleViewer))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -22,6 +22,7 @@ func New(
 	pointsSvc *services.PointsService,
 	streamerSvc *services.StreamerService,
 	claimSvc *services.ClaimService,
+	agencyHandler *handlers.AgencyHandler,
 	allowedOrigins []string,
 ) *gin.Engine {
 	r := gin.New()
@@ -140,9 +141,7 @@ func New(
 	agencies := v1.Group("/agencies")
 	agencies.Use(middleware.JWTAuth(authSvc))
 	{
-		agencies.POST("", middleware.RequireRole(models.RoleAdmin), func(c *gin.Context) {
-			c.JSON(501, gin.H{"error": "not implemented"})
-		})
+		agencies.POST("", middleware.RequireRole(models.RoleAdmin), agencyHandler.Create)
 		// PUT /agencies/:id/settings — agency or admin
 		agencies.PUT("/:id/settings",
 			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -2,8 +2,11 @@ package services
 
 import (
 	"errors"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/models"
@@ -11,6 +14,7 @@ import (
 
 var ErrAgencyEmailTaken = errors.New("email already registered")
 var ErrAgencyNameTaken = errors.New("name already taken")
+var ErrAgencyNameTooLong = errors.New("agency name exceeds 50 characters")
 
 type AgencyService struct {
 	db *gorm.DB
@@ -21,8 +25,8 @@ func NewAgencyService(db *gorm.DB) *AgencyService {
 }
 
 func (s *AgencyService) Create(name, email string) (*models.User, error) {
-	if len(name) > 50 {
-		return nil, ErrAgencyNameTaken
+	if utf8.RuneCountInString(name) > 50 {
+		return nil, ErrAgencyNameTooLong
 	}
 
 	var count int64
@@ -49,8 +53,30 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 	}
 
 	if err := s.db.Create(user).Error; err != nil {
+		// Handle race condition: unique violation reached DB despite pre-checks.
+		var pgErr *pgconn.PgError
+		isUniq := errors.Is(err, gorm.ErrDuplicatedKey) ||
+			(errors.As(err, &pgErr) && pgErr.Code == "23505")
+		if isUniq {
+			info := err.Error()
+			if pgErr != nil {
+				info = pgErr.ConstraintName
+			}
+			if strings.Contains(info, "email") {
+				return nil, ErrAgencyEmailTaken
+			}
+			return nil, ErrAgencyNameTaken
+		}
 		return nil, err
 	}
+
+	// Create email auth_providers record so /users/me/providers is consistent
+	// with accounts created via standard email registration.
+	s.db.Create(&models.AuthProvider{
+		UserID:     user.ID,
+		Provider:   models.ProviderEmail,
+		ProviderID: email,
+	})
 
 	return user, nil
 }

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -52,7 +52,18 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 		PasswordHash: nil,
 	}
 
-	if err := s.db.Create(user).Error; err != nil {
+	// Wrap user + email auth_provider in one transaction so we never end up
+	// with a users row but no auth_providers row (or vice-versa).
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(user).Error; err != nil {
+			return err
+		}
+		return tx.Create(&models.AuthProvider{
+			UserID:     user.ID,
+			Provider:   models.ProviderEmail,
+			ProviderID: email,
+		}).Error
+	}); err != nil {
 		// Handle race condition: unique violation reached DB despite pre-checks.
 		var pgErr *pgconn.PgError
 		isUniq := errors.Is(err, gorm.ErrDuplicatedKey) ||
@@ -69,14 +80,6 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 		}
 		return nil, err
 	}
-
-	// Create email auth_providers record so /users/me/providers is consistent
-	// with accounts created via standard email registration.
-	s.db.Create(&models.AuthProvider{
-		UserID:     user.ID,
-		Provider:   models.ProviderEmail,
-		ProviderID: email,
-	})
 
 	return user, nil
 }

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -10,7 +9,8 @@ import (
 	"github.com/tachigo/tachigo/internal/models"
 )
 
-var ErrAgencyEmailTaken = errors.New("agency email already taken")
+var ErrAgencyEmailTaken = errors.New("email already registered")
+var ErrAgencyNameTaken = errors.New("name already taken")
 
 type AgencyService struct {
 	db *gorm.DB
@@ -21,6 +21,26 @@ func NewAgencyService(db *gorm.DB) *AgencyService {
 }
 
 func (s *AgencyService) Create(name, email string) (*models.User, error) {
+	if len(name) > 50 {
+		return nil, ErrAgencyNameTaken
+	}
+
+	var count int64
+	if err := s.db.Model(&models.User{}).Where("email = ?", email).Count(&count).Error; err != nil {
+		return nil, err
+	}
+	if count > 0 {
+		return nil, ErrAgencyEmailTaken
+	}
+
+	count = 0
+	if err := s.db.Model(&models.User{}).Where("username = ?", name).Count(&count).Error; err != nil {
+		return nil, err
+	}
+	if count > 0 {
+		return nil, ErrAgencyNameTaken
+	}
+
 	user := &models.User{
 		Username:     &name,
 		Email:        &email,
@@ -29,9 +49,6 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 	}
 
 	if err := s.db.Create(user).Error; err != nil {
-		if errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(strings.ToLower(err.Error()), "users.email") {
-			return nil, ErrAgencyEmailTaken
-		}
 		return nil, err
 	}
 

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -1,11 +1,16 @@
 package services
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+var ErrAgencyEmailTaken = errors.New("agency email already taken")
 
 type AgencyService struct {
 	db *gorm.DB
@@ -13,6 +18,24 @@ type AgencyService struct {
 
 func NewAgencyService(db *gorm.DB) *AgencyService {
 	return &AgencyService{db: db}
+}
+
+func (s *AgencyService) Create(name, email string) (*models.User, error) {
+	user := &models.User{
+		Username:     &name,
+		Email:        &email,
+		Role:         models.RoleAgency,
+		PasswordHash: nil,
+	}
+
+	if err := s.db.Create(user).Error; err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(strings.ToLower(err.Error()), "users.email") {
+			return nil, ErrAgencyEmailTaken
+		}
+		return nil, err
+	}
+
+	return user, nil
 }
 
 func (s *AgencyService) OwnsChannel(agencyUserID uuid.UUID, channelID string) (bool, error) {

--- a/backend/internal/services/agency_service_test.go
+++ b/backend/internal/services/agency_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -128,5 +129,29 @@ func TestAgencyStreamerCascadeDelete(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("expected agency streamer row to be deleted, got %d", count)
+	}
+}
+
+func TestAgencyService_Create_DuplicateName(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+
+	if _, err := svc.Create("agency_x", "agency_x_1@example.com"); err != nil {
+		t.Fatalf("first create failed: %v", err)
+	}
+
+	_, err := svc.Create("agency_x", "agency_x_2@example.com")
+	if !errors.Is(err, ErrAgencyNameTaken) {
+		t.Fatalf("expected ErrAgencyNameTaken, got %v", err)
+	}
+}
+
+func TestAgencyService_Create_NameTooLong(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+
+	_, err := svc.Create(strings.Repeat("a", 51), "agency_long@example.com")
+	if !errors.Is(err, ErrAgencyNameTaken) {
+		t.Fatalf("expected ErrAgencyNameTaken, got %v", err)
 	}
 }

--- a/backend/internal/services/agency_service_test.go
+++ b/backend/internal/services/agency_service_test.go
@@ -151,7 +151,40 @@ func TestAgencyService_Create_NameTooLong(t *testing.T) {
 	svc := NewAgencyService(db)
 
 	_, err := svc.Create(strings.Repeat("a", 51), "agency_long@example.com")
-	if !errors.Is(err, ErrAgencyNameTaken) {
-		t.Fatalf("expected ErrAgencyNameTaken, got %v", err)
+	if !errors.Is(err, ErrAgencyNameTooLong) {
+		t.Fatalf("expected ErrAgencyNameTooLong, got %v", err)
+	}
+}
+
+func TestAgencyService_Create_DuplicateEmail(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+
+	if _, err := svc.Create("agency_a", "shared@example.com"); err != nil {
+		t.Fatalf("first create failed: %v", err)
+	}
+
+	_, err := svc.Create("agency_b", "shared@example.com")
+	if !errors.Is(err, ErrAgencyEmailTaken) {
+		t.Fatalf("expected ErrAgencyEmailTaken, got %v", err)
+	}
+}
+
+func TestAgencyService_Create_Success(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+
+	user, err := svc.Create("test_agency", "test@example.com")
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if user.ID == uuid.Nil {
+		t.Fatal("expected non-nil user ID")
+	}
+	if user.Username == nil || *user.Username != "test_agency" {
+		t.Fatalf("expected username 'test_agency', got %v", user.Username)
+	}
+	if user.Role != models.RoleAgency {
+		t.Fatalf("expected role agency, got %v", user.Role)
 	}
 }

--- a/backend/internal/services/agency_service_test.go
+++ b/backend/internal/services/agency_service_test.go
@@ -187,4 +187,13 @@ func TestAgencyService_Create_Success(t *testing.T) {
 	if user.Role != models.RoleAgency {
 		t.Fatalf("expected role agency, got %v", user.Role)
 	}
+
+	// Verify auth_providers row was created atomically with the user.
+	var apCount int64
+	db.Model(&models.AuthProvider{}).
+		Where("user_id = ? AND provider = ?", user.ID, models.ProviderEmail).
+		Count(&apCount)
+	if apCount != 1 {
+		t.Fatalf("expected 1 auth_provider(email) row, got %d", apCount)
+	}
 }

--- a/plans/agency-create.md
+++ b/plans/agency-create.md
@@ -1,0 +1,29 @@
+狀態：已完成
+
+# Agency 建立 — POST /agencies（admin only）
+
+refs #106
+
+## 背景
+
+#18 規劃了 Agency 管理系統，`POST /agencies` 路由已掛但回傳 501。需要實作 admin 建立 agency 帳號的功能。
+
+## 架構決策
+
+- 不新增獨立的 agency profile 表，直接利用 `users.role = 'agency'`
+- 不設初始密碼（`password_hash = nil`），agency 帳號建立後由 admin 通知當事人走 forgot-password 流程自行設定
+- Response 只回 `id` + `name`，不回傳任何憑證
+
+## 待實作 checklist
+
+- [x] `AgencyService.Create(name, email string) (*models.User, error)`
+  - [x] email 重複時回 `ErrAgencyEmailTaken`
+- [x] `AgencyHandler.Create` — `POST /api/v1/agencies`（admin only）
+- [x] Router 取代 501 stub
+- [x] `main.go` 初始化並注入
+- [x] Handler 測試（成功、重複 email、無效 body、非 admin 403）
+
+## 驗證方式
+
+- `go build ./...` 通過
+- `docker compose run --no-deps --rm app go test ./...` 全部通過


### PR DESCRIPTION
## 背景

#18 規劃了 Agency 管理系統，`POST /agencies` 路由已掛但回傳 501。此 PR 實作 admin 建立 agency 帳號的功能。

## Scope 對齊

Source of truth：#106

## 變更內容

- `backend/internal/services/agency_service.go` — 新增 `AgencyService.Create(name, email)`，email 重複時回 `ErrAgencyEmailTaken`
- `backend/internal/handlers/agency_handler.go` — 新增 `AgencyHandler.Create`，處理 bind error / 409 conflict / 201 created
- `backend/internal/router/router.go` — 取代 `POST /agencies` 的 501 stub
- `backend/cmd/server/main.go` — 初始化 `AgencyService` / `AgencyHandler` 並注入 router
- `plans/agency-create.md` — 實作計畫文件

## 本 PR 明確不做

- 不實作 agency 登入或密碼設定（走 forgot-password 流程）
- 不新增獨立的 agency profile 表
- 不實作 GET /agencies 或其他 agency 相關路由

## 測試

- `go build ./...` 通過
- `docker compose run --no-deps --rm app go test ./...` 全部通過

closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 管理员可通过专用 POST /api/v1/agencies 端点创建机构账户；响应仅返回机构 id 与 name（不含凭证）；系统对名称长度与邮箱格式/唯一性做校验。
* **测试**
  * 新增端到端与服务层测试：成功创建、重复邮箱/名称冲突、名称过长、无效请求体及权限拒绝场景。
* **文档**
  * 新增机构创建实施计划与规格说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->