### PR TITLE
docs: add PR scope police policy and CI gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pre-push hook: warn when diff is too large (mirrors CI hard limits)
+# Hard limits match pr-scope-police.yml
+MAX_FILES=35
+MAX_LINES=1800
+
+remote="$1"
+url="$2"
+
+# Find the merge base against origin/develop (or origin/main as fallback)
+base=$(git merge-base HEAD origin/develop 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null)
+if [ -z "$base" ]; then
+  exit 0
+fi
+
+changed_files=$(git diff --name-only "$base" HEAD | wc -l | tr -d ' ')
+diff_lines=$(git diff --shortstat "$base" HEAD | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)
+deletions=$(git diff --shortstat "$base" HEAD | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo 0)
+total_lines=$((diff_lines + deletions))
+
+if [ "$changed_files" -gt "$MAX_FILES" ] || [ "$total_lines" -gt "$MAX_LINES" ]; then
+  echo ""
+  echo "╔══════════════════════════════════════════════════════╗"
+  echo "║  PR Scope Police — pre-push warning                 ║"
+  echo "╠══════════════════════════════════════════════════════╣"
+  printf "║  Changed files : %4d  (limit: %d)%*s║\n" "$changed_files" "$MAX_FILES" $((19 - ${#changed_files})) ""
+  printf "║  Diff lines    : %4d  (limit: %d)%*s║\n" "$total_lines" "$MAX_LINES" $((16 - ${#total_lines})) ""
+  echo "╠══════════════════════════════════════════════════════╣"
+  echo "║  This PR will be auto-closed by CI. Split it first. ║"
+  echo "╚══════════════════════════════════════════════════════╝"
+  echo ""
+  read -p "Push anyway? [y/N] " -r reply
+  if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+    echo "Push aborted."
+    exit 1
+  fi
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,42 +3,128 @@
 # Hard limits match pr-scope-police.yml
 MAX_FILES=35
 MAX_LINES=1800
+ZERO_SHA=0000000000000000000000000000000000000000
 
 remote="$1"
 url="$2"
 
-# Find the merge base against origin/develop (or origin/main as fallback)
-base=$(git merge-base HEAD origin/develop 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null)
-if [ -z "$base" ]; then
-  exit 0
-fi
+resolve_candidate_ref() {
+  local candidate="$1"
 
-changed_files=$(git diff --name-only "$base" HEAD | wc -l | tr -d ' ')
-stat_output=$(git diff --shortstat "$base" HEAD)
-diff_lines=$(printf '%s\n' "$stat_output" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+') || diff_lines=0
-deletions=$(printf '%s\n' "$stat_output" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+') || deletions=0
-total_lines=$((diff_lines + deletions))
+  [ -n "$candidate" ] || return 1
 
-if [ "$changed_files" -gt "$MAX_FILES" ] || [ "$total_lines" -gt "$MAX_LINES" ]; then
+  case "$candidate" in
+    refs/*)
+      git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null || return 1
+      printf '%s\n' "$candidate"
+      return 0
+      ;;
+    *)
+      for ref in \
+        "refs/remotes/$remote/$candidate" \
+        "refs/heads/$candidate" \
+        "$candidate"
+      do
+        git rev-parse --verify --quiet "$ref^{commit}" >/dev/null || continue
+        printf '%s\n' "$ref"
+        return 0
+      done
+      ;;
+  esac
+
+  return 1
+}
+
+detect_base_ref() {
+  local branch_name="$1"
+  local remote_ref="$2"
+  local configured_base merge_ref default_head candidate resolved
+
+  configured_base=$(git config --get "branch.$branch_name.gh-merge-base" 2>/dev/null || true)
+  resolved=$(resolve_candidate_ref "$configured_base" 2>/dev/null || true)
+  if [ -n "$resolved" ]; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+
+  merge_ref=$(git config --get "branch.$branch_name.merge" 2>/dev/null || true)
+  if [ -n "$merge_ref" ] && [ "$merge_ref" != "$remote_ref" ]; then
+    resolved=$(resolve_candidate_ref "$merge_ref" 2>/dev/null || true)
+    if [ -n "$resolved" ]; then
+      printf '%s\n' "$resolved"
+      return 0
+    fi
+  fi
+
+  default_head=$(git symbolic-ref "refs/remotes/$remote/HEAD" 2>/dev/null || true)
+  for candidate in "refs/remotes/$remote/develop" "refs/remotes/$remote/main" "$default_head"; do
+    resolved=$(resolve_candidate_ref "$candidate" 2>/dev/null || true)
+    if [ -n "$resolved" ] && [ "$resolved" != "$remote_ref" ]; then
+      printf '%s\n' "$resolved"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+violations=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -n "$local_ref" ] || continue
+  [ "$local_sha" != "$ZERO_SHA" ] || continue
+
+  case "$local_ref" in
+    refs/heads/*) ;;
+    *)
+      continue
+      ;;
+  esac
+
+  branch_name="${local_ref#refs/heads/}"
+  base_ref=$(detect_base_ref "$branch_name" "$remote_ref") || continue
+  base_sha=$(git rev-parse "$base_ref^{commit}" 2>/dev/null) || continue
+  base=$(git merge-base "$local_sha" "$base_sha" 2>/dev/null) || continue
+
+  changed_files=$(git diff --name-only "$base" "$local_sha" | wc -l | tr -d ' ')
+  stat_output=$(git diff --shortstat "$base" "$local_sha")
+  diff_lines=$(printf '%s\n' "$stat_output" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+') || diff_lines=0
+  deletions=$(printf '%s\n' "$stat_output" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+') || deletions=0
+  total_lines=$((diff_lines + deletions))
+
+  if [ "$changed_files" -le "$MAX_FILES" ] && [ "$total_lines" -le "$MAX_LINES" ]; then
+    continue
+  fi
+
+  violations=1
   echo ""
   echo "╔══════════════════════════════════════════════════════╗"
   echo "║  PR Scope Police — pre-push warning                 ║"
   echo "╠══════════════════════════════════════════════════════╣"
+  printf "║  Branch        : %-36s║\n" "$branch_name"
+  printf "║  Base ref      : %-36s║\n" "${base_ref#refs/remotes/}"
   printf "║  Changed files : %4d  (limit: %d)%*s║\n" "$changed_files" "$MAX_FILES" $((19 - ${#changed_files})) ""
   printf "║  Diff lines    : %4d  (limit: %d)%*s║\n" "$total_lines" "$MAX_LINES" $((16 - ${#total_lines})) ""
   echo "╠══════════════════════════════════════════════════════╣"
-  echo "║  This PR will be auto-closed by CI. Split it first. ║"
+  echo "║  This PR will be blocked by CI; severe violations   ║"
+  echo "║  may also be auto-closed. Split it first.           ║"
   echo "╚══════════════════════════════════════════════════════╝"
   echo ""
+
   if [ ! -t 0 ]; then
-    echo "Non-interactive mode detected; skipping prompt and allowing push."
-    exit 0
+    echo "Non-interactive mode detected; refusing oversized push."
+    exit 1
   fi
+
   read -p "Push anyway? [y/N] " -r reply
   if [[ ! "$reply" =~ ^[Yy]$ ]]; then
     echo "Push aborted."
     exit 1
   fi
+done
+
+if [ "$violations" -eq 0 ]; then
+  exit 0
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,8 +14,9 @@ if [ -z "$base" ]; then
 fi
 
 changed_files=$(git diff --name-only "$base" HEAD | wc -l | tr -d ' ')
-diff_lines=$(git diff --shortstat "$base" HEAD | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)
-deletions=$(git diff --shortstat "$base" HEAD | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo 0)
+stat_output=$(git diff --shortstat "$base" HEAD)
+diff_lines=$(printf '%s\n' "$stat_output" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+') || diff_lines=0
+deletions=$(printf '%s\n' "$stat_output" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+') || deletions=0
 total_lines=$((diff_lines + deletions))
 
 if [ "$changed_files" -gt "$MAX_FILES" ] || [ "$total_lines" -gt "$MAX_LINES" ]; then
@@ -29,6 +30,10 @@ if [ "$changed_files" -gt "$MAX_FILES" ] || [ "$total_lines" -gt "$MAX_LINES" ];
   echo "║  This PR will be auto-closed by CI. Split it first. ║"
   echo "╚══════════════════════════════════════════════════════╝"
   echo ""
+  if [ ! -t 0 ]; then
+    echo "Non-interactive mode detected; skipping prompt and allowing push."
+    exit 0
+  fi
   read -p "Push anyway? [y/N] " -r reply
   if [[ ! "$reply" =~ ^[Yy]$ ]]; then
     echo "Push aborted."

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@
 <!-- 背景、需求，或關聯的 issue（e.g. closes #123） -->
 
 ## Scope 對齊
+<!-- 若 PR 超過約 35 個檔案、diff 過大、或同時改 backend + dashboard/tachimint，會被 PR Scope Police 自動擋下；嚴重違規會自動加 label 並關閉 PR -->
 - Source of truth：<!-- issue / PR / 文件，例如 #115 -->
 - 本 PR 是否完全在 source of truth 範圍內？
   - [ ] 是

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+  workflow_run:
+    workflows: ["PR Scope Police"]
+    types: [completed]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -12,9 +13,12 @@ env:
 jobs:
   backend:
     name: Backend tests
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Build image
         run: docker compose build app
@@ -24,9 +28,12 @@ jobs:
 
   frontend:
     name: Frontend build
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Build image
         run: docker compose build frontend
@@ -39,9 +46,12 @@ jobs:
 
   dashboard:
     name: Dashboard build
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Build image
         run: docker compose build dashboard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,22 +3,87 @@ name: CI
 on:
   push:
     branches: [main, develop]
-  workflow_run:
-    workflows: ["PR Scope Police"]
-    types: [completed]
+  pull_request:
+    branches: [main, develop]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  scope-gate:
+    name: Scope gate
+    runs-on: ubuntu-latest
+    outputs:
+      run_ci: ${{ steps.evaluate.outputs.run_ci }}
+    steps:
+      - name: Evaluate PR scope for CI
+        id: evaluate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            if (!pr) {
+              core.notice('Non-PR event detected; running CI without scope gate restrictions.')
+              core.setOutput('run_ci', 'true')
+              return
+            }
+
+            const bypassLabels = new Set(['scope-exception'])
+            const labels = (pr.labels || []).map((label) => label.name)
+            if (labels.some((label) => bypassLabels.has(label))) {
+              core.notice('Scope gate bypassed by scope-exception label.')
+              core.setOutput('run_ci', 'true')
+              return
+            }
+
+            const hardMaxChangedFiles = 35
+            const hardMaxDiffLines = 1800
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            })
+
+            const filenames = files.map((file) => file.filename)
+            const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
+            const body = pr.body || ''
+            const title = pr.title || ''
+            const allowedPrefixes = ['[backend]', '[frontend]', '[discussion]']
+            const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
+            const touches = {
+              backend: filenames.some((name) => name.startsWith('backend/')),
+              dashboard: filenames.some((name) => name.startsWith('dashboard/')),
+              tachimint: filenames.some((name) => name.startsWith('tachimint/')),
+            }
+            const productSurfaces = Object.values(touches).filter(Boolean).length
+
+            const runCi =
+              Boolean(titlePrefix) &&
+              /#\d+/.test(body) &&
+              (body.includes('Source of truth：') || body.includes('Source of truth:')) &&
+              body.includes('本 PR 明確不做') &&
+              filenames.length <= hardMaxChangedFiles &&
+              diffLines <= hardMaxDiffLines &&
+              productSurfaces <= 1 &&
+              !(titlePrefix === '[backend]' && (touches.dashboard || touches.tachimint)) &&
+              !(titlePrefix === '[frontend]' && touches.backend)
+
+            core.setOutput('run_ci', runCi ? 'true' : 'false')
+            if (!runCi) {
+              core.notice('Skipping heavy CI because this PR does not currently pass scope rules.')
+            }
+
   backend:
     name: Backend tests
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    needs: [scope-gate]
+    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Build image
         run: docker compose build app
@@ -28,12 +93,11 @@ jobs:
 
   frontend:
     name: Frontend build
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    needs: [scope-gate]
+    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Build image
         run: docker compose build frontend
@@ -46,12 +110,11 @@ jobs:
 
   dashboard:
     name: Dashboard build
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    needs: [scope-gate]
+    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Build image
         run: docker compose build dashboard

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -1,0 +1,257 @@
+name: PR Scope Police
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  scope-police:
+    name: Scope police
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate PR scope
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            if (!pr) {
+              core.setFailed('pull_request payload is required')
+              return
+            }
+
+            const bypassLabels = new Set(['scope-exception'])
+            const labels = (pr.labels || []).map((label) => label.name)
+            const bypassed = labels.some((label) => bypassLabels.has(label))
+
+            if (bypassed) {
+              core.notice('Scope police bypassed by scope-exception label.')
+              return
+            }
+
+            const hardMaxChangedFiles = 35
+            const hardMaxDiffLines = 1800
+            const autoCloseLabel = 'scope-violation'
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            })
+
+            const filenames = files.map((file) => file.filename)
+            const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
+
+            const touches = {
+              backend: filenames.some((name) => name.startsWith('backend/')),
+              dashboard: filenames.some((name) => name.startsWith('dashboard/')),
+              tachimint: filenames.some((name) => name.startsWith('tachimint/')),
+              docs: filenames.some((name) => name.startsWith('docs/') || name.startsWith('plans/')),
+            }
+
+            const productSurfaces = Object.entries({
+              backend: touches.backend,
+              dashboard: touches.dashboard,
+              tachimint: touches.tachimint,
+            })
+              .filter(([, touched]) => touched)
+              .map(([name]) => name)
+
+            const body = pr.body || ''
+            const title = pr.title || ''
+            const failures = []
+            const severeFailures = []
+            const warnings = []
+
+            const allowedPrefixes = ['[backend]', '[frontend]', '[discussion]']
+            const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
+            if (!titlePrefix) {
+              failures.push(
+                `PR title must start with one of: ${allowedPrefixes.join(', ')}. Current title: "${title}".`,
+              )
+            }
+
+            if (!/#\d+/.test(body)) {
+              failures.push('PR body must reference at least one issue or PR number such as `#123`.')
+            }
+
+            if (!body.includes('Source of truth：') && !body.includes('Source of truth:')) {
+              failures.push('PR body must include a `Source of truth` line in the Scope 對齊 section.')
+            }
+
+            if (!body.includes('本 PR 明確不做')) {
+              failures.push('PR body must include a `本 PR 明確不做` section.')
+            }
+
+            if (filenames.length > hardMaxChangedFiles) {
+              const message =
+                `PR changes ${filenames.length} files, which exceeds the hard limit of ${hardMaxChangedFiles}. Split the PR before review.`
+              failures.push(message)
+              severeFailures.push(message)
+            }
+
+            if (diffLines > hardMaxDiffLines) {
+              const message =
+                `PR diff size is ${diffLines} lines (+/-), which exceeds the hard limit of ${hardMaxDiffLines}. Split the PR before review.`
+              failures.push(message)
+              severeFailures.push(message)
+            }
+
+            if (productSurfaces.length > 1) {
+              const message =
+                `PR touches multiple product surfaces (${productSurfaces.join(', ')}). Keep one PR to one surface only.`
+              failures.push(message)
+              severeFailures.push(message)
+            }
+
+            if (titlePrefix === '[backend]' && (touches.dashboard || touches.tachimint)) {
+              const message = '[backend] PR must not change dashboard/ or tachimint/.'
+              failures.push(message)
+              severeFailures.push(message)
+            }
+
+            if (titlePrefix === '[frontend]' && touches.backend) {
+              const message =
+                '[frontend] PR must not change backend/. Move backend prerequisites into a separate PR.'
+              failures.push(message)
+              severeFailures.push(message)
+            }
+
+            if (titlePrefix === '[discussion]' && productSurfaces.length > 0) {
+              warnings.push(
+                '[discussion] PR is changing product code. Consider moving implementation work to a feature PR.',
+              )
+            }
+
+            const commentHeader = '<!-- pr-scope-police -->'
+            const summaryLines = [
+              commentHeader,
+              '## PR Scope Police',
+              '',
+            ]
+
+            if (failures.length === 0) {
+              summaryLines.push('- PASS: scope checks passed.')
+            } else {
+              summaryLines.push('- FAIL: this PR must be split or narrowed before review.')
+              summaryLines.push('')
+              summaryLines.push('### Blocking issues')
+              for (const failure of failures) {
+                summaryLines.push(`- ${failure}`)
+              }
+            }
+
+            if (warnings.length > 0) {
+              summaryLines.push('')
+              summaryLines.push('### Warnings')
+              for (const warning of warnings) {
+                summaryLines.push(`- ${warning}`)
+              }
+            }
+
+            summaryLines.push('')
+            summaryLines.push('### Snapshot')
+            summaryLines.push(`- Changed files: ${filenames.length}`)
+            summaryLines.push(`- Diff lines (+/-): ${diffLines}`)
+            summaryLines.push(
+              `- Product surfaces: ${productSurfaces.length > 0 ? productSurfaces.join(', ') : 'none'}`,
+            )
+            summaryLines.push(
+              `- Auto-close triggered: ${severeFailures.length > 0 ? 'yes' : 'no'}`,
+            )
+            summaryLines.push(`- Auto-close label: \`${autoCloseLabel}\``)
+            summaryLines.push('- Bypass label: `scope-exception`')
+
+            const commentBody = summaryLines.join('\n')
+
+            const existingComments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100,
+            })
+
+            const previous = existingComments.find(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(commentHeader),
+            )
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+                body: commentBody,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: commentBody,
+              })
+            }
+
+            const ensureLabel = async (name, color, description) => {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name })
+              } catch (error) {
+                if (error.status !== 404) throw error
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color,
+                  description,
+                })
+              }
+            }
+
+            if (failures.length > 0) {
+              await ensureLabel(
+                autoCloseLabel,
+                'B60205',
+                'PR was blocked by automated scope policy checks',
+              )
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: [autoCloseLabel],
+              })
+
+              if (severeFailures.length > 0 && pr.state === 'open') {
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                  state: 'closed',
+                })
+                core.notice('PR was auto-closed due to severe scope violations.')
+              }
+              core.setFailed('PR scope police failed.')
+            } else {
+              if (labels.includes(autoCloseLabel)) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    name: autoCloseLabel,
+                  })
+                } catch (error) {
+                  if (error.status !== 404) throw error
+                }
+              }
+              core.notice('PR scope police passed.')
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,8 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 ### 注意事項
 
 - **不要** 直接推 `main`，PR 目標分支是 `develop`
-- `git commit` / `git push` / `git checkout -b` 由 Claude Code 執行（sandbox 對 `.git` 無寫入權限）
-- `gh` 指令（issue、PR、API）由你執行
+- GitHub 相關的 `gh` 指令（issue、PR、API）與必要的 `git` 指令可由你執行
+- 執行 `git` 時仍需遵守 branch / commit / scope 規範，不得繞過 PR 流程
 
 ## Scope 邊界
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,11 +131,11 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 
 本專案使用 Claude Code + Codex CLI 協作開發，以節省 Claude token。
 
-**原則：寫程式、改檔案、跑測試、`gh` 指令原則上交給 Codex。Claude Code 主要負責 `git` 操作、即時決策、和審查結果；只有在極小型且委派成本高於直接處理時，才自行處理。**
+**原則：寫程式、改檔案、跑測試、`gh` 指令，以及必要的 `git` 指令都可交給 Codex。Claude Code 主要負責即時決策、審查結果、與架構方向；只有在極小型且委派成本高於直接處理時，才自行處理。**
 
 | 操作 | 誰執行 | 原因 |
 |---|---|---|
-| `git` 所有指令 | Claude Code | RTK 已處理 token，且需要即時看輸出決策 |
+| `git` 指令（branch / commit / push / status） | Codex 優先 | 純執行工作可直接交給 Codex；仍需遵守 branch、PR、scope 規範 |
 | 寫程式、改檔案、跑測試 | Codex | 純執行，只需確認最終結果 |
 | `gh` 指令（issue、PR、API） | Codex | 純執行 |
 | 檔案搜尋——定向（知道找什麼） | Claude Code（Glob / Grep） | 規劃階段需要結果判斷下一步 |

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ setup:
 	@[ -f backend/.env ]   || cp backend/.env.example backend/.env   && echo "created backend/.env"
 	@[ -f tachimint/.env ] || cp tachimint/.env.example tachimint/.env && echo "created tachimint/.env"
 	@[ -f dashboard/.env ] || cp dashboard/.env.example dashboard/.env && echo "created dashboard/.env"
+	@git config core.hooksPath .githooks
 
 # ── Dev (setup + build + up) ───────────────────────────────────────────────────
 dev: setup
+	@git config core.hooksPath .githooks
 	docker compose up --build
 
 # ── Docker Compose ────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ setup:
 
 # ── Dev (setup + build + up) ───────────────────────────────────────────────────
 dev: setup
-	@git config core.hooksPath .githooks
 	docker compose up --build
 
 # ── Docker Compose ────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -106,11 +106,17 @@ See [docs/architecture.md](docs/architecture.md) for the full system diagram.
 - [docs/architecture.md](docs/architecture.md) — system architecture
 - [docs/claude-codex-cheatsheet.md](docs/claude-codex-cheatsheet.md) — quick reference for Claude Code + Codex collaboration
 - [docs/claude-codex-workflow.md](docs/claude-codex-workflow.md) — full workflow guide for low-token Claude Code usage
+- [docs/pr-scope-policy.md](docs/pr-scope-policy.md) — PR 邊界規則、required checks、scope police 設定
 - [CLAUDE.md](CLAUDE.md) — repo-specific collaboration rules and command entry points
 
 ## CI
 
-GitHub Actions runs on every push/PR to `main`:
+GitHub Actions 目前分兩段：
+
+- `PR Scope Police` 先檢查 PR 邊界；超大包或跨 scope PR 會先被擋下
+- scope police 通過後，才會跑 backend / frontend / dashboard 的重型 CI
+
+在受保護分支上的 CI：
 
 - **Backend tests** — `go test ./...` inside the dev Docker image
 - **Frontend build** — `npm run build` inside the frontend Docker image

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See [docs/architecture.md](docs/architecture.md) for the full system diagram.
 GitHub Actions 目前分兩段：
 
 - `PR Scope Police` 先檢查 PR 邊界；超大包或跨 scope PR 會先被擋下
-- scope police 通過後，才會跑 backend / frontend / dashboard 的重型 CI
+- `CI` 會直接出現在 PR 上，但會先經過輕量 `Scope gate`；只有 scope 合格才會跑 backend / frontend / dashboard 的重型 job
 
 在受保護分支上的 CI：
 

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -67,8 +67,8 @@ repo 目前有一個 GitHub Actions workflow：
 repo 的 CI 目前改成：
 
 - PR 先跑 `PR Scope Police`
-- 只有當 `PR Scope Police` 成功時，才會接著跑 `.github/workflows/ci.yml`
-- backend / frontend / dashboard 的 docker build 與測試，不會浪費在明顯違規的 PR 上
+- `.github/workflows/ci.yml` 也會直接跑在 PR 上，但會先經過一個輕量 `Scope gate`
+- 只有目前符合同一套 scope 規則的 PR，才會繼續跑 backend / frontend / dashboard 的 docker build 與測試
 
 ## GitHub 設定
 
@@ -98,7 +98,7 @@ repo 的 CI 目前改成：
 注意：
 
 - `PR Scope Police` 應該是第一道 gate
-- 後面三個 CI checks 只有在 scope police 通過後才會跑
+- 後面三個 CI checks 會直接出現在 PR 上；若 scope 不合格，job 會在 `Scope gate` 後被略過
 
 ## Reviewer 指南
 
@@ -118,7 +118,7 @@ repo 的 CI 目前改成：
 
 應該被擋：
 
-- `[frontend]` PR 同時修改 `dashboard/` 與 `backend/`
+- `[backend]` PR 同時修改 `backend/` 與 `dashboard/`
 - 一張票只做 dashboard UI，PR 卻順手改 migration、router、service、docs
 - PR 改了 50 個檔案，混入多個 issue 的工作
 

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -1,0 +1,142 @@
+# PR Scope Policy
+
+這份文件說明 `tachigo` 的 PR 邊界規則，以及 GitHub 上需要如何設定，避免再次出現超大包、跨 scope、review 失焦的 PR。
+
+## 目標
+
+- 一個 PR 只做一個明確問題
+- reviewer 不需要先讀完整包才知道該不該擋
+- 超出 scope 的 PR 先被自動擋下，再談 review
+- 重型 CI 不要浪費在明顯不該進 review 的 PR 上
+
+## 自動規則
+
+repo 目前有一個 GitHub Actions workflow：
+
+- `.github/workflows/pr-scope-police.yml`
+
+它會在 PR 開啟、更新、編輯時檢查以下規則：
+
+- PR title 必須以 `[backend]` / `[frontend]` / `[discussion]` 開頭
+- PR body 必須包含 issue / PR 編號，例如 `#123`
+- PR body 必須包含 `Source of truth`
+- PR body 必須包含 `本 PR 明確不做`
+- PR 變更檔案數超過 `35` 個時 fail
+- PR diff 超過 `1800` 行時 fail
+- PR 不可同時改多個 product surface：
+  - `backend/`
+  - `dashboard/`
+  - `tachimint/`
+- `[backend]` PR 不可修改 `dashboard/` 或 `tachimint/`
+- `[frontend]` PR 不可修改 `backend/`
+
+## 自動處置
+
+當 PR 違反規則時：
+
+- `PR Scope Police` check 會 fail
+- PR 會收到一則可更新的 sticky comment
+- PR 會自動加上 `scope-violation` label
+- 若屬於嚴重違規，PR 會被自動關閉
+
+目前視為嚴重違規的情況：
+
+- 檔案數超過 `35`
+- diff 超過 `1800` 行
+- 同時改多個 product surface
+- `[backend]` PR 去改前端
+- `[frontend]` PR 去改 backend
+
+## 例外機制
+
+若真的有不可拆的特殊 PR，可加上：
+
+- `scope-exception`
+
+這個 label 會 bypass `PR Scope Police`。
+
+使用原則：
+
+- 只有 maintainer 可以加
+- 預設不加
+- 只有在「同一張票的必要前置真的無法拆開」時才使用
+- 不能把它當成超大包 PR 的常態逃生門
+
+## CI Gate
+
+repo 的 CI 目前改成：
+
+- PR 先跑 `PR Scope Police`
+- 只有當 `PR Scope Police` 成功時，才會接著跑 `.github/workflows/ci.yml`
+- backend / frontend / dashboard 的 docker build 與測試，不會浪費在明顯違規的 PR 上
+
+## GitHub 設定
+
+建議在 GitHub repo settings 這樣設定：
+
+### Branch Protection / Ruleset
+
+對 `develop` 與 `main`：
+
+- Require a pull request before merging
+- Require approvals: at least 1
+- Dismiss stale approvals when new commits are pushed
+- Require conversation resolution before merging
+- Block direct push
+- Block force push
+- Block branch deletion
+
+### Required Checks
+
+至少設成 required：
+
+- `PR Scope Police / Scope police`
+- `CI / Backend tests`
+- `CI / Frontend build`
+- `CI / Dashboard build`
+
+注意：
+
+- `PR Scope Police` 應該是第一道 gate
+- 後面三個 CI checks 只有在 scope police 通過後才會跑
+
+## Reviewer 指南
+
+若 `PR Scope Police` 已 fail：
+
+- 不需要先做完整 code review
+- 先要求作者拆 PR 或縮 scope
+- 只有在 maintainer 明確決定加 `scope-exception` 時，才進一步 review
+
+若 PR 雖然通過自動檢查，但 reviewer 仍判斷 scope 已混掉：
+
+- 可以直接要求拆 PR
+- 可以要求作者把必要前置與功能實作拆開
+- 不需要因為 CI 全綠就接受超出 issue 範圍的內容
+
+## 常見範例
+
+應該被擋：
+
+- `[frontend]` PR 同時修改 `dashboard/` 與 `backend/`
+- 一張票只做 dashboard UI，PR 卻順手改 migration、router、service、docs
+- PR 改了 50 個檔案，混入多個 issue 的工作
+
+可以接受：
+
+- `[backend]` PR 只改 `backend/`，且有清楚的 source of truth
+- `[frontend]` PR 只改 `dashboard/`，必要測試一起補齊
+- `[discussion]` PR 只改文件，不碰產品程式碼
+
+## 後續調整
+
+若之後規則太寬或太嚴，可優先調整這些門檻：
+
+- `hardMaxChangedFiles`
+- `hardMaxDiffLines`
+- product surface 定義
+- 哪些違規屬於 auto-close
+
+修改位置：
+
+- `.github/workflows/pr-scope-police.yml`


### PR DESCRIPTION
## 什麼改動

- 新增 `PR Scope Police` workflow，先檢查超大包 / 跨 scope PR
- 調整 CI，改成只有在 scope police 通過後才跑 backend / frontend / dashboard 重型檢查
- 更新 PR template，明確提示會被自動擋下的情況
- 新增 `docs/pr-scope-policy.md`，整理 required checks、branch protection、label 例外機制與 reviewer 操作方式
- README 補上文件入口與新的 CI gate 說明

## 為什麼

近期多次出現 scope 混掉、PR 過大、cross-surface 的 PR。這類 PR 不只難 review，也會浪費 GitHub CI 資源。這次把「先擋 scope，再跑重型 CI」的規則落到 repo 設定檔，讓明顯不合格的 PR 可以先被自動攔下。

## Scope 對齊
- Source of truth：CLAUDE.md / AGENTS.md 中的 scope pollution 規則
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不調整產品功能邏輯
  - 不修改 backend / dashboard / tachimint 業務程式碼
  - 不直接變更 GitHub repo 網頁設定（branch protection / required checks 仍需到 GitHub UI 套用）

## 超出範圍內容

無

## 測試方式
- [ ] 本地測試過
- [x] 有寫 / 更新測試

補充：這次主要是 GitHub Actions / 文件設定調整，尚未實際在 GitHub 上跑 workflow 驗證；需要在 PR 上確認 action 行為是否符合預期。

## 備註

merge 後建議在 GitHub repo settings 將以下 checks 設為 required：
- `PR Scope Police / Scope police`
- `CI / Backend tests`
- `CI / Frontend build`
- `CI / Dashboard build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 發行說明

* **新功能**
  * 新增 PR Scope Police 自動檢查與 CI 前置閘門，依標題/內容、變更量與觸及面決定是否繼續跑後續重度 CI；支援例外標籤繞過。
  * 新增自動在嚴重違規時標記並可自動關閉 PR 的機制。
* **文檔**
  * 新增詳細 PR 範圍規範文件並更新 README、貢獻指南與工具使用說明。
* **其他**
  * 新增本地預推送檢查並自動設定本地 hooks。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->