### PR TITLE
[backend] StreamerService agency scope、8-metric stats 與 dashboard API

### DIFF
--- a/backend/cmd/server/agency_migration.go
+++ b/backend/cmd/server/agency_migration.go
@@ -45,9 +45,11 @@ func failOnAgencyBackfillConflicts(db *gorm.DB) error {
 
 	var conflicts []conflictRow
 	if err := db.Table("agency_streamers").
-		Select("channel_id").
-		Group("channel_id").
-		Having("COUNT(DISTINCT agency_id) > 1").
+		Select("agency_streamers.channel_id").
+		Joins("JOIN streamers ON streamers.channel_id = agency_streamers.channel_id").
+		Where("streamers.agency_user_id IS NULL").
+		Group("agency_streamers.channel_id").
+		Having("COUNT(DISTINCT agency_streamers.agency_id) > 1").
 		Find(&conflicts).Error; err != nil {
 		return fmt.Errorf("detect agency backfill conflicts: %w", err)
 	}

--- a/backend/cmd/server/agency_migration.go
+++ b/backend/cmd/server/agency_migration.go
@@ -60,6 +60,18 @@ func failOnAgencyBackfillConflicts(db *gorm.DB) error {
 	)
 }
 
+const postgresBackfillStreamerAgencyUserIDSQL = `
+	UPDATE streamers s
+	SET agency_user_id = src.agency_id
+	FROM (
+		SELECT DISTINCT ON (channel_id) channel_id, agency_id
+		FROM agency_streamers
+		ORDER BY channel_id
+	) AS src
+	WHERE s.channel_id = src.channel_id
+	  AND s.agency_user_id IS NULL
+`
+
 func backfillStreamerAgencyUserID(db *gorm.DB) error {
 	sql := `
 		UPDATE streamers
@@ -77,17 +89,7 @@ func backfillStreamerAgencyUserID(db *gorm.DB) error {
 		)
 	`
 	if db.Dialector.Name() == "postgres" {
-		sql = `
-			UPDATE streamers s
-			SET agency_user_id = src.agency_id
-			FROM (
-				SELECT channel_id, agency_id
-				FROM agency_streamers
-				GROUP BY channel_id, agency_id
-			) AS src
-			WHERE s.channel_id = src.channel_id
-			  AND s.agency_user_id IS NULL
-		`
+		sql = postgresBackfillStreamerAgencyUserIDSQL
 	}
 	if err := db.Exec(sql).Error; err != nil {
 		return fmt.Errorf("update streamer agency_user_id from legacy mappings: %w", err)

--- a/backend/cmd/server/agency_migration.go
+++ b/backend/cmd/server/agency_migration.go
@@ -61,30 +61,36 @@ func failOnAgencyBackfillConflicts(db *gorm.DB) error {
 }
 
 func backfillStreamerAgencyUserID(db *gorm.DB) error {
-	type mappingRow struct {
-		ChannelID string
-		AgencyID  string
+	sql := `
+		UPDATE streamers
+		SET agency_user_id = (
+			SELECT agency_streamers.agency_id
+			FROM agency_streamers
+			WHERE agency_streamers.channel_id = streamers.channel_id
+			LIMIT 1
+		)
+		WHERE agency_user_id IS NULL
+		  AND EXISTS (
+			SELECT 1
+			FROM agency_streamers
+			WHERE agency_streamers.channel_id = streamers.channel_id
+		)
+	`
+	if db.Dialector.Name() == "postgres" {
+		sql = `
+			UPDATE streamers s
+			SET agency_user_id = src.agency_id
+			FROM (
+				SELECT channel_id, agency_id
+				FROM agency_streamers
+				GROUP BY channel_id, agency_id
+			) AS src
+			WHERE s.channel_id = src.channel_id
+			  AND s.agency_user_id IS NULL
+		`
 	}
-
-	var mappings []mappingRow
-	if err := db.Table("agency_streamers").
-		Select("channel_id, agency_id").
-		Group("channel_id, agency_id").
-		Find(&mappings).Error; err != nil {
-		return err
+	if err := db.Exec(sql).Error; err != nil {
+		return fmt.Errorf("update streamer agency_user_id from legacy mappings: %w", err)
 	}
-
-	for _, mapping := range mappings {
-		if err := db.Exec(
-			`UPDATE streamers
-			 SET agency_user_id = ?
-			 WHERE channel_id = ? AND agency_user_id IS NULL`,
-			mapping.AgencyID,
-			mapping.ChannelID,
-		).Error; err != nil {
-			return err
-		}
-	}
-
 	return nil
 }

--- a/backend/cmd/server/agency_migration.go
+++ b/backend/cmd/server/agency_migration.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+const migration008SchemaSQL = `
+ALTER TABLE streamers ADD COLUMN IF NOT EXISTS agency_user_id UUID;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_streamers_agency_user_id'
+    ) THEN
+        ALTER TABLE streamers
+        ADD CONSTRAINT fk_streamers_agency_user_id
+        FOREIGN KEY (agency_user_id) REFERENCES users(id);
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);
+`
+
+func applyStreamerAgencyMigration(db *gorm.DB) error {
+	if err := db.Exec(migration008SchemaSQL).Error; err != nil {
+		return fmt.Errorf("execute migration 008 schema: %w", err)
+	}
+	if err := failOnAgencyBackfillConflicts(db); err != nil {
+		return err
+	}
+	if err := backfillStreamerAgencyUserID(db); err != nil {
+		return fmt.Errorf("backfill streamer agency_user_id: %w", err)
+	}
+	return nil
+}
+
+func failOnAgencyBackfillConflicts(db *gorm.DB) error {
+	type conflictRow struct {
+		ChannelID string
+	}
+
+	var conflicts []conflictRow
+	if err := db.Table("agency_streamers").
+		Select("channel_id").
+		Group("channel_id").
+		Having("COUNT(DISTINCT agency_id) > 1").
+		Find(&conflicts).Error; err != nil {
+		return fmt.Errorf("detect agency backfill conflicts: %w", err)
+	}
+	if len(conflicts) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"agency backfill conflict: %d channel(s) map to multiple agencies in agency_streamers; resolve before deploying",
+		len(conflicts),
+	)
+}
+
+func backfillStreamerAgencyUserID(db *gorm.DB) error {
+	type mappingRow struct {
+		ChannelID string
+		AgencyID  string
+	}
+
+	var mappings []mappingRow
+	if err := db.Table("agency_streamers").
+		Select("channel_id, agency_id").
+		Group("channel_id, agency_id").
+		Find(&mappings).Error; err != nil {
+		return err
+	}
+
+	for _, mapping := range mappings {
+		if err := db.Exec(
+			`UPDATE streamers
+			 SET agency_user_id = ?
+			 WHERE channel_id = ? AND agency_user_id IS NULL`,
+			mapping.AgencyID,
+			mapping.ChannelID,
+		).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -104,18 +104,12 @@ func main() {
 	`).Error; err != nil {
 		log.Fatalf("failed to create streamer index: %v", err)
 	}
-	if err := db.Exec(`
-		ALTER TABLE streamers ADD COLUMN IF NOT EXISTS agency_user_id UUID REFERENCES users(id);
-		CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);
-		UPDATE streamers s
-		SET agency_user_id = (
-			SELECT ag.agency_id FROM agency_streamers ag
-			WHERE ag.channel_id = s.channel_id LIMIT 1
-		)
-		WHERE s.agency_user_id IS NULL
-		  AND (SELECT COUNT(DISTINCT agency_id) FROM agency_streamers ag WHERE ag.channel_id = s.channel_id) = 1;
-	`).Error; err != nil {
-		log.Fatalf("failed to run agency_user_id migration: %v", err)
+	migration008, err := os.ReadFile("migrations/008_streamers_agency.sql")
+	if err != nil {
+		log.Fatalf("failed to read migration 008: %v", err)
+	}
+	if err := db.Exec(string(migration008)).Error; err != nil {
+		log.Fatalf("failed to run migration 008: %v", err)
 	}
 	// Wire services
 	authSvc := services.NewAuthService(db, cfg)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -105,11 +104,18 @@ func main() {
 	`).Error; err != nil {
 		log.Fatalf("failed to create streamer index: %v", err)
 	}
-	migration008Path := filepath.Join("backend", "migrations", "008_streamers_agency.sql")
-	if contents, err := os.ReadFile(migration008Path); err == nil {
-		if err := db.Exec(string(contents)).Error; err != nil {
-			log.Fatalf("failed to run 008_streamers_agency.sql: %v", err)
-		}
+	if err := db.Exec(`
+		ALTER TABLE streamers ADD COLUMN IF NOT EXISTS agency_user_id UUID REFERENCES users(id);
+		CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);
+		UPDATE streamers s
+		SET agency_user_id = (
+			SELECT ag.agency_id FROM agency_streamers ag
+			WHERE ag.channel_id = s.channel_id LIMIT 1
+		)
+		WHERE s.agency_user_id IS NULL
+		  AND (SELECT COUNT(DISTINCT agency_id) FROM agency_streamers ag WHERE ag.channel_id = s.channel_id) = 1;
+	`).Error; err != nil {
+		log.Fatalf("failed to run agency_user_id migration: %v", err)
 	}
 	// Wire services
 	authSvc := services.NewAuthService(db, cfg)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -15,8 +15,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/joho/godotenv"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/joho/godotenv"
 
 	_ "github.com/tachigo/tachigo/docs"
 	"github.com/tachigo/tachigo/internal/config"
@@ -104,11 +104,7 @@ func main() {
 	`).Error; err != nil {
 		log.Fatalf("failed to create streamer index: %v", err)
 	}
-	migration008, err := os.ReadFile("migrations/008_streamers_agency.sql")
-	if err != nil {
-		log.Fatalf("failed to read migration 008: %v", err)
-	}
-	if err := db.Exec(string(migration008)).Error; err != nil {
+	if err := applyStreamerAgencyMigration(db); err != nil {
 		log.Fatalf("failed to run migration 008: %v", err)
 	}
 	// Wire services

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -103,6 +104,12 @@ func main() {
 		ON streamers (user_id, channel_id)
 	`).Error; err != nil {
 		log.Fatalf("failed to create streamer index: %v", err)
+	}
+	migration008Path := filepath.Join("backend", "migrations", "008_streamers_agency.sql")
+	if contents, err := os.ReadFile(migration008Path); err == nil {
+		if err := db.Exec(string(contents)).Error; err != nil {
+			log.Fatalf("failed to run 008_streamers_agency.sql: %v", err)
+		}
 	}
 	// Wire services
 	authSvc := services.NewAuthService(db, cfg)

--- a/backend/cmd/server/migration_test.go
+++ b/backend/cmd/server/migration_test.go
@@ -83,6 +83,17 @@ func TestFailOnAgencyBackfillConflicts_MultiAgencyChannel(t *testing.T) {
 	}
 }
 
+func TestPostgresBackfillUsesDeterministicChannelSource(t *testing.T) {
+	sql := postgresBackfillStreamerAgencyUserIDSQL
+
+	if !strings.Contains(sql, "DISTINCT ON (channel_id)") {
+		t.Fatalf("postgres backfill SQL must use DISTINCT ON (channel_id):\n%s", sql)
+	}
+	if !strings.Contains(sql, "ORDER BY channel_id") {
+		t.Fatalf("postgres backfill SQL must order its DISTINCT ON source:\n%s", sql)
+	}
+}
+
 func newAgencyMigrationTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 

--- a/backend/cmd/server/migration_test.go
+++ b/backend/cmd/server/migration_test.go
@@ -67,8 +67,11 @@ func TestBackfillStreamerAgencyUserID_SingleAgencyChannel(t *testing.T) {
 func TestFailOnAgencyBackfillConflicts_MultiAgencyChannel(t *testing.T) {
 	db := newAgencyMigrationTestDB(t)
 
-	if err := db.Exec(`INSERT INTO users (id) VALUES ('agency-1'), ('agency-2')`).Error; err != nil {
+	if err := db.Exec(`INSERT INTO users (id) VALUES ('agency-1'), ('agency-2'), ('streamer-1')`).Error; err != nil {
 		t.Fatalf("seed users: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO streamers (id, user_id, agency_user_id, channel_id) VALUES ('streamer-row-1', 'streamer-1', NULL, 'channel-1')`).Error; err != nil {
+		t.Fatalf("seed streamer needing backfill: %v", err)
 	}
 	if err := db.Exec(`INSERT INTO agency_streamers (id, agency_id, channel_id) VALUES ('link-1', 'agency-1', 'channel-1'), ('link-2', 'agency-2', 'channel-1')`).Error; err != nil {
 		t.Fatalf("seed agency_streamers: %v", err)
@@ -80,6 +83,42 @@ func TestFailOnAgencyBackfillConflicts_MultiAgencyChannel(t *testing.T) {
 	}
 	if err.Error() != "agency backfill conflict: 1 channel(s) map to multiple agencies in agency_streamers; resolve before deploying" {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFailOnAgencyBackfillConflicts_IgnoresLegacyChannelOutsideBackfillScope(t *testing.T) {
+	db := newAgencyMigrationTestDB(t)
+
+	if err := db.Exec(`INSERT INTO users (id) VALUES ('agency-1'), ('agency-2'), ('streamer-1')`).Error; err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO streamers (id, user_id, agency_user_id, channel_id) VALUES ('streamer-row-1', 'streamer-1', NULL, 'channel-ok')`).Error; err != nil {
+		t.Fatalf("seed streamer needing backfill: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO agency_streamers (id, agency_id, channel_id) VALUES ('link-1', 'agency-1', 'legacy-conflict'), ('link-2', 'agency-2', 'legacy-conflict')`).Error; err != nil {
+		t.Fatalf("seed unrelated legacy conflict: %v", err)
+	}
+
+	if err := failOnAgencyBackfillConflicts(db); err != nil {
+		t.Fatalf("unexpected conflict for unrelated legacy channel: %v", err)
+	}
+}
+
+func TestFailOnAgencyBackfillConflicts_IgnoresAlreadyBackfilledStreamer(t *testing.T) {
+	db := newAgencyMigrationTestDB(t)
+
+	if err := db.Exec(`INSERT INTO users (id) VALUES ('agency-1'), ('agency-2'), ('streamer-1')`).Error; err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO streamers (id, user_id, agency_user_id, channel_id) VALUES ('streamer-row-1', 'streamer-1', 'agency-1', 'channel-already-filled')`).Error; err != nil {
+		t.Fatalf("seed already-backfilled streamer: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO agency_streamers (id, agency_id, channel_id) VALUES ('link-1', 'agency-1', 'channel-already-filled'), ('link-2', 'agency-2', 'channel-already-filled')`).Error; err != nil {
+		t.Fatalf("seed legacy conflict for already-filled streamer: %v", err)
+	}
+
+	if err := failOnAgencyBackfillConflicts(db); err != nil {
+		t.Fatalf("unexpected conflict for already-backfilled streamer: %v", err)
 	}
 }
 

--- a/backend/cmd/server/migration_test.go
+++ b/backend/cmd/server/migration_test.go
@@ -3,12 +3,23 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestMigration008AddsAgencyUserForeignKeyConstraint(t *testing.T) {
-	path := filepath.Join("..", "..", "migrations", "008_streamers_agency.sql")
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+
+	path := filepath.Join(filepath.Dir(file), "..", "..", "migrations", "008_streamers_agency.sql")
 	body, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read migration: %v", err)
@@ -18,7 +29,87 @@ func TestMigration008AddsAgencyUserForeignKeyConstraint(t *testing.T) {
 	if !strings.Contains(sql, "fk_streamers_agency_user_id") {
 		t.Fatalf("migration must create named fk_streamers_agency_user_id constraint")
 	}
-	if !strings.Contains(sql, "FOREIGN KEY (agency_user_id) REFERENCES users(id)") {
+	fkPattern := regexp.MustCompile(`FOREIGN KEY\s*\(\s*agency_user_id\s*\)\s*REFERENCES\s+users\s*\(\s*id\s*\)`)
+	if !fkPattern.MatchString(sql) {
 		t.Fatalf("migration must add foreign key on streamers.agency_user_id")
 	}
+}
+
+func TestBackfillStreamerAgencyUserID_SingleAgencyChannel(t *testing.T) {
+	db := newAgencyMigrationTestDB(t)
+
+	if err := db.Exec(`INSERT INTO users (id) VALUES ('agency-1'), ('streamer-1')`).Error; err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO streamers (id, user_id, agency_user_id, channel_id) VALUES ('streamer-row-1', 'streamer-1', NULL, 'channel-1')`).Error; err != nil {
+		t.Fatalf("seed streamers: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO agency_streamers (id, agency_id, channel_id) VALUES ('link-1', 'agency-1', 'channel-1')`).Error; err != nil {
+		t.Fatalf("seed agency_streamers: %v", err)
+	}
+
+	if err := failOnAgencyBackfillConflicts(db); err != nil {
+		t.Fatalf("unexpected conflict: %v", err)
+	}
+	if err := backfillStreamerAgencyUserID(db); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	var agencyUserID string
+	if err := db.Raw(`SELECT agency_user_id FROM streamers WHERE id = 'streamer-row-1'`).Scan(&agencyUserID).Error; err != nil {
+		t.Fatalf("load streamer: %v", err)
+	}
+	if agencyUserID != "agency-1" {
+		t.Fatalf("want agency_user_id=agency-1, got %q", agencyUserID)
+	}
+}
+
+func TestFailOnAgencyBackfillConflicts_MultiAgencyChannel(t *testing.T) {
+	db := newAgencyMigrationTestDB(t)
+
+	if err := db.Exec(`INSERT INTO users (id) VALUES ('agency-1'), ('agency-2')`).Error; err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO agency_streamers (id, agency_id, channel_id) VALUES ('link-1', 'agency-1', 'channel-1'), ('link-2', 'agency-2', 'channel-1')`).Error; err != nil {
+		t.Fatalf("seed agency_streamers: %v", err)
+	}
+
+	err := failOnAgencyBackfillConflicts(db)
+	if err == nil {
+		t.Fatal("want conflict error, got nil")
+	}
+	if err.Error() != "agency backfill conflict: 1 channel(s) map to multiple agencies in agency_streamers; resolve before deploying" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func newAgencyMigrationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	stmts := []string{
+		`CREATE TABLE users (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE streamers (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			agency_user_id TEXT,
+			channel_id TEXT NOT NULL
+		)`,
+		`CREATE TABLE agency_streamers (
+			id TEXT PRIMARY KEY,
+			agency_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL
+		)`,
+	}
+	for _, stmt := range stmts {
+		if err := db.Exec(stmt).Error; err != nil {
+			t.Fatalf("migrate db: %v", err)
+		}
+	}
+	return db
 }

--- a/backend/cmd/server/migration_test.go
+++ b/backend/cmd/server/migration_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMigration008AddsAgencyUserForeignKeyConstraint(t *testing.T) {
+	path := filepath.Join("..", "..", "migrations", "008_streamers_agency.sql")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+
+	sql := string(body)
+	if !strings.Contains(sql, "fk_streamers_agency_user_id") {
+		t.Fatalf("migration must create named fk_streamers_agency_user_id constraint")
+	}
+	if !strings.Contains(sql, "FOREIGN KEY (agency_user_id) REFERENCES users(id)") {
+		t.Fatalf("migration must add foreign key on streamers.agency_user_id")
+	}
+}

--- a/backend/internal/handlers/channel_config_handler.go
+++ b/backend/internal/handlers/channel_config_handler.go
@@ -82,8 +82,21 @@ func (h *ChannelConfigHandler) authorizeChannelAccess(c *gin.Context) (string, b
 	case models.RoleAdmin:
 		return channelID, true
 	case models.RoleAgency:
-		c.JSON(http.StatusNotImplemented, Response{Success: false, Error: "agency channel config not implemented"})
-		return "", false
+		agencyUserID, err := uuid.Parse(claims.UserID)
+		if err != nil {
+			badRequest(c, "invalid user id")
+			return "", false
+		}
+		owns, err := h.streamerSvc.OwnsAgencyChannel(agencyUserID, channelID)
+		if err != nil {
+			internal(c)
+			return "", false
+		}
+		if !owns {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return "", false
+		}
+		return channelID, true
 	case models.RoleStreamer:
 		userID, err := uuid.Parse(claims.UserID)
 		if err != nil {

--- a/backend/internal/handlers/channel_config_handler_test.go
+++ b/backend/internal/handlers/channel_config_handler_test.go
@@ -31,10 +31,14 @@ func newDashboardTestEnv(t *testing.T) *dashboardEnv {
 	v1 := base.router.Group("/api/v1")
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(base.authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
-		dashboard.GET("/channels/:channel_id/config", configH.GetChannelConfig)
-		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
+		dashboard.GET("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
+			configH.GetChannelConfig)
+		dashboard.PUT("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
+			configH.UpdateChannelConfig)
 	}
 
 	return &dashboardEnv{testEnv: base}
@@ -114,6 +118,35 @@ func seedOwnedStreamerChannel(t *testing.T, env *dashboardEnv, email, channelID 
 	}
 }
 
+func seedAgencyOwnedStreamerChannel(t *testing.T, env *dashboardEnv, agencyEmail, channelID string) {
+	t.Helper()
+
+	var agency models.User
+	if err := env.db.Where("email = ?", agencyEmail).First(&agency).Error; err != nil {
+		t.Fatalf("load agency by email: %v", err)
+	}
+
+	streamerUser, _, err := env.authSvc.Register(services.RegisterInput{
+		Username: "agency_owned_streamer_" + channelID,
+		Email:    "agency_owned_streamer_" + channelID + "@example.com",
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("register agency-owned streamer: %v", err)
+	}
+	if err := env.db.Model(streamerUser).Update("role", models.RoleStreamer).Error; err != nil {
+		t.Fatalf("set streamer role: %v", err)
+	}
+	if err := env.db.Create(&models.Streamer{
+		UserID:       streamerUser.ID,
+		AgencyUserID: &agency.ID,
+		ChannelID:    channelID,
+		DisplayName:  "Agency owned channel",
+	}).Error; err != nil {
+		t.Fatalf("seed agency streamer ownership: %v", err)
+	}
+}
+
 func TestUpdateChannelConfig_NoToken(t *testing.T) {
 	env := newDashboardTestEnv(t)
 
@@ -138,8 +171,9 @@ func TestUpdateChannelConfig_ViewerForbidden(t *testing.T) {
 func TestUpdateChannelConfig_AgencyForbidden(t *testing.T) {
 	env := newDashboardTestEnv(t)
 	token := env.tokenForRole(t, models.RoleAgency)
+	seedAgencyOwnedStreamerChannel(t, env, "agency_dashboard@example.com", "agency_owned_channel")
 
-	w := updateChannelConfig(t, env.router, token, "channel_123", `{"seconds_per_point":45}`)
+	w := updateChannelConfig(t, env.router, token, "agency_owned_channel", `{"seconds_per_point":45}`)
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
@@ -182,6 +216,17 @@ func TestGetChannelConfig_StreamerForbidden(t *testing.T) {
 	w := getChannelConfig(t, env.router, token, "channel_other")
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetChannelConfig_AgencyOwned(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleAgency)
+	seedAgencyOwnedStreamerChannel(t, env, "agency_dashboard@example.com", "agency_owned_channel")
+
+	w := getChannelConfig(t, env.router, token, "agency_owned_channel")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -50,6 +50,46 @@ func (h *StreamerHandler) Register(c *gin.Context) {
 	ok(c, gin.H{"streamer": streamer})
 }
 
+func (h *StreamerHandler) Create(c *gin.Context) {
+	var body struct {
+		UserID       string  `json:"user_id" binding:"required"`
+		AgencyUserID *string `json:"agency_user_id"`
+		ChannelID    string  `json:"channel_id" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+
+	userID, err := uuid.Parse(body.UserID)
+	if err != nil {
+		badRequest(c, "invalid user_id")
+		return
+	}
+
+	var agencyUserID *uuid.UUID
+	if body.AgencyUserID != nil {
+		aid, err := uuid.Parse(*body.AgencyUserID)
+		if err != nil {
+			badRequest(c, "invalid agency_user_id")
+			return
+		}
+		agencyUserID = &aid
+	}
+
+	streamer, err := h.streamerSvc.Create(userID, agencyUserID, body.ChannelID)
+	if err != nil {
+		if errors.Is(err, services.ErrChannelNotOwned) {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "channel_id does not match user's Twitch account"})
+			return
+		}
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"streamer": streamer})
+}
+
 func (h *StreamerHandler) ListChannels(c *gin.Context) {
 	claims := middleware.MustClaims(c)
 	userID, err := uuid.Parse(claims.UserID)
@@ -65,6 +105,36 @@ func (h *StreamerHandler) ListChannels(c *gin.Context) {
 	}
 
 	ok(c, gin.H{"channels": channels})
+}
+
+func (h *StreamerHandler) List(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+
+	var (
+		streamers []models.Streamer
+		err       error
+	)
+	switch claims.Role {
+	case models.RoleAdmin:
+		streamers, err = h.streamerSvc.ListAll()
+	case models.RoleAgency:
+		agencyUserID, parseErr := uuid.Parse(claims.UserID)
+		if parseErr != nil {
+			badRequest(c, "invalid user id")
+			return
+		}
+		streamers, err = h.streamerSvc.ListByAgencyUserID(agencyUserID)
+	default:
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return
+	}
+
+	if err != nil {
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"streamers": streamers})
 }
 
 func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
@@ -103,4 +173,62 @@ func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
 	}
 
 	ok(c, gin.H{"stats": stats})
+}
+
+func (h *StreamerHandler) GetStats(c *gin.Context) {
+	streamerID, err := uuid.Parse(c.Param("streamer_id"))
+	if err != nil {
+		badRequest(c, "invalid streamer_id")
+		return
+	}
+
+	streamer, err := h.streamerSvc.GetByID(streamerID)
+	if err != nil {
+		if errors.Is(err, services.ErrStreamerNotFound) {
+			notFound(c, "streamer not found")
+			return
+		}
+		internal(c)
+		return
+	}
+
+	claims := middleware.MustClaims(c)
+	switch claims.Role {
+	case models.RoleStreamer:
+		if claims.UserID != streamer.UserID.String() {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return
+		}
+	case models.RoleAgency:
+		agencyUserID, parseErr := uuid.Parse(claims.UserID)
+		if parseErr != nil {
+			badRequest(c, "invalid user id")
+			return
+		}
+		owns, ownErr := h.streamerSvc.OwnsStreamer(agencyUserID, streamerID)
+		if ownErr != nil {
+			internal(c)
+			return
+		}
+		if !owns {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return
+		}
+	case models.RoleAdmin:
+	default:
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return
+	}
+
+	stats, err := h.streamerSvc.GetStats(streamer.UserID)
+	if err != nil {
+		if errors.Is(err, services.ErrStreamerNotFound) {
+			notFound(c, "streamer not found")
+			return
+		}
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"stats": stats, "channel_id": streamer.ChannelID})
 }

--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -83,6 +83,10 @@ func (h *StreamerHandler) Create(c *gin.Context) {
 			c.JSON(http.StatusForbidden, Response{Success: false, Error: "channel_id does not match user's Twitch account"})
 			return
 		}
+		if errors.Is(err, services.ErrAgencyUserInvalid) {
+			badRequest(c, "agency_user_id must reference an agency user")
+			return
+		}
 		internal(c)
 		return
 	}

--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -193,10 +193,12 @@ func (h *StreamerHandler) GetStats(c *gin.Context) {
 	}
 
 	claims := middleware.MustClaims(c)
+	// Non-admin callers get 404 for both unknown and unauthorized streamer_ids
+	// to prevent existence enumeration via 403 vs 404 distinction.
 	switch claims.Role {
 	case models.RoleStreamer:
 		if claims.UserID != streamer.UserID.String() {
-			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			notFound(c, "streamer not found")
 			return
 		}
 	case models.RoleAgency:
@@ -211,7 +213,7 @@ func (h *StreamerHandler) GetStats(c *gin.Context) {
 			return
 		}
 		if !owns {
-			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			notFound(c, "streamer not found")
 			return
 		}
 	case models.RoleAdmin:
@@ -220,7 +222,7 @@ func (h *StreamerHandler) GetStats(c *gin.Context) {
 		return
 	}
 
-	stats, err := h.streamerSvc.GetStats(streamer.UserID)
+	stats, err := h.streamerSvc.GetStats(streamer.ID)
 	if err != nil {
 		if errors.Is(err, services.ErrStreamerNotFound) {
 			notFound(c, "streamer not found")

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -554,11 +554,26 @@ func TestGetStats_MultiChannelSameUser(t *testing.T) {
 		t.Fatalf("streamer1: want channel_id=ch_multi_1, got %v", data1["channel_id"])
 	}
 	stats1 := data1["stats"].(map[string]interface{})
+	if stats1["current_session_seconds"] != float64(5) {
+		t.Fatalf("streamer1: want current_session_seconds=5, got %v", stats1["current_session_seconds"])
+	}
 	if stats1["daily_seconds"] != float64(11) {
 		t.Fatalf("streamer1: want daily_seconds=11, got %v", stats1["daily_seconds"])
 	}
+	if stats1["monthly_seconds"] != float64(11) {
+		t.Fatalf("streamer1: want monthly_seconds=11, got %v", stats1["monthly_seconds"])
+	}
+	if stats1["yearly_seconds"] != float64(11) {
+		t.Fatalf("streamer1: want yearly_seconds=11, got %v", stats1["yearly_seconds"])
+	}
+	if stats1["avg_session_seconds"] != float64(5) {
+		t.Fatalf("streamer1: want avg_session_seconds=5, got %v", stats1["avg_session_seconds"])
+	}
 	if stats1["total_token_minted"] != float64(101) {
 		t.Fatalf("streamer1: want total_token_minted=101, got %v", stats1["total_token_minted"])
+	}
+	if stats1["spendable_in_circulation"] != float64(51) {
+		t.Fatalf("streamer1: want spendable_in_circulation=51, got %v", stats1["spendable_in_circulation"])
 	}
 	if stats1["unique_miners"] != float64(1) {
 		t.Fatalf("streamer1: want unique_miners=1, got %v", stats1["unique_miners"])
@@ -574,11 +589,26 @@ func TestGetStats_MultiChannelSameUser(t *testing.T) {
 		t.Fatalf("streamer2: want channel_id=ch_multi_2, got %v", data2["channel_id"])
 	}
 	stats2 := data2["stats"].(map[string]interface{})
+	if stats2["current_session_seconds"] != float64(17) {
+		t.Fatalf("streamer2: want current_session_seconds=17, got %v", stats2["current_session_seconds"])
+	}
 	if stats2["daily_seconds"] != float64(29) {
 		t.Fatalf("streamer2: want daily_seconds=29, got %v", stats2["daily_seconds"])
 	}
+	if stats2["monthly_seconds"] != float64(29) {
+		t.Fatalf("streamer2: want monthly_seconds=29, got %v", stats2["monthly_seconds"])
+	}
+	if stats2["yearly_seconds"] != float64(29) {
+		t.Fatalf("streamer2: want yearly_seconds=29, got %v", stats2["yearly_seconds"])
+	}
+	if stats2["avg_session_seconds"] != float64(17) {
+		t.Fatalf("streamer2: want avg_session_seconds=17, got %v", stats2["avg_session_seconds"])
+	}
 	if stats2["total_token_minted"] != float64(202) {
 		t.Fatalf("streamer2: want total_token_minted=202, got %v", stats2["total_token_minted"])
+	}
+	if stats2["spendable_in_circulation"] != float64(102) {
+		t.Fatalf("streamer2: want spendable_in_circulation=102, got %v", stats2["spendable_in_circulation"])
 	}
 	if stats2["unique_miners"] != float64(1) {
 		t.Fatalf("streamer2: want unique_miners=1, got %v", stats2["unique_miners"])

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -49,7 +49,9 @@ func newStreamerDashboardEnv(t *testing.T) *dashboardEnv {
 		dashboard.GET("/channels/:channel_id/config",
 			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
 			configH.GetChannelConfig)
-		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
+		dashboard.PUT("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
+			configH.UpdateChannelConfig)
 	}
 
 	return &dashboardEnv{testEnv: base}

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -313,6 +313,34 @@ func TestCreate_AgencyForbidden(t *testing.T) {
 	}
 }
 
+func TestCreate_RejectsAgencyUserIDForNonAgencyUser(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "admin_non_agency")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_non_agency_target")
+	viewerUser, _ := createDashboardUser(t, env, models.RoleViewer, "viewer_not_agency")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "non_agency_target_ch")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","agency_user_id":"` + viewerUser.ID.String() + `","channel_id":"non_agency_target_ch"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", adminToken, body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_RejectsUnknownAgencyUserID(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "admin_unknown_agency")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_unknown_agency_target")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "unknown_agency_target_ch")
+
+	unknownAgencyID := uuid.New()
+	body := `{"user_id":"` + streamerUser.ID.String() + `","agency_user_id":"` + unknownAgencyID.String() + `","channel_id":"unknown_agency_target_ch"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", adminToken, body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestList_AgencySeesOwnOnly(t *testing.T) {
 	env := newStreamerDashboardEnv(t)
 	agencyA, agencyToken := createDashboardUser(t, env, models.RoleAgency, "agency_a")

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -266,6 +266,23 @@ func TestCreate_AdminOK(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
+
+	var created models.Streamer
+	if err := env.db.Where("user_id = ? AND channel_id = ?", streamerUser.ID, "target_ch_id").First(&created).Error; err != nil {
+		t.Fatalf("load created streamer: %v", err)
+	}
+	if created.UserID != streamerUser.ID {
+		t.Fatalf("created streamer user_id: want %s, got %s", streamerUser.ID, created.UserID)
+	}
+	if created.AgencyUserID == nil {
+		t.Fatal("created streamer agency_user_id: want non-nil")
+	}
+	if *created.AgencyUserID != agencyUser.ID {
+		t.Fatalf("created streamer agency_user_id: want %s, got %s", agencyUser.ID, *created.AgencyUserID)
+	}
+	if created.ChannelID != "target_ch_id" {
+		t.Fatalf("created streamer channel_id: want target_ch_id, got %s", created.ChannelID)
+	}
 }
 
 func TestCreate_StreamerForbidden(t *testing.T) {

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -30,11 +30,17 @@ func newStreamerDashboardEnv(t *testing.T) *dashboardEnv {
 	v1 := base.router.Group("/api/v1")
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(base.authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
+		dashboard.POST("/streamers", middleware.RequireRole(models.RoleAdmin), streamerH.Create)
+		dashboard.GET("/streamers", middleware.RequireRole(models.RoleAgency, models.RoleAdmin), streamerH.List)
+		dashboard.GET("/streamers/:streamer_id/stats",
+			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
+			streamerH.GetStats)
 		dashboard.POST("/streamers/register", streamerH.Register)
 		dashboard.GET("/streamers/channels", streamerH.ListChannels)
 		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
+		dashboard.GET("/channels/:channel_id/config", configH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
 	}
 
@@ -70,6 +76,56 @@ func seedTwitchProvider(t *testing.T, env *dashboardEnv, email, channelID string
 	).Error; err != nil {
 		t.Fatalf("seed auth provider: %v", err)
 	}
+}
+
+func createDashboardUser(t *testing.T, env *dashboardEnv, role models.UserRole, prefix string) (models.User, string) {
+	t.Helper()
+
+	email := prefix + "@example.com"
+	username := prefix
+	password := "password123"
+
+	user, _, err := env.authSvc.Register(services.RegisterInput{
+		Username: username,
+		Email:    email,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("register %s: %v", prefix, err)
+	}
+	if err := env.db.Model(user).Update("role", role).Error; err != nil {
+		t.Fatalf("set role %s: %v", prefix, err)
+	}
+
+	_, tokens, err := env.authSvc.Login(services.LoginInput{Email: email, Password: password})
+	if err != nil {
+		t.Fatalf("login %s: %v", prefix, err)
+	}
+	return *user, tokens.AccessToken
+}
+
+func seedTwitchProviderForUser(t *testing.T, env *dashboardEnv, userID uuid.UUID, channelID string) {
+	t.Helper()
+	if err := env.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		uuid.New(), userID, models.ProviderTwitch, channelID,
+	).Error; err != nil {
+		t.Fatalf("seed auth provider: %v", err)
+	}
+}
+
+func seedStreamerRow(t *testing.T, env *dashboardEnv, userID uuid.UUID, agencyUserID *uuid.UUID, channelID string) *models.Streamer {
+	t.Helper()
+	streamer := &models.Streamer{
+		UserID:      userID,
+		AgencyUserID: agencyUserID,
+		ChannelID:   channelID,
+	}
+	if err := env.db.Create(streamer).Error; err != nil {
+		t.Fatalf("seed streamer: %v", err)
+	}
+	return streamer
 }
 
 func TestStreamerRegister_AndListChannels(t *testing.T) {
@@ -187,5 +243,155 @@ func TestGetChannelStats_ForbiddenForOtherStreamer(t *testing.T) {
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_A/stats", tokenB, "")
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_AdminOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "streamer_admin")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target")
+	agencyUser, _ := createDashboardUser(t, env, models.RoleAgency, "agency_target")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_ch_id")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","agency_user_id":"` + agencyUser.ID.String() + `","channel_id":"target_ch_id"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", adminToken, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_StreamerForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "forbidden_streamer")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target_s")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_ch_id")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","channel_id":"target_ch_id"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", streamerToken, body)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_AgencyForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, agencyToken := createDashboardUser(t, env, models.RoleAgency, "forbidden_agency")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target_a")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_ch_id")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","channel_id":"target_ch_id"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", agencyToken, body)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestList_AgencySeesOwnOnly(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	agencyA, agencyToken := createDashboardUser(t, env, models.RoleAgency, "agency_a")
+	agencyB, _ := createDashboardUser(t, env, models.RoleAgency, "agency_b")
+	streamerA1, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_a_streamer1")
+	streamerA2, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_a_streamer2")
+	streamerB1, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_b_streamer1")
+
+	seedStreamerRow(t, env, streamerA1.ID, &agencyA.ID, "a1_login")
+	seedStreamerRow(t, env, streamerA2.ID, &agencyA.ID, "a2_login")
+	seedStreamerRow(t, env, streamerB1.ID, &agencyB.ID, "b1_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", agencyToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestList_AdminSeesAll(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "list_admin")
+	agencyA, _ := createDashboardUser(t, env, models.RoleAgency, "list_agency_a")
+	agencyB, _ := createDashboardUser(t, env, models.RoleAgency, "list_agency_b")
+	streamerA, _ := createDashboardUser(t, env, models.RoleStreamer, "list_streamer_a")
+	streamerB, _ := createDashboardUser(t, env, models.RoleStreamer, "list_streamer_b")
+
+	seedStreamerRow(t, env, streamerA.ID, &agencyA.ID, "admin_a_login")
+	seedStreamerRow(t, env, streamerB.ID, &agencyB.ID, "admin_b_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", adminToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_StreamerOwnOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	streamerUser, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_self")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "self_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, nil, "self_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", streamerToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_StreamerOtherForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	otherStreamer, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_other")
+	seedTwitchProviderForUser(t, env, otherStreamer.ID, "other_login")
+	streamer := seedStreamerRow(t, env, otherStreamer.ID, nil, "other_login")
+	_, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_requester")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", streamerToken, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AgencyOwnOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	agency, agencyToken := createDashboardUser(t, env, models.RoleAgency, "stats_agency_self")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_agency_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "agency_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, &agency.ID, "agency_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", agencyToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AgencyOtherForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	otherAgency, _ := createDashboardUser(t, env, models.RoleAgency, "stats_agency_other")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_agency_other_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "other_agency_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, &otherAgency.ID, "other_agency_login")
+	_, agencyToken := createDashboardUser(t, env, models.RoleAgency, "stats_agency_requester")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", agencyToken, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AdminAllOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "stats_admin")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_admin_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "admin_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, nil, "admin_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", adminToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_NotFound(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "stats_not_found_admin")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+uuid.New().String()+"/stats", adminToken, "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -302,9 +302,9 @@ func TestList_AgencySeesOwnOnly(t *testing.T) {
 	streamerA2, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_a_streamer2")
 	streamerB1, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_b_streamer1")
 
-	seedStreamerRow(t, env, streamerA1.ID, &agencyA.ID, "a1_login")
-	seedStreamerRow(t, env, streamerA2.ID, &agencyA.ID, "a2_login")
-	seedStreamerRow(t, env, streamerB1.ID, &agencyB.ID, "b1_login")
+	seededA1 := seedStreamerRow(t, env, streamerA1.ID, &agencyA.ID, "a1_login")
+	seededA2 := seedStreamerRow(t, env, streamerA2.ID, &agencyA.ID, "a2_login")
+	seededB1 := seedStreamerRow(t, env, streamerB1.ID, &agencyB.ID, "b1_login")
 
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", agencyToken, "")
 	if w.Code != http.StatusOK {
@@ -317,11 +317,34 @@ func TestList_AgencySeesOwnOnly(t *testing.T) {
 	if len(streamers) != 2 {
 		t.Fatalf("agency_a: want 2 streamers, got %d", len(streamers))
 	}
+	expected := map[string]struct {
+		channelID    string
+		agencyUserID string
+	}{
+		seededA1.ID.String(): {channelID: "a1_login", agencyUserID: agencyA.ID.String()},
+		seededA2.ID.String(): {channelID: "a2_login", agencyUserID: agencyA.ID.String()},
+	}
+	seen := make(map[string]bool)
 	for _, s := range streamers {
 		row := s.(map[string]interface{})
-		if row["agency_user_id"] != agencyA.ID.String() {
-			t.Fatalf("agency_a: got streamer with agency_user_id=%v, want %s", row["agency_user_id"], agencyA.ID.String())
+		id := row["id"].(string)
+		want, ok := expected[id]
+		if !ok {
+			t.Fatalf("agency_a: unexpected streamer id=%s (streamer_b1=%s should be excluded)", id, seededB1.ID)
 		}
+		if seen[id] {
+			t.Fatalf("agency_a: duplicate streamer id=%s", id)
+		}
+		seen[id] = true
+		if row["agency_user_id"] != want.agencyUserID {
+			t.Fatalf("agency_a: streamer id=%s got agency_user_id=%v, want %s", id, row["agency_user_id"], want.agencyUserID)
+		}
+		if row["channel_id"] != want.channelID {
+			t.Fatalf("agency_a: streamer id=%s got channel_id=%v, want %s", id, row["channel_id"], want.channelID)
+		}
+	}
+	if seen[seededB1.ID.String()] {
+		t.Fatalf("agency_a: streamer_b1=%s must be excluded", seededB1.ID)
 	}
 }
 
@@ -347,17 +370,36 @@ func TestList_AdminSeesAll(t *testing.T) {
 	if len(streamers) != 2 {
 		t.Fatalf("admin: want 2 streamers, got %d", len(streamers))
 	}
-
-	ids := make(map[string]bool)
+	expected := map[string]struct {
+		channelID    string
+		agencyUserID string
+	}{
+		seededA.ID.String(): {channelID: "admin_a_login", agencyUserID: agencyA.ID.String()},
+		seededB.ID.String(): {channelID: "admin_b_login", agencyUserID: agencyB.ID.String()},
+	}
+	seen := make(map[string]bool)
 	for _, s := range streamers {
 		row := s.(map[string]interface{})
-		ids[row["id"].(string)] = true
+		id := row["id"].(string)
+		want, ok := expected[id]
+		if !ok {
+			t.Fatalf("admin: unexpected streamer id=%s", id)
+		}
+		if seen[id] {
+			t.Fatalf("admin: duplicate streamer id=%s", id)
+		}
+		seen[id] = true
+		if row["agency_user_id"] != want.agencyUserID {
+			t.Fatalf("admin: streamer id=%s got agency_user_id=%v, want %s", id, row["agency_user_id"], want.agencyUserID)
+		}
+		if row["channel_id"] != want.channelID {
+			t.Fatalf("admin: streamer id=%s got channel_id=%v, want %s", id, row["channel_id"], want.channelID)
+		}
 	}
-	if !ids[seededA.ID.String()] {
-		t.Fatalf("admin: missing streamer A (id=%s)", seededA.ID)
-	}
-	if !ids[seededB.ID.String()] {
-		t.Fatalf("admin: missing streamer B (id=%s)", seededB.ID)
+	for id := range expected {
+		if !seen[id] {
+			t.Fatalf("admin: missing streamer id=%s", id)
+		}
 	}
 }
 
@@ -443,13 +485,48 @@ func TestGetStats_NotFound(t *testing.T) {
 func TestGetStats_MultiChannelSameUser(t *testing.T) {
 	env := newStreamerDashboardEnv(t)
 	streamerUser, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "multi_ch_streamer")
+	viewer1, _ := createDashboardUser(t, env, models.RoleViewer, "multi_ch_viewer1")
+	viewer2, _ := createDashboardUser(t, env, models.RoleViewer, "multi_ch_viewer2")
 	seedTwitchProviderForUser(t, env, streamerUser.ID, "ch_multi_1")
 	seedTwitchProviderForUser(t, env, streamerUser.ID, "ch_multi_2")
 
 	streamer1 := seedStreamerRow(t, env, streamerUser.ID, nil, "ch_multi_1")
 	streamer2 := seedStreamerRow(t, env, streamerUser.ID, nil, "ch_multi_2")
 
-	// Both streamers should return 200 with their own channel_id.
+	now := time.Now()
+	if err := env.db.Exec(`
+		INSERT INTO broadcast_time_logs (id, streamer_id, channel_id, seconds, recorded_at)
+		VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)
+	`,
+		uuid.New(), streamerUser.ID, "ch_multi_1", 11, now,
+		uuid.New(), streamerUser.ID, "ch_multi_2", 29, now,
+	).Error; err != nil {
+		t.Fatalf("seed broadcast logs: %v", err)
+	}
+	if err := env.db.Exec(`
+		INSERT INTO points_ledgers (id, user_id, channel_id, cumulative_total, spendable_balance, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		       (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`,
+		uuid.New(), viewer1.ID, "ch_multi_1", 101, 51,
+		uuid.New(), viewer2.ID, "ch_multi_2", 202, 102,
+	).Error; err != nil {
+		t.Fatalf("seed points ledgers: %v", err)
+	}
+	if err := env.db.Exec(`
+		INSERT INTO watch_sessions (
+			id, user_id, channel_id, accumulated_seconds, rewarded_seconds,
+			last_heartbeat_at, click_cooldown_until, is_active, created_at, updated_at
+		) VALUES
+			(?, ?, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+			(?, ?, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`,
+		uuid.New(), viewer1.ID, "ch_multi_1", 5,
+		uuid.New(), viewer2.ID, "ch_multi_2", 17,
+	).Error; err != nil {
+		t.Fatalf("seed watch sessions: %v", err)
+	}
+
 	w1 := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer1.ID.String()+"/stats", streamerToken, "")
 	if w1.Code != http.StatusOK {
 		t.Fatalf("streamer1: want 200, got %d: %s", w1.Code, w1.Body.String())
@@ -458,6 +535,16 @@ func TestGetStats_MultiChannelSameUser(t *testing.T) {
 	data1 := resp1["data"].(map[string]interface{})
 	if data1["channel_id"] != "ch_multi_1" {
 		t.Fatalf("streamer1: want channel_id=ch_multi_1, got %v", data1["channel_id"])
+	}
+	stats1 := data1["stats"].(map[string]interface{})
+	if stats1["daily_seconds"] != float64(11) {
+		t.Fatalf("streamer1: want daily_seconds=11, got %v", stats1["daily_seconds"])
+	}
+	if stats1["total_token_minted"] != float64(101) {
+		t.Fatalf("streamer1: want total_token_minted=101, got %v", stats1["total_token_minted"])
+	}
+	if stats1["unique_miners"] != float64(1) {
+		t.Fatalf("streamer1: want unique_miners=1, got %v", stats1["unique_miners"])
 	}
 
 	w2 := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer2.ID.String()+"/stats", streamerToken, "")
@@ -468,6 +555,16 @@ func TestGetStats_MultiChannelSameUser(t *testing.T) {
 	data2 := resp2["data"].(map[string]interface{})
 	if data2["channel_id"] != "ch_multi_2" {
 		t.Fatalf("streamer2: want channel_id=ch_multi_2, got %v", data2["channel_id"])
+	}
+	stats2 := data2["stats"].(map[string]interface{})
+	if stats2["daily_seconds"] != float64(29) {
+		t.Fatalf("streamer2: want daily_seconds=29, got %v", stats2["daily_seconds"])
+	}
+	if stats2["total_token_minted"] != float64(202) {
+		t.Fatalf("streamer2: want total_token_minted=202, got %v", stats2["total_token_minted"])
+	}
+	if stats2["unique_miners"] != float64(1) {
+		t.Fatalf("streamer2: want unique_miners=1, got %v", stats2["unique_miners"])
 	}
 }
 

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -37,10 +37,18 @@ func newStreamerDashboardEnv(t *testing.T) *dashboardEnv {
 		dashboard.GET("/streamers/:streamer_id/stats",
 			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
 			streamerH.GetStats)
-		dashboard.POST("/streamers/register", streamerH.Register)
-		dashboard.GET("/streamers/channels", streamerH.ListChannels)
-		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
-		dashboard.GET("/channels/:channel_id/config", configH.GetChannelConfig)
+		dashboard.POST("/streamers/register",
+			middleware.RequireRole(models.RoleStreamer),
+			streamerH.Register)
+		dashboard.GET("/streamers/channels",
+			middleware.RequireRole(models.RoleStreamer),
+			streamerH.ListChannels)
+		dashboard.GET("/channels/:channel_id/stats",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
+			streamerH.GetChannelStats)
+		dashboard.GET("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
+			configH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
 	}
 
@@ -118,9 +126,9 @@ func seedTwitchProviderForUser(t *testing.T, env *dashboardEnv, userID uuid.UUID
 func seedStreamerRow(t *testing.T, env *dashboardEnv, userID uuid.UUID, agencyUserID *uuid.UUID, channelID string) *models.Streamer {
 	t.Helper()
 	streamer := &models.Streamer{
-		UserID:      userID,
+		UserID:       userID,
 		AgencyUserID: agencyUserID,
-		ChannelID:   channelID,
+		ChannelID:    channelID,
 	}
 	if err := env.db.Create(streamer).Error; err != nil {
 		t.Fatalf("seed streamer: %v", err)
@@ -302,6 +310,19 @@ func TestList_AgencySeesOwnOnly(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != 2 {
+		t.Fatalf("agency_a: want 2 streamers, got %d", len(streamers))
+	}
+	for _, s := range streamers {
+		row := s.(map[string]interface{})
+		if row["agency_user_id"] != agencyA.ID.String() {
+			t.Fatalf("agency_a: got streamer with agency_user_id=%v, want %s", row["agency_user_id"], agencyA.ID.String())
+		}
+	}
 }
 
 func TestList_AdminSeesAll(t *testing.T) {
@@ -312,12 +333,31 @@ func TestList_AdminSeesAll(t *testing.T) {
 	streamerA, _ := createDashboardUser(t, env, models.RoleStreamer, "list_streamer_a")
 	streamerB, _ := createDashboardUser(t, env, models.RoleStreamer, "list_streamer_b")
 
-	seedStreamerRow(t, env, streamerA.ID, &agencyA.ID, "admin_a_login")
-	seedStreamerRow(t, env, streamerB.ID, &agencyB.ID, "admin_b_login")
+	seededA := seedStreamerRow(t, env, streamerA.ID, &agencyA.ID, "admin_a_login")
+	seededB := seedStreamerRow(t, env, streamerB.ID, &agencyB.ID, "admin_b_login")
 
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", adminToken, "")
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != 2 {
+		t.Fatalf("admin: want 2 streamers, got %d", len(streamers))
+	}
+
+	ids := make(map[string]bool)
+	for _, s := range streamers {
+		row := s.(map[string]interface{})
+		ids[row["id"].(string)] = true
+	}
+	if !ids[seededA.ID.String()] {
+		t.Fatalf("admin: missing streamer A (id=%s)", seededA.ID)
+	}
+	if !ids[seededB.ID.String()] {
+		t.Fatalf("admin: missing streamer B (id=%s)", seededB.ID)
 	}
 }
 
@@ -340,9 +380,10 @@ func TestGetStats_StreamerOtherForbidden(t *testing.T) {
 	streamer := seedStreamerRow(t, env, otherStreamer.ID, nil, "other_login")
 	_, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_requester")
 
+	// Non-admin callers receive 404 for unauthorized streamer_ids to prevent existence enumeration.
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", streamerToken, "")
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -367,9 +408,10 @@ func TestGetStats_AgencyOtherForbidden(t *testing.T) {
 	streamer := seedStreamerRow(t, env, streamerUser.ID, &otherAgency.ID, "other_agency_login")
 	_, agencyToken := createDashboardUser(t, env, models.RoleAgency, "stats_agency_requester")
 
+	// Non-admin callers receive 404 for unauthorized streamer_ids to prevent existence enumeration.
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", agencyToken, "")
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -393,5 +435,60 @@ func TestGetStats_NotFound(t *testing.T) {
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+uuid.New().String()+"/stats", adminToken, "")
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestGetStats_MultiChannelSameUser verifies that GetStats returns stats for
+// the requested streamer_id even when the same user owns multiple channels.
+func TestGetStats_MultiChannelSameUser(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	streamerUser, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "multi_ch_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "ch_multi_1")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "ch_multi_2")
+
+	streamer1 := seedStreamerRow(t, env, streamerUser.ID, nil, "ch_multi_1")
+	streamer2 := seedStreamerRow(t, env, streamerUser.ID, nil, "ch_multi_2")
+
+	// Both streamers should return 200 with their own channel_id.
+	w1 := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer1.ID.String()+"/stats", streamerToken, "")
+	if w1.Code != http.StatusOK {
+		t.Fatalf("streamer1: want 200, got %d: %s", w1.Code, w1.Body.String())
+	}
+	resp1 := parseBody(t, w1.Body.Bytes())
+	data1 := resp1["data"].(map[string]interface{})
+	if data1["channel_id"] != "ch_multi_1" {
+		t.Fatalf("streamer1: want channel_id=ch_multi_1, got %v", data1["channel_id"])
+	}
+
+	w2 := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer2.ID.String()+"/stats", streamerToken, "")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("streamer2: want 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	resp2 := parseBody(t, w2.Body.Bytes())
+	data2 := resp2["data"].(map[string]interface{})
+	if data2["channel_id"] != "ch_multi_2" {
+		t.Fatalf("streamer2: want channel_id=ch_multi_2, got %v", data2["channel_id"])
+	}
+}
+
+// TestLegacyChannelStats_AgencyForbidden verifies that the legacy
+// GET /dashboard/channels/:channel_id/stats is not accessible to agency role.
+func TestLegacyChannelStats_AgencyForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	agencyUser, agencyToken := createDashboardUser(t, env, models.RoleAgency, "legacy_stats_agency")
+	seedTwitchProviderForUser(t, env, agencyUser.ID, "agency_owned_channel")
+	seedStreamerRow(t, env, agencyUser.ID, nil, "agency_owned_channel")
+	if err := env.db.Create(&models.BroadcastTimeLog{
+		StreamerID: agencyUser.ID,
+		ChannelID:  "agency_owned_channel",
+		Seconds:    15,
+		RecordedAt: time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/agency_owned_channel/stats", agencyToken, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("agency on legacy stats: want 403, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -105,6 +105,7 @@ func migrateTestDB(db *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS streamers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
+			agency_user_id TEXT REFERENCES users(id),
 			channel_id TEXT NOT NULL,
 			display_name TEXT,
 			created_at DATETIME,
@@ -112,6 +113,8 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
 			ON streamers (user_id, channel_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id
+			ON streamers (agency_user_id)`,
 		`CREATE TABLE IF NOT EXISTS watch_sessions (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -227,6 +227,9 @@ func newTestEnv(t *testing.T) *testEnv {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("enable foreign keys: %v", err)
+	}
 	if err := migrateTestDB(db); err != nil {
 		t.Fatalf("migrate db: %v", err)
 	}

--- a/backend/internal/models/streamer.go
+++ b/backend/internal/models/streamer.go
@@ -8,12 +8,13 @@ import (
 )
 
 type Streamer struct {
-	ID          uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	UserID      uuid.UUID `gorm:"type:uuid;not null;index;uniqueIndex:idx_streamers_user_channel" json:"user_id"`
-	ChannelID   string    `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_streamers_user_channel" json:"channel_id"`
-	DisplayName string    `gorm:"type:varchar(255)"                              json:"display_name"`
-	CreatedAt   time.Time `                                                      json:"created_at"`
-	UpdatedAt   time.Time `                                                      json:"updated_at"`
+	ID           uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"                        json:"id"`
+	UserID       uuid.UUID  `gorm:"type:uuid;not null;index;uniqueIndex:idx_streamers_user_channel"      json:"user_id"`
+	AgencyUserID *uuid.UUID `gorm:"type:uuid;index:idx_streamers_agency_user_id"                          json:"agency_user_id"`
+	ChannelID    string     `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_streamers_user_channel" json:"channel_id"`
+	DisplayName  string     `gorm:"type:varchar(255)"                                                     json:"display_name"`
+	CreatedAt    time.Time  `                                                                             json:"created_at"`
+	UpdatedAt    time.Time  `                                                                             json:"updated_at"`
 }
 
 func (s *Streamer) BeforeCreate(tx *gorm.DB) error {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -126,12 +126,19 @@ func New(
 
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
+		dashboard.POST("/streamers", middleware.RequireRole(models.RoleAdmin), streamerH.Create)
+		dashboard.GET("/streamers", middleware.RequireRole(models.RoleAgency, models.RoleAdmin), streamerH.List)
+		dashboard.GET("/streamers/:streamer_id/stats",
+			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
+			streamerH.GetStats)
 		dashboard.POST("/streamers/register", streamerH.Register)
 		dashboard.GET("/streamers/channels", streamerH.ListChannels)
 		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
-		dashboard.GET("/channels/:channel_id/config", channelConfigH.GetChannelConfig)
+		dashboard.GET("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
+			channelConfigH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", channelConfigH.UpdateChannelConfig)
 	}
 

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -150,6 +150,35 @@ func New(
 			channelConfigH.UpdateChannelConfig)
 	}
 
+	// ── Agency management ─────────────────────────────────────────────────
+	// POST /agencies — admin only
+	agencies := v1.Group("/agencies")
+	agencies.Use(middleware.JWTAuth(authSvc))
+	{
+		agencies.POST("", middleware.RequireRole(models.RoleAdmin), func(c *gin.Context) {
+			c.JSON(501, gin.H{"error": "not implemented"})
+		})
+		// PUT /agencies/:id/settings — agency or admin
+		agencies.PUT("/:id/settings",
+			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		// GET /agencies/:id/streamers — agency or admin
+		agencies.GET("/:id/streamers",
+			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+	}
+
+	// ── Events ────────────────────────────────────────────────────────────
+	events := v1.Group("/events")
+	events.Use(middleware.JWTAuth(authSvc))
+	events.Use(middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin))
+	{
+		events.POST("/create", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
+		events.POST("/:id/settle", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
+	}
+
 	// ── Admin (admin only) ──────────────────────────────────────────
 	admin := v1.Group("/admin")
 	admin.Use(middleware.JWTAuth(authSvc))

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -133,9 +133,15 @@ func New(
 		dashboard.GET("/streamers/:streamer_id/stats",
 			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
 			streamerH.GetStats)
-		dashboard.POST("/streamers/register", streamerH.Register)
-		dashboard.GET("/streamers/channels", streamerH.ListChannels)
-		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
+		dashboard.POST("/streamers/register",
+			middleware.RequireRole(models.RoleStreamer),
+			streamerH.Register)
+		dashboard.GET("/streamers/channels",
+			middleware.RequireRole(models.RoleStreamer),
+			streamerH.ListChannels)
+		dashboard.GET("/channels/:channel_id/stats",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
+			streamerH.GetChannelStats)
 		dashboard.GET("/channels/:channel_id/config",
 			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
 			channelConfigH.GetChannelConfig)

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -145,7 +145,9 @@ func New(
 		dashboard.GET("/channels/:channel_id/config",
 			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
 			channelConfigH.GetChannelConfig)
-		dashboard.PUT("/channels/:channel_id/config", channelConfigH.UpdateChannelConfig)
+		dashboard.PUT("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
+			channelConfigH.UpdateChannelConfig)
 	}
 
 	// ── Agency management ─────────────────────────────────────────────────

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -150,35 +150,6 @@ func New(
 			channelConfigH.UpdateChannelConfig)
 	}
 
-	// ── Agency management ─────────────────────────────────────────────────
-	// POST /agencies — admin only
-	agencies := v1.Group("/agencies")
-	agencies.Use(middleware.JWTAuth(authSvc))
-	{
-		agencies.POST("", middleware.RequireRole(models.RoleAdmin), func(c *gin.Context) {
-			c.JSON(501, gin.H{"error": "not implemented"})
-		})
-		// PUT /agencies/:id/settings — agency or admin
-		agencies.PUT("/:id/settings",
-			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
-			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
-		)
-		// GET /agencies/:id/streamers — agency or admin
-		agencies.GET("/:id/streamers",
-			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
-			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
-		)
-	}
-
-	// ── Events ────────────────────────────────────────────────────────────
-	events := v1.Group("/events")
-	events.Use(middleware.JWTAuth(authSvc))
-	events.Use(middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin))
-	{
-		events.POST("/create", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
-		events.POST("/:id/settle", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
-	}
-
 	// ── Admin (admin only) ──────────────────────────────────────────
 	admin := v1.Group("/admin")
 	admin.Use(middleware.JWTAuth(authSvc))

--- a/backend/internal/services/points_service.go
+++ b/backend/internal/services/points_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"time"
 	"unicode/utf8"
 
@@ -285,11 +286,13 @@ func (s *PointsService) GetBroadcastStats(streamerID uuid.UUID, channelID string
 	var currentSession struct {
 		AccumulatedSeconds int64
 	}
-	s.db.Raw(`
+	if err := s.db.Raw(`
 		SELECT COALESCE(SUM(accumulated_seconds), 0) AS accumulated_seconds
 		FROM watch_sessions
 		WHERE channel_id = ? AND is_active = true
-	`, channelID).Scan(&currentSession)
+	`, channelID).Scan(&currentSession).Error; err != nil {
+		return nil, fmt.Errorf("query current broadcast session seconds: %w", err)
+	}
 
 	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
@@ -302,16 +305,31 @@ func (s *PointsService) GetBroadcastStats(streamerID uuid.UUID, channelID string
 		WHERE streamer_id = ? AND channel_id = ? AND recorded_at >= ?
 	`
 
-	fetch := func(since time.Time) int64 {
+	fetch := func(label string, since time.Time) (int64, error) {
 		var r struct{ Total int64 }
-		s.db.Raw(logQuery, streamerID, channelID, since).Scan(&r)
-		return r.Total
+		if err := s.db.Raw(logQuery, streamerID, channelID, since).Scan(&r).Error; err != nil {
+			return 0, fmt.Errorf("query %s broadcast seconds: %w", label, err)
+		}
+		return r.Total, nil
+	}
+
+	dailySeconds, err := fetch("daily", startOfDay)
+	if err != nil {
+		return nil, err
+	}
+	monthlySeconds, err := fetch("monthly", startOfMonth)
+	if err != nil {
+		return nil, err
+	}
+	yearlySeconds, err := fetch("yearly", startOfYear)
+	if err != nil {
+		return nil, err
 	}
 
 	return &BroadcastStats{
 		CurrentSessionSeconds: currentSession.AccumulatedSeconds,
-		DailySeconds:          fetch(startOfDay),
-		MonthlySeconds:        fetch(startOfMonth),
-		YearlySeconds:         fetch(startOfYear),
+		DailySeconds:          dailySeconds,
+		MonthlySeconds:        monthlySeconds,
+		YearlySeconds:         yearlySeconds,
 	}, nil
 }

--- a/backend/internal/services/points_service_test.go
+++ b/backend/internal/services/points_service_test.go
@@ -547,3 +547,35 @@ func TestPointsService_GetBroadcastStats_TimeWindows(t *testing.T) {
 		t.Errorf("yearly: want 360, got %d", stats.YearlySeconds)
 	}
 }
+
+func TestGetBroadcastStats_ReturnsCurrentSessionQueryError(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+
+	if err := svc.db.Exec("DROP TABLE watch_sessions").Error; err != nil {
+		t.Fatalf("drop watch_sessions: %v", err)
+	}
+
+	_, err := svc.GetBroadcastStats(uuid.New(), "ch_missing_table")
+	if err == nil {
+		t.Fatal("want error when watch_sessions is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "query current broadcast session seconds") {
+		t.Fatalf("error = %v, want context 'query current broadcast session seconds'", err)
+	}
+}
+
+func TestGetBroadcastStats_ReturnsLogQueryError(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+
+	if err := svc.db.Exec("DROP TABLE broadcast_time_logs").Error; err != nil {
+		t.Fatalf("drop broadcast_time_logs: %v", err)
+	}
+
+	_, err := svc.GetBroadcastStats(uuid.New(), "ch_any")
+	if err == nil {
+		t.Fatal("want error when broadcast_time_logs is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "broadcast seconds") {
+		t.Fatalf("error = %v, want context containing 'broadcast seconds'", err)
+	}
+}

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	ErrStreamerNotFound = errors.New("streamer not found")
-	ErrChannelNotOwned  = errors.New("channel not owned by user")
+	ErrStreamerNotFound  = errors.New("streamer not found")
+	ErrChannelNotOwned   = errors.New("channel not owned by user")
+	ErrAgencyUserInvalid = errors.New("agency user invalid")
 )
 
 type StreamerService struct {
@@ -71,6 +72,19 @@ func (s *StreamerService) Create(userID uuid.UUID, agencyUserID *uuid.UUID, chan
 	}
 	if count == 0 {
 		return nil, ErrChannelNotOwned
+	}
+
+	if agencyUserID != nil {
+		var agency models.User
+		if err := s.db.Select("id", "role").Where("id = ?", *agencyUserID).First(&agency).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, ErrAgencyUserInvalid
+			}
+			return nil, err
+		}
+		if agency.Role != models.RoleAgency {
+			return nil, ErrAgencyUserInvalid
+		}
 	}
 
 	streamer := &models.Streamer{

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -178,16 +178,14 @@ func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, er
 }
 
 func (s *StreamerService) GetStats(streamerUserID uuid.UUID) (*StreamerStats, error) {
-	var provider models.AuthProvider
-	if err := s.db.
-		Where("user_id = ? AND provider = ?", streamerUserID, models.ProviderTwitch).
-		First(&provider).Error; err != nil {
+	var streamer models.Streamer
+	if err := s.db.Where("user_id = ?", streamerUserID).First(&streamer).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrStreamerNotFound
 		}
 		return nil, err
 	}
-	channelID := provider.ProviderID
+	channelID := streamer.ChannelID
 
 	broadcast, err := s.pointsSvc.GetBroadcastStats(streamerUserID, channelID)
 	if err != nil {

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -19,6 +19,17 @@ type StreamerService struct {
 	pointsSvc *PointsService
 }
 
+type StreamerStats struct {
+	CurrentSessionSeconds  int64   `json:"current_session_seconds"`
+	DailySeconds           int64   `json:"daily_seconds"`
+	MonthlySeconds         int64   `json:"monthly_seconds"`
+	YearlySeconds          int64   `json:"yearly_seconds"`
+	UniqueMiners           int64   `json:"unique_miners"`
+	AvgSessionSeconds      float64 `json:"avg_session_seconds"`
+	TotalTokenMinted       int64   `json:"total_token_minted"`
+	SpendableInCirculation int64   `json:"spendable_in_circulation"`
+}
+
 func NewStreamerService(db *gorm.DB, pointsSvc *PointsService) *StreamerService {
 	return &StreamerService{db: db, pointsSvc: pointsSvc}
 }
@@ -51,10 +62,47 @@ func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName stri
 	return streamer, nil
 }
 
+func (s *StreamerService) Create(userID uuid.UUID, agencyUserID *uuid.UUID, channelID string) (*models.Streamer, error) {
+	var count int64
+	if err := s.db.Model(&models.AuthProvider{}).
+		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderTwitch, channelID).
+		Count(&count).Error; err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, ErrChannelNotOwned
+	}
+
+	streamer := &models.Streamer{
+		UserID:       userID,
+		AgencyUserID: agencyUserID,
+		ChannelID:    channelID,
+	}
+
+	if err := s.db.
+		Where("user_id = ? AND channel_id = ?", userID, channelID).
+		Assign(models.Streamer{AgencyUserID: agencyUserID}).
+		FirstOrCreate(streamer).Error; err != nil {
+		return nil, err
+	}
+
+	return streamer, nil
+}
+
 func (s *StreamerService) OwnsChannel(userID uuid.UUID, channelID string) (bool, error) {
 	var count int64
 	if err := s.db.Model(&models.Streamer{}).
 		Where("user_id = ? AND channel_id = ?", userID, channelID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (s *StreamerService) OwnsAgencyChannel(agencyUserID uuid.UUID, channelID string) (bool, error) {
+	var count int64
+	if err := s.db.Model(&models.Streamer{}).
+		Where("agency_user_id = ? AND channel_id = ?", agencyUserID, channelID).
 		Count(&count).Error; err != nil {
 		return false, err
 	}
@@ -75,6 +123,46 @@ func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, err
 	return streamers, nil
 }
 
+func (s *StreamerService) GetByID(id uuid.UUID) (*models.Streamer, error) {
+	var streamer models.Streamer
+	if err := s.db.Where("id = ?", id).First(&streamer).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStreamerNotFound
+		}
+		return nil, err
+	}
+	return &streamer, nil
+}
+
+func (s *StreamerService) ListAll() ([]models.Streamer, error) {
+	var streamers []models.Streamer
+	if err := s.db.Order("created_at ASC").Find(&streamers).Error; err != nil {
+		return nil, err
+	}
+	return streamers, nil
+}
+
+func (s *StreamerService) ListByAgencyUserID(agencyUserID uuid.UUID) ([]models.Streamer, error) {
+	var streamers []models.Streamer
+	if err := s.db.
+		Where("agency_user_id = ?", agencyUserID).
+		Order("created_at ASC").
+		Find(&streamers).Error; err != nil {
+		return nil, err
+	}
+	return streamers, nil
+}
+
+func (s *StreamerService) OwnsStreamer(agencyUserID uuid.UUID, streamerID uuid.UUID) (bool, error) {
+	var count int64
+	if err := s.db.Model(&models.Streamer{}).
+		Where("id = ? AND agency_user_id = ?", streamerID, agencyUserID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, error) {
 	var provider models.AuthProvider
 	if err := s.db.
@@ -87,4 +175,61 @@ func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, er
 	}
 
 	return s.pointsSvc.GetBroadcastStats(provider.UserID, channelID)
+}
+
+func (s *StreamerService) GetStats(streamerUserID uuid.UUID) (*StreamerStats, error) {
+	var provider models.AuthProvider
+	if err := s.db.
+		Where("user_id = ? AND provider = ?", streamerUserID, models.ProviderTwitch).
+		First(&provider).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStreamerNotFound
+		}
+		return nil, err
+	}
+	channelID := provider.ProviderID
+
+	broadcast, err := s.pointsSvc.GetBroadcastStats(streamerUserID, channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	var traffic struct {
+		UniqueMiners      int64   `gorm:"column:unique_miners"`
+		AvgSessionSeconds float64 `gorm:"column:avg_session_seconds"`
+	}
+	if err := s.db.Raw(`
+		SELECT
+			COUNT(DISTINCT user_id) AS unique_miners,
+			COALESCE(AVG(accumulated_seconds), 0) AS avg_session_seconds
+		FROM watch_sessions
+		WHERE channel_id = ?
+	`, channelID).Scan(&traffic).Error; err != nil {
+		return nil, err
+	}
+
+	var economy struct {
+		TotalTokenMinted       int64 `gorm:"column:total_token_minted"`
+		SpendableInCirculation int64 `gorm:"column:spendable_in_circulation"`
+	}
+	if err := s.db.Raw(`
+		SELECT
+			COALESCE(SUM(cumulative_total), 0) AS total_token_minted,
+			COALESCE(SUM(spendable_balance), 0) AS spendable_in_circulation
+		FROM points_ledgers
+		WHERE channel_id = ?
+	`, channelID).Scan(&economy).Error; err != nil {
+		return nil, err
+	}
+
+	return &StreamerStats{
+		CurrentSessionSeconds:  broadcast.CurrentSessionSeconds,
+		DailySeconds:           broadcast.DailySeconds,
+		MonthlySeconds:         broadcast.MonthlySeconds,
+		YearlySeconds:          broadcast.YearlySeconds,
+		UniqueMiners:           traffic.UniqueMiners,
+		AvgSessionSeconds:      traffic.AvgSessionSeconds,
+		TotalTokenMinted:       economy.TotalTokenMinted,
+		SpendableInCirculation: economy.SpendableInCirculation,
+	}, nil
 }

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -177,9 +177,9 @@ func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, er
 	return s.pointsSvc.GetBroadcastStats(provider.UserID, channelID)
 }
 
-func (s *StreamerService) GetStats(streamerUserID uuid.UUID) (*StreamerStats, error) {
+func (s *StreamerService) GetStats(streamerID uuid.UUID) (*StreamerStats, error) {
 	var streamer models.Streamer
-	if err := s.db.Where("user_id = ?", streamerUserID).First(&streamer).Error; err != nil {
+	if err := s.db.Where("id = ?", streamerID).First(&streamer).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrStreamerNotFound
 		}
@@ -187,7 +187,7 @@ func (s *StreamerService) GetStats(streamerUserID uuid.UUID) (*StreamerStats, er
 	}
 	channelID := streamer.ChannelID
 
-	broadcast, err := s.pointsSvc.GetBroadcastStats(streamerUserID, channelID)
+	broadcast, err := s.pointsSvc.GetBroadcastStats(streamer.UserID, channelID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -138,6 +138,7 @@ func migrateTestDB(db *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS streamers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
+			agency_user_id TEXT REFERENCES users(id),
 			channel_id TEXT NOT NULL,
 			display_name TEXT,
 			created_at DATETIME,
@@ -145,6 +146,8 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
 			ON streamers (user_id, channel_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id
+			ON streamers (agency_user_id)`,
 		`CREATE TABLE IF NOT EXISTS points_ledgers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL,

--- a/backend/migrations/008_streamers_agency.sql
+++ b/backend/migrations/008_streamers_agency.sql
@@ -1,0 +1,3 @@
+ALTER TABLE streamers ADD COLUMN IF NOT EXISTS agency_user_id UUID REFERENCES users(id);
+
+CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);

--- a/backend/migrations/008_streamers_agency.sql
+++ b/backend/migrations/008_streamers_agency.sql
@@ -1,3 +1,40 @@
-ALTER TABLE streamers ADD COLUMN IF NOT EXISTS agency_user_id UUID REFERENCES users(id);
+ALTER TABLE streamers ADD COLUMN IF NOT EXISTS agency_user_id UUID;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_streamers_agency_user_id'
+    ) THEN
+        ALTER TABLE streamers
+        ADD CONSTRAINT fk_streamers_agency_user_id
+        FOREIGN KEY (agency_user_id) REFERENCES users(id);
+    END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);
+
+-- Fail fast if any streamer/channel maps to multiple agencies in legacy data.
+-- One streamer can belong to at most one agency (business rule).
+DO $$
+DECLARE conflict_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO conflict_count
+    FROM (
+        SELECT channel_id
+        FROM agency_streamers
+        GROUP BY channel_id
+        HAVING COUNT(DISTINCT agency_id) > 1
+    ) conflicts;
+    IF conflict_count > 0 THEN
+        RAISE EXCEPTION 'agency backfill conflict: % channel(s) map to multiple agencies in agency_streamers; resolve before deploying', conflict_count;
+    END IF;
+END $$;
+
+-- Backfill agency_user_id from legacy agency_streamers table.
+UPDATE streamers s
+SET agency_user_id = ag.agency_id
+FROM agency_streamers ag
+WHERE ag.channel_id = s.channel_id
+  AND s.agency_user_id IS NULL;

--- a/backend/migrations/008_streamers_agency.sql
+++ b/backend/migrations/008_streamers_agency.sql
@@ -14,27 +14,3 @@ BEGIN
 END $$;
 
 CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);
-
--- Fail fast if any streamer/channel maps to multiple agencies in legacy data.
--- One streamer can belong to at most one agency (business rule).
-DO $$
-DECLARE conflict_count INTEGER;
-BEGIN
-    SELECT COUNT(*) INTO conflict_count
-    FROM (
-        SELECT channel_id
-        FROM agency_streamers
-        GROUP BY channel_id
-        HAVING COUNT(DISTINCT agency_id) > 1
-    ) conflicts;
-    IF conflict_count > 0 THEN
-        RAISE EXCEPTION 'agency backfill conflict: % channel(s) map to multiple agencies in agency_streamers; resolve before deploying', conflict_count;
-    END IF;
-END $$;
-
--- Backfill agency_user_id from legacy agency_streamers table.
-UPDATE streamers s
-SET agency_user_id = ag.agency_id
-FROM agency_streamers ag
-WHERE ag.channel_id = s.channel_id
-  AND s.agency_user_id IS NULL;


### PR DESCRIPTION
## 背景

refs #69

在 develop 現有 `StreamerService`（Register / ListChannels / GetChannelStats）基礎上，補齊 agency scope 與完整 8 指標統計，供前端 Dashboard 頁面使用。

## Scope 對齊

- Source of truth: issue #69 — [backend] Dashboard — 實況主數據管理頁面
- Product surface: backend
- Changed files: 10
- Diff lines: 542

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 變更內容

- `backend/migrations/008_streamers_agency.sql` — streamers 表新增 `agency_user_id` 欄位與 index，並加入 fail-fast 衝突檢查與 FK 建立
- `backend/internal/models/streamer.go` — 新增 `AgencyUserID *uuid.UUID` 欄位
- `backend/internal/services/streamer_service.go` — 新增 `Create`（admin 指定 agency）、`GetByID`、`ListAll`、`ListByAgencyUserID`、`OwnsStreamer`、`GetStats`
- `backend/internal/handlers/streamer_handler.go` — 新增 `Create`、`List`、`GetStats`；保留既有 `Register` / `ListChannels` / `GetChannelStats`
- `backend/internal/router/router.go` — 新增 `POST /streamers`、`GET /streamers`、`GET /streamers/:streamer_id/stats`；legacy route 角色邊界收斂
- `backend/cmd/server/main.go` — 讀取並執行 migration 008
- `backend/internal/handlers/channel_config_handler.go` — Agency 授權調整
- `backend/internal/handlers/testutil_test.go` / `backend/internal/handlers/streamer_handler_test.go` — 補齊 SQLite FK 與 route parity / payload tests

## 本 PR 明確不做

- 不實作 Agency CRUD（/agencies 路由）
- 不實作 Event 功能
- 不修改前端 Dashboard 頁面
- 不更動 Auth / Points / Watch 既有邏輯

## 自動化驗證

- [x] `docker compose run --rm --no-deps --entrypoint sh app -lc "export PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; go test ./internal/handlers -run TestLegacyChannelStats_AgencyForbidden && go test ./cmd/server -run TestMigration008AddsAgencyUserForeignKeyConstraint"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 机构用户现可创建、列出并管理其关联的直播主；新增直播主统计接口，展示广播时长、流量与经济指标
  * 仪表盘路由与权限细化，按角色（管理员/机构/直播主）暴露不同操作

* **Bug 修复**
  * 强化频道/直播主所有权校验与错误映射，避免越权与信息泄露

* **测试**
  * 增补迁移与授权相关单元测试，覆盖回填、冲突检测与角色访问场景
<!-- end of auto-generated comment: release notes by coderabbit.ai -->