### PR TITLE
[frontend] Dashboard — 實況主數據管理頁面

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -105,11 +104,18 @@ func main() {
 	`).Error; err != nil {
 		log.Fatalf("failed to create streamer index: %v", err)
 	}
-	migration008Path := filepath.Join("backend", "migrations", "008_streamers_agency.sql")
-	if contents, err := os.ReadFile(migration008Path); err == nil {
-		if err := db.Exec(string(contents)).Error; err != nil {
-			log.Fatalf("failed to run 008_streamers_agency.sql: %v", err)
-		}
+	if err := db.Exec(`
+		ALTER TABLE streamers ADD COLUMN IF NOT EXISTS agency_user_id UUID REFERENCES users(id);
+		CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);
+		UPDATE streamers s
+		SET agency_user_id = (
+			SELECT ag.agency_id FROM agency_streamers ag
+			WHERE ag.channel_id = s.channel_id LIMIT 1
+		)
+		WHERE s.agency_user_id IS NULL
+		  AND (SELECT COUNT(DISTINCT agency_id) FROM agency_streamers ag WHERE ag.channel_id = s.channel_id) = 1;
+	`).Error; err != nil {
+		log.Fatalf("failed to run agency_user_id migration: %v", err)
 	}
 	// Wire services
 	authSvc := services.NewAuthService(db, cfg)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -103,6 +104,12 @@ func main() {
 		ON streamers (user_id, channel_id)
 	`).Error; err != nil {
 		log.Fatalf("failed to create streamer index: %v", err)
+	}
+	migration008Path := filepath.Join("backend", "migrations", "008_streamers_agency.sql")
+	if contents, err := os.ReadFile(migration008Path); err == nil {
+		if err := db.Exec(string(contents)).Error; err != nil {
+			log.Fatalf("failed to run 008_streamers_agency.sql: %v", err)
+		}
 	}
 	// Wire services
 	authSvc := services.NewAuthService(db, cfg)

--- a/backend/internal/handlers/channel_config_handler.go
+++ b/backend/internal/handlers/channel_config_handler.go
@@ -82,8 +82,21 @@ func (h *ChannelConfigHandler) authorizeChannelAccess(c *gin.Context) (string, b
 	case models.RoleAdmin:
 		return channelID, true
 	case models.RoleAgency:
-		c.JSON(http.StatusNotImplemented, Response{Success: false, Error: "agency channel config not implemented"})
-		return "", false
+		agencyUserID, err := uuid.Parse(claims.UserID)
+		if err != nil {
+			badRequest(c, "invalid user id")
+			return "", false
+		}
+		owns, err := h.streamerSvc.OwnsAgencyChannel(agencyUserID, channelID)
+		if err != nil {
+			internal(c)
+			return "", false
+		}
+		if !owns {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return "", false
+		}
+		return channelID, true
 	case models.RoleStreamer:
 		userID, err := uuid.Parse(claims.UserID)
 		if err != nil {

--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -50,6 +50,46 @@ func (h *StreamerHandler) Register(c *gin.Context) {
 	ok(c, gin.H{"streamer": streamer})
 }
 
+func (h *StreamerHandler) Create(c *gin.Context) {
+	var body struct {
+		UserID       string  `json:"user_id" binding:"required"`
+		AgencyUserID *string `json:"agency_user_id"`
+		ChannelID    string  `json:"channel_id" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+
+	userID, err := uuid.Parse(body.UserID)
+	if err != nil {
+		badRequest(c, "invalid user_id")
+		return
+	}
+
+	var agencyUserID *uuid.UUID
+	if body.AgencyUserID != nil {
+		aid, err := uuid.Parse(*body.AgencyUserID)
+		if err != nil {
+			badRequest(c, "invalid agency_user_id")
+			return
+		}
+		agencyUserID = &aid
+	}
+
+	streamer, err := h.streamerSvc.Create(userID, agencyUserID, body.ChannelID)
+	if err != nil {
+		if errors.Is(err, services.ErrChannelNotOwned) {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "channel_id does not match user's Twitch account"})
+			return
+		}
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"streamer": streamer})
+}
+
 func (h *StreamerHandler) ListChannels(c *gin.Context) {
 	claims := middleware.MustClaims(c)
 	userID, err := uuid.Parse(claims.UserID)
@@ -65,6 +105,36 @@ func (h *StreamerHandler) ListChannels(c *gin.Context) {
 	}
 
 	ok(c, gin.H{"channels": channels})
+}
+
+func (h *StreamerHandler) List(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+
+	var (
+		streamers []models.Streamer
+		err       error
+	)
+	switch claims.Role {
+	case models.RoleAdmin:
+		streamers, err = h.streamerSvc.ListAll()
+	case models.RoleAgency:
+		agencyUserID, parseErr := uuid.Parse(claims.UserID)
+		if parseErr != nil {
+			badRequest(c, "invalid user id")
+			return
+		}
+		streamers, err = h.streamerSvc.ListByAgencyUserID(agencyUserID)
+	default:
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return
+	}
+
+	if err != nil {
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"streamers": streamers})
 }
 
 func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
@@ -103,4 +173,62 @@ func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
 	}
 
 	ok(c, gin.H{"stats": stats})
+}
+
+func (h *StreamerHandler) GetStats(c *gin.Context) {
+	streamerID, err := uuid.Parse(c.Param("streamer_id"))
+	if err != nil {
+		badRequest(c, "invalid streamer_id")
+		return
+	}
+
+	streamer, err := h.streamerSvc.GetByID(streamerID)
+	if err != nil {
+		if errors.Is(err, services.ErrStreamerNotFound) {
+			notFound(c, "streamer not found")
+			return
+		}
+		internal(c)
+		return
+	}
+
+	claims := middleware.MustClaims(c)
+	switch claims.Role {
+	case models.RoleStreamer:
+		if claims.UserID != streamer.UserID.String() {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return
+		}
+	case models.RoleAgency:
+		agencyUserID, parseErr := uuid.Parse(claims.UserID)
+		if parseErr != nil {
+			badRequest(c, "invalid user id")
+			return
+		}
+		owns, ownErr := h.streamerSvc.OwnsStreamer(agencyUserID, streamerID)
+		if ownErr != nil {
+			internal(c)
+			return
+		}
+		if !owns {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return
+		}
+	case models.RoleAdmin:
+	default:
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return
+	}
+
+	stats, err := h.streamerSvc.GetStats(streamer.UserID)
+	if err != nil {
+		if errors.Is(err, services.ErrStreamerNotFound) {
+			notFound(c, "streamer not found")
+			return
+		}
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"stats": stats, "channel_id": streamer.ChannelID})
 }

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -302,6 +302,12 @@ func TestList_AgencySeesOwnOnly(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != 2 {
+		t.Fatalf("want 2 streamers for agency_a, got %d", len(streamers))
+	}
 }
 
 func TestList_AdminSeesAll(t *testing.T) {
@@ -318,6 +324,12 @@ func TestList_AdminSeesAll(t *testing.T) {
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", adminToken, "")
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != 2 {
+		t.Fatalf("want 2 streamers for admin, got %d", len(streamers))
 	}
 }
 

--- a/backend/internal/handlers/streamer_handler_test.go
+++ b/backend/internal/handlers/streamer_handler_test.go
@@ -30,11 +30,17 @@ func newStreamerDashboardEnv(t *testing.T) *dashboardEnv {
 	v1 := base.router.Group("/api/v1")
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(base.authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
+		dashboard.POST("/streamers", middleware.RequireRole(models.RoleAdmin), streamerH.Create)
+		dashboard.GET("/streamers", middleware.RequireRole(models.RoleAgency, models.RoleAdmin), streamerH.List)
+		dashboard.GET("/streamers/:streamer_id/stats",
+			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
+			streamerH.GetStats)
 		dashboard.POST("/streamers/register", streamerH.Register)
 		dashboard.GET("/streamers/channels", streamerH.ListChannels)
 		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
+		dashboard.GET("/channels/:channel_id/config", configH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", configH.UpdateChannelConfig)
 	}
 
@@ -70,6 +76,56 @@ func seedTwitchProvider(t *testing.T, env *dashboardEnv, email, channelID string
 	).Error; err != nil {
 		t.Fatalf("seed auth provider: %v", err)
 	}
+}
+
+func createDashboardUser(t *testing.T, env *dashboardEnv, role models.UserRole, prefix string) (models.User, string) {
+	t.Helper()
+
+	email := prefix + "@example.com"
+	username := prefix
+	password := "password123"
+
+	user, _, err := env.authSvc.Register(services.RegisterInput{
+		Username: username,
+		Email:    email,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("register %s: %v", prefix, err)
+	}
+	if err := env.db.Model(user).Update("role", role).Error; err != nil {
+		t.Fatalf("set role %s: %v", prefix, err)
+	}
+
+	_, tokens, err := env.authSvc.Login(services.LoginInput{Email: email, Password: password})
+	if err != nil {
+		t.Fatalf("login %s: %v", prefix, err)
+	}
+	return *user, tokens.AccessToken
+}
+
+func seedTwitchProviderForUser(t *testing.T, env *dashboardEnv, userID uuid.UUID, channelID string) {
+	t.Helper()
+	if err := env.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		uuid.New(), userID, models.ProviderTwitch, channelID,
+	).Error; err != nil {
+		t.Fatalf("seed auth provider: %v", err)
+	}
+}
+
+func seedStreamerRow(t *testing.T, env *dashboardEnv, userID uuid.UUID, agencyUserID *uuid.UUID, channelID string) *models.Streamer {
+	t.Helper()
+	streamer := &models.Streamer{
+		UserID:      userID,
+		AgencyUserID: agencyUserID,
+		ChannelID:   channelID,
+	}
+	if err := env.db.Create(streamer).Error; err != nil {
+		t.Fatalf("seed streamer: %v", err)
+	}
+	return streamer
 }
 
 func TestStreamerRegister_AndListChannels(t *testing.T) {
@@ -187,5 +243,155 @@ func TestGetChannelStats_ForbiddenForOtherStreamer(t *testing.T) {
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_A/stats", tokenB, "")
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_AdminOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "streamer_admin")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target")
+	agencyUser, _ := createDashboardUser(t, env, models.RoleAgency, "agency_target")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_ch_id")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","agency_user_id":"` + agencyUser.ID.String() + `","channel_id":"target_ch_id"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", adminToken, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_StreamerForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "forbidden_streamer")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target_s")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_ch_id")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","channel_id":"target_ch_id"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", streamerToken, body)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_AgencyForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, agencyToken := createDashboardUser(t, env, models.RoleAgency, "forbidden_agency")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "streamer_target_a")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "target_ch_id")
+
+	body := `{"user_id":"` + streamerUser.ID.String() + `","channel_id":"target_ch_id"}`
+	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", agencyToken, body)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestList_AgencySeesOwnOnly(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	agencyA, agencyToken := createDashboardUser(t, env, models.RoleAgency, "agency_a")
+	agencyB, _ := createDashboardUser(t, env, models.RoleAgency, "agency_b")
+	streamerA1, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_a_streamer1")
+	streamerA2, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_a_streamer2")
+	streamerB1, _ := createDashboardUser(t, env, models.RoleStreamer, "agency_b_streamer1")
+
+	seedStreamerRow(t, env, streamerA1.ID, &agencyA.ID, "a1_login")
+	seedStreamerRow(t, env, streamerA2.ID, &agencyA.ID, "a2_login")
+	seedStreamerRow(t, env, streamerB1.ID, &agencyB.ID, "b1_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", agencyToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestList_AdminSeesAll(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "list_admin")
+	agencyA, _ := createDashboardUser(t, env, models.RoleAgency, "list_agency_a")
+	agencyB, _ := createDashboardUser(t, env, models.RoleAgency, "list_agency_b")
+	streamerA, _ := createDashboardUser(t, env, models.RoleStreamer, "list_streamer_a")
+	streamerB, _ := createDashboardUser(t, env, models.RoleStreamer, "list_streamer_b")
+
+	seedStreamerRow(t, env, streamerA.ID, &agencyA.ID, "admin_a_login")
+	seedStreamerRow(t, env, streamerB.ID, &agencyB.ID, "admin_b_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers", adminToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_StreamerOwnOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	streamerUser, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_self")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "self_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, nil, "self_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", streamerToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_StreamerOtherForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	otherStreamer, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_other")
+	seedTwitchProviderForUser(t, env, otherStreamer.ID, "other_login")
+	streamer := seedStreamerRow(t, env, otherStreamer.ID, nil, "other_login")
+	_, streamerToken := createDashboardUser(t, env, models.RoleStreamer, "stats_streamer_requester")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", streamerToken, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AgencyOwnOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	agency, agencyToken := createDashboardUser(t, env, models.RoleAgency, "stats_agency_self")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_agency_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "agency_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, &agency.ID, "agency_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", agencyToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AgencyOtherForbidden(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	otherAgency, _ := createDashboardUser(t, env, models.RoleAgency, "stats_agency_other")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_agency_other_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "other_agency_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, &otherAgency.ID, "other_agency_login")
+	_, agencyToken := createDashboardUser(t, env, models.RoleAgency, "stats_agency_requester")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", agencyToken, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_AdminAllOK(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "stats_admin")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "stats_admin_streamer")
+	seedTwitchProviderForUser(t, env, streamerUser.ID, "admin_login")
+	streamer := seedStreamerRow(t, env, streamerUser.ID, nil, "admin_login")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+streamer.ID.String()+"/stats", adminToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetStats_NotFound(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "stats_not_found_admin")
+
+	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/streamers/"+uuid.New().String()+"/stats", adminToken, "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -105,6 +105,7 @@ func migrateTestDB(db *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS streamers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
+			agency_user_id TEXT REFERENCES users(id),
 			channel_id TEXT NOT NULL,
 			display_name TEXT,
 			created_at DATETIME,
@@ -112,6 +113,8 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
 			ON streamers (user_id, channel_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id
+			ON streamers (agency_user_id)`,
 		`CREATE TABLE IF NOT EXISTS watch_sessions (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),

--- a/backend/internal/models/streamer.go
+++ b/backend/internal/models/streamer.go
@@ -8,12 +8,13 @@ import (
 )
 
 type Streamer struct {
-	ID          uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	UserID      uuid.UUID `gorm:"type:uuid;not null;index;uniqueIndex:idx_streamers_user_channel" json:"user_id"`
-	ChannelID   string    `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_streamers_user_channel" json:"channel_id"`
-	DisplayName string    `gorm:"type:varchar(255)"                              json:"display_name"`
-	CreatedAt   time.Time `                                                      json:"created_at"`
-	UpdatedAt   time.Time `                                                      json:"updated_at"`
+	ID           uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"                        json:"id"`
+	UserID       uuid.UUID  `gorm:"type:uuid;not null;index;uniqueIndex:idx_streamers_user_channel"      json:"user_id"`
+	AgencyUserID *uuid.UUID `gorm:"type:uuid;index:idx_streamers_agency_user_id"                          json:"agency_user_id"`
+	ChannelID    string     `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_streamers_user_channel" json:"channel_id"`
+	DisplayName  string     `gorm:"type:varchar(255)"                                                     json:"display_name"`
+	CreatedAt    time.Time  `                                                                             json:"created_at"`
+	UpdatedAt    time.Time  `                                                                             json:"updated_at"`
 }
 
 func (s *Streamer) BeforeCreate(tx *gorm.DB) error {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -126,12 +126,19 @@ func New(
 
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
+		dashboard.POST("/streamers", middleware.RequireRole(models.RoleAdmin), streamerH.Create)
+		dashboard.GET("/streamers", middleware.RequireRole(models.RoleAgency, models.RoleAdmin), streamerH.List)
+		dashboard.GET("/streamers/:streamer_id/stats",
+			middleware.RequireRole(models.RoleStreamer, models.RoleAgency, models.RoleAdmin),
+			streamerH.GetStats)
 		dashboard.POST("/streamers/register", streamerH.Register)
 		dashboard.GET("/streamers/channels", streamerH.ListChannels)
 		dashboard.GET("/channels/:channel_id/stats", streamerH.GetChannelStats)
-		dashboard.GET("/channels/:channel_id/config", channelConfigH.GetChannelConfig)
+		dashboard.GET("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
+			channelConfigH.GetChannelConfig)
 		dashboard.PUT("/channels/:channel_id/config", channelConfigH.UpdateChannelConfig)
 	}
 

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -178,16 +178,14 @@ func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, er
 }
 
 func (s *StreamerService) GetStats(streamerUserID uuid.UUID) (*StreamerStats, error) {
-	var provider models.AuthProvider
-	if err := s.db.
-		Where("user_id = ? AND provider = ?", streamerUserID, models.ProviderTwitch).
-		First(&provider).Error; err != nil {
+	var streamer models.Streamer
+	if err := s.db.Where("user_id = ?", streamerUserID).First(&streamer).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrStreamerNotFound
 		}
 		return nil, err
 	}
-	channelID := provider.ProviderID
+	channelID := streamer.ChannelID
 
 	broadcast, err := s.pointsSvc.GetBroadcastStats(streamerUserID, channelID)
 	if err != nil {

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -19,6 +19,17 @@ type StreamerService struct {
 	pointsSvc *PointsService
 }
 
+type StreamerStats struct {
+	CurrentSessionSeconds  int64   `json:"current_session_seconds"`
+	DailySeconds           int64   `json:"daily_seconds"`
+	MonthlySeconds         int64   `json:"monthly_seconds"`
+	YearlySeconds          int64   `json:"yearly_seconds"`
+	UniqueMiners           int64   `json:"unique_miners"`
+	AvgSessionSeconds      float64 `json:"avg_session_seconds"`
+	TotalTokenMinted       int64   `json:"total_token_minted"`
+	SpendableInCirculation int64   `json:"spendable_in_circulation"`
+}
+
 func NewStreamerService(db *gorm.DB, pointsSvc *PointsService) *StreamerService {
 	return &StreamerService{db: db, pointsSvc: pointsSvc}
 }
@@ -51,10 +62,47 @@ func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName stri
 	return streamer, nil
 }
 
+func (s *StreamerService) Create(userID uuid.UUID, agencyUserID *uuid.UUID, channelID string) (*models.Streamer, error) {
+	var count int64
+	if err := s.db.Model(&models.AuthProvider{}).
+		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderTwitch, channelID).
+		Count(&count).Error; err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, ErrChannelNotOwned
+	}
+
+	streamer := &models.Streamer{
+		UserID:       userID,
+		AgencyUserID: agencyUserID,
+		ChannelID:    channelID,
+	}
+
+	if err := s.db.
+		Where("user_id = ? AND channel_id = ?", userID, channelID).
+		Assign(models.Streamer{AgencyUserID: agencyUserID}).
+		FirstOrCreate(streamer).Error; err != nil {
+		return nil, err
+	}
+
+	return streamer, nil
+}
+
 func (s *StreamerService) OwnsChannel(userID uuid.UUID, channelID string) (bool, error) {
 	var count int64
 	if err := s.db.Model(&models.Streamer{}).
 		Where("user_id = ? AND channel_id = ?", userID, channelID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (s *StreamerService) OwnsAgencyChannel(agencyUserID uuid.UUID, channelID string) (bool, error) {
+	var count int64
+	if err := s.db.Model(&models.Streamer{}).
+		Where("agency_user_id = ? AND channel_id = ?", agencyUserID, channelID).
 		Count(&count).Error; err != nil {
 		return false, err
 	}
@@ -75,6 +123,46 @@ func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, err
 	return streamers, nil
 }
 
+func (s *StreamerService) GetByID(id uuid.UUID) (*models.Streamer, error) {
+	var streamer models.Streamer
+	if err := s.db.Where("id = ?", id).First(&streamer).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStreamerNotFound
+		}
+		return nil, err
+	}
+	return &streamer, nil
+}
+
+func (s *StreamerService) ListAll() ([]models.Streamer, error) {
+	var streamers []models.Streamer
+	if err := s.db.Order("created_at ASC").Find(&streamers).Error; err != nil {
+		return nil, err
+	}
+	return streamers, nil
+}
+
+func (s *StreamerService) ListByAgencyUserID(agencyUserID uuid.UUID) ([]models.Streamer, error) {
+	var streamers []models.Streamer
+	if err := s.db.
+		Where("agency_user_id = ?", agencyUserID).
+		Order("created_at ASC").
+		Find(&streamers).Error; err != nil {
+		return nil, err
+	}
+	return streamers, nil
+}
+
+func (s *StreamerService) OwnsStreamer(agencyUserID uuid.UUID, streamerID uuid.UUID) (bool, error) {
+	var count int64
+	if err := s.db.Model(&models.Streamer{}).
+		Where("id = ? AND agency_user_id = ?", streamerID, agencyUserID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, error) {
 	var provider models.AuthProvider
 	if err := s.db.
@@ -87,4 +175,61 @@ func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, er
 	}
 
 	return s.pointsSvc.GetBroadcastStats(provider.UserID, channelID)
+}
+
+func (s *StreamerService) GetStats(streamerUserID uuid.UUID) (*StreamerStats, error) {
+	var provider models.AuthProvider
+	if err := s.db.
+		Where("user_id = ? AND provider = ?", streamerUserID, models.ProviderTwitch).
+		First(&provider).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrStreamerNotFound
+		}
+		return nil, err
+	}
+	channelID := provider.ProviderID
+
+	broadcast, err := s.pointsSvc.GetBroadcastStats(streamerUserID, channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	var traffic struct {
+		UniqueMiners      int64   `gorm:"column:unique_miners"`
+		AvgSessionSeconds float64 `gorm:"column:avg_session_seconds"`
+	}
+	if err := s.db.Raw(`
+		SELECT
+			COUNT(DISTINCT user_id) AS unique_miners,
+			COALESCE(AVG(accumulated_seconds), 0) AS avg_session_seconds
+		FROM watch_sessions
+		WHERE channel_id = ?
+	`, channelID).Scan(&traffic).Error; err != nil {
+		return nil, err
+	}
+
+	var economy struct {
+		TotalTokenMinted       int64 `gorm:"column:total_token_minted"`
+		SpendableInCirculation int64 `gorm:"column:spendable_in_circulation"`
+	}
+	if err := s.db.Raw(`
+		SELECT
+			COALESCE(SUM(cumulative_total), 0) AS total_token_minted,
+			COALESCE(SUM(spendable_balance), 0) AS spendable_in_circulation
+		FROM points_ledgers
+		WHERE channel_id = ?
+	`, channelID).Scan(&economy).Error; err != nil {
+		return nil, err
+	}
+
+	return &StreamerStats{
+		CurrentSessionSeconds:  broadcast.CurrentSessionSeconds,
+		DailySeconds:           broadcast.DailySeconds,
+		MonthlySeconds:         broadcast.MonthlySeconds,
+		YearlySeconds:          broadcast.YearlySeconds,
+		UniqueMiners:           traffic.UniqueMiners,
+		AvgSessionSeconds:      traffic.AvgSessionSeconds,
+		TotalTokenMinted:       economy.TotalTokenMinted,
+		SpendableInCirculation: economy.SpendableInCirculation,
+	}, nil
 }

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -138,6 +138,7 @@ func migrateTestDB(db *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS streamers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
+			agency_user_id TEXT REFERENCES users(id),
 			channel_id TEXT NOT NULL,
 			display_name TEXT,
 			created_at DATETIME,
@@ -145,6 +146,8 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
 			ON streamers (user_id, channel_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id
+			ON streamers (agency_user_id)`,
 		`CREATE TABLE IF NOT EXISTS points_ledgers (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL,

--- a/backend/migrations/008_streamers_agency.sql
+++ b/backend/migrations/008_streamers_agency.sql
@@ -1,0 +1,3 @@
+ALTER TABLE streamers ADD COLUMN IF NOT EXISTS agency_user_id UUID REFERENCES users(id);
+
+CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id ON streamers (agency_user_id);

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,7 +9,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
@@ -30,14 +31,17 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.27",
+    "axios-mock-adapter": "^2.1.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.0.1",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.2"
   }
 }

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
+      axios-mock-adapter:
+        specifier: ^2.1.0
+        version: 2.1.0(axios@1.14.0)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
@@ -69,6 +72,9 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.2
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
@@ -84,12 +90,26 @@ importers:
       vite:
         specifier: ^8.0.1
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.3(@types/node@24.12.0)(jsdom@29.0.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.6':
+    resolution: {integrity: sha512-BXWCh8dHs9GOfpo/fWGDJtDmleta2VePN9rn6WQt3GjEbxzutVF4t0x2pmH+7dbMCLtuv3MlwqRsAuxlzFXqFg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.8':
+    resolution: {integrity: sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -158,6 +178,46 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
@@ -204,6 +264,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -365,6 +434,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
@@ -460,6 +532,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -549,6 +627,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
+
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
+
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
+
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
+
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
+
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -569,6 +676,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -578,6 +689,11 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axios-mock-adapter@2.1.0:
+    resolution: {integrity: sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==}
+    peerDependencies:
+      axios: '>= 0.17.0'
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
@@ -593,6 +709,9 @@ packages:
     resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
@@ -616,6 +735,10 @@ packages:
 
   caniuse-lite@1.0.30001784:
     resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -653,8 +776,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -664,6 +795,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -687,6 +821,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -694,6 +832,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -764,9 +905,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -878,6 +1026,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -894,6 +1046,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -901,6 +1057,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -915,6 +1074,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1023,6 +1191,10 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lru-cache@11.3.2:
+    resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1037,6 +1209,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1067,6 +1242,9 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1083,6 +1261,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1090,6 +1271,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1136,6 +1320,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1144,6 +1332,10 @@ packages:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1168,9 +1360,18 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1179,6 +1380,9 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -1190,9 +1394,35 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1221,6 +1451,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1274,14 +1508,83 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1302,6 +1605,22 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.6':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.0.8':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1403,6 +1722,34 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -1464,6 +1811,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -1571,6 +1920,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1644,6 +1995,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -1757,6 +2115,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)
 
+  '@vitest/expect@4.1.3':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.3(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.3':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.3':
+    dependencies:
+      '@vitest/utils': 4.1.3
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.3': {}
+
+  '@vitest/utils@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -1776,6 +2175,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   asynckit@0.4.0: {}
 
   autoprefixer@10.4.27(postcss@8.5.8):
@@ -1786,6 +2187,12 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
+
+  axios-mock-adapter@2.1.0(axios@1.14.0):
+    dependencies:
+      axios: 1.14.0
+      fast-deep-equal: 3.1.3
+      is-buffer: 2.0.5
 
   axios@1.14.0:
     dependencies:
@@ -1800,6 +2207,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.13: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.13:
     dependencies:
@@ -1826,6 +2237,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001784: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -1860,11 +2273,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -1885,9 +2312,13 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
+  entities@6.0.1: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -1987,7 +2418,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2082,6 +2519,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -2093,11 +2536,15 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  is-buffer@2.0.5: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-potential-custom-element-name@1.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -2108,6 +2555,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.6
+      '@asamuzakjp/dom-selector': 7.0.8
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.2
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -2183,6 +2656,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lru-cache@11.3.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2196,6 +2671,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mime-db@1.52.0: {}
 
@@ -2219,6 +2696,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  obug@2.1.1: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2240,9 +2719,15 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -2277,6 +2762,8 @@ snapshots:
 
   react@19.2.4: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
@@ -2303,6 +2790,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -2317,7 +2808,13 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -2325,16 +2822,38 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -2362,6 +2881,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@7.24.7: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2387,11 +2908,64 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vitest@4.1.3(@types/node@24.12.0)(jsdom@29.0.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.0
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -3,6 +3,7 @@ import Layout from '@/components/Layout'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import LoginPage from '@/pages/LoginPage'
 import DashboardPage from '@/pages/DashboardPage'
+import StreamerDetailPage from '@/pages/StreamerDetailPage'
 import StreamersPage from '@/pages/StreamersPage'
 import TransactionsPage from '@/pages/TransactionsPage'
 import SettingsPage from '@/pages/SettingsPage'
@@ -20,6 +21,7 @@ const router = createBrowserRouter([
         children: [
           { index: true, element: <DashboardPage /> },
           { path: 'streamers', element: <StreamersPage /> },
+          { path: 'streamers/:streamerId', element: <StreamerDetailPage /> },
           { path: 'transactions', element: <TransactionsPage /> },
           { path: 'settings', element: <SettingsPage /> },
         ],

--- a/dashboard/src/components/ui/skeleton.tsx
+++ b/dashboard/src/components/ui/skeleton.tsx
@@ -1,0 +1,8 @@
+import type { HTMLAttributes } from 'react'
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />
+}
+
+export { Skeleton }

--- a/dashboard/src/pages/StreamerDetailPage.tsx
+++ b/dashboard/src/pages/StreamerDetailPage.tsx
@@ -71,7 +71,8 @@ export default function StreamerDetailPage() {
           const configData = await getChannelConfig(channelId)
           if (!mounted) return
           setConfig(configData)
-        } catch {
+        } catch (err) {
+          console.error('Failed to load channel config:', err)
           if (!mounted) return
           setConfig(null)
         }

--- a/dashboard/src/pages/StreamerDetailPage.tsx
+++ b/dashboard/src/pages/StreamerDetailPage.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getCurrentUserRole } from '@/services/auth'
+import {
+  getChannelConfig,
+  getStreamerStats,
+  type ChannelConfig,
+  type StreamerStats,
+} from '@/services/channels'
+
+function formatHours(seconds?: number) {
+  if (seconds === undefined) return '—'
+  return `${(seconds / 3600).toFixed(1)} 小時`
+}
+
+function formatMinutes(seconds?: number) {
+  if (seconds === undefined) return '—'
+  return `${Math.round(seconds / 60)} 分`
+}
+
+function formatNumber(value?: number, unit?: string) {
+  if (value === undefined) return '—'
+  return `${value.toLocaleString()}${unit ? ` ${unit}` : ''}`
+}
+
+function calcPerMinute(config: ChannelConfig | null) {
+  if (!config || config.seconds_per_point === 0) return '—'
+  return `${((60 / config.seconds_per_point) * config.multiplier).toFixed(1)} 點`
+}
+
+function TimeCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex-1 rounded-lg border border-border bg-secondary/30 p-4 text-center">
+      <p className="mb-1 text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-bold text-foreground">{value}</p>
+    </div>
+  )
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex-1 space-y-1 rounded-lg border border-border bg-secondary/30 p-5">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold text-foreground">{value}</p>
+    </div>
+  )
+}
+
+export default function StreamerDetailPage() {
+  const { streamerId } = useParams()
+  const navigate = useNavigate()
+  const role = getCurrentUserRole()
+  const [stats, setStats] = useState<StreamerStats | null>(null)
+  const [config, setConfig] = useState<ChannelConfig | null>(null)
+  const [loading, setLoading] = useState(Boolean(streamerId))
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (!streamerId) return
+
+    let mounted = true
+
+    getStreamerStats(streamerId)
+      .then(async ({ stats, channelId }) => {
+        if (!mounted) return
+        setStats(stats)
+
+        try {
+          const configData = await getChannelConfig(channelId)
+          if (!mounted) return
+          setConfig(configData)
+        } catch {
+          if (!mounted) return
+          setConfig(null)
+        }
+      })
+      .catch(() => {
+        if (!mounted) return
+        setError(true)
+      })
+      .finally(() => {
+        if (!mounted) return
+        setLoading(false)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [streamerId])
+
+  const timeCards = [
+    { label: '本次', value: formatHours(stats?.current_session_seconds) },
+    { label: '本日', value: formatHours(stats?.daily_seconds) },
+    { label: '本月', value: formatHours(stats?.monthly_seconds) },
+    { label: '年度', value: formatHours(stats?.yearly_seconds) },
+  ]
+
+  const metricCards = [
+    { label: '挖礦參與人數', value: formatNumber(stats?.unique_miners, '人') },
+    { label: '觀眾平均停留', value: formatMinutes(stats?.avg_session_seconds) },
+    { label: '總產出點數', value: formatNumber(stats?.total_token_minted, '點') },
+    { label: '可用點數總量', value: formatNumber(stats?.spendable_in_circulation, '點') },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {role !== 'streamer' && (
+            <button
+              onClick={() => navigate('/streamers')}
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              ← 返回列表
+            </button>
+          )}
+          <h1 className="text-2xl font-bold text-foreground">{streamerId}</h1>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => console.log('TODO: #71')}>
+            空投
+          </Button>
+          <Button variant="outline" onClick={() => console.log('TODO: #71')}>
+            調整倍率
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-28 w-full" />
+          <div className="grid gap-4 md:grid-cols-4">
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+          </div>
+          <Skeleton className="h-40 w-full" />
+        </div>
+      ) : error || !stats || !streamerId ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          無法載入頻道詳細資料
+        </div>
+      ) : (
+        <>
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              開台時數
+            </h2>
+            <div className="grid gap-3 md:grid-cols-4">
+              {timeCards.map((card) => (
+                <TimeCard key={card.label} label={card.label} value={card.value} />
+              ))}
+            </div>
+          </section>
+
+          <div className="grid gap-3 md:grid-cols-4">
+            {metricCards.map((card) => (
+              <MetricCard key={card.label} label={card.label} value={card.value} />
+            ))}
+          </div>
+
+          <section className="space-y-4 rounded-lg border border-border bg-secondary/30 p-6">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              挖礦倍率設定
+            </h2>
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">每秒點數基準</span>
+                <span className="font-medium text-foreground">
+                  {config ? `${config.seconds_per_point} 秒 / 點` : '—'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">目前倍率</span>
+                <span className="font-medium text-foreground">
+                  {config ? `${config.multiplier}x` : '—'}
+                </span>
+              </div>
+              <div className="mt-2 flex justify-between border-t border-border pt-2">
+                <span className="text-muted-foreground">每分鐘產出</span>
+                <span className="font-semibold text-primary">{calcPerMinute(config)}</span>
+              </div>
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/pages/StreamersPage.tsx
+++ b/dashboard/src/pages/StreamersPage.tsx
@@ -1,3 +1,89 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getCurrentUserRole } from '@/services/auth'
+import { getStreamers, type Streamer } from '@/services/channels'
+
 export default function StreamersPage() {
-  return <h1 className="text-2xl font-bold text-foreground">實況主管理</h1>
+  const navigate = useNavigate()
+  const role = getCurrentUserRole()
+  const [streamers, setStreamers] = useState<Streamer[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+
+    getStreamers()
+      .then((data) => {
+        if (!mounted) return
+        setStreamers(data)
+      })
+      .catch(() => {
+        if (!mounted) return
+        setError(true)
+      })
+      .finally(() => {
+        if (!mounted) return
+        setLoading(false)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (loading || role !== 'streamer') return
+    const first = streamers[0]
+    if (!first) return
+    navigate(`/streamers/${first.id}`, { replace: true })
+  }, [loading, navigate, role, streamers])
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-foreground">實況主管理</h1>
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-11 w-full" />
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          無法載入實況主資料
+        </div>
+      ) : streamers.length === 0 ? (
+        <div className="rounded-lg border border-border bg-secondary/20 px-4 py-8 text-center text-sm text-muted-foreground">
+          目前沒有可顯示的實況主資料
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-secondary/50">
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">實況主名稱</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Channel ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {streamers.map((streamer, index) => (
+                <tr
+                  key={streamer.id}
+                  className={`cursor-pointer border-b border-border transition-colors last:border-0 hover:bg-accent/30 ${index % 2 === 0 ? '' : 'bg-secondary/20'}`}
+                  onClick={() => navigate(`/streamers/${streamer.id}`)}
+                >
+                  <td className="px-4 py-3 font-medium text-foreground">
+                    {streamer.display_name || streamer.channel_id}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{streamer.channel_id}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
 }

--- a/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
+++ b/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
@@ -1,0 +1,170 @@
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import StreamerDetailPage from '@/pages/StreamerDetailPage'
+
+const navigateMock = vi.fn()
+const getStreamerStatsMock = vi.fn()
+const getChannelConfigMock = vi.fn()
+const getCurrentUserRoleMock = vi.fn()
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => ({ streamerId: 'uuid-streamer-1' }),
+  }
+})
+
+vi.mock('@/services/channels', () => ({
+  getStreamerStats: (...args: unknown[]) => getStreamerStatsMock(...args),
+  getChannelConfig: (...args: unknown[]) => getChannelConfigMock(...args),
+}))
+
+vi.mock('@/services/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/services/auth')>('@/services/auth')
+  return {
+    ...actual,
+    getCurrentUserRole: () => getCurrentUserRoleMock(),
+  }
+})
+
+async function renderPage() {
+  const { MemoryRouter } = await import('react-router')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <StreamerDetailPage />
+      </MemoryRouter>,
+    )
+  })
+
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount()
+      })
+      container.remove()
+    },
+  }
+}
+
+describe('StreamerDetailPage', () => {
+  beforeEach(() => {
+    navigateMock.mockReset()
+    getStreamerStatsMock.mockReset()
+    getChannelConfigMock.mockReset()
+    getCurrentUserRoleMock.mockReset()
+  })
+
+  it('秒數換算與倍率顯示正確', async () => {
+    getCurrentUserRoleMock.mockReturnValue('admin')
+    getStreamerStatsMock.mockResolvedValue({
+      stats: {
+        current_session_seconds: 5400,
+        daily_seconds: 7200,
+        monthly_seconds: 14400,
+        yearly_seconds: 28800,
+        avg_session_seconds: 600,
+        unique_miners: 42,
+        total_token_minted: 128,
+        spendable_in_circulation: 60,
+      },
+      channelId: 'channel-1',
+    })
+    getChannelConfigMock.mockResolvedValue({
+      channel_id: 'channel-1',
+      seconds_per_point: 30,
+      multiplier: 2,
+    })
+
+    const { container, unmount } = await renderPage()
+
+    expect(container.textContent).toContain('1.5 小時')
+    expect(container.textContent).toContain('10 分')
+    expect(container.textContent).toContain('4.0 點')
+
+    await unmount()
+  })
+
+  it('streamer 角色不顯示返回列表', async () => {
+    getCurrentUserRoleMock.mockReturnValue('streamer')
+    getStreamerStatsMock.mockResolvedValue({
+      stats: {
+        current_session_seconds: 0,
+        daily_seconds: 0,
+        monthly_seconds: 0,
+        yearly_seconds: 0,
+        avg_session_seconds: 0,
+        unique_miners: 0,
+        total_token_minted: 0,
+        spendable_in_circulation: 0,
+      },
+      channelId: 'channel-1',
+    })
+    getChannelConfigMock.mockResolvedValue({
+      channel_id: 'channel-1',
+      seconds_per_point: 60,
+      multiplier: 1,
+    })
+
+    const { container, unmount } = await renderPage()
+
+    expect(container.textContent).not.toContain('返回列表')
+
+    await unmount()
+  })
+
+  it('stats API 失敗時顯示整頁錯誤訊息', async () => {
+    getCurrentUserRoleMock.mockReturnValue('admin')
+    getStreamerStatsMock.mockRejectedValue(new Error('server error'))
+
+    const { container, unmount } = await renderPage()
+
+    expect(container.textContent).toContain('無法載入頻道詳細資料')
+
+    await unmount()
+  })
+
+  it('config API 失敗時靜默降級為破折號', async () => {
+    getCurrentUserRoleMock.mockReturnValue('admin')
+    getStreamerStatsMock.mockResolvedValue({
+      stats: {
+        current_session_seconds: 5400,
+        daily_seconds: 7200,
+        monthly_seconds: 14400,
+        yearly_seconds: 28800,
+        avg_session_seconds: 600,
+        unique_miners: 42,
+        total_token_minted: 128,
+        spendable_in_circulation: 60,
+      },
+      channelId: 'channel-1',
+    })
+    getChannelConfigMock.mockRejectedValue(new Error('config unavailable'))
+
+    const { container, unmount } = await renderPage()
+
+    expect(container.textContent).toContain('1.5 小時')
+    expect(container.textContent).not.toContain('無法載入頻道詳細資料')
+    expect(container.textContent).toContain('每秒點數基準')
+    expect(container.textContent).toContain('目前倍率')
+    expect(container.textContent).toContain('每分鐘產出')
+    expect(container.textContent).toContain('—')
+
+    await unmount()
+  })
+})

--- a/dashboard/src/pages/__tests__/StreamersPage.test.tsx
+++ b/dashboard/src/pages/__tests__/StreamersPage.test.tsx
@@ -1,0 +1,127 @@
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import StreamersPage from '@/pages/StreamersPage'
+
+const navigateMock = vi.fn()
+const getStreamersMock = vi.fn()
+const getCurrentUserRoleMock = vi.fn()
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+vi.mock('@/services/channels', () => ({
+  getStreamers: (...args: unknown[]) => getStreamersMock(...args),
+}))
+
+vi.mock('@/services/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/services/auth')>('@/services/auth')
+  return {
+    ...actual,
+    getCurrentUserRole: () => getCurrentUserRoleMock(),
+  }
+})
+
+async function renderPage() {
+  const { MemoryRouter } = await import('react-router')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <StreamersPage />
+      </MemoryRouter>,
+    )
+  })
+
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount()
+      })
+      container.remove()
+    },
+  }
+}
+
+describe('StreamersPage', () => {
+  beforeEach(() => {
+    navigateMock.mockReset()
+    getStreamersMock.mockReset()
+    getCurrentUserRoleMock.mockReset()
+  })
+
+  it('載入成功時顯示 API 資料', async () => {
+    getCurrentUserRoleMock.mockReturnValue('admin')
+    getStreamersMock.mockResolvedValue([
+      {
+        id: 'uuid-1',
+        user_id: 'user-1',
+        channel_id: 'channel-1',
+        display_name: 'Nurock',
+      },
+    ])
+
+    const { container, unmount } = await renderPage()
+
+    expect(container.textContent).toContain('Nurock')
+    expect(container.textContent).toContain('channel-1')
+
+    await unmount()
+  })
+
+  it('streamer 角色在載入完成後自動跳轉到自己的詳細頁', async () => {
+    getCurrentUserRoleMock.mockReturnValue('streamer')
+    getStreamersMock.mockResolvedValue([
+      {
+        id: 'uuid-1',
+        user_id: 'user-1',
+        channel_id: 'channel-1',
+        display_name: 'Nurock',
+      },
+    ])
+
+    const { unmount } = await renderPage()
+
+    expect(navigateMock).toHaveBeenCalledWith('/streamers/uuid-1', { replace: true })
+
+    await unmount()
+  })
+
+  it('API 失敗時顯示錯誤訊息', async () => {
+    getCurrentUserRoleMock.mockReturnValue('admin')
+    getStreamersMock.mockRejectedValue(new Error('boom'))
+
+    const { container, unmount } = await renderPage()
+
+    expect(container.textContent).toContain('無法載入實況主資料')
+
+    await unmount()
+  })
+
+  it('API 回傳空陣列時顯示無資料訊息', async () => {
+    getCurrentUserRoleMock.mockReturnValue('admin')
+    getStreamersMock.mockResolvedValue([])
+
+    const { container, unmount } = await renderPage()
+
+    expect(container.textContent).toContain('目前沒有可顯示的實況主資料')
+
+    await unmount()
+  })
+})

--- a/dashboard/src/services/auth.ts
+++ b/dashboard/src/services/auth.ts
@@ -3,6 +3,7 @@ import client, { setAuthToken, clearAuthToken } from '@/services/api'
 
 // 記憶體儲存，不 export
 let accessToken: string | null = null
+let currentUser: Record<string, unknown> | null = null
 
 interface LoginResponse {
   data: {
@@ -20,7 +21,9 @@ export async function login(email: string, password: string): Promise<void> {
     password,
   })
   accessToken = data.data.tokens.access_token
+  currentUser = data.data.user
   localStorage.setItem('refresh_token', data.data.tokens.refresh_token)
+  localStorage.setItem('current_user', JSON.stringify(data.data.user))
   setAuthToken(accessToken)
 }
 
@@ -30,12 +33,31 @@ export async function logout(): Promise<void> {
     await client.post('/api/v1/auth/logout', { refresh_token: refreshToken }).catch(() => {})
   }
   accessToken = null
+  currentUser = null
   localStorage.removeItem('refresh_token')
+  localStorage.removeItem('current_user')
   clearAuthToken()
 }
 
 export function isAuthenticated(): boolean {
   return accessToken !== null
+}
+
+export function getCurrentUserRole(): string | null {
+  if (currentUser && typeof currentUser.role === 'string') {
+    return currentUser.role
+  }
+
+  const stored = localStorage.getItem('current_user')
+  if (!stored) return null
+
+  try {
+    const parsed = JSON.parse(stored) as Record<string, unknown>
+    currentUser = parsed
+    return typeof parsed.role === 'string' ? parsed.role : null
+  } catch {
+    return null
+  }
 }
 
 export { isAxiosError }

--- a/dashboard/src/services/channels.ts
+++ b/dashboard/src/services/channels.ts
@@ -1,0 +1,57 @@
+import client from '@/services/api'
+
+type ApiResponse<T> = {
+  success: boolean
+  data: T
+}
+
+export interface Streamer {
+  id: string
+  user_id: string
+  agency_user_id?: string
+  channel_id: string
+  display_name: string
+}
+
+export interface StreamerStats {
+  current_session_seconds: number
+  daily_seconds: number
+  monthly_seconds: number
+  yearly_seconds: number
+  unique_miners: number
+  avg_session_seconds: number
+  total_token_minted: number
+  spendable_in_circulation: number
+}
+
+export interface ChannelConfig {
+  channel_id: string
+  seconds_per_point: number
+  multiplier: number
+}
+
+export interface StreamerStatsResponse {
+  stats: StreamerStats
+  channelId: string
+}
+
+export async function getStreamers(): Promise<Streamer[]> {
+  const { data } = await client.get<ApiResponse<{ streamers: Streamer[] }>>(
+    '/api/v1/dashboard/streamers',
+  )
+  return data.data.streamers
+}
+
+export async function getStreamerStats(streamerId: string): Promise<StreamerStatsResponse> {
+  const { data } = await client.get<ApiResponse<{ stats: StreamerStats; channel_id: string }>>(
+    `/api/v1/dashboard/streamers/${streamerId}/stats`,
+  )
+  return { stats: data.data.stats, channelId: data.data.channel_id }
+}
+
+export async function getChannelConfig(channelId: string): Promise<ChannelConfig> {
+  const { data } = await client.get<ApiResponse<{ config: ChannelConfig }>>(
+    `/api/v1/dashboard/channels/${channelId}/config`,
+  )
+  return data.data.config
+}

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
## 背景

closes #69

依賴：#123（backend agency scope + 8-metric stats）需先 merge。

Streamer / Agency / Admin 查看實況主頻道數據統計的前端頁面。

## 變更內容

- `dashboard/src/services/auth.ts` — 新增 `getCurrentUserRole()` helper（適配 develop 基線，不使用 Refine hook）
- `dashboard/src/services/channels.ts` — `getStreamers()`、`getStreamerStats()`（回傳 `{ stats, channelId }`）、`getChannelConfig()`
- `dashboard/src/components/ui/skeleton.tsx` — Skeleton 載入元件
- `dashboard/src/pages/StreamersPage.tsx` — Agency/Admin 顯示列表；Streamer 登入後自動跳轉詳細頁
- `dashboard/src/pages/StreamerDetailPage.tsx` — 4 維度開台時數卡片 + 3 指標小卡 + 倍率設定區塊；config 失敗靜默降級為 `—`
- `dashboard/src/App.tsx` — 新增 `/streamers/:streamerId` 路由

## 完成條件

- [x] Agency / Admin 列表正常顯示（Agency 只看旗下）
- [x] Streamer 登入後直接進入自己頻道詳細頁
- [x] 詳細頁頂部右側顯示「空投」與「調整倍率」按鈕預留位置（功能由 #71 實作）
- [x] 開台時數以分組卡片呈現四個維度
- [x] 挖礦參與人數、觀眾平均停留、總產出點數以獨立小卡呈現
- [x] 顯示挖礦倍率設定區塊（seconds_per_point、multiplier、每分鐘產出計算）
- [x] 資料載入中顯示 skeleton
- [x] PR 指向 `develop`

## 自動化驗證

- [x] `pnpm test` — 8 passed
- [x] `pnpm build` — no errors
- [x] `pnpm lint` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增實況主管理介面：建立、列出與檢視統計資料（含頻道統計與每分鐘產出計算）
  * 新增實況主詳細頁面與頻道配置頁面，顯示挖礦倍率與配置值
  * 新增骨架屏元件改善載入體驗
  * 儀表板路由與角色權限擴充（支援機構角色）

* **測試**
  * 擴充前端/後端測試覆蓋與測試設定（包含 Vitest 設定與測試腳本）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->