### PR TITLE
[contract] Foundry 專案初始化（contracts/ 目錄建立）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,24 @@ jobs:
 
       - name: Build
         run: docker compose run --no-deps --rm dashboard pnpm build
+
+  contracts:
+    name: Contracts build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install dependencies
+        working-directory: contracts
+        run: forge install OpenZeppelin/openzeppelin-contracts@v5.6.1 --no-git
+
+      - name: Build
+        working-directory: contracts
+        run: forge build
+
+      - name: Test
+        working-directory: contracts
+        run: forge test

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ dashboard/*.local
 
 # OS
 .DS_Store
+
+# Foundry
+contracts/out/
+contracts/cache/
+contracts/lib/

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,91 @@
+## Foundry
+
+**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+
+Foundry consists of:
+
+- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
+- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
+- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
+- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+
+## Documentation
+
+https://book.getfoundry.sh/
+
+## Setup
+
+初次 clone 後需安裝 Solidity 依賴：
+
+```shell
+cd contracts
+forge install OpenZeppelin/openzeppelin-contracts@v5.6.1 --no-git
+```
+
+接著即可執行 build 與測試：
+
+```shell
+forge build
+forge test
+```
+
+為避免在 monorepo 根目錄產生 nested submodule / gitlink 汙染，可在安裝後額外確認：
+
+```shell
+test ! -f ../.gitmodules
+git ls-files --stage .. | grep 160000
+```
+
+上述檢查都不應輸出任何內容；`contracts/lib/` 也已列入 repo 的 `.gitignore`，因此依 README 操作不會把相依套件納入版控。
+
+## Usage
+
+### Build
+
+```shell
+forge build
+```
+
+### Test
+
+```shell
+forge test
+```
+
+### Format
+
+```shell
+forge fmt
+```
+
+### Gas Snapshots
+
+```shell
+forge snapshot
+```
+
+### Anvil
+
+```shell
+anvil
+```
+
+### Deploy
+
+```shell
+forge script script/<YourScript>.s.sol:<YourScriptContract> --rpc-url <your_rpc_url> --private-key <your_private_key>
+```
+
+### Cast
+
+```shell
+cast <subcommand>
+```
+
+### Help
+
+```shell
+forge --help
+anvil --help
+cast --help
+```

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+remappings = [
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+]


### PR DESCRIPTION
## 什麼改動
`forge init contracts --no-git` 建立 Foundry 專案骨架，安裝 `OpenZeppelin/openzeppelin-contracts@v5.6.1 --no-git`，設定 remappings，刪除 Counter.* 預設樣板，根目錄 `.gitignore` 補上 Foundry 產物與 `contracts/lib/`，並保留 contracts 專用的 CI build/test 驗證。

## 為什麼
closes #125

## Scope 對齊
- Source of truth：#125
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不撰寫任何 Solidity 合約邏輯
  - 不設定 deploy script
  - 不修改 backend / frontend
  - 不調整 repo-level workflow governance

## 超出範圍內容
- `.github/PULL_REQUEST_TEMPLATE.md` 的流程治理調整已自本 PR 移除，改由後續獨立 PR 處理，避免超出 [contract] Foundry 專案初始化（contracts/ 目錄建立） #125 的必要範圍。

## 測試方式
- [x] 本地測試過
- [x] `cd contracts && forge build` 通過（exit 0，輸出 `Nothing to compile`）
- [x] `cd contracts && forge test` 通過（exit 0，輸出 `Nothing to compile`）
- [x] README 與 CI 已統一使用 `forge install OpenZeppelin/openzeppelin-contracts@v5.6.1 --no-git`
- [x] fresh clone / repo 汙染驗證：repo 根目錄不存在 `.gitmodules`
- [x] fresh clone / repo 汙染驗證：`git ls-files --stage | grep 160000` 無輸出，確認沒有 gitlink
- [x] `contracts/lib/` 已在 `.gitignore`，不進 repo
- [x] 無 Counter.* 樣板殘留

## 備註
- 本次保留的 `.github/workflows/ci.yml` 變更僅用於 contracts 的 build/test 驗證，目的是讓 #125 建立出的 Foundry workspace 可在 PR 階段被重現與驗證，不涉及 repo-level workflow governance 調整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
