### PR TITLE
[backend] Agency 查詢旗下 streamer — GET /agencies/:id/streamers

### DIFF
--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -83,6 +83,10 @@ func (h *AgencyHandler) ListStreamers(c *gin.Context) {
 
 	streamers, err := h.agencySvc.ListStreamers(agencyID)
 	if err != nil {
+		if errors.Is(err, services.ErrAgencyNotFound) {
+			notFound(c, "agency not found")
+			return
+		}
 		log.Printf("agency list streamers: unexpected error: %v", err)
 		internal(c)
 		return

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -102,9 +102,15 @@ func (h *AgencyHandler) ListStreamers(c *gin.Context) {
 
 	response := make([]agencyStreamerResponse, 0, len(streamers))
 	for _, streamer := range streamers {
+		userID, ok := userIDsByChannel[streamer.ChannelID]
+		if !ok {
+			log.Printf("agency %s: channel %s has no matching streamer user", agencyID, streamer.ChannelID)
+			internal(c)
+			return
+		}
 		response = append(response, agencyStreamerResponse{
 			ChannelID: streamer.ChannelID,
-			UserID:    userIDsByChannel[streamer.ChannelID],
+			UserID:    userID,
 		})
 	}
 

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -3,10 +3,13 @@ package handlers
 import (
 	"errors"
 	"log"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
 
@@ -26,6 +29,11 @@ type createAgencyRequest struct {
 type createAgencyResponse struct {
 	ID   uuid.UUID `json:"id"`
 	Name string    `json:"name"`
+}
+
+type agencyStreamerResponse struct {
+	ChannelID string    `json:"channel_id"`
+	UserID    uuid.UUID `json:"user_id"`
 }
 
 func (h *AgencyHandler) Create(c *gin.Context) {
@@ -58,4 +66,47 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 		ID:   user.ID,
 		Name: req.Name,
 	})
+}
+
+func (h *AgencyHandler) ListStreamers(c *gin.Context) {
+	agencyID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid agency id")
+		return
+	}
+
+	claims := middleware.MustClaims(c)
+	if claims.Role == models.RoleAgency && claims.UserID != agencyID.String() {
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return
+	}
+
+	streamers, err := h.agencySvc.ListStreamers(agencyID)
+	if err != nil {
+		log.Printf("agency list streamers: unexpected error: %v", err)
+		internal(c)
+		return
+	}
+
+	channelIDs := make([]string, 0, len(streamers))
+	for _, streamer := range streamers {
+		channelIDs = append(channelIDs, streamer.ChannelID)
+	}
+
+	userIDsByChannel, err := h.agencySvc.ListStreamerUserIDs(channelIDs)
+	if err != nil {
+		log.Printf("agency list streamer users: unexpected error: %v", err)
+		internal(c)
+		return
+	}
+
+	response := make([]agencyStreamerResponse, 0, len(streamers))
+	for _, streamer := range streamers {
+		response = append(response, agencyStreamerResponse{
+			ChannelID: streamer.ChannelID,
+			UserID:    userIDsByChannel[streamer.ChannelID],
+		})
+	}
+
+	ok(c, gin.H{"streamers": response})
 }

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/middleware"
@@ -31,6 +32,10 @@ func newAgencyTestEnv(t *testing.T) (*testEnv, http.Handler) {
 	agencies := v1.Group("/agencies")
 	agencies.Use(middleware.JWTAuth(env.authSvc))
 	agencies.POST("", middleware.RequireRole(models.RoleAdmin), agencyH.Create)
+	agencies.GET("/:id/streamers",
+		middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+		agencyH.ListStreamers,
+	)
 
 	return env, r
 }
@@ -38,14 +43,13 @@ func newAgencyTestEnv(t *testing.T) (*testEnv, http.Handler) {
 func makeAccessToken(t *testing.T, role models.UserRole) string {
 	t.Helper()
 
-	subject := uuid.NewString()
 	claims := services.Claims{
 		UserID: uuid.NewString(),
 		Role:   role,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			Subject:   subject,
+			Subject:   uuid.NewString(),
 		},
 	}
 
@@ -55,6 +59,72 @@ func makeAccessToken(t *testing.T, role models.UserRole) string {
 	}
 
 	return token
+}
+
+func makeAccessTokenForUser(t *testing.T, userID uuid.UUID, role models.UserRole) string {
+	t.Helper()
+
+	claims := services.Claims{
+		UserID: userID.String(),
+		Role:   role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Subject:   userID.String(),
+		},
+	}
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(agencyTestAccessSecret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	return token
+}
+
+func seedAgencyStreamerListData(t *testing.T, db *gorm.DB, agencyID uuid.UUID) []map[string]string {
+	t.Helper()
+
+	rows := []struct {
+		userID    uuid.UUID
+		channelID string
+		email     string
+		username  string
+	}{
+		{userID: uuid.New(), channelID: "ch_alpha", email: "streamer-alpha@example.com", username: "streamer-alpha"},
+		{userID: uuid.New(), channelID: "ch_beta", email: "streamer-beta@example.com", username: "streamer-beta"},
+	}
+
+	for _, row := range rows {
+		if err := db.Exec(
+			`INSERT INTO users (id, username, email, role, is_active, email_verified, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			row.userID, row.username, row.email, models.RoleStreamer,
+		).Error; err != nil {
+			t.Fatalf("seed streamer user: %v", err)
+		}
+
+		if err := db.Exec(
+			`INSERT INTO streamers (id, user_id, channel_id, display_name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			uuid.New(), row.userID, row.channelID, row.username,
+		).Error; err != nil {
+			t.Fatalf("seed streamer row: %v", err)
+		}
+
+		if err := db.Exec(
+			`INSERT INTO agency_streamers (id, agency_id, channel_id, created_at)
+			 VALUES (?, ?, ?, CURRENT_TIMESTAMP)`,
+			uuid.New(), agencyID, row.channelID,
+		).Error; err != nil {
+			t.Fatalf("seed agency streamer row: %v", err)
+		}
+	}
+
+	return []map[string]string{
+		{"channel_id": rows[0].channelID, "user_id": rows[0].userID.String()},
+		{"channel_id": rows[1].channelID, "user_id": rows[1].userID.String()},
+	}
 }
 
 func TestAgencyHandler_Create_Success(t *testing.T) {
@@ -152,5 +222,97 @@ func TestAgencyHandler_Create_RequiresAdmin(t *testing.T) {
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_ListStreamers_AdminCanQuery(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := uuid.New()
+	expected := seedAgencyStreamerListData(t, env.db, agencyID)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/"+agencyID.String()+"/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != len(expected) {
+		t.Fatalf("expected %d streamers, got %d", len(expected), len(streamers))
+	}
+
+	for i, item := range streamers {
+		streamer := item.(map[string]interface{})
+		if streamer["channel_id"] != expected[i]["channel_id"] {
+			t.Fatalf("streamer %d channel_id: expected %s, got %v", i, expected[i]["channel_id"], streamer["channel_id"])
+		}
+		if streamer["user_id"] != expected[i]["user_id"] {
+			t.Fatalf("streamer %d user_id: expected %s, got %v", i, expected[i]["user_id"], streamer["user_id"])
+		}
+	}
+}
+
+func TestAgencyHandler_ListStreamers_AgencyCanQueryOwn(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := uuid.New()
+	expected := seedAgencyStreamerListData(t, env.db, agencyID)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/"+agencyID.String()+"/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessTokenForUser(t, agencyID, models.RoleAgency))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != len(expected) {
+		t.Fatalf("expected %d streamers, got %d", len(expected), len(streamers))
+	}
+}
+
+func TestAgencyHandler_ListStreamers_AgencyCannotQueryOthers(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/"+uuid.NewString()+"/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessTokenForUser(t, uuid.New(), models.RoleAgency))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_ListStreamers_InvalidID(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/not-a-uuid/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_ListStreamers_RequiresAuth(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/"+uuid.NewString()+"/streamers", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -305,6 +305,29 @@ func TestAgencyHandler_ListStreamers_InvalidID(t *testing.T) {
 	}
 }
 
+func TestAgencyHandler_ListStreamers_OrphanChannelReturns500(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := uuid.New()
+
+	// Insert agency_streamers row for a channel that has NO matching streamers row.
+	if err := env.db.Exec(
+		`INSERT INTO agency_streamers (id, agency_id, channel_id, created_at)
+		 VALUES (?, ?, ?, CURRENT_TIMESTAMP)`,
+		uuid.New(), agencyID, "ch_orphan",
+	).Error; err != nil {
+		t.Fatalf("seed orphan agency streamer: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/"+agencyID.String()+"/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for orphan channel, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAgencyHandler_ListStreamers_RequiresAuth(t *testing.T) {
 	_, r := newAgencyTestEnv(t)
 

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -328,6 +328,92 @@ func TestAgencyHandler_ListStreamers_OrphanChannelReturns500(t *testing.T) {
 	}
 }
 
+func TestAgencyHandler_ListStreamers_EmptyAgency(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := uuid.New()
+
+	// Seed a real agency user so the agency exists, but with no streamers.
+	if err := env.db.Exec(
+		`INSERT INTO users (id, username, email, role, is_active, email_verified, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		agencyID, "agency-empty", "agency-empty@example.com", models.RoleAgency,
+	).Error; err != nil {
+		t.Fatalf("seed agency user: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/"+agencyID.String()+"/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	streamers := data["streamers"].([]interface{})
+	if len(streamers) != 0 {
+		t.Fatalf("expected empty streamers, got %d", len(streamers))
+	}
+}
+
+func TestAgencyHandler_ListStreamers_NotFound(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/"+uuid.NewString()+"/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_ListStreamers_DuplicateChannelReturns500(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := uuid.New()
+
+	// Insert two different streamer users that both claim the same channel_id.
+	// streamers has UNIQUE(user_id, channel_id) but NOT UNIQUE(channel_id),
+	// so this is valid at the DB level and must be caught at the service layer.
+	for i, email := range []string{"dup-a@example.com", "dup-b@example.com"} {
+		userID := uuid.New()
+		username := email
+		if err := env.db.Exec(
+			`INSERT INTO users (id, username, email, role, is_active, email_verified, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			userID, username, email, models.RoleStreamer,
+		).Error; err != nil {
+			t.Fatalf("seed streamer user %d: %v", i, err)
+		}
+		if err := env.db.Exec(
+			`INSERT INTO streamers (id, user_id, channel_id, display_name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			uuid.New(), userID, "ch_dup", username,
+		).Error; err != nil {
+			t.Fatalf("seed streamer row %d: %v", i, err)
+		}
+	}
+	if err := env.db.Exec(
+		`INSERT INTO agency_streamers (id, agency_id, channel_id, created_at)
+		 VALUES (?, ?, ?, CURRENT_TIMESTAMP)`,
+		uuid.New(), agencyID, "ch_dup",
+	).Error; err != nil {
+		t.Fatalf("seed agency streamer: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/agencies/"+agencyID.String()+"/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for duplicate channel_id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAgencyHandler_ListStreamers_RequiresAuth(t *testing.T) {
 	_, r := newAgencyTestEnv(t)
 

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -150,7 +150,7 @@ func New(
 		// GET /agencies/:id/streamers — agency or admin
 		agencies.GET("/:id/streamers",
 			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
-			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+			agencyHandler.ListStreamers,
 		)
 	}
 

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -91,3 +91,43 @@ func (s *AgencyService) OwnsChannel(agencyUserID uuid.UUID, channelID string) (b
 		Count(&count).Error
 	return count > 0, err
 }
+
+func (s *AgencyService) ListStreamers(agencyID uuid.UUID) ([]models.AgencyStreamer, error) {
+	var streamers []models.AgencyStreamer
+	if err := s.db.
+		Where("agency_id = ?", agencyID).
+		Order("created_at ASC").
+		Find(&streamers).Error; err != nil {
+		return nil, err
+	}
+	if streamers == nil {
+		return []models.AgencyStreamer{}, nil
+	}
+	return streamers, nil
+}
+
+func (s *AgencyService) ListStreamerUserIDs(channelIDs []string) (map[string]uuid.UUID, error) {
+	type streamerUserRow struct {
+		ChannelID string
+		UserID    uuid.UUID
+	}
+
+	if len(channelIDs) == 0 {
+		return map[string]uuid.UUID{}, nil
+	}
+
+	var rows []streamerUserRow
+	if err := s.db.Model(&models.Streamer{}).
+		Select("channel_id, user_id").
+		Where("channel_id IN ?", channelIDs).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	userIDs := make(map[string]uuid.UUID, len(rows))
+	for _, row := range rows {
+		userIDs[row.ChannelID] = row.UserID
+	}
+
+	return userIDs, nil
+}

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -15,6 +15,8 @@ import (
 var ErrAgencyEmailTaken = errors.New("email already registered")
 var ErrAgencyNameTaken = errors.New("name already taken")
 var ErrAgencyNameTooLong = errors.New("agency name exceeds 50 characters")
+var ErrAgencyNotFound = errors.New("agency not found")
+var ErrDuplicateChannelID = errors.New("channel_id maps to multiple streamer users")
 
 type AgencyService struct {
 	db *gorm.DB
@@ -100,8 +102,16 @@ func (s *AgencyService) ListStreamers(agencyID uuid.UUID) ([]models.AgencyStream
 		Find(&streamers).Error; err != nil {
 		return nil, err
 	}
-	if streamers == nil {
-		return []models.AgencyStreamer{}, nil
+	if len(streamers) == 0 {
+		var count int64
+		if err := s.db.Model(&models.User{}).
+			Where("id = ? AND role = ?", agencyID, models.RoleAgency).
+			Count(&count).Error; err != nil {
+			return nil, err
+		}
+		if count == 0 {
+			return nil, ErrAgencyNotFound
+		}
 	}
 	return streamers, nil
 }
@@ -126,6 +136,9 @@ func (s *AgencyService) ListStreamerUserIDs(channelIDs []string) (map[string]uui
 
 	userIDs := make(map[string]uuid.UUID, len(rows))
 	for _, row := range rows {
+		if _, exists := userIDs[row.ChannelID]; exists {
+			return nil, ErrDuplicateChannelID
+		}
 		userIDs[row.ChannelID] = row.UserID
 	}
 

--- a/plans/agency-list-streamers.md
+++ b/plans/agency-list-streamers.md
@@ -1,0 +1,27 @@
+狀態：已完成
+
+# Agency 查詢旗下 streamer — GET /agencies/:id/streamers
+
+refs #107
+
+## 背景
+
+#18 規劃了 Agency 管理系統，`GET /agencies/:id/streamers` 路由已掛但回傳 501。`agency_streamers` 關係表已存在，需要實作查詢邏輯。
+
+## 架構決策
+
+- `AgencyService.ListStreamers` 直接查 `agency_streamers` 表，回傳 `[]models.AgencyStreamer`
+- RBAC：agency 只能查自己（`id` == 自己的 user ID），admin 可查任何人
+- Response 只回 `channel_id` + `user_id`，不回傳其他敏感欄位
+
+## 待實作 checklist
+
+- [x] `AgencyService.ListStreamers(agencyID uuid.UUID) ([]models.AgencyStreamer, error)`
+- [x] `AgencyHandler.ListStreamers` — `GET /api/v1/agencies/:id/streamers`（agency or admin）
+- [x] Router 取代 501 stub
+- [x] Handler 測試（admin 成功、agency 查自己成功、agency 查他人 403、無效 UUID 400、未登入 401）
+
+## 驗證方式
+
+- `go build ./...` 通過
+- `docker compose run --no-deps --rm app go test ./...` 全部通過


### PR DESCRIPTION
## 什麼改動

實作 `GET /api/v1/agencies/:id/streamers`，取代原本回傳 501 的 stub。

## 為什麼

#18 規劃了 Agency 管理系統，此路由已掛但尚未實作。

## Scope 對齊

- Source of truth：#107
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作 POST/DELETE agency streamers 關聯管理
  - 不回傳 streamer 的詳細資料（只回 channel_id + user_id）
  - 不修改 agency_streamers schema

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

`docker compose run --no-deps --rm app go test ./...` 全部通過，涵蓋：admin 成功、agency 查自己成功、agency 查他人 403、無效 UUID 400、未登入 401、orphan channel 500

closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 機構可透過 API 端點查詢其旗下的直播主清單，並取得相應的頻道 ID 與使用者 ID。
  * 實施了身份驗證和授權控制，確保機構僅可查詢自身的資料，而管理員可查詢任意機構。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->