### PR TITLE
[discussion] Local PR guardrails and preflight checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
 remote="${1:-origin}"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,130 +1,16 @@
 #!/usr/bin/env bash
-# Pre-push hook: warn when diff is too large (mirrors CI hard limits)
-# Hard limits match pr-scope-police.yml
-MAX_FILES=35
-MAX_LINES=1800
-ZERO_SHA=0000000000000000000000000000000000000000
 
-remote="$1"
-url="$2"
+set -euo pipefail
 
-resolve_candidate_ref() {
-  local candidate="$1"
+remote="${1:-origin}"
+script_dir="$(cd "$(dirname "$0")/.." && pwd)"
+checker="$script_dir/scripts/pr-scope-check.sh"
 
-  [ -n "$candidate" ] || return 1
-
-  case "$candidate" in
-    refs/*)
-      git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null || return 1
-      printf '%s\n' "$candidate"
-      return 0
-      ;;
-    *)
-      for ref in \
-        "refs/remotes/$remote/$candidate" \
-        "refs/heads/$candidate" \
-        "$candidate"
-      do
-        git rev-parse --verify --quiet "$ref^{commit}" >/dev/null || continue
-        printf '%s\n' "$ref"
-        return 0
-      done
-      ;;
-  esac
-
-  return 1
-}
-
-detect_base_ref() {
-  local branch_name="$1"
-  local remote_ref="$2"
-  local configured_base merge_ref default_head candidate resolved
-
-  configured_base=$(git config --get "branch.$branch_name.gh-merge-base" 2>/dev/null || true)
-  resolved=$(resolve_candidate_ref "$configured_base" 2>/dev/null || true)
-  if [ -n "$resolved" ]; then
-    printf '%s\n' "$resolved"
-    return 0
-  fi
-
-  merge_ref=$(git config --get "branch.$branch_name.merge" 2>/dev/null || true)
-  if [ -n "$merge_ref" ] && [ "$merge_ref" != "$remote_ref" ]; then
-    resolved=$(resolve_candidate_ref "$merge_ref" 2>/dev/null || true)
-    if [ -n "$resolved" ]; then
-      printf '%s\n' "$resolved"
-      return 0
-    fi
-  fi
-
-  default_head=$(git symbolic-ref "refs/remotes/$remote/HEAD" 2>/dev/null || true)
-  for candidate in "refs/remotes/$remote/develop" "refs/remotes/$remote/main" "$default_head"; do
-    resolved=$(resolve_candidate_ref "$candidate" 2>/dev/null || true)
-    if [ -n "$resolved" ] && [ "$resolved" != "$remote_ref" ]; then
-      printf '%s\n' "$resolved"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-violations=0
+if [ ! -x "$checker" ]; then
+  chmod +x "$checker"
+fi
 
 while read -r local_ref local_sha remote_ref remote_sha; do
   [ -n "$local_ref" ] || continue
-  [ "$local_sha" != "$ZERO_SHA" ] || continue
-
-  case "$local_ref" in
-    refs/heads/*) ;;
-    *)
-      continue
-      ;;
-  esac
-
-  branch_name="${local_ref#refs/heads/}"
-  base_ref=$(detect_base_ref "$branch_name" "$remote_ref") || continue
-  base_sha=$(git rev-parse "$base_ref^{commit}" 2>/dev/null) || continue
-  base=$(git merge-base "$local_sha" "$base_sha" 2>/dev/null) || continue
-
-  changed_files=$(git diff --name-only "$base" "$local_sha" | wc -l | tr -d ' ')
-  stat_output=$(git diff --shortstat "$base" "$local_sha")
-  diff_lines=$(printf '%s\n' "$stat_output" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+') || diff_lines=0
-  deletions=$(printf '%s\n' "$stat_output" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+') || deletions=0
-  total_lines=$((diff_lines + deletions))
-
-  if [ "$changed_files" -le "$MAX_FILES" ] && [ "$total_lines" -le "$MAX_LINES" ]; then
-    continue
-  fi
-
-  violations=1
-  echo ""
-  echo "╔══════════════════════════════════════════════════════╗"
-  echo "║  PR Scope Police — pre-push warning                 ║"
-  echo "╠══════════════════════════════════════════════════════╣"
-  printf "║  Branch        : %-36s║\n" "$branch_name"
-  printf "║  Base ref      : %-36s║\n" "${base_ref#refs/remotes/}"
-  printf "║  Changed files : %4d  (limit: %d)%*s║\n" "$changed_files" "$MAX_FILES" $((19 - ${#changed_files})) ""
-  printf "║  Diff lines    : %4d  (limit: %d)%*s║\n" "$total_lines" "$MAX_LINES" $((16 - ${#total_lines})) ""
-  echo "╠══════════════════════════════════════════════════════╣"
-  echo "║  This PR will be blocked by CI; severe violations   ║"
-  echo "║  may also be auto-closed. Split it first.           ║"
-  echo "╚══════════════════════════════════════════════════════╝"
-  echo ""
-
-  if [ ! -t 0 ]; then
-    echo "Non-interactive mode detected; refusing oversized push."
-    exit 1
-  fi
-
-  read -p "Push anyway? [y/N] " -r reply
-  if [[ ! "$reply" =~ ^[Yy]$ ]]; then
-    echo "Push aborted."
-    exit 1
-  fi
+  "$checker" --ref "$local_ref" "$local_sha" "$remote" "$remote_ref"
 done
-
-if [ "$violations" -eq 0 ]; then
-  exit 0
-fi
-
-exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,56 @@
 
 3. 在 GitHub 發 PR，目標分支：`develop`（不直接推 `main`）
 
+### Push 前本地強制檢查
+
+- 執行過 `make setup` 後，repo 會把 `core.hooksPath` 指到 `.githooks`
+- 之後每次 `git push` 都會先跑本地 `pre-push`
+- 目前本地會強制阻擋：
+  - diff 檔案數超過 hard limit
+  - diff 行數超過 hard limit
+  - 同時修改多個 product surface（如 `backend/` + `dashboard/`）
+- 也可手動先跑一次：
+
+  ```bash
+  make pr-check
+  ```
+
+### 開 PR 前本地強制檢查
+
+- 建議不要直接手打 `gh pr create`
+- 先準備好 PR body 檔案，再先跑：
+
+  ```bash
+  make pr-meta-check TITLE='[frontend] Dashboard — 實況主數據管理頁面' BODY_FILE=/tmp/pr-body.md
+  ```
+
+- 或直接用 wrapper 開 PR：
+  最簡單可以直接用：
+
+  ```bash
+  make pr-open TITLE='[frontend] Dashboard — 實況主數據管理頁面' BODY_FILE=/tmp/pr-body.md
+  ```
+
+  需要指定 base / head 或開 draft 時：
+
+  ```bash
+  make pr-open \
+    TITLE='[frontend] Dashboard — 實況主數據管理頁面' \
+    BODY_FILE=/tmp/pr-body.md \
+    BASE=develop \
+    HEAD=feat/dashboard-page \
+    DRAFT=1
+  ```
+
+- 這一層會在本地先擋：
+  - PR title prefix 不合法
+  - PR body 缺少 `Source of truth` / `Depends on PR` / `本 PR 明確不做`
+  - `Backend contract already in develop` 沒有正確勾選
+  - `[frontend]` PR 混入 `backend/`
+  - `Depends on PR: #123` 但該 PR 尚未 merge
+  - frontend PR 宣告 backend contract 尚未進 `develop`
+- 若 PR body 有填 `Depends on PR: #123`，需先完成 `gh auth login`，本地檢查才可查 GitHub 上的 merge 狀態
+
 ## Scope 邊界
 
 禁止 scope pollution：不要把 issue 沒有明確要求的內容混進同一個 PR。

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev up down logs
+.PHONY: setup dev up down logs pr-check pr-meta-check pr-open
 
 # ── Setup (run once after cloning) ────────────────────────────────────────────
 setup:
@@ -20,3 +20,21 @@ down:
 
 logs:
 	docker compose logs -f
+
+pr-check:
+	@./scripts/pr-scope-check.sh
+
+pr-meta-check:
+	@[ -n "$(TITLE)" ] || (echo "TITLE is required"; exit 2)
+	@[ -n "$(BODY_FILE)" ] || (echo "BODY_FILE is required"; exit 2)
+	@./scripts/pr-metadata-check.sh --title "$(TITLE)" --body-file "$(BODY_FILE)"
+
+pr-open:
+	@[ -n "$(TITLE)" ] || (echo "TITLE is required"; exit 2)
+	@[ -n "$(BODY_FILE)" ] || (echo "BODY_FILE is required"; exit 2)
+	@./scripts/pr-open.sh \
+		--title "$(TITLE)" \
+		--body-file "$(BODY_FILE)" \
+		$(if $(BASE),--base "$(BASE)",) \
+		$(if $(HEAD),--head "$(HEAD)",) \
+		$(if $(DRAFT),--draft,)

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pr-metadata-check.sh --title "<pr title>" --body-file <path> [--base develop] [--head <branch>]
+
+Checks local PR metadata before opening a PR:
+  - title prefix
+  - required PR body sections
+  - dependency PR state
+  - backend contract gating for frontend PRs
+  - title prefix vs changed product surface
+EOF
+}
+
+parse_repo_from_remote() {
+  local remote_url
+  remote_url=$(git remote get-url origin)
+
+  case "$remote_url" in
+    git@github.com:*)
+      remote_url="${remote_url#git@github.com:}"
+      printf '%s\n' "${remote_url%.git}"
+      return 0
+      ;;
+    https://github.com/*)
+      remote_url="${remote_url#https://github.com/}"
+      printf '%s\n' "${remote_url%.git}"
+      return 0
+      ;;
+  esac
+
+  echo "無法從 origin remote 解析 GitHub repo：$remote_url" >&2
+  return 1
+}
+
+detect_changed_files() {
+  local base="$1"
+  local head="$2"
+  git diff-tree -r --no-commit-id --name-only "$base" "$head"
+}
+
+product_surfaces_from_files() {
+  local files="$1"
+  local surfaces=()
+
+  if printf '%s\n' "$files" | grep -qE '^backend/'; then
+    surfaces+=("backend")
+  fi
+  if printf '%s\n' "$files" | grep -qE '^dashboard/'; then
+    surfaces+=("dashboard")
+  fi
+  if printf '%s\n' "$files" | grep -qE '^tachimint/'; then
+    surfaces+=("tachimint")
+  fi
+  if printf '%s\n' "$files" | grep -qE '^contracts/'; then
+    surfaces+=("contracts")
+  fi
+
+  if [ "${#surfaces[@]}" -eq 0 ]; then
+    printf 'none\n'
+    return 0
+  fi
+
+  local joined=""
+  local surface
+  for surface in "${surfaces[@]}"; do
+    if [ -n "$joined" ]; then
+      joined="$joined, "
+    fi
+    joined="$joined$surface"
+  done
+  printf '%s\n' "$joined"
+}
+
+has_checked_item() {
+  local pattern="$1"
+  local file="$2"
+  if grep -Eq "^[[:space:]-]*\\[[xX]\\][[:space:]]+$pattern([[:space:]]|\$)" "$file"; then
+    return 0
+  fi
+  return 1
+}
+
+main() {
+  local title=""
+  local body_file=""
+  local base_branch="develop"
+  local head_branch=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --title)
+        title="${2:-}"
+        shift 2
+        ;;
+      --body-file)
+        body_file="${2:-}"
+        shift 2
+        ;;
+      --base)
+        base_branch="${2:-}"
+        shift 2
+        ;;
+      --head)
+        head_branch="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        echo "未知參數：$1" >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  [ -n "$title" ] || {
+    echo "--title 為必填" >&2
+    exit 2
+  }
+  [ -n "$body_file" ] || {
+    echo "--body-file 為必填" >&2
+    exit 2
+  }
+  [ -f "$body_file" ] || {
+    echo "找不到 body file：$body_file" >&2
+    exit 2
+  }
+
+  if [ -z "$head_branch" ]; then
+    head_branch=$(git branch --show-current)
+  fi
+  [ -n "$head_branch" ] || {
+    echo "無法判斷目前 branch，請用 --head 指定。" >&2
+    exit 2
+  }
+
+  local title_prefix=""
+  case "$title" in
+    "[backend]"*) title_prefix="[backend]" ;;
+    "[frontend]"*) title_prefix="[frontend]" ;;
+    "[contract]"*) title_prefix="[contract]" ;;
+    "[discussion]"*) title_prefix="[discussion]" ;;
+  esac
+
+  local repo head_sha base_ref base_sha merge_base changed_files product_surfaces
+  local failures=()
+
+  [ -n "$title_prefix" ] || failures+=("PR title 必須以 [backend] / [frontend] / [contract] / [discussion] 開頭")
+
+  repo=$(parse_repo_from_remote) || exit 2
+  head_sha=$(git rev-parse "refs/heads/$head_branch^{commit}" 2>/dev/null) || {
+    echo "找不到 head branch：$head_branch" >&2
+    exit 2
+  }
+  base_ref="refs/remotes/origin/$base_branch"
+  base_sha=$(git rev-parse "$base_ref^{commit}" 2>/dev/null) || {
+    echo "找不到 base branch：origin/$base_branch" >&2
+    exit 2
+  }
+  merge_base=$(git merge-base "$head_sha" "$base_sha" 2>/dev/null) || {
+    echo "無法計算 merge-base：$head_branch vs $base_branch" >&2
+    exit 2
+  }
+
+  changed_files=$(detect_changed_files "$merge_base" "$head_sha")
+  product_surfaces=$(product_surfaces_from_files "$changed_files")
+
+  grep -Eq '#[0-9]+' "$body_file" || failures+=("PR body 必須引用至少一個 issue / PR 編號，例如 #123")
+  grep -Eq 'Source of truth[：:]' "$body_file" || failures+=("PR body 缺少 Source of truth")
+  grep -Eq 'Depends on PR[：:]' "$body_file" || failures+=("PR body 缺少 Depends on PR")
+  grep -Eq '本 PR 明確不做' "$body_file" || failures+=("PR body 缺少 本 PR 明確不做 區塊")
+
+  local depends_on_raw
+  depends_on_raw=$(sed -nE 's/.*Depends on PR[：:][[:space:]]*([^[:space:]].*)/\1/p' "$body_file" | head -n1 | sed 's/[[:space:]]*$//')
+  [ -n "$depends_on_raw" ] || failures+=("Depends on PR 必須填 none 或 #123")
+
+  local backend_contract_yes=0
+  local backend_contract_no=0
+  has_checked_item "yes" "$body_file" && backend_contract_yes=1
+  has_checked_item "no" "$body_file" && backend_contract_no=1
+
+  if [ "$backend_contract_yes" -eq 0 ] && [ "$backend_contract_no" -eq 0 ]; then
+    failures+=("Backend contract already in develop 必須勾選 yes 或 no")
+  fi
+  if [ "$backend_contract_yes" -eq 1 ] && [ "$backend_contract_no" -eq 1 ]; then
+    failures+=("Backend contract already in develop 不能同時勾 yes 與 no")
+  fi
+
+  local stacked_on_dependency=0
+  local intentionally_blocked=0
+  has_checked_item "stacked on dependency branch" "$body_file" && stacked_on_dependency=1
+  has_checked_item "intentionally blocked until dependency merges" "$body_file" && intentionally_blocked=1
+
+  if [ "$backend_contract_no" -eq 1 ] && [ "$stacked_on_dependency" -eq 0 ] && [ "$intentionally_blocked" -eq 0 ]; then
+    failures+=("backend contract 不在 develop 時，必須勾選 stacked 或 intentionally blocked")
+  fi
+
+  if [ "$title_prefix" = "[frontend]" ] && printf '%s\n' "$changed_files" | grep -qE '^backend/'; then
+    failures+=("[frontend] PR 不可修改 backend/")
+  fi
+  if [ "$title_prefix" = "[backend]" ] && printf '%s\n' "$changed_files" | grep -qE '^(dashboard|tachimint)/'; then
+    failures+=("[backend] PR 不可修改 dashboard/ 或 tachimint/")
+  fi
+  if [ "$title_prefix" = "[contract]" ] && printf '%s\n' "$changed_files" | grep -qE '^(backend|dashboard|tachimint)/'; then
+    failures+=("[contract] PR 不可修改 backend/、dashboard/、tachimint/")
+  fi
+
+  local depends_on_lower=""
+  depends_on_lower=$(printf '%s' "$depends_on_raw" | tr '[:upper:]' '[:lower:]')
+
+  if [ -n "$depends_on_raw" ] && [ "$depends_on_lower" != "none" ]; then
+    if [[ ! "$depends_on_raw" =~ ^#([0-9]+)$ ]]; then
+      failures+=("Depends on PR 只能填 none 或單一 PR 編號，例如 #123")
+    else
+      local dep_number="${BASH_REMATCH[1]}"
+      command -v gh >/dev/null 2>&1 || {
+        echo "需要先安裝 gh，才能檢查依賴 PR 狀態。" >&2
+        exit 2
+      }
+      gh auth status >/dev/null 2>&1 || {
+        echo "需要先登入 gh（gh auth login），才能檢查依賴 PR 狀態。" >&2
+        exit 2
+      }
+
+      local dep_state dep_merged_at
+      dep_state=$(gh pr view "$dep_number" --repo "$repo" --json state --jq '.state' 2>/dev/null || true)
+      dep_merged_at=$(gh pr view "$dep_number" --repo "$repo" --json mergedAt --jq '.mergedAt // ""' 2>/dev/null || true)
+
+      if [ -z "$dep_state" ]; then
+        failures+=("無法讀取依賴 PR #$dep_number 的狀態")
+      elif [ -z "$dep_merged_at" ]; then
+        failures+=("依賴 PR #$dep_number 尚未 merge，請先等它進 develop 再開 PR")
+      fi
+    fi
+  fi
+
+  if [ "$title_prefix" = "[frontend]" ] && [ "$backend_contract_no" -eq 1 ]; then
+    failures+=("[frontend] PR 不應在 backend contract 尚未進 develop 時開出")
+  fi
+
+  if [ "${#failures[@]}" -gt 0 ]; then
+    echo ""
+    echo "PR metadata check failed:"
+    local failure
+    for failure in "${failures[@]}"; do
+      echo "  - $failure"
+    done
+    echo ""
+    echo "Title   : $title"
+    echo "Base    : $base_branch"
+    echo "Head    : $head_branch"
+    echo "Surface : $product_surfaces"
+    exit 1
+  fi
+
+  echo "PR metadata check passed: title=$title_prefix base=$base_branch head=$head_branch surface=$product_surfaces"
+}
+
+main "$@"

--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pr-open.sh --title "<pr title>" --body-file <path> [--base develop] [--head <branch>] [--draft]
+
+Runs local PR checks, then opens a PR with gh.
+EOF
+}
+
+main() {
+  local title=""
+  local body_file=""
+  local base_branch="develop"
+  local head_branch=""
+  local draft=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --title)
+        title="${2:-}"
+        shift 2
+        ;;
+      --body-file)
+        body_file="${2:-}"
+        shift 2
+        ;;
+      --base)
+        base_branch="${2:-}"
+        shift 2
+        ;;
+      --head)
+        head_branch="${2:-}"
+        shift 2
+        ;;
+      --draft)
+        draft=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        echo "未知參數：$1" >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  [ -n "$title" ] || {
+    echo "--title 為必填" >&2
+    exit 2
+  }
+  [ -n "$body_file" ] || {
+    echo "--body-file 為必填" >&2
+    exit 2
+  }
+
+  if [ -z "$head_branch" ]; then
+    head_branch=$(git branch --show-current)
+  fi
+  [ -n "$head_branch" ] || {
+    echo "無法判斷目前 branch，請用 --head 指定。" >&2
+    exit 2
+  }
+
+  local root_dir
+  root_dir="$(cd "$(dirname "$0")/.." && pwd)"
+
+  "$root_dir/scripts/pr-scope-check.sh"
+  "$root_dir/scripts/pr-metadata-check.sh" \
+    --title "$title" \
+    --body-file "$body_file" \
+    --base "$base_branch" \
+    --head "$head_branch"
+
+  local cmd=(gh pr create --base "$base_branch" --head "$head_branch" --title "$title" --body-file "$body_file")
+  if [ "$draft" -eq 1 ]; then
+    cmd+=(--draft)
+  fi
+
+  echo "Opening PR with gh..."
+  "${cmd[@]}"
+}
+
+main "$@"

--- a/scripts/pr-scope-check.sh
+++ b/scripts/pr-scope-check.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MAX_FILES=35
+MAX_LINES=1800
+ZERO_SHA=0000000000000000000000000000000000000000
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pr-scope-check.sh
+  scripts/pr-scope-check.sh --ref <local_ref> <local_sha> <remote> <remote_ref>
+
+Checks the current branch diff against its likely base branch using the same
+hard limits as PR Scope Police for:
+  - changed files
+  - diff lines
+  - multiple product surfaces
+EOF
+}
+
+resolve_candidate_ref() {
+  local remote="$1"
+  local candidate="${2:-}"
+
+  [ -n "$candidate" ] || return 1
+
+  case "$candidate" in
+    refs/*)
+      git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null || return 1
+      printf '%s\n' "$candidate"
+      return 0
+      ;;
+    *)
+      for ref in \
+        "refs/remotes/$remote/$candidate" \
+        "refs/heads/$candidate" \
+        "$candidate"
+      do
+        git rev-parse --verify --quiet "$ref^{commit}" >/dev/null || continue
+        printf '%s\n' "$ref"
+        return 0
+      done
+      ;;
+  esac
+
+  return 1
+}
+
+detect_base_ref() {
+  local remote="$1"
+  local branch_name="$2"
+  local remote_ref="$3"
+  local configured_base merge_ref default_head candidate resolved
+
+  configured_base=$(git config --get "branch.$branch_name.gh-merge-base" 2>/dev/null || true)
+  resolved=$(resolve_candidate_ref "$remote" "$configured_base" 2>/dev/null || true)
+  if [ -n "$resolved" ]; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+
+  merge_ref=$(git config --get "branch.$branch_name.merge" 2>/dev/null || true)
+  if [ -n "$merge_ref" ] && [ "$merge_ref" != "$remote_ref" ]; then
+    resolved=$(resolve_candidate_ref "$remote" "$merge_ref" 2>/dev/null || true)
+    if [ -n "$resolved" ]; then
+      printf '%s\n' "$resolved"
+      return 0
+    fi
+  fi
+
+  default_head=$(git symbolic-ref "refs/remotes/$remote/HEAD" 2>/dev/null || true)
+  for candidate in "refs/remotes/$remote/develop" "refs/remotes/$remote/main" "$default_head"; do
+    resolved=$(resolve_candidate_ref "$remote" "$candidate" 2>/dev/null || true)
+    if [ -n "$resolved" ] && [ "$resolved" != "$remote_ref" ]; then
+      printf '%s\n' "$resolved"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+count_product_surfaces() {
+  local files="$1"
+  local count=0
+
+  local touches_backend=0
+  local touches_dashboard=0
+  local touches_tachimint=0
+  local touches_contracts=0
+
+  if printf '%s\n' "$files" | grep -qE '^backend/'; then
+    touches_backend=1
+  fi
+  if printf '%s\n' "$files" | grep -qE '^dashboard/'; then
+    touches_dashboard=1
+  fi
+  if printf '%s\n' "$files" | grep -qE '^tachimint/'; then
+    touches_tachimint=1
+  fi
+  if printf '%s\n' "$files" | grep -qE '^contracts/'; then
+    touches_contracts=1
+  fi
+
+  count=$((touches_backend + touches_dashboard + touches_tachimint + touches_contracts))
+  printf '%s\n' "$count"
+}
+
+list_product_surfaces() {
+  local files="$1"
+  local surfaces=()
+
+  if printf '%s\n' "$files" | grep -qE '^backend/'; then
+    surfaces+=("backend")
+  fi
+  if printf '%s\n' "$files" | grep -qE '^dashboard/'; then
+    surfaces+=("dashboard")
+  fi
+  if printf '%s\n' "$files" | grep -qE '^tachimint/'; then
+    surfaces+=("tachimint")
+  fi
+  if printf '%s\n' "$files" | grep -qE '^contracts/'; then
+    surfaces+=("contracts")
+  fi
+
+  if [ "${#surfaces[@]}" -eq 0 ]; then
+    printf 'none\n'
+    return 0
+  fi
+
+  local joined=""
+  local surface
+  for surface in "${surfaces[@]}"; do
+    if [ -n "$joined" ]; then
+      joined="$joined, "
+    fi
+    joined="$joined$surface"
+  done
+  printf '%s\n' "$joined"
+}
+
+run_check() {
+  local local_ref="$1"
+  local local_sha="$2"
+  local remote="$3"
+  local remote_ref="$4"
+
+  [ -n "$local_ref" ] || return 0
+  [ "$local_sha" != "$ZERO_SHA" ] || return 0
+
+  case "$local_ref" in
+    refs/heads/*) ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  local branch_name="${local_ref#refs/heads/}"
+  local base_ref base_sha base files changed_files log_numstat_output total_lines
+  base_ref=$(detect_base_ref "$remote" "$branch_name" "$remote_ref") || {
+    echo "無法判斷 branch '$branch_name' 的 base ref，略過 scope 檢查。" >&2
+    return 0
+  }
+  base_sha=$(git rev-parse "$base_ref^{commit}" 2>/dev/null) || return 0
+  base=$(git merge-base "$local_sha" "$base_sha" 2>/dev/null) || return 0
+
+  files=$(git diff-tree -r --no-commit-id --name-only "$base" "$local_sha")
+  changed_files=$(printf '%s\n' "$files" | sed '/^$/d' | wc -l | tr -d ' ')
+  log_numstat_output=$(git log --format=tformat: --numstat "$base..$local_sha")
+  total_lines=$(printf '%s\n' "$log_numstat_output" | awk '
+    NF >= 3 {
+      add = ($1 == "-" ? 0 : $1)
+      del = ($2 == "-" ? 0 : $2)
+      sum += add + del
+    }
+    END { print sum + 0 }
+  ')
+
+  local product_surface_count product_surfaces
+  product_surface_count=$(count_product_surfaces "$files")
+  product_surfaces=$(list_product_surfaces "$files")
+
+  local failures=()
+  if [ "$changed_files" -gt "$MAX_FILES" ]; then
+    failures+=("Changed files $changed_files 超過上限 $MAX_FILES")
+  fi
+  if [ "$total_lines" -gt "$MAX_LINES" ]; then
+    failures+=("Diff lines $total_lines 超過上限 $MAX_LINES")
+  fi
+  if [ "$product_surface_count" -gt 1 ]; then
+    failures+=("同時修改多個 product surface：$product_surfaces")
+  fi
+
+  if [ "${#failures[@]}" -eq 0 ]; then
+    echo "PR scope check passed: branch=$branch_name base=${base_ref#refs/remotes/} files=$changed_files lines=$total_lines surfaces=$product_surfaces"
+    return 0
+  fi
+
+  echo ""
+  echo "╔══════════════════════════════════════════════════════╗"
+  echo "║  PR Scope Police — pre-push blocked                 ║"
+  echo "╠══════════════════════════════════════════════════════╣"
+  printf "║  Branch        : %-36s║\n" "$branch_name"
+  printf "║  Base ref      : %-36s║\n" "${base_ref#refs/remotes/}"
+  printf "║  Changed files : %-36s║\n" "$changed_files / $MAX_FILES"
+  printf "║  Diff lines    : %-36s║\n" "$total_lines / $MAX_LINES"
+  printf "║  Surfaces      : %-36s║\n" "$product_surfaces"
+  echo "╠══════════════════════════════════════════════════════╣"
+  local failure
+  for failure in "${failures[@]}"; do
+    printf "║  %-50s║\n" "$failure"
+  done
+  echo "╚══════════════════════════════════════════════════════╝"
+  echo ""
+  echo "請先拆 branch / 縮 scope，再重新 push。"
+
+  return 1
+}
+
+main() {
+  local remote="origin"
+  local local_ref local_sha remote_ref
+
+  case "${1:-}" in
+    --ref)
+      shift
+      [ "$#" -eq 4 ] || {
+        usage >&2
+        exit 2
+      }
+      run_check "$1" "$2" "$3" "$4"
+      ;;
+    "" )
+      local_ref=$(git symbolic-ref HEAD 2>/dev/null) || {
+        echo "目前不在 branch 上，無法執行 pr-scope-check。" >&2
+        exit 2
+      }
+      local_sha=$(git rev-parse HEAD)
+      remote_ref="$local_ref"
+      run_check "$local_ref" "$local_sha" "$remote" "$remote_ref"
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/pr-scope-check.sh
+++ b/scripts/pr-scope-check.sh
@@ -232,7 +232,7 @@ main() {
       }
       run_check "$1" "$2" "$3" "$4"
       ;;
-    "" )
+    "")
       local_ref=$(git symbolic-ref HEAD 2>/dev/null) || {
         echo "目前不在 branch 上，無法執行 pr-scope-check。" >&2
         exit 2


### PR DESCRIPTION
## 什麼改動
- 新增本地 `pre-push` scope 檢查，會阻擋過大 diff 與跨多個 product surface
- 新增 PR metadata 檢查腳本，會檢查 title prefix、PR body 必填欄位、frontend/backend contract 規則
- 新增 `pr-open` wrapper 與 `Makefile` 入口，讓本地檢查到開 PR 走同一套流程
- 補上 [CLAUDE.md](https://github.com/nurockplayer/tachigo/blob/chore/pr-local-guardrails/CLAUDE.md) 使用說明

## 為什麼
closes #133

近期多支 PR 反覆出現 scope 過大、依賴未 merge PR、PR body 缺欄位、frontend/backend contract 尚未收斂就送 review 等問題。這支 PR 先把一部分防線前移到本地。

## Scope 對齊
- Source of truth：#133
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 backend / dashboard / tachimint 功能本身
  - 不改動既有產品邏輯，只加入本地流程防呆與文件

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

已驗證：
- `make pr-check`
- `make pr-meta-check TITLE='[frontend] Test PR' BODY_FILE=/tmp/pr-body-pass.md`
- `bash -n scripts/pr-scope-check.sh`
- `bash -n scripts/pr-metadata-check.sh`
- `bash -n scripts/pr-open.sh`

## 備註
- 目前 `origin/develop` 落後本地 `develop` 一個 commit，若直接對 `develop` 開 PR 會混入其他變更
- 因此這支先暫時以 `chore/pr-local-guardrails-base` 當 stacked draft PR base，等 base commit 進 `develop` 後再 retarget