### PR TITLE
[discussion] Sync Codex review-state labels

### DIFF
--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -62,10 +62,15 @@ jobs:
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner, repo, pull_number: prNumber, per_page: 100,
               })
-              const lastCR = [...reviews]
+              const latestStatefulReview = [...reviews]
                 .reverse()
-                .find(r => r.user?.login === reviewer && r.state === 'CHANGES_REQUESTED')
-              if (!lastCR) return false
+                .find(r =>
+                  r.user?.login === reviewer &&
+                  ['CHANGES_REQUESTED', 'APPROVED'].includes(r.state)
+                )
+              if (!latestStatefulReview || latestStatefulReview.state !== 'CHANGES_REQUESTED') {
+                return false
+              }
 
               const commits = await github.paginate(github.rest.pulls.listCommits, {
                 owner, repo, pull_number: prNumber, per_page: 100,
@@ -73,7 +78,7 @@ jobs:
               if (commits.length === 0) return false
 
               const lastCommitDate = new Date(commits[commits.length - 1].commit.committer.date)
-              const crDate = new Date(lastCR.submitted_at)
+              const crDate = new Date(latestStatefulReview.submitted_at)
               return lastCommitDate > crDate
             }
 

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -8,7 +8,6 @@ on:
     branches: [main, develop]
   pull_request_review:
     types: [submitted]
-    branches: [main, develop]
 
 permissions:
   pull-requests: write
@@ -28,6 +27,9 @@ jobs:
             const reviewLabel = 'needs-codex-review'
             const changesLabel = 'changes-requested'
             const reviewer = 'nurockplayer'
+            const targetBaseBranches = new Set(['main', 'develop'])
+
+            const isTargetBase = (pr) => targetBaseBranches.has(pr.base?.ref)
 
             const ensureLabel = async (name, color, description) => {
               try {
@@ -90,6 +92,11 @@ jobs:
               const pr = context.payload.pull_request
               const review = context.payload.review
 
+              if (!isTargetBase(pr)) {
+                core.notice(`Skipping PR #${pr.number} (base: ${pr.base?.ref || 'unknown'}).`)
+                return
+              }
+
               if (review.user?.login !== reviewer) {
                 core.notice(`Ignoring review from ${review.user?.login || 'unknown reviewer'}.`)
                 return
@@ -123,6 +130,10 @@ jobs:
             }
 
             for (const pr of prs) {
+              if (!isTargetBase(pr)) {
+                core.notice(`Skipping PR #${pr.number} (base: ${pr.base?.ref || 'unknown'}).`)
+                continue
+              }
               const labels = (pr.labels || []).map(l => l.name)
               const isNewPR = context.eventName === 'pull_request' && context.payload.action === 'opened'
               if (isNewPR || await shouldFlag(pr.number)) {

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -6,36 +6,53 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: [main, develop]
+  pull_request_review:
+    types: [submitted]
+    branches: [main, develop]
 
 permissions:
   pull-requests: write
   issues: write
 
 jobs:
-  flag:
-    name: Flag needs-codex-review
+  label-state:
+    name: Manage Codex review labels
     runs-on: ubuntu-latest
     steps:
-      - name: Check and flag
+      - name: Sync labels
         uses: actions/github-script@v7
         with:
           script: |
             const owner = context.repo.owner
             const repo = context.repo.repo
-            const flagLabel = 'needs-codex-review'
+            const reviewLabel = 'needs-codex-review'
+            const changesLabel = 'changes-requested'
             const reviewer = 'nurockplayer'
 
-            const ensureLabel = async () => {
+            const ensureLabel = async (name, color, description) => {
               try {
-                await github.rest.issues.getLabel({ owner, repo, name: flagLabel })
+                await github.rest.issues.getLabel({ owner, repo, name })
               } catch (e) {
                 if (e.status !== 404) throw e
                 await github.rest.issues.createLabel({
                   owner, repo,
-                  name: flagLabel,
-                  color: '0075ca',
-                  description: 'New commits pushed after CHANGES_REQUESTED — pending Codex review',
+                  name,
+                  color,
+                  description,
                 })
+              }
+            }
+
+            const addLabels = async (issue_number, labels) => {
+              if (labels.length === 0) return
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels })
+            }
+
+            const removeLabel = async (issue_number, name) => {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name })
+              } catch (e) {
+                if (e.status !== 404) throw e
               }
             }
 
@@ -58,7 +75,44 @@ jobs:
               return lastCommitDate > crDate
             }
 
-            // Collect PRs to check
+            await ensureLabel(
+              reviewLabel,
+              '0075ca',
+              'New commits pushed after CHANGES_REQUESTED — pending Codex review',
+            )
+            await ensureLabel(
+              changesLabel,
+              'd73a4a',
+              'Codex has requested changes — author should update the PR',
+            )
+
+            if (context.eventName === 'pull_request_review') {
+              const pr = context.payload.pull_request
+              const review = context.payload.review
+
+              if (review.user?.login !== reviewer) {
+                core.notice(`Ignoring review from ${review.user?.login || 'unknown reviewer'}.`)
+                return
+              }
+
+              if (review.state === 'changes_requested') {
+                await addLabels(pr.number, [changesLabel])
+                await removeLabel(pr.number, reviewLabel)
+                core.notice(`PR #${pr.number} marked as ${changesLabel}.`)
+                return
+              }
+
+              if (review.state === 'approved') {
+                await removeLabel(pr.number, changesLabel)
+                await removeLabel(pr.number, reviewLabel)
+                core.notice(`PR #${pr.number} cleared review-state labels after approval.`)
+                return
+              }
+
+              core.notice(`No label action for review state: ${review.state}.`)
+              return
+            }
+
             let prs = []
             if (context.eventName === 'pull_request') {
               prs = [context.payload.pull_request]
@@ -68,19 +122,14 @@ jobs:
               })
             }
 
-            await ensureLabel()
-
             for (const pr of prs) {
               const labels = (pr.labels || []).map(l => l.name)
-              if (labels.includes(flagLabel)) continue  // already flagged
-
               const isNewPR = context.eventName === 'pull_request' && context.payload.action === 'opened'
               if (isNewPR || await shouldFlag(pr.number)) {
-                await github.rest.issues.addLabels({
-                  owner, repo,
-                  issue_number: pr.number,
-                  labels: [flagLabel],
-                })
+                if (!labels.includes(reviewLabel)) {
+                  await addLabels(pr.number, [reviewLabel])
+                }
+                await removeLabel(pr.number, changesLabel)
                 core.notice(`PR #${pr.number} flagged for Codex review.`)
               }
             }

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -111,10 +111,24 @@ jobs:
                 return
               }
 
-              if (review.state === 'approved' || context.payload.action === 'dismissed') {
+              if (review.state === 'approved') {
                 await removeLabel(pr.number, changesLabel)
                 await removeLabel(pr.number, reviewLabel)
-                core.notice(`PR #${pr.number} cleared review-state labels after ${context.payload.action === 'dismissed' ? 'dismissal' : 'approval'}.`)
+                core.notice(`PR #${pr.number} cleared review-state labels after approval.`)
+                return
+              }
+
+              if (context.payload.action === 'dismissed') {
+                if (await shouldFlag(pr)) {
+                  await addLabels(pr.number, [reviewLabel])
+                  await removeLabel(pr.number, changesLabel)
+                  core.notice(`PR #${pr.number} flagged for Codex review after dismissal.`)
+                  return
+                }
+
+                await removeLabel(pr.number, changesLabel)
+                await removeLabel(pr.number, reviewLabel)
+                core.notice(`PR #${pr.number} cleared review-state labels after dismissal.`)
                 return
               }
 

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize]
     branches: [main, develop]
   pull_request_review:
-    types: [submitted]
+    types: [submitted, dismissed]
 
 permissions:
   pull-requests: write
@@ -58,9 +58,9 @@ jobs:
               }
             }
 
-            const shouldFlag = async (prNumber) => {
+            const shouldFlag = async (pr) => {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                owner, repo, pull_number: prNumber, per_page: 100,
+                owner, repo, pull_number: pr.number, per_page: 100,
               })
               const latestStatefulReview = [...reviews]
                 .reverse()
@@ -72,20 +72,17 @@ jobs:
                 return false
               }
 
-              const commits = await github.paginate(github.rest.pulls.listCommits, {
-                owner, repo, pull_number: prNumber, per_page: 100,
-              })
-              if (commits.length === 0) return false
+              if (!pr.head?.sha || !latestStatefulReview.commit_id) {
+                return false
+              }
 
-              const lastCommitDate = new Date(commits[commits.length - 1].commit.committer.date)
-              const crDate = new Date(latestStatefulReview.submitted_at)
-              return lastCommitDate > crDate
+              return pr.head.sha !== latestStatefulReview.commit_id
             }
 
             await ensureLabel(
               reviewLabel,
               '0075ca',
-              'New commits pushed after CHANGES_REQUESTED — pending Codex review',
+              'New PR opened or new commits pushed after CHANGES_REQUESTED — pending Codex review',
             )
             await ensureLabel(
               changesLabel,
@@ -114,10 +111,10 @@ jobs:
                 return
               }
 
-              if (review.state === 'approved') {
+              if (review.state === 'approved' || context.payload.action === 'dismissed') {
                 await removeLabel(pr.number, changesLabel)
                 await removeLabel(pr.number, reviewLabel)
-                core.notice(`PR #${pr.number} cleared review-state labels after approval.`)
+                core.notice(`PR #${pr.number} cleared review-state labels after ${context.payload.action === 'dismissed' ? 'dismissal' : 'approval'}.`)
                 return
               }
 
@@ -141,7 +138,7 @@ jobs:
               }
               const labels = (pr.labels || []).map(l => l.name)
               const isNewPR = context.eventName === 'pull_request' && context.payload.action === 'opened'
-              if (isNewPR || await shouldFlag(pr.number)) {
+              if (isNewPR || await shouldFlag(pr)) {
                 if (!labels.includes(reviewLabel)) {
                   await addLabels(pr.number, [reviewLabel])
                 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,13 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - GitHub 相關的 `gh` 指令（issue、PR、API）與必要的 `git` 指令可由你執行
 - 執行 `git` 時仍需遵守 branch / commit / scope 規範，不得繞過 PR 流程
 
+### PR Label
+
+| Label | 用途 |
+|---|---|
+| `needs-codex-review` | PR 有新 commit，輪到 Codex 重新審查 |
+| `changes-requested` | Codex 已提出 blocker，輪到作者修正 |
+
 ## Scope 邊界
 
 禁止 scope pollution：不要把 issue 沒有明確要求的內容混進同一個 PR。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@
 |---|---|
 | `feature` | 開發任務 |
 | `discussion` | 討論票（搭配 `[discussion]` 前綴使用） |
+| `needs-codex-review` | PR 有新 commit，輪到 Codex 重新審查 |
+| `changes-requested` | Codex 已提出 blocker，輪到作者修正 |
 
 ### Issue 內容格式
 


### PR DESCRIPTION
## 什麼改動
- 調整 `.github/workflows/codex-review-flag.yml`，把 review label 流程改成狀態機
- 新增 `changes-requested` label，讓 PR 在 Codex 發出 blocker 後切到待作者修正狀態
- 同步更新 `CLAUDE.md` 與 `AGENTS.md` 的 label 語意說明

## 為什麼
refs #137

目前 `needs-codex-review` 只表達「待 Codex 重審」，但在 Codex 已送出 `Request changes` 之後，如果 label 不切換，容易讓人誤以為還是輪到 Codex 看，造成重複叫審。

## Scope 對齊
- Source of truth：#137
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改產品功能
  - 不修改 CI 之外的 repo automation
  - 不調整其他 label 命名或看板流程

## 超出範圍內容
無

## 測試方式
- [x] 本地檢查過 workflow 內容與文件同步
- [ ] 有寫 / 更新測試

已驗證：
- 檢查 `.github/workflows/codex-review-flag.yml` YAML 結構與事件分支
- 檢查 `CLAUDE.md` / `AGENTS.md` label 語意一致

## 備註
- 新流程：Codex 送出 `Request changes` 時改掛 `changes-requested`；作者 push 新 commit 後再切回 `needs-codex-review`；approve 後清掉兩者

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在 PR 建立/同步與審查事件時自動管理兩種標籤（needs-codex-review / changes-requested），依審查結果新增或移除標籤。
  * 增加審查事件處理：支援提交、變更請求、駁回等狀態的明確標籤轉換與判定邏輯，並僅對 main/develop 分支生效。
  * 確保標籤存在且安全移除已不再造成錯誤。

* **文檔**
  * 新增 PR 標籤規範與用途說明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->