### PR TITLE
[backend] Agency Onboarding — POST /agencies 建立後自動觸發密碼設定信

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -118,7 +118,7 @@ func main() {
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	claimSvc := services.NewClaimService(db)
 	agencySvc := services.NewAgencyService(db)
-	agencyH := handlers.NewAgencyHandler(agencySvc)
+	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	// CORS origins from env, default to localhost for dev
 	originsEnv := os.Getenv("ALLOWED_ORIGINS")

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -64,12 +64,12 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.emailAuthSvc.ForgotPassword(*user.Email); err != nil {
+		// Agency is already committed; ForgotPassword failure is non-fatal.
+		// Admin can re-trigger via POST /auth/forgot-password if needed.
 		if errors.Is(err, services.ErrPasswordResetEmailSend) {
-			log.Printf("agency create: failed to send password setup email for user %s: %v", user.ID, err)
+			log.Printf("agency create: password setup email not delivered for user %s: %v", user.ID, err)
 		} else {
-			log.Printf("agency create: password reset setup failed for user %s: %v", user.ID, err)
-			internal(c)
-			return
+			log.Printf("agency create: password reset token setup failed for user %s: %v", user.ID, err)
 		}
 	}
 

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -64,7 +64,13 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.emailAuthSvc.ForgotPassword(*user.Email); err != nil {
-		log.Printf("agency create: failed to send password setup email for user %s: %v", user.ID, err)
+		if errors.Is(err, services.ErrPasswordResetEmailSend) {
+			log.Printf("agency create: failed to send password setup email for user %s: %v", user.ID, err)
+		} else {
+			log.Printf("agency create: password reset setup failed for user %s: %v", user.ID, err)
+			internal(c)
+			return
+		}
 	}
 
 	created(c, createAgencyResponse{

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -14,11 +14,12 @@ import (
 )
 
 type AgencyHandler struct {
-	agencySvc *services.AgencyService
+	agencySvc    *services.AgencyService
+	emailAuthSvc *services.EmailAuthService
 }
 
-func NewAgencyHandler(agencySvc *services.AgencyService) *AgencyHandler {
-	return &AgencyHandler{agencySvc: agencySvc}
+func NewAgencyHandler(agencySvc *services.AgencyService, emailAuthSvc *services.EmailAuthService) *AgencyHandler {
+	return &AgencyHandler{agencySvc: agencySvc, emailAuthSvc: emailAuthSvc}
 }
 
 type createAgencyRequest struct {
@@ -60,6 +61,10 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 		log.Printf("agency create: unexpected error: %v", err)
 		internal(c)
 		return
+	}
+
+	if err := h.emailAuthSvc.ForgotPassword(*user.Email); err != nil {
+		log.Printf("agency create: failed to send password setup email to %s: %v", *user.Email, err)
 	}
 
 	created(c, createAgencyResponse{

--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -64,7 +64,7 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.emailAuthSvc.ForgotPassword(*user.Email); err != nil {
-		log.Printf("agency create: failed to send password setup email to %s: %v", *user.Email, err)
+		log.Printf("agency create: failed to send password setup email for user %s: %v", user.ID, err)
 	}
 
 	created(c, createAgencyResponse{

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -254,7 +254,11 @@ func TestAgencyHandler_Create_MailerFailureStillReturns201(t *testing.T) {
 	}
 }
 
-func TestAgencyHandler_Create_NonMailerForgotPasswordFailureReturns500(t *testing.T) {
+// TestAgencyHandler_Create_PartialSuccess_TokenWriteFailure verifies that
+// POST /agencies returns 201 and the agency user is created even when the
+// password_resets write fails (partial success: agency committed, setup incomplete).
+// Admin can re-trigger password setup via POST /auth/forgot-password.
+func TestAgencyHandler_Create_PartialSuccess_TokenWriteFailure(t *testing.T) {
 	env := newTestEnv(t)
 
 	agencySvc := services.NewAgencyService(env.db)
@@ -283,8 +287,21 @@ func TestAgencyHandler_Create_NonMailerForgotPasswordFailureReturns500(t *testin
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500 when password_resets write fails, got %d: %s", w.Code, w.Body.String())
+	// Partial success: agency is created, password setup failed, but caller gets 201
+	// so they don't retry and hit duplicate email/name errors.
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 (partial success), got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Agency user must exist — the core operation succeeded.
+	var userCount int64
+	if err := env.db.Table("users").
+		Where("email = ? AND role = ?", "agency-dbfail@example.com", models.RoleAgency).
+		Count(&userCount).Error; err != nil {
+		t.Fatalf("query users: %v", err)
+	}
+	if userCount != 1 {
+		t.Fatalf("expected agency user to exist after partial success, got %d", userCount)
 	}
 }
 

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -25,7 +25,7 @@ func newAgencyTestEnv(t *testing.T) (*testEnv, http.Handler) {
 
 	env := newTestEnv(t)
 	agencySvc := services.NewAgencyService(env.db)
-	agencyH := handlers.NewAgencyHandler(agencySvc)
+	agencyH := handlers.NewAgencyHandler(agencySvc, env.emailAuthSvc)
 
 	r := env.router
 	v1 := r.Group("/api/v1")
@@ -152,6 +152,35 @@ func TestAgencyHandler_Create_Success(t *testing.T) {
 	}
 	if data["name"] != "agency-one" {
 		t.Fatalf("expected name agency-one, got %v", data["name"])
+	}
+}
+
+func TestAgencyHandler_Create_TriggersPasswordReset(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"name":  "agency-onboard",
+		"email": "agency-onboard@example.com",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/agencies", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var count int64
+	if err := env.db.Table("password_resets").
+		Where("email = ?", "agency-onboard@example.com").
+		Count(&count).Error; err != nil {
+		t.Fatalf("query password_resets: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 password_resets row, got %d", count)
 	}
 }
 

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -254,6 +254,40 @@ func TestAgencyHandler_Create_MailerFailureStillReturns201(t *testing.T) {
 	}
 }
 
+func TestAgencyHandler_Create_NonMailerForgotPasswordFailureReturns500(t *testing.T) {
+	env := newTestEnv(t)
+
+	agencySvc := services.NewAgencyService(env.db)
+	agencyH := handlers.NewAgencyHandler(agencySvc, env.emailAuthSvc)
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	v1 := r.Group("/api/v1")
+	agencies := v1.Group("/agencies")
+	agencies.Use(middleware.JWTAuth(env.authSvc))
+	agencies.POST("", middleware.RequireRole(models.RoleAdmin), agencyH.Create)
+
+	// Drop password_resets table so ForgotPassword fails at DB write (before mailer.Send).
+	if err := env.db.Exec("DROP TABLE IF EXISTS password_resets").Error; err != nil {
+		t.Fatalf("drop password_resets: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"name":  "agency-dbfail",
+		"email": "agency-dbfail@example.com",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/agencies", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when password_resets write fails, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAgencyHandler_Create_DuplicateEmail(t *testing.T) {
 	_, r := newAgencyTestEnv(t)
 

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -3,20 +3,29 @@ package handlers_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
+	"github.com/tachigo/tachigo/internal/config"
 	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/middleware"
 	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
+
+type failingMailer struct{}
+
+func (m *failingMailer) Send(to, subject, body string) error {
+	return errors.New("smtp: connection refused")
+}
 
 const agencyTestAccessSecret = "test-access-secret-at-least-32-chars!"
 
@@ -181,6 +190,67 @@ func TestAgencyHandler_Create_TriggersPasswordReset(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected 1 password_resets row, got %d", count)
+	}
+}
+
+func TestAgencyHandler_Create_MailerFailureStillReturns201(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Wire up an EmailAuthService backed by a mailer that always fails.
+	testCfg := &config.Config{
+		JWT: config.JWTConfig{
+			AccessSecret:  "test-access-secret-at-least-32-chars!",
+			RefreshSecret: "test-refresh-secret",
+			AccessTTL:     15 * time.Minute,
+			RefreshTTL:    30 * 24 * time.Hour,
+		},
+	}
+	failSvc := services.NewEmailAuthService(env.db, testCfg, &failingMailer{})
+	agencySvc := services.NewAgencyService(env.db)
+	agencyH := handlers.NewAgencyHandler(agencySvc, failSvc)
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	v1 := r.Group("/api/v1")
+	agencies := v1.Group("/agencies")
+	agencies.Use(middleware.JWTAuth(env.authSvc))
+	agencies.POST("", middleware.RequireRole(models.RoleAdmin), agencyH.Create)
+
+	body, _ := json.Marshal(map[string]string{
+		"name":  "agency-mailfail",
+		"email": "agency-mailfail@example.com",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/agencies", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 even when mailer fails, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Agency user must exist.
+	var userCount int64
+	if err := env.db.Table("users").
+		Where("email = ? AND role = ?", "agency-mailfail@example.com", models.RoleAgency).
+		Count(&userCount).Error; err != nil {
+		t.Fatalf("query users: %v", err)
+	}
+	if userCount != 1 {
+		t.Fatalf("expected 1 agency user, got %d", userCount)
+	}
+
+	// password_resets token must still be written (token is persisted before mailer.Send).
+	var resetCount int64
+	if err := env.db.Table("password_resets").
+		Where("email = ?", "agency-mailfail@example.com").
+		Count(&resetCount).Error; err != nil {
+		t.Fatalf("query password_resets: %v", err)
+	}
+	if resetCount != 1 {
+		t.Fatalf("expected 1 password_resets row even on mailer failure, got %d", resetCount)
 	}
 }
 

--- a/backend/internal/services/email_auth_service.go
+++ b/backend/internal/services/email_auth_service.go
@@ -14,9 +14,10 @@ import (
 )
 
 var (
-	ErrAlreadyVerified   = errors.New("email already verified")
-	ErrInvalidVerifyToken = errors.New("invalid or expired verification token")
-	ErrInvalidResetToken  = errors.New("invalid or expired password reset token")
+	ErrAlreadyVerified          = errors.New("email already verified")
+	ErrInvalidVerifyToken        = errors.New("invalid or expired verification token")
+	ErrInvalidResetToken         = errors.New("invalid or expired password reset token")
+	ErrPasswordResetEmailSend    = errors.New("failed to send password reset email")
 )
 
 const (
@@ -121,7 +122,10 @@ func (s *EmailAuthService) ForgotPassword(email string) error {
 
 	link := fmt.Sprintf("%s/reset-password?token=%s", s.cfg.App.FrontendURL, rawToken)
 	body := passwordResetEmailBody(link)
-	return s.mailer.Send(email, "Reset your Tachigo password", body)
+	if err := s.mailer.Send(email, "Reset your Tachigo password", body); err != nil {
+		return fmt.Errorf("%w: %w", ErrPasswordResetEmailSend, err)
+	}
+	return nil
 }
 
 // ResetPassword validates the token and updates the user's password.


### PR DESCRIPTION
## Summary

### Agency 建立後自動觸發密碼設定信（closes #139）

- `AgencyHandler` 注入 `EmailAuthService`
- `Create` 成功後呼叫 `ForgotPassword`，寄出設定密碼連結

**ForgotPassword 錯誤處理語意決策（接受部分成功）：**

| 錯誤類型 | 行為 |
|---|---|
| `ErrPasswordResetEmailSend`（mailer 送信失敗） | log + 仍回 201 |
| 非 mailer 錯誤（token 生成、DB 寫入失敗） | log + 仍回 201 |

Agency 建立已先 commit，回 500 會讓 caller 誤以為整體失敗並重試，接著撞 duplicate email/name。接受部分成功：agency 已建立，password setup 未完成時，admin 可手動呼叫 `POST /auth/forgot-password` 補送。

**Tests：**
- `TestAgencyHandler_Create_TriggersPasswordReset` — 成功路徑
- `TestAgencyHandler_Create_MailerFailureStillReturns201` — mailer 失敗仍回 201 + 驗 agency / reset token 都存在
- `TestAgencyHandler_Create_PartialSuccess_TokenWriteFailure` — DB 寫入失敗仍回 201 + 驗 agency 已建立

### GET /agencies/:id/streamers — review 修正（refs #130）

> `agency_service.go` 的修正（`ErrAgencyNotFound`、`ErrDuplicateChannelID`）已隨 PR #130 merge 進 `develop`，不在此 PR diff 內。本 PR 包含對應的 handler + test 改動（404 轉譯、三個新測試）。

## Scope 對齊

- Source of truth: #139、#130 review [#4072571533](https://github.com/nurockplayer/tachigo/pull/130#pullrequestreview-4072571533)
- Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 本 PR 明確不做

- 不實作 agency 專屬登入 route
- 不修改 `POST /api/v1/auth/forgot-password` 的現有邏輯
- 不實作 invitation token 或臨時密碼等替代機制
- 不將 agency 建立與 reset token 建立納入同一 transaction（設計上接受部分成功）
- 不修改未列於本票的 schema / API contract

## Test plan

- [x] `go build ./...` 通過
- [x] `go test ./...` 通過
- [ ] 手動驗證：建立 agency 後收到設定密碼信，點連結設定密碼，可正常登入

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新增功能
  * 创建新机构时自动发送密码重置邮件，简化用户账户初始化流程

## 改进
  * 增强系统容错能力：邮件发送失败不影响机构创建成功

<!-- end of auto-generated comment: release notes by coderabbit.ai -->