### PR TITLE
[backend] Agency 建立 — email_verified 與 response 補 email

### DIFF
--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -27,8 +27,9 @@ type createAgencyRequest struct {
 }
 
 type createAgencyResponse struct {
-	ID   uuid.UUID `json:"id"`
-	Name string    `json:"name"`
+	ID    uuid.UUID `json:"id"`
+	Name  string    `json:"name"`
+	Email string    `json:"email"`
 }
 
 type agencyStreamerResponse struct {
@@ -63,8 +64,9 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 	}
 
 	created(c, createAgencyResponse{
-		ID:   user.ID,
-		Name: req.Name,
+		ID:    user.ID,
+		Name:  req.Name,
+		Email: req.Email,
 	})
 }
 

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -128,7 +128,7 @@ func seedAgencyStreamerListData(t *testing.T, db *gorm.DB, agencyID uuid.UUID) [
 }
 
 func TestAgencyHandler_Create_Success(t *testing.T) {
-	_, r := newAgencyTestEnv(t)
+	env, r := newAgencyTestEnv(t)
 
 	body, _ := json.Marshal(map[string]string{
 		"name":  "agency-one",
@@ -152,6 +152,21 @@ func TestAgencyHandler_Create_Success(t *testing.T) {
 	}
 	if data["name"] != "agency-one" {
 		t.Fatalf("expected name agency-one, got %v", data["name"])
+	}
+	if data["email"] != "agency-one@example.com" {
+		t.Fatalf("expected email agency-one@example.com, got %v", data["email"])
+	}
+
+	// email_verified must be true for admin-created accounts.
+	var emailVerified bool
+	if err := env.db.Table("users").
+		Where("email = ?", "agency-one@example.com").
+		Select("email_verified").
+		Scan(&emailVerified).Error; err != nil {
+		t.Fatalf("query email_verified: %v", err)
+	}
+	if !emailVerified {
+		t.Fatal("expected email_verified = true for admin-created agency")
 	}
 }
 

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -48,10 +48,11 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 	}
 
 	user := &models.User{
-		Username:     &name,
-		Email:        &email,
-		Role:         models.RoleAgency,
-		PasswordHash: nil,
+		Username:      &name,
+		Email:         &email,
+		Role:          models.RoleAgency,
+		PasswordHash:  nil,
+		EmailVerified: true,
 	}
 
 	// Wrap user + email auth_provider in one transaction so we never end up


### PR DESCRIPTION
## Summary

補齊 #106 遺留的兩個小問題：

- **`email_verified = true`**：`AgencyService.Create` 建立 agency user 時，改為 `EmailVerified: true`。Admin 手動建立的帳號不需要 email 驗證流程，預設 `false` 會導致未來 email verified middleware 擋住 agency。
- **Response 補 `email`**：`POST /agencies` 回應加入 `email` 欄位，admin 建完帳號可從 response 確認 email 是否正確。

## Scope 對齊

- Source of truth: #106
- Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 本 PR 明確不做

- 不實作 agency 登入或 onboarding flow（另見 #139）
- 不修改 `POST /agencies` 以外的 API
- 不修改未列於本票的 schema

## Test plan

- [x] `go build ./...` 通過
- [x] `go test ./...` 通過
- [x] `TestAgencyHandler_Create_Success`：驗證 response 有 `email`，DB 的 `email_verified = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发行说明

* **新功能**
  * 创建机构时的响应现在包含电子邮件地址

* **改进**
  * 管理员创建的用户账户电子邮件自动标记为已验证

<!-- end of auto-generated comment: release notes by coderabbit.ai -->