### PR TITLE
[backend] Agency 更新設定 — PUT /agencies/:id/settings

### DIFF
--- a/backend/internal/handlers/agency_handler.go
+++ b/backend/internal/handlers/agency_handler.go
@@ -81,6 +81,50 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 	})
 }
 
+type updateAgencySettingsRequest struct {
+	Name string `json:"name" binding:"required"`
+}
+
+func (h *AgencyHandler) UpdateSettings(c *gin.Context) {
+	agencyID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid agency id")
+		return
+	}
+
+	claims := middleware.MustClaims(c)
+	if claims.Role == models.RoleAgency && claims.UserID != agencyID.String() {
+		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		return
+	}
+
+	var req updateAgencySettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+
+	if err := h.agencySvc.UpdateSettings(agencyID, req.Name); err != nil {
+		if errors.Is(err, services.ErrAgencyNotFound) {
+			notFound(c, "agency not found")
+			return
+		}
+		if errors.Is(err, services.ErrAgencyNameTaken) {
+			conflict(c, err.Error())
+			return
+		}
+		if errors.Is(err, services.ErrAgencyNameTooLong) {
+			badRequest(c, err.Error())
+			return
+		}
+		log.Printf("agency update settings: unexpected error: %v", err)
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{"name": req.Name})
+}
+
 func (h *AgencyHandler) ListStreamers(c *gin.Context) {
 	agencyID, err := uuid.Parse(c.Param("id"))
 	if err != nil {

--- a/backend/internal/handlers/agency_handler_test.go
+++ b/backend/internal/handlers/agency_handler_test.go
@@ -41,6 +41,10 @@ func newAgencyTestEnv(t *testing.T) (*testEnv, http.Handler) {
 	agencies := v1.Group("/agencies")
 	agencies.Use(middleware.JWTAuth(env.authSvc))
 	agencies.POST("", middleware.RequireRole(models.RoleAdmin), agencyH.Create)
+	agencies.PUT("/:id/settings",
+		middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+		agencyH.UpdateSettings,
+	)
 	agencies.GET("/:id/streamers",
 		middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
 		agencyH.ListStreamers,
@@ -387,6 +391,134 @@ func TestAgencyHandler_Create_RequiresAdmin(t *testing.T) {
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func seedAgencyUser(t *testing.T, db *gorm.DB, name, email string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := db.Exec(
+		`INSERT INTO users (id, username, email, role, is_active, email_verified, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		id, name, email, models.RoleAgency,
+	).Error; err != nil {
+		t.Fatalf("seed agency user: %v", err)
+	}
+	return id
+}
+
+func TestAgencyHandler_UpdateSettings_AdminSuccess(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := seedAgencyUser(t, env.db, "agency-orig", "agency-orig@example.com")
+
+	body, _ := json.Marshal(map[string]string{"name": "agency-renamed"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/v1/agencies/"+agencyID.String()+"/settings", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if resp["data"].(map[string]interface{})["name"] != "agency-renamed" {
+		t.Fatalf("expected name agency-renamed in response, got %v", resp["data"])
+	}
+}
+
+func TestAgencyHandler_UpdateSettings_AgencyCanUpdateOwn(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := seedAgencyUser(t, env.db, "agency-self", "agency-self@example.com")
+
+	body, _ := json.Marshal(map[string]string{"name": "agency-self-new"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/v1/agencies/"+agencyID.String()+"/settings", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessTokenForUser(t, agencyID, models.RoleAgency))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_UpdateSettings_AgencyCannotUpdateOthers(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := seedAgencyUser(t, env.db, "agency-other", "agency-other@example.com")
+
+	body, _ := json.Marshal(map[string]string{"name": "hacked"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/v1/agencies/"+agencyID.String()+"/settings", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessTokenForUser(t, uuid.New(), models.RoleAgency))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_UpdateSettings_NotFound(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{"name": "ghost"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/v1/agencies/"+uuid.NewString()+"/settings", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_UpdateSettings_NameTaken(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	seedAgencyUser(t, env.db, "taken-name", "taken@example.com")
+	agencyID := seedAgencyUser(t, env.db, "agency-b", "agency-b@example.com")
+
+	body, _ := json.Marshal(map[string]string{"name": "taken-name"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/v1/agencies/"+agencyID.String()+"/settings", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_UpdateSettings_NameTooLong(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := seedAgencyUser(t, env.db, "agency-toolong", "agency-toolong@example.com")
+
+	body, _ := json.Marshal(map[string]string{"name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}) // 51 chars
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/v1/agencies/"+agencyID.String()+"/settings", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgencyHandler_UpdateSettings_InvalidID(t *testing.T) {
+	_, r := newAgencyTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{"name": "x"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/v1/agencies/not-a-uuid/settings", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -160,7 +160,7 @@ func New(
 		// PUT /agencies/:id/settings — agency or admin
 		agencies.PUT("/:id/settings",
 			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
-			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+			agencyHandler.UpdateSettings,
 		)
 		// GET /agencies/:id/streamers — agency or admin
 		agencies.GET("/:id/streamers",

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -92,29 +92,23 @@ func (s *AgencyService) UpdateSettings(agencyID uuid.UUID, name string) error {
 		return ErrAgencyNameTooLong
 	}
 
-	var count int64
-	if err := s.db.Model(&models.User{}).
+	res := s.db.Model(&models.User{}).
 		Where("id = ? AND role = ?", agencyID, models.RoleAgency).
-		Count(&count).Error; err != nil {
-		return err
+		Update("username", name)
+	if res.Error != nil {
+		var pgErr *pgconn.PgError
+		isUniq := errors.Is(res.Error, gorm.ErrDuplicatedKey) ||
+			(errors.As(res.Error, &pgErr) && pgErr.Code == "23505") ||
+			strings.Contains(res.Error.Error(), "UNIQUE constraint failed")
+		if isUniq {
+			return ErrAgencyNameTaken
+		}
+		return res.Error
 	}
-	if count == 0 {
+	if res.RowsAffected == 0 {
 		return ErrAgencyNotFound
 	}
-
-	count = 0
-	if err := s.db.Model(&models.User{}).
-		Where("username = ? AND id != ?", name, agencyID).
-		Count(&count).Error; err != nil {
-		return err
-	}
-	if count > 0 {
-		return ErrAgencyNameTaken
-	}
-
-	return s.db.Model(&models.User{}).
-		Where("id = ? AND role = ?", agencyID, models.RoleAgency).
-		Update("username", name).Error
+	return nil
 }
 
 func (s *AgencyService) OwnsChannel(agencyUserID uuid.UUID, channelID string) (bool, error) {

--- a/backend/internal/services/agency_service.go
+++ b/backend/internal/services/agency_service.go
@@ -87,6 +87,36 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 	return user, nil
 }
 
+func (s *AgencyService) UpdateSettings(agencyID uuid.UUID, name string) error {
+	if utf8.RuneCountInString(name) > 50 {
+		return ErrAgencyNameTooLong
+	}
+
+	var count int64
+	if err := s.db.Model(&models.User{}).
+		Where("id = ? AND role = ?", agencyID, models.RoleAgency).
+		Count(&count).Error; err != nil {
+		return err
+	}
+	if count == 0 {
+		return ErrAgencyNotFound
+	}
+
+	count = 0
+	if err := s.db.Model(&models.User{}).
+		Where("username = ? AND id != ?", name, agencyID).
+		Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return ErrAgencyNameTaken
+	}
+
+	return s.db.Model(&models.User{}).
+		Where("id = ? AND role = ?", agencyID, models.RoleAgency).
+		Update("username", name).Error
+}
+
 func (s *AgencyService) OwnsChannel(agencyUserID uuid.UUID, channelID string) (bool, error) {
 	var count int64
 	err := s.db.Model(&models.AgencyStreamer{}).


### PR DESCRIPTION
## Summary

取代現有 501 stub，實作 `PUT /agencies/:id/settings`。

本票只允許更新 `name`（username）。`email` 的修改因需同步 `auth_providers.provider_id` 並重新驗證，另開 issue 處理。

**API：**
```
PUT /api/v1/agencies/:id/settings
Role: agency（只能改自己）or admin
Body: { "name": "string" }
Response 200: { "name": "string" }
```

**錯誤對應：**

| 情況 | Status |
|---|---|
| name > 50 字元 | 400 |
| agency 不存在 | 404 |
| name 已被其他帳號使用 | 409 |
| agency 改別人的 settings | 403 |

## Scope 對齊

- Source of truth: #108
- Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 本 PR 明確不做

- 不允許更新 `email`（需另開 issue 處理 auth_providers 同步與驗證流程）
- 不新增 agency profile 欄位或獨立 profile 表
- 不修改未列於本票的 schema / API contract

## Test plan

- [x] `go build ./...` 通過
- [x] `go test ./...` 通過（7 個新測試）
- [ ] 手動驗證：admin 與 agency 各自呼叫 PUT /agencies/:id/settings 確認行為

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 机构可通过新的设置接口更新信息（包含机构名称）。
  * 名称长度限制为最多50字符，并校验唯一性以避免重名冲突。

* **Bug 修复**
  * 更新端点已实现，不再返回“未实现”错误。
  * 增强授权校验：机构用户无法修改他机构设置（返回403）。

* **测试**
  * 增加覆盖成功、权限、未找到、冲突、名称过长与非法ID等场景的端到端测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->