### PR TITLE
[discussion] improve codex review workflows

### DIFF
--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -71,23 +71,32 @@ jobs:
             // It re-evaluates:
             // 1. PRs stuck with `changes-requested` that have received new commits
             //    since the last review.
-            // 2. PRs with no review-state labels and no Codex review history yet,
-            //    as a fallback if the original `opened` event was missed.
+            // 2. PRs with no Codex review history yet, as a fallback if the
+            //    original `opened` event was missed.
+            // 3. PRs previously reviewed by Codex that have new commits since
+            //    that review, but currently lack the review label because a
+            //    `synchronize` event was missed.
             const shouldFlag = async (pr) => {
               const labels = (pr.labels || []).map(l => l.name)
+              if (labels.includes(reviewLabel)) return false
 
               const lastReview = await getLastReviewBySelf(pr)
 
-              // No labels + no prior Codex review means the PR likely missed the
-              // original flagging event and should be put into the review queue.
-              if (!labels.includes(changesLabel) && !labels.includes(reviewLabel)) {
-                return !lastReview
+              // No prior Codex review means the PR likely missed the original
+              // flagging event and should be put into the review queue.
+              if (!lastReview) {
+                return !labels.includes(changesLabel)
               }
 
-              if (!labels.includes(changesLabel)) return false
-              if (!lastReview || !pr.head?.sha || !lastReview.commit_id) return false
+              if (!pr.head?.sha) return false
 
-              return pr.head.sha !== lastReview.commit_id
+              if (lastReview.commit_id) {
+                return pr.head.sha !== lastReview.commit_id
+              }
+
+              if (!lastReview.submitted_at || !pr.updated_at) return false
+
+              return Date.parse(pr.updated_at) > Date.parse(lastReview.submitted_at)
             }
 
             await ensureLabel(
@@ -158,8 +167,9 @@ jobs:
 
               const action = context.payload.action
 
-              if (context.eventName === 'pull_request' && pr.draft) {
-                core.notice(`Skipping PR #${pr.number} (${action}): draft PR.`)
+              if (pr.draft) {
+                const reason = context.eventName === 'pull_request' ? `${action}` : 'schedule'
+                core.notice(`Skipping PR #${pr.number} (${reason}): draft PR.`)
                 continue
               }
 

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '*/10 * * * *'
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, develop]
   pull_request_review:
     types: [submitted, dismissed]
@@ -58,31 +58,42 @@ jobs:
               }
             }
 
-            const shouldFlag = async (pr) => {
+            // For schedule cron: find the last review by self (any state)
+            // to detect whether new commits have been pushed since the last review.
+            const getLastReviewBySelf = async (pr) => {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner, repo, pull_number: pr.number, per_page: 100,
               })
-              const latestStatefulReview = [...reviews]
-                .reverse()
-                .find(r =>
-                  r.user?.login === reviewer &&
-                  ['CHANGES_REQUESTED', 'APPROVED'].includes(r.state)
-                )
-              if (!latestStatefulReview || latestStatefulReview.state !== 'CHANGES_REQUESTED') {
-                return false
+              return [...reviews].reverse().find(r => r.user?.login === reviewer)
+            }
+
+            // shouldFlag is only used by the schedule cron as a fallback sweep.
+            // It re-evaluates:
+            // 1. PRs stuck with `changes-requested` that have received new commits
+            //    since the last review.
+            // 2. PRs with no review-state labels and no Codex review history yet,
+            //    as a fallback if the original `opened` event was missed.
+            const shouldFlag = async (pr) => {
+              const labels = (pr.labels || []).map(l => l.name)
+
+              const lastReview = await getLastReviewBySelf(pr)
+
+              // No labels + no prior Codex review means the PR likely missed the
+              // original flagging event and should be put into the review queue.
+              if (!labels.includes(changesLabel) && !labels.includes(reviewLabel)) {
+                return !lastReview
               }
 
-              if (!pr.head?.sha || !latestStatefulReview.commit_id) {
-                return false
-              }
+              if (!labels.includes(changesLabel)) return false
+              if (!lastReview || !pr.head?.sha || !lastReview.commit_id) return false
 
-              return pr.head.sha !== latestStatefulReview.commit_id
+              return pr.head.sha !== lastReview.commit_id
             }
 
             await ensureLabel(
               reviewLabel,
               '0075ca',
-              'New PR opened or new commits pushed after CHANGES_REQUESTED — pending Codex review',
+              'New PR opened or new commits pushed after the latest Codex review — pending Codex review',
             )
             await ensureLabel(
               changesLabel,
@@ -119,16 +130,10 @@ jobs:
               }
 
               if (context.payload.action === 'dismissed') {
-                if (await shouldFlag(pr)) {
-                  await addLabels(pr.number, [reviewLabel])
-                  await removeLabel(pr.number, changesLabel)
-                  core.notice(`PR #${pr.number} flagged for Codex review after dismissal.`)
-                  return
-                }
-
+                // Dismissed means the review is no longer active — always re-flag.
+                await addLabels(pr.number, [reviewLabel])
                 await removeLabel(pr.number, changesLabel)
-                await removeLabel(pr.number, reviewLabel)
-                core.notice(`PR #${pr.number} cleared review-state labels after dismissal.`)
+                core.notice(`PR #${pr.number} flagged for Codex review after dismissal.`)
                 return
               }
 
@@ -150,13 +155,33 @@ jobs:
                 core.notice(`Skipping PR #${pr.number} (base: ${pr.base?.ref || 'unknown'}).`)
                 continue
               }
-              const labels = (pr.labels || []).map(l => l.name)
-              const isNewPR = context.eventName === 'pull_request' && context.payload.action === 'opened'
-              if (isNewPR || await shouldFlag(pr)) {
-                if (!labels.includes(reviewLabel)) {
-                  await addLabels(pr.number, [reviewLabel])
-                }
+
+              const action = context.payload.action
+
+              if (context.eventName === 'pull_request' && pr.draft) {
+                core.notice(`Skipping PR #${pr.number} (${action}): draft PR.`)
+                continue
+              }
+
+              // New PR, ready-for-review transition, reopen, or new commit pushed:
+              // always flag unconditionally.
+              if (
+                action === 'opened' ||
+                action === 'synchronize' ||
+                action === 'reopened' ||
+                action === 'ready_for_review'
+              ) {
+                await addLabels(pr.number, [reviewLabel])
                 await removeLabel(pr.number, changesLabel)
-                core.notice(`PR #${pr.number} flagged for Codex review.`)
+                core.notice(`PR #${pr.number} flagged for Codex review (${action}).`)
+                continue
+              }
+
+              // Schedule cron fallback: catch PRs stuck with changes-requested
+              // that have received new commits since the last review.
+              if (await shouldFlag(pr)) {
+                await addLabels(pr.number, [reviewLabel])
+                await removeLabel(pr.number, changesLabel)
+                core.notice(`PR #${pr.number} flagged for Codex review (schedule catch-up).`)
               }
             }

--- a/.github/workflows/codex-review-slack.yml
+++ b/.github/workflows/codex-review-slack.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 permissions:
-  actions: read
+  actions: write
   pull-requests: read
   issues: read
 
@@ -16,9 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Restore notification dedup cache
+        id: dedup-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/codex-review-slack/${{ github.event.workflow_run.id }}
+          key: codex-review-slack-${{ github.repository }}-${{ github.event.workflow_run.id }}
+
       - name: Evaluate PR readiness
         id: evaluate
         uses: actions/github-script@v7
+        env:
+          CACHE_HIT: ${{ steps.dedup-cache.outputs.cache-hit }}
         with:
           script: |
             const run = context.payload.workflow_run
@@ -76,8 +85,8 @@ jobs:
               return
             }
 
-            if ((run.run_attempt || 1) > 1) {
-              core.notice(`Skipping PR #${fullPr.number}: CI rerun detected (attempt ${run.run_attempt}).`)
+            if (process.env.CACHE_HIT === 'true') {
+              core.notice(`Skipping PR #${fullPr.number}: Slack notification already sent for workflow run ${run.id}.`)
               core.setOutput('should_notify', 'false')
               return
             }
@@ -153,4 +162,13 @@ jobs:
             echo "Slack webhook POST failed (non-2xx response): $RESPONSE"
             exit 1
           }
+          mkdir -p "${RUNNER_TEMP}/codex-review-slack/${{ github.event.workflow_run.id }}"
+          touch "${RUNNER_TEMP}/codex-review-slack/${{ github.event.workflow_run.id }}/sent"
           echo "Slack webhook response: $RESPONSE"
+
+      - name: Persist notification dedup cache
+        if: steps.evaluate.outputs.should_notify == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/codex-review-slack/${{ github.event.workflow_run.id }}
+          key: codex-review-slack-${{ github.repository }}-${{ github.event.workflow_run.id }}

--- a/.github/workflows/codex-review-slack.yml
+++ b/.github/workflows/codex-review-slack.yml
@@ -1,0 +1,134 @@
+name: Notify Codex review queue in Slack
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  notify:
+    name: Slack notify when PR is ready for Codex review
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Evaluate PR readiness
+        id: evaluate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const reviewLabel = 'needs-codex-review'
+            const changesLabel = 'changes-requested'
+            const targetBaseBranches = new Set(['main', 'develop'])
+
+            const pr = run.pull_requests?.[0]
+            if (!pr) {
+              core.notice('No pull request is associated with this CI run.')
+              core.setOutput('should_notify', 'false')
+              return
+            }
+
+            const { data: fullPr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number,
+            })
+
+            const labels = (fullPr.labels || []).map((label) => label.name)
+            const hasReviewLabel = labels.includes(reviewLabel)
+            const hasChangesRequestedLabel = labels.includes(changesLabel)
+            const isTargetBase = targetBaseBranches.has(fullPr.base?.ref)
+
+            if (!isTargetBase) {
+              core.notice(`Skipping PR #${fullPr.number}: unsupported base branch ${fullPr.base?.ref || 'unknown'}.`)
+              core.setOutput('should_notify', 'false')
+              return
+            }
+
+            if (fullPr.draft) {
+              core.notice(`Skipping PR #${fullPr.number}: draft PR.`)
+              core.setOutput('should_notify', 'false')
+              return
+            }
+
+            if (!hasReviewLabel) {
+              core.notice(`Skipping PR #${fullPr.number}: missing ${reviewLabel} label.`)
+              core.setOutput('should_notify', 'false')
+              return
+            }
+
+            if (hasChangesRequestedLabel) {
+              core.notice(`Skipping PR #${fullPr.number}: ${changesLabel} label is still present.`)
+              core.setOutput('should_notify', 'false')
+              return
+            }
+
+            const shortSha = (run.head_sha || '').slice(0, 7)
+            const payload = {
+              text: `PR #${fullPr.number} is ready for Codex review`,
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: `*PR ready for Codex review*\n<${fullPr.html_url}|#${fullPr.number} ${fullPr.title}>`,
+                  },
+                },
+                {
+                  type: 'section',
+                  fields: [
+                    {
+                      type: 'mrkdwn',
+                      text: `*Author*\n${fullPr.user?.login || 'unknown'}`,
+                    },
+                    {
+                      type: 'mrkdwn',
+                      text: `*Base branch*\n${fullPr.base?.ref || 'unknown'}`,
+                    },
+                    {
+                      type: 'mrkdwn',
+                      text: `*Head SHA*\n${shortSha || 'unknown'}`,
+                    },
+                    {
+                      type: 'mrkdwn',
+                      text: `*CI run*\n<${run.html_url}|workflow_run #${run.run_number}>`,
+                    },
+                  ],
+                },
+                {
+                  type: 'context',
+                  elements: [
+                    {
+                      type: 'mrkdwn',
+                      text: 'Triggered only when CI is green and the PR is labeled needs-codex-review.',
+                    },
+                  ],
+                },
+              ],
+            }
+
+            core.setOutput('should_notify', 'true')
+            core.setOutput('payload', JSON.stringify(payload))
+
+      - name: Send Slack notification
+        if: steps.evaluate.outputs.should_notify == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CODEX_REVIEW_WEBHOOK_URL }}
+          SLACK_PAYLOAD: ${{ steps.evaluate.outputs.payload }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_CODEX_REVIEW_WEBHOOK_URL is not configured; skipping Slack notification."
+            exit 0
+          fi
+
+          curl -sS -X POST \
+            -H 'Content-type: application/json' \
+            --data "$SLACK_PAYLOAD" \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/codex-review-slack.yml
+++ b/.github/workflows/codex-review-slack.yml
@@ -70,6 +70,12 @@ jobs:
               return
             }
 
+            if (run.head_sha !== fullPr.head.sha) {
+              core.notice(`Skipping PR #${fullPr.number}: CI run head_sha (${run.head_sha}) does not match PR latest sha (${fullPr.head.sha}); notification suppressed for stale commit.`)
+              core.setOutput('should_notify', 'false')
+              return
+            }
+
             const shortSha = (run.head_sha || '').slice(0, 7)
             const payload = {
               text: `PR #${fullPr.number} is ready for Codex review`,
@@ -128,7 +134,11 @@ jobs:
             exit 0
           fi
 
-          curl -sS -X POST \
+          RESPONSE=$(curl -sS --fail-with-body -X POST \
             -H 'Content-type: application/json' \
             --data "$SLACK_PAYLOAD" \
-            "$SLACK_WEBHOOK_URL"
+            "$SLACK_WEBHOOK_URL") || {
+            echo "Slack webhook POST failed (non-2xx response): $RESPONSE"
+            exit 1
+          }
+          echo "Slack webhook response: $RESPONSE"

--- a/.github/workflows/codex-review-slack.yml
+++ b/.github/workflows/codex-review-slack.yml
@@ -76,6 +76,12 @@ jobs:
               return
             }
 
+            if ((run.run_attempt || 1) > 1) {
+              core.notice(`Skipping PR #${fullPr.number}: CI rerun detected (attempt ${run.run_attempt}).`)
+              core.setOutput('should_notify', 'false')
+              return
+            }
+
             if (run.head_sha !== fullPr.head.sha) {
               core.notice(`Skipping PR #${fullPr.number}: CI run head_sha (${run.head_sha}) does not match PR latest sha (${fullPr.head.sha}); notification suppressed for stale commit.`)
               core.setOutput('should_notify', 'false')

--- a/.github/workflows/codex-review-slack.yml
+++ b/.github/workflows/codex-review-slack.yml
@@ -41,6 +41,12 @@ jobs:
               pull_number: pr.number,
             })
 
+            if (fullPr.state !== 'open') {
+              core.notice(`Skipping PR #${fullPr.number}: PR is not open.`)
+              core.setOutput('should_notify', 'false')
+              return
+            }
+
             const labels = (fullPr.labels || []).map((label) => label.name)
             const hasReviewLabel = labels.includes(reviewLabel)
             const hasChangesRequestedLabel = labels.includes(changesLabel)

--- a/.github/workflows/codex-review-slack.yml
+++ b/.github/workflows/codex-review-slack.yml
@@ -4,6 +4,8 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  pull_request:
+    types: [labeled]
 
 permissions:
   actions: write
@@ -11,144 +13,200 @@ permissions:
   issues: read
 
 jobs:
-  notify:
-    name: Slack notify when PR is ready for Codex review
+  evaluate:
+    name: Evaluate Codex review Slack notifications
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      has_notifications: ${{ steps.evaluate.outputs.has_notifications }}
+      notifications: ${{ steps.evaluate.outputs.notifications }}
     steps:
-      - name: Restore notification dedup cache
-        id: dedup-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ runner.temp }}/codex-review-slack/${{ github.event.workflow_run.id }}
-          key: codex-review-slack-${{ github.repository }}-${{ github.event.workflow_run.id }}
-
       - name: Evaluate PR readiness
         id: evaluate
         uses: actions/github-script@v7
-        env:
-          CACHE_HIT: ${{ steps.dedup-cache.outputs.cache-hit }}
         with:
           script: |
-            const run = context.payload.workflow_run
             const owner = context.repo.owner
             const repo = context.repo.repo
             const reviewLabel = 'needs-codex-review'
             const changesLabel = 'changes-requested'
             const targetBaseBranches = new Set(['main', 'develop'])
-
-            const pr = run.pull_requests?.[0]
-            if (!pr) {
-              core.notice('No pull request is associated with this CI run.')
-              core.setOutput('should_notify', 'false')
-              return
+            async function getFullPr(pullNumber) {
+              const { data } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber,
+              })
+              return data
             }
 
-            const { data: fullPr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pr.number,
-            })
+            async function getSuccessfulCiRun(headSha) {
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner,
+                repo,
+                head_sha: headSha,
+                status: 'completed',
+                per_page: 100,
+              })
 
-            if (fullPr.state !== 'open') {
-              core.notice(`Skipping PR #${fullPr.number}: PR is not open.`)
-              core.setOutput('should_notify', 'false')
-              return
+              return data.workflow_runs.find((workflowRun) =>
+                workflowRun.name === 'CI' && workflowRun.conclusion === 'success'
+              )
             }
 
-            const labels = (fullPr.labels || []).map((label) => label.name)
-            const hasReviewLabel = labels.includes(reviewLabel)
-            const hasChangesRequestedLabel = labels.includes(changesLabel)
-            const isTargetBase = targetBaseBranches.has(fullPr.base?.ref)
-
-            if (!isTargetBase) {
-              core.notice(`Skipping PR #${fullPr.number}: unsupported base branch ${fullPr.base?.ref || 'unknown'}.`)
-              core.setOutput('should_notify', 'false')
-              return
-            }
-
-            if (fullPr.draft) {
-              core.notice(`Skipping PR #${fullPr.number}: draft PR.`)
-              core.setOutput('should_notify', 'false')
-              return
-            }
-
-            if (!hasReviewLabel) {
-              core.notice(`Skipping PR #${fullPr.number}: missing ${reviewLabel} label.`)
-              core.setOutput('should_notify', 'false')
-              return
-            }
-
-            if (hasChangesRequestedLabel) {
-              core.notice(`Skipping PR #${fullPr.number}: ${changesLabel} label is still present.`)
-              core.setOutput('should_notify', 'false')
-              return
-            }
-
-            if (process.env.CACHE_HIT === 'true') {
-              core.notice(`Skipping PR #${fullPr.number}: Slack notification already sent for workflow run ${run.id}.`)
-              core.setOutput('should_notify', 'false')
-              return
-            }
-
-            if (run.head_sha !== fullPr.head.sha) {
-              core.notice(`Skipping PR #${fullPr.number}: CI run head_sha (${run.head_sha}) does not match PR latest sha (${fullPr.head.sha}); notification suppressed for stale commit.`)
-              core.setOutput('should_notify', 'false')
-              return
-            }
-
-            const shortSha = (run.head_sha || '').slice(0, 7)
-            const payload = {
-              text: `PR #${fullPr.number} is ready for Codex review`,
-              blocks: [
-                {
-                  type: 'section',
-                  text: {
-                    type: 'mrkdwn',
-                    text: `*PR ready for Codex review*\n<${fullPr.html_url}|#${fullPr.number} ${fullPr.title}>`,
+            function buildPayload(fullPr, sourceRun) {
+              const shortSha = (fullPr.head?.sha || sourceRun.head_sha || '').slice(0, 7)
+              return {
+                text: `PR #${fullPr.number} is ready for Codex review`,
+                blocks: [
+                  {
+                    type: 'section',
+                    text: {
+                      type: 'mrkdwn',
+                      text: `*PR ready for Codex review*\n<${fullPr.html_url}|#${fullPr.number} ${fullPr.title}>`,
+                    },
                   },
-                },
-                {
-                  type: 'section',
-                  fields: [
-                    {
-                      type: 'mrkdwn',
-                      text: `*Author*\n${fullPr.user?.login || 'unknown'}`,
-                    },
-                    {
-                      type: 'mrkdwn',
-                      text: `*Base branch*\n${fullPr.base?.ref || 'unknown'}`,
-                    },
-                    {
-                      type: 'mrkdwn',
-                      text: `*Head SHA*\n${shortSha || 'unknown'}`,
-                    },
-                    {
-                      type: 'mrkdwn',
-                      text: `*CI run*\n<${run.html_url}|workflow_run #${run.run_number}>`,
-                    },
-                  ],
-                },
-                {
-                  type: 'context',
-                  elements: [
-                    {
-                      type: 'mrkdwn',
-                      text: 'Triggered only when CI is green and the PR is labeled needs-codex-review.',
-                    },
-                  ],
-                },
-              ],
+                  {
+                    type: 'section',
+                    fields: [
+                      {
+                        type: 'mrkdwn',
+                        text: `*Author*\n${fullPr.user?.login || 'unknown'}`,
+                      },
+                      {
+                        type: 'mrkdwn',
+                        text: `*Base branch*\n${fullPr.base?.ref || 'unknown'}`,
+                      },
+                      {
+                        type: 'mrkdwn',
+                        text: `*Head SHA*\n${shortSha || 'unknown'}`,
+                      },
+                      {
+                        type: 'mrkdwn',
+                        text: `*CI run*\n<${sourceRun.html_url}|workflow_run #${sourceRun.run_number}>`,
+                      },
+                    ],
+                  },
+                  {
+                    type: 'context',
+                    elements: [
+                      {
+                        type: 'mrkdwn',
+                        text: 'Triggered when CI is green and the PR is labeled needs-codex-review.',
+                      },
+                    ],
+                  },
+                ],
+              }
             }
 
-            core.setOutput('should_notify', 'true')
-            core.setOutput('payload', JSON.stringify(payload))
+            async function collectNotification(fullPr, sourceRun) {
+              if (fullPr.state !== 'open') {
+                core.notice(`Skipping PR #${fullPr.number}: PR is not open.`)
+                return null
+              }
+
+              const labels = (fullPr.labels || []).map((label) => label.name)
+              const hasReviewLabel = labels.includes(reviewLabel)
+              const hasChangesRequestedLabel = labels.includes(changesLabel)
+              const isTargetBase = targetBaseBranches.has(fullPr.base?.ref)
+
+              if (!isTargetBase) {
+                core.notice(`Skipping PR #${fullPr.number}: unsupported base branch ${fullPr.base?.ref || 'unknown'}.`)
+                return null
+              }
+
+              if (fullPr.draft) {
+                core.notice(`Skipping PR #${fullPr.number}: draft PR.`)
+                return null
+              }
+
+              if (!hasReviewLabel) {
+                core.notice(`Skipping PR #${fullPr.number}: missing ${reviewLabel} label.`)
+                return null
+              }
+
+              if (hasChangesRequestedLabel) {
+                core.notice(`Skipping PR #${fullPr.number}: ${changesLabel} label is still present.`)
+                return null
+              }
+
+              if (sourceRun.head_sha !== fullPr.head.sha) {
+                core.notice(`Skipping PR #${fullPr.number}: CI run head_sha (${sourceRun.head_sha}) does not match PR latest sha (${fullPr.head.sha}); notification suppressed for stale commit.`)
+                return null
+              }
+
+              return {
+                dedup_key: `${sourceRun.id}-${fullPr.number}`,
+                payload: JSON.stringify(buildPayload(fullPr, sourceRun)),
+              }
+            }
+
+            const notifications = []
+
+            if (context.eventName === 'workflow_run') {
+              const run = context.payload.workflow_run
+              if (run.conclusion !== 'success') {
+                core.notice(`Skipping workflow_run ${run.id}: conclusion is ${run.conclusion || 'unknown'}.`)
+              } else {
+                const pullNumbers = [...new Set((run.pull_requests || []).map((pr) => pr.number).filter(Boolean))]
+                if (pullNumbers.length === 0) {
+                  core.notice('No pull requests are associated with this CI run.')
+                }
+
+                for (const pullNumber of pullNumbers) {
+                  const fullPr = await getFullPr(pullNumber)
+                  const notification = await collectNotification(fullPr, run)
+                  if (notification) {
+                    notifications.push(notification)
+                  }
+                }
+              }
+            } else if (context.eventName === 'pull_request') {
+              const labelName = context.payload.label?.name
+              if (labelName !== reviewLabel) {
+                core.notice(`Skipping pull_request labeled event: label ${labelName || 'unknown'} is not ${reviewLabel}.`)
+              } else {
+                const fullPr = await getFullPr(context.payload.pull_request.number)
+                const sourceRun = await getSuccessfulCiRun(fullPr.head.sha)
+
+                if (!sourceRun) {
+                  core.notice(`Skipping PR #${fullPr.number}: no successful CI workflow run found for head sha ${fullPr.head.sha}.`)
+                } else {
+                  const notification = await collectNotification(fullPr, sourceRun)
+                  if (notification) {
+                    notifications.push(notification)
+                  }
+                }
+              }
+            } else {
+              core.notice(`Unsupported event: ${context.eventName}`)
+            }
+
+            core.setOutput('has_notifications', notifications.length > 0 ? 'true' : 'false')
+            core.setOutput('notifications', JSON.stringify(notifications))
+
+  notify:
+    name: Slack notify when PR is ready for Codex review
+    needs: evaluate
+    if: needs.evaluate.outputs.has_notifications == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        notification: ${{ fromJson(needs.evaluate.outputs.notifications) }}
+    steps:
+      - name: Restore notification dedup cache
+        id: dedup-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/codex-review-slack/${{ matrix.notification.dedup_key }}
+          key: codex-review-slack-${{ github.repository }}-${{ matrix.notification.dedup_key }}
 
       - name: Send Slack notification
-        if: steps.evaluate.outputs.should_notify == 'true'
+        if: steps.dedup-cache.outputs.cache-hit != 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CODEX_REVIEW_WEBHOOK_URL }}
-          SLACK_PAYLOAD: ${{ steps.evaluate.outputs.payload }}
+          SLACK_PAYLOAD: ${{ matrix.notification.payload }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "SLACK_CODEX_REVIEW_WEBHOOK_URL is not configured; skipping Slack notification."
@@ -162,13 +220,13 @@ jobs:
             echo "Slack webhook POST failed (non-2xx response): $RESPONSE"
             exit 1
           }
-          mkdir -p "${RUNNER_TEMP}/codex-review-slack/${{ github.event.workflow_run.id }}"
-          touch "${RUNNER_TEMP}/codex-review-slack/${{ github.event.workflow_run.id }}/sent"
+          mkdir -p "${RUNNER_TEMP}/codex-review-slack/${{ matrix.notification.dedup_key }}"
+          touch "${RUNNER_TEMP}/codex-review-slack/${{ matrix.notification.dedup_key }}/sent"
           echo "Slack webhook response: $RESPONSE"
 
       - name: Persist notification dedup cache
-        if: steps.evaluate.outputs.should_notify == 'true'
+        if: steps.dedup-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: ${{ runner.temp }}/codex-review-slack/${{ github.event.workflow_run.id }}
-          key: codex-review-slack-${{ github.repository }}-${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/codex-review-slack/${{ matrix.notification.dedup_key }}
+          key: codex-review-slack-${{ github.repository }}-${{ matrix.notification.dedup_key }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ backend/bin/
 
 # Claude Code
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
+.superpowers/
 
 # Frontend
 tachimint/node_modules/
@@ -23,6 +25,9 @@ dashboard/*.local
 
 # pnpm
 .pnpm-store/
+
+# Local caches
+.gocache/
 
 # IDE
 .vscode/


### PR DESCRIPTION
## 什麼改動

- 更新 `.github/workflows/codex-review-flag.yml`
  - 修正 `needs-codex-review` label 在新 commit、`reopened`、`ready_for_review`、review dismissed 後的回補邏輯
  - 補上 cron fallback，處理先前可能漏掉 label 的 PR
- 新增 `.github/workflows/codex-review-slack.yml`
  - 只在 `CI success + needs-codex-review + 非 draft + 非 changes-requested` 時送 Slack 通知
- 更新 `.gitignore`
  - 忽略本機 cache / tool artifacts，避免污染 Source Control

## 為什麼

目前 Codex review queue 有兩個實際問題：

1. PR push 新 commit 後，`needs-codex-review` 不一定會正確切回來
2. Slack 若用過於寬鬆的 PR / commit 通知，噪音太高，無法真正反映「現在該 review 的 PR」

這張 PR 的目標是把 review queue 與通知機制收斂成更可依賴的狀態。

拆自 #141
refs #141

## Scope 對齊

- Source of truth：Codex review workflow / label flow 調整
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分

## 本 PR 明確不做

- 不修改 backend / dashboard / tachimint 功能
- 不調整產品定位或 Chrome Extension terminology
- 不修改 branch protection 規則本身
- 不直接啟用 GitHub auto-merge
- 不處理 Slack channel / webhook 建立流程以外的組織治理設定

## 超出範圍內容

無

## 測試方式

- [x] workflow 邏輯檢查
- [ ] 自動化測試

補充：
- `codex-review-slack.yml` 需要 repo secret：`SLACK_CODEX_REVIEW_WEBHOOK_URL`
- 這張 PR 只負責 workflow 與 ignore 規則，不包含 Slack webhook 建立本身

## 備註

這張 PR 是從原本混在文件 PR 裡的 workflow / repo hygiene 變更拆出來，避免和 Chrome Extension terminology cleanup 混在同一個 scope。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **优化项**
  * 扩展 PR 触发事件（含 reopened、ready_for_review）；对草稿 PR 跳过并给出提示。
  * 改进自动标记逻辑：优化自审检测与时间/提交比较规则；在更多场景下更新/移除审查相关标签并调整标签描述为“latest Codex review”相应措辞。

* **新功能**
  * 新增 Slack 通知工作流：CI 成功且 PR 符合就绪条件时发送通知，避免重复或过时通知；缺少 webhook 时安全跳过。

* **杂项**
  * 更新 .gitignore，新增若干本地缓存与工具相关条目。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->