### PR TITLE
[discussion] support develop-to-main release promotion PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,12 @@
 ## 為什麼
 <!-- 背景、需求，或關聯的 issue（e.g. closes #123） -->
 
+## Release Context
+<!-- 若這是正式 release PR，請填：`develop -> main`；否則填 `n/a` -->
+- Release type：<!-- `develop -> main` 或 `n/a` -->
+
 ## Scope 對齊
-<!-- 若 PR 超過約 35 個檔案、diff 過大、同時改多個 product surface，或依賴尚未 merge 的 backend contract，會被 PR Scope Police 自動擋下；嚴重 scope 違規會自動加 label 並關閉 PR -->
+<!-- 一般 feature PR 若超過約 35 個檔案、diff 過大、同時改多個 product surface，或依賴尚未 merge 的 backend contract，會被 PR Scope Police 自動擋下。正式 `develop -> main` release PR 請使用 `[release]` title prefix，並在上方 Release Context 填 `develop -> main`。 -->
 - Source of truth：<!-- issue / PR / 文件，例如 #115 -->
 - Depends on PR：<!-- `none` 或 `#123` -->
 - Backend contract already in develop:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
               return
             }
 
+            const isSameRepoHead =
+              pr.head?.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`
+            const isReleasePromotionPr =
+              isSameRepoHead &&
+              pr.base?.ref === 'main' &&
+              pr.head?.ref === 'develop'
+
             const bypassLabels = new Set(['scope-exception'])
             const labels = (pr.labels || []).map((label) => label.name)
             if (labels.some((label) => bypassLabels.has(label))) {
@@ -52,7 +59,7 @@ jobs:
             const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
             const body = pr.body || ''
             const title = pr.title || ''
-            const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]']
+            const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]']
             const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
             const touches = {
               backend: filenames.some((name) => name.startsWith('backend/')),
@@ -74,20 +81,34 @@ jobs:
               backendContractNo &&
               !backendContractYes
 
-            const runCi =
+            const releaseBodyValid =
+              titlePrefix === '[release]' &&
+              (body.includes('Source of truth：') || body.includes('Source of truth:')) &&
+              Boolean(dependsOnRaw) &&
+              (dependsOnNone || Boolean(dependsOnPrMatch)) &&
+              body.includes('本 PR 明確不做') &&
+              backendContractYes &&
+              !backendContractNo
+
+            const standardBodyValid =
               Boolean(titlePrefix) &&
+              titlePrefix !== '[release]' &&
               /#\d+/.test(body) &&
               (body.includes('Source of truth：') || body.includes('Source of truth:')) &&
               Boolean(dependsOnRaw) &&
               (dependsOnNone || Boolean(dependsOnPrMatch)) &&
               (backendContractYes !== backendContractNo) &&
-              body.includes('本 PR 明確不做') &&
-              filenames.length <= hardMaxChangedFiles &&
-              diffLines <= hardMaxDiffLines &&
-              productSurfaces <= 1 &&
-              !(titlePrefix === '[backend]' && (touches.dashboard || touches.tachimint)) &&
-              !(titlePrefix === '[frontend]' && touches.backend) &&
-              !(titlePrefix === '[contract]' && (touches.backend || touches.dashboard || touches.tachimint)) &&
+              body.includes('本 PR 明確不做')
+
+            const runCi =
+              (isReleasePromotionPr && releaseBodyValid) ||
+              standardBodyValid &&
+              (isReleasePromotionPr || filenames.length <= hardMaxChangedFiles) &&
+              (isReleasePromotionPr || diffLines <= hardMaxDiffLines) &&
+              (isReleasePromotionPr || productSurfaces <= 1) &&
+              (isReleasePromotionPr || !(titlePrefix === '[backend]' && (touches.dashboard || touches.tachimint))) &&
+              (isReleasePromotionPr || !(titlePrefix === '[frontend]' && touches.backend)) &&
+              (isReleasePromotionPr || !(titlePrefix === '[contract]' && (touches.backend || touches.dashboard || touches.tachimint))) &&
               !dependencyBlocked
 
             core.setOutput('run_ci', runCi ? 'true' : 'false')

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -25,6 +25,13 @@ jobs:
               return
             }
 
+            const isSameRepoHead =
+              pr.head?.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`
+            const isReleasePromotionPr =
+              isSameRepoHead &&
+              pr.base?.ref === 'main' &&
+              pr.head?.ref === 'develop'
+
             const bypassLabels = new Set(['scope-exception'])
             const labels = (pr.labels || []).map((label) => label.name)
             const bypassed = labels.some((label) => bypassLabels.has(label))
@@ -76,7 +83,7 @@ jobs:
             const severeFailures = []
             const warnings = []
 
-            const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]']
+            const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]']
             const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
             if (!titlePrefix) {
               policyFailures.push(
@@ -84,7 +91,15 @@ jobs:
               )
             }
 
-            if (!/#\d+/.test(body)) {
+            if (isReleasePromotionPr && titlePrefix !== '[release]') {
+              policyFailures.push('`develop -> main` release PR must use the `[release]` title prefix.')
+            }
+
+            if (!isReleasePromotionPr && titlePrefix === '[release]') {
+              policyFailures.push('`[release]` PR is reserved for formal `develop -> main` promotion PRs only.')
+            }
+
+            if (!isReleasePromotionPr && !/#\d+/.test(body)) {
               policyFailures.push('PR body must reference at least one issue or PR number such as `#123`.')
             }
 
@@ -116,6 +131,9 @@ jobs:
             if (backendContractYes && backendContractNo) {
               policyFailures.push('`Backend contract already in develop` cannot select both yes and no.')
             }
+            if (isReleasePromotionPr && !backendContractYes) {
+              policyFailures.push('Formal `[release]` PR must mark `Backend contract already in develop` as yes.')
+            }
 
             const stackedOnDependency = /If no, this PR is:[\s\S]*?- \[[xX]\] stacked on dependency branch/i.test(body)
             const intentionallyBlocked = /If no, this PR is:[\s\S]*?- \[[xX]\] intentionally blocked until dependency merges/i.test(body)
@@ -141,41 +159,41 @@ jobs:
               dependencyFailures.push(message)
             }
 
-            if (filenames.length > hardMaxChangedFiles) {
+            if (!isReleasePromotionPr && filenames.length > hardMaxChangedFiles) {
               const message =
                 `PR changes ${filenames.length} files, which exceeds the hard limit of ${hardMaxChangedFiles}. Split the PR before review.`
               failures.push(message)
               severeFailures.push(message)
             }
 
-            if (diffLines > hardMaxDiffLines) {
+            if (!isReleasePromotionPr && diffLines > hardMaxDiffLines) {
               const message =
                 `PR diff size is ${diffLines} lines (+/-), which exceeds the hard limit of ${hardMaxDiffLines}. Split the PR before review.`
               failures.push(message)
               severeFailures.push(message)
             }
 
-            if (productSurfaces.length > 1) {
+            if (!isReleasePromotionPr && productSurfaces.length > 1) {
               const message =
                 `PR touches multiple product surfaces (${productSurfaces.join(', ')}). Keep one PR to one surface only.`
               failures.push(message)
               severeFailures.push(message)
             }
 
-            if (titlePrefix === '[backend]' && (touches.dashboard || touches.tachimint)) {
+            if (!isReleasePromotionPr && titlePrefix === '[backend]' && (touches.dashboard || touches.tachimint)) {
               const message = '[backend] PR must not change dashboard/ or tachimint/.'
               failures.push(message)
               severeFailures.push(message)
             }
 
-            if (titlePrefix === '[frontend]' && touches.backend) {
+            if (!isReleasePromotionPr && titlePrefix === '[frontend]' && touches.backend) {
               const message =
                 '[frontend] PR must not change backend/. Move backend prerequisites into a separate PR.'
               failures.push(message)
               severeFailures.push(message)
             }
 
-            if (titlePrefix === '[contract]' && (touches.backend || touches.dashboard || touches.tachimint)) {
+            if (!isReleasePromotionPr && titlePrefix === '[contract]' && (touches.backend || touches.dashboard || touches.tachimint)) {
               const message = '[contract] PR must not change backend/, dashboard/, or tachimint/.'
               failures.push(message)
               severeFailures.push(message)
@@ -236,6 +254,7 @@ jobs:
 
             summaryLines.push('')
             summaryLines.push('### Snapshot')
+            summaryLines.push(`- Mode: ${isReleasePromotionPr ? 'release promotion (develop -> main)' : 'standard PR'}`)
             summaryLines.push(`- Changed files: ${filenames.length}`)
             summaryLines.push(`- Diff lines (+/-): ${diffLines}`)
             summaryLines.push(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,11 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 
 ### 注意事項
 
-- **不要** 直接推 `main`，PR 目標分支是 `develop`
+- **不要** 直接推 `main`
+- 日常 feature PR 目標分支是 `develop`
+- 正式 release 依 Git Flow 由 `develop` 開 PR 到 `main`
+- 目前暫不使用 `release/*` branch
+- 未來若有正式部署、freeze window、hotfix/backport 需求，再升級 release 流程
 - GitHub 相關的 `gh` 指令（issue、PR、API）與必要的 `git` 指令可由你執行
 - 執行 `git` 時仍需遵守 branch / commit / scope 規範，不得繞過 PR 流程
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,16 @@
    git push -u origin feat/points-service
    ```
 
-3. 在 GitHub 發 PR，目標分支：`develop`（不直接推 `main`）
+3. 在 GitHub 發 PR，日常 feature PR 目標分支：`develop`
+
+4. 正式 release 流程走 Git Flow：
+
+   - `main` 不接受日常 feature PR
+   - 每兩週由 `develop` 開一張正式 release PR 到 `main`
+   - release PR 使用 `[release]` title prefix
+   - `develop -> main` release PR 屬於正式 promotion 流程，不視為 scope exception
+   - 目前暫不使用 `release/*` branch
+   - 等未來有正式部署、freeze window、hotfix/backport 需求時，再升級為 release branch 流程
 
 ## Scope 邊界
 
@@ -91,11 +100,15 @@
 
 ### PR 不得依賴未 merge 的 PR
 
-禁止在 PR body 中宣告對其他尚未 merge 的 PR 的依賴（例如「依賴：#123 需先 merge」）。
+禁止在一般 feature PR body 中宣告對其他尚未 merge 的 PR 的依賴（例如「依賴：#123 需先 merge」）。
 
 - 若前置 PR 尚未 merge，後續 PR 不應開出來
 - 若真有順序依賴，先等前置 PR merge，再從最新 `develop` 拉新 branch 開發
 - scope police 會自動偵測 `依賴：#xxx` 或 `depends on #xxx` 語法，若引用的 PR 仍為 open 狀態，該 PR 會被自動關閉
+
+例外：
+
+- 正式 `[release]` 的 `develop -> main` promotion PR 不屬於這條規則的限制對象
 
 ### 遇到岔路時怎麼做
 

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -2,6 +2,14 @@
 
 這份文件說明 `tachigo` 的 PR 邊界規則，以及 GitHub 上需要如何設定，避免再次出現超大包、跨 scope、review 失焦，或前端建立在未落地 backend contract 上的 PR。
 
+另外，repo 採用 Git Flow：
+
+- 日常功能開發與功能 PR 一律先進 `develop`
+- `main` 只接受正式 release promotion
+- 預設 cadence 為每兩週一次 `develop -> main` release PR
+- 目前暫不使用 `release/*` branch
+- 待未來有正式部署、freeze window、hotfix/backport 需求時，再升級為完整 release branch 流程
+
 ## 目標
 
 - 一個 PR 只做一個明確問題
@@ -17,8 +25,8 @@ repo 目前有一個 GitHub Actions workflow：
 
 它會在 PR 開啟、更新、編輯時檢查以下規則：
 
-- PR title 必須以 `[backend]` / `[frontend]` / `[contract]` / `[discussion]` 開頭
-- PR body 必須包含 issue / PR 編號，例如 `#123`
+- PR title 必須以 `[backend]` / `[frontend]` / `[contract]` / `[discussion]` / `[release]` 開頭
+- 一般 feature PR 的 body 必須包含 issue / PR 編號，例如 `#123`
 - PR body 必須包含 `Source of truth`
 - PR body 必須包含 `Depends on PR`
 - PR body 必須明確標記 backend contract 是否已經在 `develop`
@@ -33,6 +41,24 @@ repo 目前有一個 GitHub Actions workflow：
 - `[frontend]` PR 不可修改 `backend/`
 - `[contract]` PR 不可修改 `backend/` / `dashboard/` / `tachimint/`
 - `[frontend]` PR 若依賴尚未 merge 的 backend contract，會被 dependency gate 擋下
+
+## 正式 release PR
+
+以下情況視為正式支援的 release promotion PR，而不是 scope exception：
+
+- base branch = `main`
+- head branch = `develop`
+- title prefix = `[release]`
+
+這類 PR 的性質是把已在 `develop` 收斂完成的內容整批 promotion 到 `main`，因此：
+
+- 不套用一般 feature PR 的檔案數上限 `35`
+- 不套用一般 feature PR 的 diff 行數上限 `1800`
+- 不套用單一 product surface 限制
+- 不會因為大包而被 `PR Scope Police` 自動關閉
+- 仍會要求 PR body 補齊基本資訊，例如 `Source of truth`、`Depends on PR`、`Backend contract already in develop`、`本 PR 明確不做`
+
+換句話說，超大包 `develop -> main` PR 在這個流程裡是正式合法路徑，但其他分支組合仍照一般 scope 規則檢查。
 
 ## 自動處置
 
@@ -68,6 +94,11 @@ repo 目前有一個 GitHub Actions workflow：
 - 只有在「同一張票的必要前置真的無法拆開」時才使用
 - 不能把它當成超大包 PR 的常態逃生門
 
+注意：
+
+- 正式 `develop -> main` release PR 不需要使用 `scope-exception`
+- `scope-exception` 只保留給非正式 release promotion 的特殊情況
+
 ## CI Gate
 
 repo 的 CI 目前改成：
@@ -76,6 +107,7 @@ repo 的 CI 目前改成：
 - `.github/workflows/ci.yml` 也會直接跑在 PR 上，但會先經過一個輕量 `Scope gate`
 - 只有目前符合同一套 scope 規則、且沒有被 dependency gate 擋住的 PR，才會繼續跑 backend / frontend / dashboard 的 docker build 與測試
 - 若 `[frontend]` PR 依賴尚未 merge 的 backend contract，重型 CI 會直接跳過
+- 若 PR 是正式 `[release]` 的 `develop -> main` promotion，重型 CI 會照常執行，不因 diff 過大而被 scope gate 跳過
 
 ## GitHub 設定
 
@@ -92,6 +124,11 @@ repo 的 CI 目前改成：
 - Block direct push
 - Block force push
 - Block branch deletion
+
+建議補充：
+
+- `main` 僅允許來自 `develop` 的正式 release PR 合併
+- release PR title 使用 `[release]`
 
 ### Required Checks
 
@@ -116,6 +153,11 @@ repo 的 CI 目前改成：
 - 若是 dependency block，先要求作者等依賴 merge，或改成 stacked PR
 - 只有在 maintainer 明確決定加 `scope-exception` 時，才進一步 review
 
+若 PR 是正式 `[release]` 的 `develop -> main` promotion：
+
+- 不要用 feature PR 的檔案數 / diff 大小標準要求它拆 PR
+- review 重點改成 release readiness：CI、branch protection、是否包含不該進版的內容、是否需要延後到下個 release cycle
+
 若 PR 雖然通過自動檢查，但 reviewer 仍判斷 scope 已混掉：
 
 - 可以直接要求拆 PR
@@ -136,6 +178,7 @@ repo 的 CI 目前改成：
 - `[backend]` PR 只改 `backend/`，且有清楚的 source of truth
 - `[frontend]` PR 只改 `dashboard/`，必要測試一起補齊
 - `[discussion]` PR 只改文件，不碰產品程式碼
+- `[release]` PR 從 `develop` 整批 promotion 到 `main`
 
 ## 後續調整
 


### PR DESCRIPTION
## 什麼改動

- 更新 `.github/workflows/pr-scope-police.yml`
  - 正式支援 `[release]` 類型的 `develop -> main` promotion PR
  - 不再把正式 release PR 當成一般 feature PR 的超大包 scope violation
- 更新 `.github/workflows/ci.yml`
  - `Scope gate` 允許正式 release PR 照常跑重型 CI
- 更新 `.github/PULL_REQUEST_TEMPLATE.md`
  - 加入 `Release Context`
- 更新 `docs/pr-scope-policy.md`
  - 明文化 repo 採用簡化版 Git Flow
  - 明確記錄目前雙週 `develop -> main` release PR 為正式流程
  - 明確記錄目前暫不使用 `release/*` branch`
- 更新 `CLAUDE.md` 與 `AGENTS.md`
  - 同步 release flow 規範

## 為什麼

目前 repo 的 scope police / CI 規則預設所有進 `main` 的 PR 都應符合一般 feature PR 的檔案數、diff size 與單一 surface 限制，這與我們採用的 Git Flow 不一致。

在現在的流程下，正式的 `develop -> main` promotion PR 會被誤判成 scope violation 並自動關閉。這張 PR 的目的就是把「雙週 release promotion」改成正式受支援的路徑，而不是每次都走例外處理。

refs #155

## Release Context
- Release type：`n/a`

## Scope 對齊
- Source of truth：`#155` 暴露出的流程衝突，以及本 repo 現在採用的 Git Flow release 共識
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 `release/*` branch` 流程
  - 不修改實際產品功能或部署腳本
  - 不改動 `develop -> main` 以外的 release automation

## 超出範圍內容

無

## 測試方式
- [x] 文件與 workflow 規則檢查
- [ ] 自動化測試

補充：
- 已驗證 `.github/workflows/pr-scope-police.yml` 與 `.github/workflows/ci.yml` YAML 可正常解析

## 備註

目前先採簡化版 Git Flow：
- feature PR -> `develop`
- 雙週 `[release] develop -> main`
- 暫不使用 `release/*` branch`

若未來有正式部署、freeze window、hotfix/backport 需求，再升級為完整 release branch 流程。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持正式的 develop -> main 发布 promotion 流程，新增必须以 `[release]` 为前缀的发布 PR 识别与校验。
  * 在 PR 模板中新增“Release Context / Release type”字段以便填写发布信息。

* **文档**
  * 更新工作流程与 PR 范围政策，明确发布 PR 的校验规则、放宽范围/大小限制及审查重点（发布就绪性）。
  * 更新使用说明与注意事项，区分日常 feature PR 与正式发布 PR 的要求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->