### PR TITLE
fix: restore agency dashboard access and watch session flow

### DIFF
--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -130,7 +130,7 @@ func New(
 
 	dashboard := v1.Group("/dashboard")
 	dashboard.Use(middleware.JWTAuth(authSvc))
-	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
 		dashboard.POST("/streamers", middleware.RequireRole(models.RoleAdmin), streamerH.Create)
 		dashboard.GET("/streamers", middleware.RequireRole(models.RoleAgency, models.RoleAdmin), streamerH.List)

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -1,0 +1,362 @@
+package router_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/tachigo/tachigo/internal/config"
+	"github.com/tachigo/tachigo/internal/handlers"
+	"github.com/tachigo/tachigo/internal/models"
+	"github.com/tachigo/tachigo/internal/router"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+type mockMailer struct{}
+
+func (m *mockMailer) Send(to, subject, body string) error {
+	return nil
+}
+
+type routerTestEnv struct {
+	db      *gorm.DB
+	authSvc *services.AuthService
+	router  *gin.Engine
+}
+
+func newRouterTestEnv(t *testing.T) *routerTestEnv {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("enable foreign keys: %v", err)
+	}
+	if err := migrateTestDB(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			AccessSecret:  "test-access-secret-at-least-32-chars!",
+			RefreshSecret: "test-refresh-secret",
+			AccessTTL:     15 * time.Minute,
+			RefreshTTL:    30 * 24 * time.Hour,
+		},
+		App: config.AppConfig{
+			FrontendURL: "http://localhost:3000",
+		},
+	}
+
+	authSvc := services.NewAuthService(db, cfg)
+	userSvc := services.NewUserService(db)
+	addrSvc := services.NewAddressService(db)
+	emailAuthSvc := services.NewEmailAuthService(db, cfg, &mockMailer{})
+	extSvc := services.NewExtensionService(db, cfg, authSvc)
+	watchSvc := services.NewWatchService(db)
+	channelConfigSvc := services.NewChannelConfigService(db)
+	pointsSvc := services.NewPointsService(db, watchSvc)
+	airdropSvc := services.NewAirdropService(db, pointsSvc, channelConfigSvc)
+	streamerSvc := services.NewStreamerService(db, pointsSvc)
+	agencySvc := services.NewAgencyService(db)
+	claimSvc := services.NewClaimService(db)
+	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
+
+	engine := router.New(
+		authSvc,
+		userSvc,
+		addrSvc,
+		extSvc,
+		emailAuthSvc,
+		watchSvc,
+		channelConfigSvc,
+		pointsSvc,
+		airdropSvc,
+		streamerSvc,
+		agencySvc,
+		claimSvc,
+		agencyHandler,
+		[]string{"http://localhost:3000"},
+	)
+
+	return &routerTestEnv{
+		db:      db,
+		authSvc: authSvc,
+		router:  engine,
+	}
+}
+
+func migrateTestDB(db *gorm.DB) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS users (
+			id TEXT PRIMARY KEY,
+			username TEXT UNIQUE,
+			email TEXT UNIQUE,
+			password_hash TEXT,
+			avatar_url TEXT,
+			role TEXT NOT NULL DEFAULT 'viewer',
+			is_active INTEGER NOT NULL DEFAULT 1,
+			email_verified INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME,
+			updated_at DATETIME,
+			deleted_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS auth_providers (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			provider TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			access_token TEXT,
+			refresh_token TEXT,
+			token_expires_at DATETIME,
+			metadata TEXT,
+			created_at DATETIME,
+			updated_at DATETIME,
+			deleted_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS shipping_addresses (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			recipient_name TEXT NOT NULL,
+			phone TEXT,
+			address_line1 TEXT NOT NULL,
+			address_line2 TEXT,
+			city TEXT NOT NULL,
+			district TEXT,
+			postal_code TEXT,
+			country TEXT NOT NULL DEFAULT 'TW',
+			is_default INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME,
+			updated_at DATETIME,
+			deleted_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS refresh_tokens (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			token_hash TEXT NOT NULL UNIQUE,
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS web3_nonces (
+			id TEXT PRIMARY KEY,
+			nonce TEXT NOT NULL UNIQUE,
+			address TEXT NOT NULL,
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS email_verifications (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			token_hash TEXT NOT NULL UNIQUE,
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS password_resets (
+			id TEXT PRIMARY KEY,
+			email TEXT NOT NULL,
+			token_hash TEXT NOT NULL UNIQUE,
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS channel_configs (
+			channel_id TEXT PRIMARY KEY,
+			seconds_per_point INTEGER NOT NULL DEFAULT 60,
+			multiplier INTEGER NOT NULL DEFAULT 1,
+			daily_airdrop_limit INTEGER NOT NULL DEFAULT 5000,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS agency_streamers (
+			id TEXT PRIMARY KEY,
+			agency_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			created_at DATETIME,
+			UNIQUE (agency_id, channel_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS streamers (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			agency_user_id TEXT REFERENCES users(id),
+			channel_id TEXT NOT NULL,
+			display_name TEXT,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_streamers_user_channel
+			ON streamers (user_id, channel_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_streamers_agency_user_id
+			ON streamers (agency_user_id)`,
+		`CREATE TABLE IF NOT EXISTS watch_sessions (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			channel_id TEXT NOT NULL,
+			accumulated_seconds INTEGER NOT NULL DEFAULT 0,
+			rewarded_seconds INTEGER NOT NULL DEFAULT 0,
+			last_heartbeat_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			click_cooldown_until DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00',
+			is_active INTEGER NOT NULL DEFAULT 1,
+			ended_at DATETIME,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_sessions_active_user_channel
+			ON watch_sessions (user_id, channel_id)
+			WHERE is_active = 1`,
+		`CREATE TABLE IF NOT EXISTS points_ledgers (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			channel_id TEXT NOT NULL,
+			cumulative_total INTEGER NOT NULL DEFAULT 0,
+			spendable_balance INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_user_channel
+			ON points_ledgers (user_id, channel_id)`,
+		`CREATE TABLE IF NOT EXISTS points_transactions (
+			id TEXT PRIMARY KEY,
+			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
+			watch_session_id TEXT,
+			source TEXT NOT NULL,
+			delta INTEGER NOT NULL,
+			balance_after INTEGER NOT NULL,
+			sku TEXT,
+			note TEXT,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE TABLE IF NOT EXISTS watch_time_stats (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			channel_id TEXT NOT NULL,
+			total_watch_seconds INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_time_user_channel
+			ON watch_time_stats (user_id, channel_id)`,
+		`CREATE TABLE IF NOT EXISTS broadcast_time_stats (
+			id TEXT PRIMARY KEY,
+			streamer_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			total_broadcast_seconds INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_broadcast_time_streamer_channel
+			ON broadcast_time_stats (streamer_id, channel_id)`,
+		`CREATE TABLE IF NOT EXISTS broadcast_time_logs (
+			id TEXT PRIMARY KEY,
+			streamer_id TEXT NOT NULL,
+			channel_id TEXT NOT NULL,
+			seconds INTEGER NOT NULL,
+			recorded_at DATETIME NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS tachi_balances (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			balance INTEGER NOT NULL DEFAULT 0,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE (user_id),
+			CHECK (balance >= 0)
+		)`,
+	}
+
+	for _, stmt := range stmts {
+		if err := db.Exec(stmt).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *routerTestEnv) tokenForRole(t *testing.T, role models.UserRole, prefix string) (string, string) {
+	t.Helper()
+
+	email := prefix + "@example.com"
+	username := prefix
+	password := "password123"
+
+	user, _, err := e.authSvc.Register(services.RegisterInput{
+		Username: username,
+		Email:    email,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("register(%s): %v", role, err)
+	}
+
+	if err := e.db.Model(user).Update("role", role).Error; err != nil {
+		t.Fatalf("set role(%s): %v", role, err)
+	}
+
+	_, tokens, err := e.authSvc.Login(services.LoginInput{
+		Email:    email,
+		Password: password,
+	})
+	if err != nil {
+		t.Fatalf("login(%s): %v", role, err)
+	}
+
+	return email, tokens.AccessToken
+}
+
+func seedAgencyOwnedStreamerChannel(t *testing.T, env *routerTestEnv, agencyEmail, channelID string) {
+	t.Helper()
+
+	var agency models.User
+	if err := env.db.Where("email = ?", agencyEmail).First(&agency).Error; err != nil {
+		t.Fatalf("load agency: %v", err)
+	}
+
+	streamer, _, err := env.authSvc.Register(services.RegisterInput{
+		Username: "streamer_" + channelID,
+		Email:    "streamer_" + channelID + "@example.com",
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("register streamer: %v", err)
+	}
+	if err := env.db.Model(streamer).Update("role", models.RoleStreamer).Error; err != nil {
+		t.Fatalf("set streamer role: %v", err)
+	}
+
+	if err := env.db.Create(&models.Streamer{
+		UserID:       streamer.ID,
+		AgencyUserID: &agency.ID,
+		ChannelID:    channelID,
+		DisplayName:  "Agency owned channel",
+	}).Error; err != nil {
+		t.Fatalf("seed streamer channel: %v", err)
+	}
+}
+
+func TestDashboardRouter_AgencyOwnedChannelConfigAccessible(t *testing.T) {
+	env := newRouterTestEnv(t)
+	agencyEmail, token := env.tokenForRole(t, models.RoleAgency, "agency_router")
+	seedAgencyOwnedStreamerChannel(t, env, agencyEmail, "agency_owned_channel")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard/channels/agency_owned_channel/config", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/tachimint/src/App.tsx
+++ b/tachimint/src/App.tsx
@@ -6,18 +6,18 @@ import { useClickBoost } from './hooks/useClickBoost'
 
 export default function App() {
   const { t } = useTranslation()
-  const { context, jwt, products, bitsEnabled, authError } = useTwitch()
+  const { context, jwt, products, bitsEnabled, authError, backendReady } = useTwitch()
   const { buyWithBits, status, error } = useBits(jwt)
   const isViewer = context?.role === 'viewer'
-  const { balance, gain, isAnimating, syncBalance } = useHeartbeat(jwt, {
-    enabled: isViewer,
+  const { balance, gain, isAnimating, syncBalance } = useHeartbeat(context?.channelId, {
+    enabled: isViewer && backendReady,
   })
   const {
     handleClick,
     cooldownMs,
     isAnimating: clickAnimating,
     gain: clickGain,
-  } = useClickBoost(context?.channelId, isViewer, syncBalance)
+  } = useClickBoost(context?.channelId, isViewer && backendReady, syncBalance)
 
   if (!context) {
     return (
@@ -64,7 +64,7 @@ export default function App() {
             <button
               className={`ext-mine__btn${cooldownMs > 0 ? ' ext-mine__btn--cooldown' : ''}`}
               onClick={handleClick}
-              disabled={cooldownMs > 0}
+              disabled={cooldownMs > 0 || !backendReady}
               aria-label="Click to mine points"
             >
               ⛏

--- a/tachimint/src/hooks/useHeartbeat.ts
+++ b/tachimint/src/hooks/useHeartbeat.ts
@@ -6,7 +6,7 @@ interface UseHeartbeatOptions {
   intervalMs?: number
 }
 
-export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions = {}) {
+export function useHeartbeat(channelId: string | undefined, options: UseHeartbeatOptions = {}) {
   const { enabled = true, intervalMs = 30_000 } = options
   const [balance, setBalance] = useState<number | null>(null)
   const [gain, setGain] = useState<number | null>(null)
@@ -16,7 +16,7 @@ export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions 
   const stopAnimationTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
-    if (!enabled || !extensionJwt) return
+    if (!enabled || !channelId) return
 
     let isDisposed = false
     let heartbeatTimer: number | null = null
@@ -30,7 +30,7 @@ export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions 
 
     const runHeartbeat = async () => {
       try {
-        const data = await sendHeartbeat(extensionJwt)
+        const data = await sendHeartbeat(channelId)
         if (isDisposed) return
 
         const nextBalance = data.balance
@@ -68,7 +68,7 @@ export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions 
       }
       clearAnimationTimer()
     }
-  }, [enabled, extensionJwt, intervalMs])
+  }, [channelId, enabled, intervalMs])
 
   // Allow external callers (e.g. click boost) to sync the baseline so the
   // next heartbeat gain animation doesn't double-count already-awarded points.

--- a/tachimint/src/hooks/useTwitch.ts
+++ b/tachimint/src/hooks/useTwitch.ts
@@ -16,6 +16,7 @@ export function useTwitch() {
   const [products, setProducts] = useState<TwitchBitsProduct[]>([])
   const [bitsEnabled, setBitsEnabled] = useState(false)
   const [authError, setAuthError] = useState<string | null>(null)
+  const [backendReady, setBackendReady] = useState(false)
 
   useEffect(() => {
     const ext = window.Twitch?.ext
@@ -41,6 +42,7 @@ export function useTwitch() {
 
     ext.onAuthorized(async (auth: TwitchExtAuth) => {
       setJwt(auth.token)
+      setBackendReady(false)
 
       // Login to tachigo backend with the extension JWT
       try {
@@ -50,9 +52,12 @@ export function useTwitch() {
         const tokens = (result as any)?.data?.tokens ?? (result as any)?.tokens
         if (tokens?.access_token) {
           setAuthToken(tokens.access_token)
+          setBackendReady(true)
+          setAuthError(null)
         }
       } catch {
         // Non-fatal: bits flow still works via extension JWT directly
+        setBackendReady(false)
         setAuthError('Backend unavailable')
       }
 
@@ -68,5 +73,5 @@ export function useTwitch() {
     })
   }, [])
 
-  return { context, jwt, products, bitsEnabled, authError }
+  return { context, jwt, products, bitsEnabled, authError, backendReady }
 }

--- a/tachimint/src/services/api.test.ts
+++ b/tachimint/src/services/api.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import test from 'node:test'
+
+type RecordedRequest = {
+  method: string
+  url: string
+  authorization: string | undefined
+  body: unknown
+}
+
+async function withApiServer(
+  handler: (requests: RecordedRequest[]) => http.RequestListener,
+  run: (baseUrl: string, requests: RecordedRequest[]) => Promise<void>,
+) {
+  const requests: RecordedRequest[] = []
+  const server = http.createServer(handler(requests))
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('failed to resolve test server address')
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`
+
+  try {
+    await run(baseUrl, requests)
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }
+}
+
+async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+
+  if (chunks.length === 0) {
+    return null
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+}
+
+test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes balance', async () => {
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/start') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { started: true } }))
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/heartbeat') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { points_earned: 2 } }))
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/extension/watch/balance?channel_id=channel-123') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            success: true,
+            data: { spendable_balance: 42, cumulative_total: 42 },
+          }),
+        )
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+      const api = await import(`./api.ts?heartbeat=${Date.now()}`)
+
+      api.setAuthToken('tachigo-access-token')
+      const result = await api.sendHeartbeat('channel-123')
+
+      assert.equal(result.balance, 42)
+      assert.deepEqual(
+        requests.map(({ method, url, authorization, body }) => ({
+          method,
+          url,
+          authorization,
+          body,
+        })),
+        [
+          {
+            method: 'POST',
+            url: '/api/v1/extension/watch/start',
+            authorization: 'Bearer tachigo-access-token',
+            body: { channel_id: 'channel-123' },
+          },
+          {
+            method: 'POST',
+            url: '/api/v1/extension/watch/heartbeat',
+            authorization: 'Bearer tachigo-access-token',
+            body: { channel_id: 'channel-123' },
+          },
+          {
+            method: 'GET',
+            url: '/api/v1/extension/watch/balance?channel_id=channel-123',
+            authorization: 'Bearer tachigo-access-token',
+            body: null,
+          },
+        ],
+      )
+    },
+  )
+})
+
+test('sendClick ensures the watch session exists before sending click rewards', async () => {
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/start') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { started: true } }))
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/click') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { balance: 9, delta: 1 } }))
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+      const api = await import(`./api.ts?click=${Date.now()}`)
+
+      api.setAuthToken('tachigo-access-token')
+      const result = await api.sendClick('channel-123')
+
+      assert.deepEqual(result, { balance: 9, delta: 1 })
+      assert.deepEqual(
+        requests.map(({ method, url, authorization, body }) => ({
+          method,
+          url,
+          authorization,
+          body,
+        })),
+        [
+          {
+            method: 'POST',
+            url: '/api/v1/extension/watch/start',
+            authorization: 'Bearer tachigo-access-token',
+            body: { channel_id: 'channel-123' },
+          },
+          {
+            method: 'POST',
+            url: '/api/v1/extension/watch/click',
+            authorization: 'Bearer tachigo-access-token',
+            body: { channel_id: 'channel-123' },
+          },
+        ],
+      )
+    },
+  )
+})

--- a/tachimint/src/services/api.ts
+++ b/tachimint/src/services/api.ts
@@ -1,7 +1,21 @@
 import axios from 'axios'
 import type { TachigoToken } from '../types/twitch'
 
-const BASE_URL = import.meta.env.VITE_TACHIGO_API_URL ?? 'http://localhost:8080'
+const processEnv =
+  typeof globalThis === 'object' && 'process' in globalThis
+    ? (
+        globalThis as {
+          process?: {
+            env?: Record<string, string | undefined>
+          }
+        }
+      ).process?.env
+    : undefined
+
+const BASE_URL =
+  import.meta.env?.VITE_TACHIGO_API_URL ??
+  processEnv?.VITE_TACHIGO_API_URL ??
+  'http://localhost:8080'
 
 const client = axios.create({
   baseURL: BASE_URL,
@@ -42,21 +56,24 @@ interface HeartbeatResponse {
   balance: number
 }
 
-function parseBalanceFromHeartbeatResponse(payload: unknown): number {
+function parseBalanceFromPayload(payload: unknown): number {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid heartbeat response')
+    throw new Error('Invalid balance response')
   }
 
-  // Accept a few common API shapes to keep frontend resilient while backend evolves.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const raw = payload as any
   const direct = raw.balance
   const nested = raw.data?.balance
   const legacy = raw.points_balance
+  const spendable = raw.spendable_balance
+  const nestedSpendable = raw.data?.spendable_balance
 
-  const value = [direct, nested, legacy].find((candidate) => typeof candidate === 'number')
+  const value = [direct, nested, legacy, spendable, nestedSpendable].find(
+    (candidate) => typeof candidate === 'number',
+  )
   if (typeof value !== 'number') {
-    throw new Error('Heartbeat response missing balance')
+    throw new Error('Balance response missing balance')
   }
 
   return value
@@ -67,7 +84,21 @@ interface ClickResponse {
   delta: number
 }
 
+async function ensureWatchSession(channelId: string) {
+  await client.post('/api/v1/extension/watch/start', { channel_id: channelId })
+}
+
+async function getWatchBalance(channelId: string): Promise<number> {
+  const { data } = await client.get('/api/v1/extension/watch/balance', {
+    params: { channel_id: channelId },
+  })
+
+  return parseBalanceFromPayload(data)
+}
+
 export async function sendClick(channelId: string): Promise<ClickResponse> {
+  await ensureWatchSession(channelId)
+
   const { data } = await client.post<{ success: boolean; data: ClickResponse }>(
     '/api/v1/extension/watch/click',
     { channel_id: channelId },
@@ -75,12 +106,14 @@ export async function sendClick(channelId: string): Promise<ClickResponse> {
   return data.data
 }
 
-export async function sendHeartbeat(extensionJwt: string): Promise<HeartbeatResponse> {
-  const { data } = await client.post('/api/v1/extension/heartbeat', {
-    extension_jwt: extensionJwt,
+export async function sendHeartbeat(channelId: string): Promise<HeartbeatResponse> {
+  await ensureWatchSession(channelId)
+
+  await client.post('/api/v1/extension/watch/heartbeat', {
+    channel_id: channelId,
   })
 
   return {
-    balance: parseBalanceFromHeartbeatResponse(data),
+    balance: await getWatchBalance(channelId),
   }
 }

--- a/tachimint/tsconfig.app.json
+++ b/tachimint/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## What Changed

- allow `agency` through the top-level `/api/v1/dashboard` router guard so agency-permitted endpoints are reachable again
- fix tachimint watch flows to create a watch session before heartbeat / click requests
- switch heartbeat to the correct `/api/v1/extension/watch/*` endpoints and refresh balance from the watch balance API
- add regression tests for the real dashboard router and tachimint watch API flow

## Why

PR #155 is a `develop -> main` release promotion PR, and review found three P1 regressions already present on `develop`:

- agency users were blocked by the dashboard group middleware before route-level RBAC could allow them
- tachimint heartbeat called the wrong endpoint with the wrong payload
- tachimint never established a watch session before heartbeat / click polling

This PR fixes those blockers on `develop` so PR #155 can be reviewed for merge without carrying known regressions.

## Validation

- `go test ./internal/router -run TestDashboardRouter_AgencyOwnedChannelConfigAccessible -count=1`
- `go test ./internal/handlers -run 'Test(GetChannelConfig_AgencyOwned|StreamerRegister_AndListChannels|GetStats_AgencyOwnOK)' -count=1`
- `node --experimental-strip-types --test src/services/api.test.ts`
- `pnpm lint`
- `pnpm build`

## Notes

- A broader `go test ./internal/handlers` run still hits pre-existing airdrop test failures on clean `origin/develop`; those failures are not introduced by this PR.
- Once this PR merges into `develop`, PR #155 will automatically include these fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 仪表盘现已支持代理商角色访问权限。

* **错误修复**
  * 添加后端可用性检测，防止后端离线时执行用户操作。
  * 改进心跳检测和点击奖励的会话管理机制。

* **测试**
  * 添加仪表盘路由和API服务的全面测试覆盖。

* **其他**
  * 优化项目配置和内部代码结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->