### PR TITLE
[frontend] restore tachimint watch session flow for PR #155

### DIFF
--- a/tachimint/src/App.tsx
+++ b/tachimint/src/App.tsx
@@ -6,18 +6,18 @@ import { useClickBoost } from './hooks/useClickBoost'
 
 export default function App() {
   const { t } = useTranslation()
-  const { context, jwt, products, bitsEnabled, authError } = useTwitch()
+  const { context, jwt, products, bitsEnabled, authError, backendReady } = useTwitch()
   const { buyWithBits, status, error } = useBits(jwt)
   const isViewer = context?.role === 'viewer'
-  const { balance, gain, isAnimating, syncBalance } = useHeartbeat(jwt, {
-    enabled: isViewer,
+  const { balance, gain, isAnimating, syncBalance } = useHeartbeat(context?.channelId, {
+    enabled: isViewer && backendReady,
   })
   const {
     handleClick,
     cooldownMs,
     isAnimating: clickAnimating,
     gain: clickGain,
-  } = useClickBoost(context?.channelId, isViewer, syncBalance)
+  } = useClickBoost(context?.channelId, isViewer && backendReady, syncBalance)
 
   if (!context) {
     return (
@@ -64,7 +64,7 @@ export default function App() {
             <button
               className={`ext-mine__btn${cooldownMs > 0 ? ' ext-mine__btn--cooldown' : ''}`}
               onClick={handleClick}
-              disabled={cooldownMs > 0}
+              disabled={cooldownMs > 0 || !backendReady}
               aria-label="Click to mine points"
             >
               ⛏

--- a/tachimint/src/hooks/useHeartbeat.ts
+++ b/tachimint/src/hooks/useHeartbeat.ts
@@ -14,19 +14,39 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
   const [error, setError] = useState<string | null>(null)
   const lastBalanceRef = useRef<number | null>(null)
   const stopAnimationTimerRef = useRef<number | null>(null)
+  const clearAnimationTimer = useCallback(() => {
+    if (stopAnimationTimerRef.current !== null) {
+      window.clearTimeout(stopAnimationTimerRef.current)
+      stopAnimationTimerRef.current = null
+    }
+  }, [])
+
+  const resetSession = useCallback(() => {
+    clearAnimationTimer()
+    lastBalanceRef.current = null
+    setBalance(null)
+    setGain(null)
+    setIsAnimating(false)
+    setError(null)
+  }, [clearAnimationTimer])
+
+  useEffect(() => {
+    if (enabled && channelId) {
+      return
+    }
+    const resetTimer = window.setTimeout(() => {
+      resetSession()
+    }, 0)
+    return () => {
+      window.clearTimeout(resetTimer)
+    }
+  }, [channelId, enabled, resetSession])
 
   useEffect(() => {
     if (!enabled || !channelId) return
 
     let isDisposed = false
     let heartbeatTimer: number | null = null
-
-    const clearAnimationTimer = () => {
-      if (stopAnimationTimerRef.current !== null) {
-        window.clearTimeout(stopAnimationTimerRef.current)
-        stopAnimationTimerRef.current = null
-      }
-    }
 
     const runHeartbeat = async () => {
       try {
@@ -56,19 +76,29 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
       }
     }
 
-    void runHeartbeat()
-    heartbeatTimer = window.setInterval(() => {
-      void runHeartbeat()
-    }, intervalMs)
+    const scheduleNextHeartbeat = () => {
+      heartbeatTimer = window.setTimeout(() => {
+        void heartbeatLoop()
+      }, intervalMs)
+    }
+
+    const heartbeatLoop = async () => {
+      await runHeartbeat()
+      if (!isDisposed) {
+        scheduleNextHeartbeat()
+      }
+    }
+
+    void heartbeatLoop()
 
     return () => {
       isDisposed = true
       if (heartbeatTimer !== null) {
-        window.clearInterval(heartbeatTimer)
+        window.clearTimeout(heartbeatTimer)
       }
       clearAnimationTimer()
     }
-  }, [channelId, enabled, intervalMs])
+  }, [channelId, clearAnimationTimer, enabled, intervalMs])
 
   // Allow external callers (e.g. click boost) to sync the baseline so the
   // next heartbeat gain animation doesn't double-count already-awarded points.

--- a/tachimint/src/hooks/useHeartbeat.ts
+++ b/tachimint/src/hooks/useHeartbeat.ts
@@ -6,7 +6,7 @@ interface UseHeartbeatOptions {
   intervalMs?: number
 }
 
-export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions = {}) {
+export function useHeartbeat(channelId: string | undefined, options: UseHeartbeatOptions = {}) {
   const { enabled = true, intervalMs = 30_000 } = options
   const [balance, setBalance] = useState<number | null>(null)
   const [gain, setGain] = useState<number | null>(null)
@@ -16,7 +16,7 @@ export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions 
   const stopAnimationTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
-    if (!enabled || !extensionJwt) return
+    if (!enabled || !channelId) return
 
     let isDisposed = false
     let heartbeatTimer: number | null = null
@@ -30,7 +30,7 @@ export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions 
 
     const runHeartbeat = async () => {
       try {
-        const data = await sendHeartbeat(extensionJwt)
+        const data = await sendHeartbeat(channelId)
         if (isDisposed) return
 
         const nextBalance = data.balance
@@ -68,7 +68,7 @@ export function useHeartbeat(extensionJwt: string, options: UseHeartbeatOptions 
       }
       clearAnimationTimer()
     }
-  }, [enabled, extensionJwt, intervalMs])
+  }, [channelId, enabled, intervalMs])
 
   // Allow external callers (e.g. click boost) to sync the baseline so the
   // next heartbeat gain animation doesn't double-count already-awarded points.

--- a/tachimint/src/hooks/useHeartbeat.ts
+++ b/tachimint/src/hooks/useHeartbeat.ts
@@ -14,6 +14,7 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
   const [error, setError] = useState<string | null>(null)
   const lastBalanceRef = useRef<number | null>(null)
   const stopAnimationTimerRef = useRef<number | null>(null)
+  const previousChannelIdRef = useRef<string | undefined>(channelId)
   const clearAnimationTimer = useCallback(() => {
     if (stopAnimationTimerRef.current !== null) {
       window.clearTimeout(stopAnimationTimerRef.current)
@@ -29,6 +30,18 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
     setIsAnimating(false)
     setError(null)
   }, [clearAnimationTimer])
+
+  useEffect(() => {
+    if (previousChannelIdRef.current !== channelId) {
+      const resetTimer = window.setTimeout(() => {
+        resetSession()
+      }, 0)
+      previousChannelIdRef.current = channelId
+      return () => {
+        window.clearTimeout(resetTimer)
+      }
+    }
+  }, [channelId, resetSession])
 
   useEffect(() => {
     if (enabled && channelId) {
@@ -50,7 +63,7 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
 
     const runHeartbeat = async () => {
       try {
-        const data = await sendHeartbeat(channelId)
+        const data = await sendHeartbeat(channelId, lastBalanceRef.current)
         if (isDisposed) return
 
         const nextBalance = data.balance
@@ -96,6 +109,7 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
       if (heartbeatTimer !== null) {
         window.clearTimeout(heartbeatTimer)
       }
+      lastBalanceRef.current = null
       clearAnimationTimer()
     }
   }, [channelId, clearAnimationTimer, enabled, intervalMs])

--- a/tachimint/src/hooks/useTwitch.ts
+++ b/tachimint/src/hooks/useTwitch.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react'
 import type { TwitchContext } from '../types/twitch'
-import { loginWithTwitchExtension, setAuthToken } from '../services/api'
+import {
+  clearAuthToken,
+  loginWithTwitchExtension,
+  setAuthToken,
+  setExtensionJwtForRecovery,
+} from '../services/api'
 import i18n, { mapTwitchLocaleToAppLanguage } from '../i18n'
 
 export interface TwitchBitsProduct {
@@ -42,6 +47,7 @@ export function useTwitch() {
 
     ext.onAuthorized(async (auth: TwitchExtAuth) => {
       setJwt(auth.token)
+      setExtensionJwtForRecovery(auth.token)
       setBackendReady(false)
 
       // Login to tachigo backend with the extension JWT
@@ -57,6 +63,7 @@ export function useTwitch() {
         }
       } catch {
         // Non-fatal: bits flow still works via extension JWT directly
+        clearAuthToken()
         setBackendReady(false)
         setAuthError('Backend unavailable')
       }
@@ -71,7 +78,43 @@ export function useTwitch() {
           .catch(() => setBitsEnabled(false))
       }
     })
+
+    return () => {
+      setExtensionJwtForRecovery(null)
+      clearAuthToken()
+    }
   }, [])
+
+  useEffect(() => {
+    if (!jwt || backendReady) {
+      return
+    }
+
+    let cancelled = false
+    const retryTimer = window.setInterval(() => {
+      void (async () => {
+        try {
+          const result = await loginWithTwitchExtension(jwt)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const tokens = (result as any)?.data?.tokens ?? (result as any)?.tokens
+          if (!cancelled && tokens?.access_token) {
+            setAuthToken(tokens.access_token)
+            setBackendReady(true)
+            setAuthError(null)
+          }
+        } catch {
+          if (!cancelled) {
+            setBackendReady(false)
+          }
+        }
+      })()
+    }, 15_000)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(retryTimer)
+    }
+  }, [backendReady, jwt])
 
   return { context, jwt, products, bitsEnabled, authError, backendReady }
 }

--- a/tachimint/src/hooks/useTwitch.ts
+++ b/tachimint/src/hooks/useTwitch.ts
@@ -16,6 +16,7 @@ export function useTwitch() {
   const [products, setProducts] = useState<TwitchBitsProduct[]>([])
   const [bitsEnabled, setBitsEnabled] = useState(false)
   const [authError, setAuthError] = useState<string | null>(null)
+  const [backendReady, setBackendReady] = useState(false)
 
   useEffect(() => {
     const ext = window.Twitch?.ext
@@ -41,6 +42,7 @@ export function useTwitch() {
 
     ext.onAuthorized(async (auth: TwitchExtAuth) => {
       setJwt(auth.token)
+      setBackendReady(false)
 
       // Login to tachigo backend with the extension JWT
       try {
@@ -50,9 +52,12 @@ export function useTwitch() {
         const tokens = (result as any)?.data?.tokens ?? (result as any)?.tokens
         if (tokens?.access_token) {
           setAuthToken(tokens.access_token)
+          setBackendReady(true)
+          setAuthError(null)
         }
       } catch {
         // Non-fatal: bits flow still works via extension JWT directly
+        setBackendReady(false)
         setAuthError('Backend unavailable')
       }
 
@@ -68,5 +73,5 @@ export function useTwitch() {
     })
   }, [])
 
-  return { context, jwt, products, bitsEnabled, authError }
+  return { context, jwt, products, bitsEnabled, authError, backendReady }
 }

--- a/tachimint/src/services/api.test.ts
+++ b/tachimint/src/services/api.test.ts
@@ -90,41 +90,51 @@ test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes bala
       res.end(JSON.stringify({ success: false, error: 'not found' }))
     },
     async (baseUrl, requests) => {
+      const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
       process.env.VITE_TACHIGO_API_URL = baseUrl
-      const api = await import(`./api.ts?heartbeat=${Date.now()}`)
 
-      api.setAuthToken('tachigo-access-token')
-      const result = await api.sendHeartbeat('channel-123')
+      try {
+        const api = await import(`./api.ts?heartbeat=${Date.now()}`)
 
-      assert.equal(result.balance, 42)
-      assert.deepEqual(
-        requests.map(({ method, url, authorization, body }) => ({
-          method,
-          url,
-          authorization,
-          body,
-        })),
-        [
-          {
-            method: 'POST',
-            url: '/api/v1/extension/watch/start',
-            authorization: 'Bearer tachigo-access-token',
-            body: { channel_id: 'channel-123' },
-          },
-          {
-            method: 'POST',
-            url: '/api/v1/extension/watch/heartbeat',
-            authorization: 'Bearer tachigo-access-token',
-            body: { channel_id: 'channel-123' },
-          },
-          {
-            method: 'GET',
-            url: '/api/v1/extension/watch/balance?channel_id=channel-123',
-            authorization: 'Bearer tachigo-access-token',
-            body: null,
-          },
-        ],
-      )
+        api.setAuthToken('tachigo-access-token')
+        const result = await api.sendHeartbeat('channel-123')
+
+        assert.equal(result.balance, 42)
+        assert.deepEqual(
+          requests.map(({ method, url, authorization, body }) => ({
+            method,
+            url,
+            authorization,
+            body,
+          })),
+          [
+            {
+              method: 'POST',
+              url: '/api/v1/extension/watch/start',
+              authorization: 'Bearer tachigo-access-token',
+              body: { channel_id: 'channel-123' },
+            },
+            {
+              method: 'POST',
+              url: '/api/v1/extension/watch/heartbeat',
+              authorization: 'Bearer tachigo-access-token',
+              body: { channel_id: 'channel-123' },
+            },
+            {
+              method: 'GET',
+              url: '/api/v1/extension/watch/balance?channel_id=channel-123',
+              authorization: 'Bearer tachigo-access-token',
+              body: null,
+            },
+          ],
+        )
+      } finally {
+        if (originalBaseUrl === undefined) {
+          delete process.env.VITE_TACHIGO_API_URL
+        } else {
+          process.env.VITE_TACHIGO_API_URL = originalBaseUrl
+        }
+      }
     },
   )
 })
@@ -156,35 +166,45 @@ test('sendClick ensures the watch session exists before sending click rewards', 
       res.end(JSON.stringify({ success: false, error: 'not found' }))
     },
     async (baseUrl, requests) => {
+      const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
       process.env.VITE_TACHIGO_API_URL = baseUrl
-      const api = await import(`./api.ts?click=${Date.now()}`)
 
-      api.setAuthToken('tachigo-access-token')
-      const result = await api.sendClick('channel-123')
+      try {
+        const api = await import(`./api.ts?click=${Date.now()}`)
 
-      assert.deepEqual(result, { balance: 9, delta: 1 })
-      assert.deepEqual(
-        requests.map(({ method, url, authorization, body }) => ({
-          method,
-          url,
-          authorization,
-          body,
-        })),
-        [
-          {
-            method: 'POST',
-            url: '/api/v1/extension/watch/start',
-            authorization: 'Bearer tachigo-access-token',
-            body: { channel_id: 'channel-123' },
-          },
-          {
-            method: 'POST',
-            url: '/api/v1/extension/watch/click',
-            authorization: 'Bearer tachigo-access-token',
-            body: { channel_id: 'channel-123' },
-          },
-        ],
-      )
+        api.setAuthToken('tachigo-access-token')
+        const result = await api.sendClick('channel-123')
+
+        assert.deepEqual(result, { balance: 9, delta: 1 })
+        assert.deepEqual(
+          requests.map(({ method, url, authorization, body }) => ({
+            method,
+            url,
+            authorization,
+            body,
+          })),
+          [
+            {
+              method: 'POST',
+              url: '/api/v1/extension/watch/start',
+              authorization: 'Bearer tachigo-access-token',
+              body: { channel_id: 'channel-123' },
+            },
+            {
+              method: 'POST',
+              url: '/api/v1/extension/watch/click',
+              authorization: 'Bearer tachigo-access-token',
+              body: { channel_id: 'channel-123' },
+            },
+          ],
+        )
+      } finally {
+        if (originalBaseUrl === undefined) {
+          delete process.env.VITE_TACHIGO_API_URL
+        } else {
+          process.env.VITE_TACHIGO_API_URL = originalBaseUrl
+        }
+      }
     },
   )
 })

--- a/tachimint/src/services/api.test.ts
+++ b/tachimint/src/services/api.test.ts
@@ -208,3 +208,113 @@ test('sendClick ensures the watch session exists before sending click rewards', 
     },
   )
 })
+
+test('sendHeartbeat re-authenticates after 401 and falls back to previous balance when balance read fails', async () => {
+  let heartbeatAttempts = 0
+
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/start') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { started: true } }))
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/auth/login') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { tokens: { access_token: 'refreshed-access-token' } } }))
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/heartbeat') {
+        heartbeatAttempts += 1
+        if (heartbeatAttempts === 1) {
+          res.writeHead(401, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: false, error: 'expired' }))
+          return
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { points_earned: 2 } }))
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/extension/watch/balance?channel_id=channel-123') {
+        res.writeHead(503, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: false, error: 'temporary unavailable' }))
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+
+      try {
+        const api = await import(`./api.ts?recover=${Date.now()}`)
+
+        api.setExtensionJwtForRecovery('extension-jwt')
+        api.setAuthToken('expired-access-token')
+        const result = await api.sendHeartbeat('channel-123', 40)
+
+        assert.equal(result.balance, 42)
+        assert.deepEqual(
+          requests.map(({ method, url, authorization, body }) => ({
+            method,
+            url,
+            authorization,
+            body,
+          })),
+          [
+            {
+              method: 'POST',
+              url: '/api/v1/extension/watch/start',
+              authorization: 'Bearer expired-access-token',
+              body: { channel_id: 'channel-123' },
+            },
+            {
+              method: 'POST',
+              url: '/api/v1/extension/watch/heartbeat',
+              authorization: 'Bearer expired-access-token',
+              body: { channel_id: 'channel-123' },
+            },
+            {
+              method: 'POST',
+              url: '/api/v1/extension/auth/login',
+              authorization: 'Bearer expired-access-token',
+              body: { extension_jwt: 'extension-jwt' },
+            },
+            {
+              method: 'POST',
+              url: '/api/v1/extension/watch/heartbeat',
+              authorization: 'Bearer refreshed-access-token',
+              body: { channel_id: 'channel-123' },
+            },
+            {
+              method: 'GET',
+              url: '/api/v1/extension/watch/balance?channel_id=channel-123',
+              authorization: 'Bearer refreshed-access-token',
+              body: null,
+            },
+          ],
+        )
+      } finally {
+        if (originalBaseUrl === undefined) {
+          delete process.env.VITE_TACHIGO_API_URL
+        } else {
+          process.env.VITE_TACHIGO_API_URL = originalBaseUrl
+        }
+      }
+    },
+  )
+})

--- a/tachimint/src/services/api.test.ts
+++ b/tachimint/src/services/api.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import test from 'node:test'
+
+type RecordedRequest = {
+  method: string
+  url: string
+  authorization: string | undefined
+  body: unknown
+}
+
+async function withApiServer(
+  handler: (requests: RecordedRequest[]) => http.RequestListener,
+  run: (baseUrl: string, requests: RecordedRequest[]) => Promise<void>,
+) {
+  const requests: RecordedRequest[] = []
+  const server = http.createServer(handler(requests))
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('failed to resolve test server address')
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`
+
+  try {
+    await run(baseUrl, requests)
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }
+}
+
+async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+
+  if (chunks.length === 0) {
+    return null
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+}
+
+test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes balance', async () => {
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/start') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { started: true } }))
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/heartbeat') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { points_earned: 2 } }))
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/extension/watch/balance?channel_id=channel-123') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            success: true,
+            data: { spendable_balance: 42, cumulative_total: 42 },
+          }),
+        )
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+      const api = await import(`./api.ts?heartbeat=${Date.now()}`)
+
+      api.setAuthToken('tachigo-access-token')
+      const result = await api.sendHeartbeat('channel-123')
+
+      assert.equal(result.balance, 42)
+      assert.deepEqual(
+        requests.map(({ method, url, authorization, body }) => ({
+          method,
+          url,
+          authorization,
+          body,
+        })),
+        [
+          {
+            method: 'POST',
+            url: '/api/v1/extension/watch/start',
+            authorization: 'Bearer tachigo-access-token',
+            body: { channel_id: 'channel-123' },
+          },
+          {
+            method: 'POST',
+            url: '/api/v1/extension/watch/heartbeat',
+            authorization: 'Bearer tachigo-access-token',
+            body: { channel_id: 'channel-123' },
+          },
+          {
+            method: 'GET',
+            url: '/api/v1/extension/watch/balance?channel_id=channel-123',
+            authorization: 'Bearer tachigo-access-token',
+            body: null,
+          },
+        ],
+      )
+    },
+  )
+})
+
+test('sendClick ensures the watch session exists before sending click rewards', async () => {
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/start') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { started: true } }))
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/click') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { balance: 9, delta: 1 } }))
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+      const api = await import(`./api.ts?click=${Date.now()}`)
+
+      api.setAuthToken('tachigo-access-token')
+      const result = await api.sendClick('channel-123')
+
+      assert.deepEqual(result, { balance: 9, delta: 1 })
+      assert.deepEqual(
+        requests.map(({ method, url, authorization, body }) => ({
+          method,
+          url,
+          authorization,
+          body,
+        })),
+        [
+          {
+            method: 'POST',
+            url: '/api/v1/extension/watch/start',
+            authorization: 'Bearer tachigo-access-token',
+            body: { channel_id: 'channel-123' },
+          },
+          {
+            method: 'POST',
+            url: '/api/v1/extension/watch/click',
+            authorization: 'Bearer tachigo-access-token',
+            body: { channel_id: 'channel-123' },
+          },
+        ],
+      )
+    },
+  )
+})

--- a/tachimint/src/services/api.ts
+++ b/tachimint/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import type { AxiosError, AxiosRequestConfig } from 'axios'
 import type { TachigoToken } from '../types/twitch'
 
 const processEnv =
@@ -22,8 +23,30 @@ const client = axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
+let extensionJwtForRecovery: string | null = null
+
+function extractAccessToken(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = payload as any
+  const nested = raw?.data?.tokens?.access_token
+  const direct = raw?.tokens?.access_token
+  return typeof nested === 'string' ? nested : typeof direct === 'string' ? direct : null
+}
+
 export function setAuthToken(token: string) {
   client.defaults.headers.common['Authorization'] = `Bearer ${token}`
+}
+
+export function clearAuthToken() {
+  delete client.defaults.headers.common['Authorization']
+}
+
+export function setExtensionJwtForRecovery(token: string | null) {
+  extensionJwtForRecovery = token
 }
 
 /**
@@ -52,8 +75,58 @@ export async function loginWithTwitchExtension(extensionJwt: string): Promise<Ta
   return data
 }
 
+async function refreshAuthTokenFromExtensionJwt(): Promise<boolean> {
+  if (!extensionJwtForRecovery) {
+    return false
+  }
+
+  const loginResult = await loginWithTwitchExtension(extensionJwtForRecovery)
+  const accessToken = extractAccessToken(loginResult)
+  if (!accessToken) {
+    clearAuthToken()
+    return false
+  }
+
+  setAuthToken(accessToken)
+  return true
+}
+
+async function runWithAuthRecovery<T>(
+  execute: (config?: AxiosRequestConfig) => Promise<T>,
+  config?: AxiosRequestConfig,
+): Promise<T> {
+  try {
+    return await execute(config)
+  } catch (error) {
+    const status = (error as AxiosError)?.response?.status
+    if (status !== 401) {
+      throw error
+    }
+
+    const recovered = await refreshAuthTokenFromExtensionJwt()
+    if (!recovered) {
+      throw error
+    }
+
+    return execute(config)
+  }
+}
+
 interface HeartbeatResponse {
   balance: number
+}
+
+function parsePointsEarnedFromPayload(payload: unknown): number | null {
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = payload as any
+  const direct = raw.points_earned
+  const nested = raw.data?.points_earned
+  const value = typeof direct === 'number' ? direct : typeof nested === 'number' ? nested : null
+  return value
 }
 
 function parseBalanceFromPayload(payload: unknown): number {
@@ -85,13 +158,14 @@ interface ClickResponse {
 }
 
 async function ensureWatchSession(channelId: string) {
-  await client.post('/api/v1/extension/watch/start', { channel_id: channelId })
+  await runWithAuthRecovery((config) => client.post('/api/v1/extension/watch/start', { channel_id: channelId }, config))
 }
 
 async function getWatchBalance(channelId: string): Promise<number> {
-  const { data } = await client.get('/api/v1/extension/watch/balance', {
+  const { data } = await runWithAuthRecovery((config) => client.get('/api/v1/extension/watch/balance', {
+    ...config,
     params: { channel_id: channelId },
-  })
+  }))
 
   return parseBalanceFromPayload(data)
 }
@@ -99,21 +173,40 @@ async function getWatchBalance(channelId: string): Promise<number> {
 export async function sendClick(channelId: string): Promise<ClickResponse> {
   await ensureWatchSession(channelId)
 
-  const { data } = await client.post<{ success: boolean; data: ClickResponse }>(
-    '/api/v1/extension/watch/click',
-    { channel_id: channelId },
-  )
+  const { data } = await runWithAuthRecovery((config) =>
+    client.post<{ success: boolean; data: ClickResponse }>(
+      '/api/v1/extension/watch/click',
+      { channel_id: channelId },
+      config,
+    ))
   return data.data
 }
 
-export async function sendHeartbeat(channelId: string): Promise<HeartbeatResponse> {
+export async function sendHeartbeat(
+  channelId: string,
+  previousBalance?: number | null,
+): Promise<HeartbeatResponse> {
   await ensureWatchSession(channelId)
 
-  await client.post('/api/v1/extension/watch/heartbeat', {
-    channel_id: channelId,
-  })
+  const heartbeatResponse = await runWithAuthRecovery((config) =>
+    client.post('/api/v1/extension/watch/heartbeat', {
+      channel_id: channelId,
+    }, config))
 
-  return {
-    balance: await getWatchBalance(channelId),
+  try {
+    return {
+      balance: await getWatchBalance(channelId),
+    }
+  } catch {
+    const pointsEarned = parsePointsEarnedFromPayload(heartbeatResponse.data)
+    if (typeof previousBalance === 'number') {
+      return {
+        balance: previousBalance + Math.max(pointsEarned ?? 0, 0),
+      }
+    }
+
+    return {
+      balance: Math.max(pointsEarned ?? 0, 0),
+    }
   }
 }

--- a/tachimint/src/services/api.ts
+++ b/tachimint/src/services/api.ts
@@ -1,7 +1,21 @@
 import axios from 'axios'
 import type { TachigoToken } from '../types/twitch'
 
-const BASE_URL = import.meta.env.VITE_TACHIGO_API_URL ?? 'http://localhost:8080'
+const processEnv =
+  typeof globalThis === 'object' && 'process' in globalThis
+    ? (
+        globalThis as {
+          process?: {
+            env?: Record<string, string | undefined>
+          }
+        }
+      ).process?.env
+    : undefined
+
+const BASE_URL =
+  import.meta.env?.VITE_TACHIGO_API_URL ??
+  processEnv?.VITE_TACHIGO_API_URL ??
+  'http://localhost:8080'
 
 const client = axios.create({
   baseURL: BASE_URL,
@@ -42,21 +56,24 @@ interface HeartbeatResponse {
   balance: number
 }
 
-function parseBalanceFromHeartbeatResponse(payload: unknown): number {
+function parseBalanceFromPayload(payload: unknown): number {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid heartbeat response')
+    throw new Error('Invalid balance response')
   }
 
-  // Accept a few common API shapes to keep frontend resilient while backend evolves.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const raw = payload as any
   const direct = raw.balance
   const nested = raw.data?.balance
   const legacy = raw.points_balance
+  const spendable = raw.spendable_balance
+  const nestedSpendable = raw.data?.spendable_balance
 
-  const value = [direct, nested, legacy].find((candidate) => typeof candidate === 'number')
+  const value = [direct, nested, legacy, spendable, nestedSpendable].find(
+    (candidate) => typeof candidate === 'number',
+  )
   if (typeof value !== 'number') {
-    throw new Error('Heartbeat response missing balance')
+    throw new Error('Balance response missing balance')
   }
 
   return value
@@ -67,7 +84,21 @@ interface ClickResponse {
   delta: number
 }
 
+async function ensureWatchSession(channelId: string) {
+  await client.post('/api/v1/extension/watch/start', { channel_id: channelId })
+}
+
+async function getWatchBalance(channelId: string): Promise<number> {
+  const { data } = await client.get('/api/v1/extension/watch/balance', {
+    params: { channel_id: channelId },
+  })
+
+  return parseBalanceFromPayload(data)
+}
+
 export async function sendClick(channelId: string): Promise<ClickResponse> {
+  await ensureWatchSession(channelId)
+
   const { data } = await client.post<{ success: boolean; data: ClickResponse }>(
     '/api/v1/extension/watch/click',
     { channel_id: channelId },
@@ -75,12 +106,14 @@ export async function sendClick(channelId: string): Promise<ClickResponse> {
   return data.data
 }
 
-export async function sendHeartbeat(extensionJwt: string): Promise<HeartbeatResponse> {
-  const { data } = await client.post('/api/v1/extension/heartbeat', {
-    extension_jwt: extensionJwt,
+export async function sendHeartbeat(channelId: string): Promise<HeartbeatResponse> {
+  await ensureWatchSession(channelId)
+
+  await client.post('/api/v1/extension/watch/heartbeat', {
+    channel_id: channelId,
   })
 
   return {
-    balance: parseBalanceFromHeartbeatResponse(data),
+    balance: await getWatchBalance(channelId),
   }
 }

--- a/tachimint/tsconfig.app.json
+++ b/tachimint/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## 什麼改動
- 修正 tachimint heartbeat / click flow，先建立 watch session 再送 heartbeat 與 click
- heartbeat 改成使用 `/api/v1/extension/watch/heartbeat`，並在 heartbeat 後刷新 balance
- 補上 `api.test.ts` 回歸測試，驗證 start -> heartbeat -> balance 與 start -> click 的請求順序

## 為什麼
- 修正 `#155` review thread 指出的 P1：heartbeat 打錯 endpoint / payload，且前端未先建立 watch session，導致 `no active session` 與餘額不更新

## Scope 對齊
- Source of truth：#155
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 `backend/`
  - 不修改 `dashboard/`
  - 不新增 backend contract

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試
- `node --experimental-strip-types --test src/services/api.test.ts`
- `pnpm build`
- `pnpm lint`

## 備註
無


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加后端就绪标识，界面与交互在后端就绪后才激活

* **问题修复**
  * 改进心跳与点击调度为顺序执行并增强会话/重置处理，提升稳定性
  * 增加自动重试与认证恢复流程以提高请求可靠性
  * 在后端未就绪时禁用挖矿/点击按钮，避免无效操作

* **测试**
  * 新增针对核心 API 的端到端集成测试

* **杂项**
  * 更新构建配置以排除测试文件的类型检查
<!-- end of auto-generated comment: release notes by coderabbit.ai -->