### PR TITLE
[contract] Soulbound ERC-20 TachiToken 實作 + Foundry 測試

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+remappings = [
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+]

--- a/contracts/src/TachiToken.sol
+++ b/contracts/src/TachiToken.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title TachiToken
+/// @notice Soulbound ERC-20；持有者不可自由轉讓，所有流動操作須透過平台 Router Contract。
+contract TachiToken is ERC20, Ownable {
+    uint256 public constant MAX_SUPPLY = 1_000_000_000 * 10 ** 18;
+
+    constructor() ERC20("Tachi", "TACHI") Ownable(msg.sender) {}
+
+    /// @notice 鑄造代幣（僅限 owner）。
+    function mint(address to, uint256 amount) external onlyOwner {
+        require(totalSupply() + amount <= MAX_SUPPLY, "TachiToken: cap exceeded");
+        _mint(to, amount);
+    }
+
+    /// @notice 銷毀代幣（消費路徑，僅限 owner）。
+    function burn(address from, uint256 amount) external onlyOwner {
+        _burn(from, amount);
+    }
+
+    /// @dev Soulbound：禁止持有者自由轉帳。
+    function transfer(address, uint256) public pure override returns (bool) {
+        revert("TachiToken: soulbound");
+    }
+
+    /// @dev Soulbound：禁止持有者自由轉帳。
+    function transferFrom(address, address, uint256) public pure override returns (bool) {
+        revert("TachiToken: soulbound");
+    }
+}

--- a/contracts/src/TachiToken.sol
+++ b/contracts/src/TachiToken.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 /// @title TachiToken
 /// @notice Soulbound ERC-20；持有者不可自由轉讓，所有流動操作須透過平台 Router Contract。
 contract TachiToken is ERC20, Ownable {
-    uint256 public constant MAX_SUPPLY = 1_000_000_000 * 10 ** 18;
+    uint256 public constant MAX_SUPPLY = 1_000_000_000 * 10 ** 18; // 10 億枚，單位為 wei（最小單位）
 
     constructor() ERC20("Tachi", "TACHI") Ownable(msg.sender) {}
 

--- a/contracts/src/TachiToken.sol
+++ b/contracts/src/TachiToken.sol
@@ -31,4 +31,9 @@ contract TachiToken is ERC20, Ownable {
     function transferFrom(address, address, uint256) public pure override returns (bool) {
         revert("TachiToken: soulbound");
     }
+
+    /// @dev Soulbound：禁止建立 allowance，避免產生永遠無法執行的授權假象。
+    function approve(address, uint256) public pure override returns (bool) {
+        revert("TachiToken: soulbound");
+    }
 }

--- a/contracts/test/TachiToken.t.sol
+++ b/contracts/test/TachiToken.t.sol
@@ -31,7 +31,7 @@ contract TachiTokenTest is Test {
     function test_mint_exceedsCap_reverts() public {
         uint256 cap = 1_000_000_000e18;
         token.mint(alice, cap);
-        vm.expectRevert();
+        vm.expectRevert(bytes("TachiToken: cap exceeded"));
         token.mint(alice, 1);
     }
 
@@ -40,7 +40,7 @@ contract TachiTokenTest is Test {
     function test_transfer_reverts() public {
         token.mint(alice, 1_000e18);
         vm.prank(alice);
-        vm.expectRevert();
+        vm.expectRevert(bytes("TachiToken: soulbound"));
         token.transfer(bob, 100e18);
     }
 
@@ -49,7 +49,7 @@ contract TachiTokenTest is Test {
         vm.prank(alice);
         token.approve(bob, 100e18);
         vm.prank(bob);
-        vm.expectRevert();
+        vm.expectRevert(bytes("TachiToken: soulbound"));
         token.transferFrom(alice, bob, 100e18);
     }
 

--- a/contracts/test/TachiToken.t.sol
+++ b/contracts/test/TachiToken.t.sol
@@ -61,6 +61,13 @@ contract TachiTokenTest is Test {
         assertEq(token.balanceOf(alice), 600e18);
     }
 
+    function test_burn_nonOwner_reverts() public {
+        token.mint(alice, 1_000e18);
+        vm.prank(alice);
+        vm.expectRevert(); // OZ OwnableUnauthorizedAccount custom error，不適用 bytes()
+        token.burn(alice, 1e18);
+    }
+
     // --- zero address ---
 
     function test_mint_zeroAddress_reverts() public {

--- a/contracts/test/TachiToken.t.sol
+++ b/contracts/test/TachiToken.t.sol
@@ -60,4 +60,28 @@ contract TachiTokenTest is Test {
         token.burn(alice, 400e18);
         assertEq(token.balanceOf(alice), 600e18);
     }
+
+    // --- zero address ---
+
+    function test_mint_zeroAddress_reverts() public {
+        vm.expectRevert();
+        token.mint(address(0), 1_000e18);
+    }
+
+    // --- burn edge ---
+
+    function test_burn_zeroAmount_succeeds() public {
+        token.mint(alice, 1_000e18);
+        token.burn(alice, 0);
+        assertEq(token.balanceOf(alice), 1_000e18);
+    }
+
+    // --- approve ---
+
+    function test_approve_succeeds_even_though_transfer_blocked() public {
+        token.mint(alice, 1_000e18);
+        vm.prank(alice);
+        token.approve(bob, 500e18);
+        assertEq(token.allowance(alice, bob), 500e18);
+    }
 }

--- a/contracts/test/TachiToken.t.sol
+++ b/contracts/test/TachiToken.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/TachiToken.sol";
+
+contract TachiTokenTest is Test {
+    TachiToken token;
+    address alice;
+    address bob;
+
+    function setUp() public {
+        alice = address(0xA1);
+        bob   = address(0xB0);
+        token = new TachiToken();
+    }
+
+    // --- mint ---
+
+    function test_mint_owner_succeeds() public {
+        token.mint(alice, 1_000e18);
+        assertEq(token.balanceOf(alice), 1_000e18);
+    }
+
+    function test_mint_nonOwner_reverts() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        token.mint(bob, 1_000e18);
+    }
+
+    function test_mint_exceedsCap_reverts() public {
+        uint256 cap = 1_000_000_000e18;
+        token.mint(alice, cap);
+        vm.expectRevert();
+        token.mint(alice, 1);
+    }
+
+    // --- transfer (Soulbound) ---
+
+    function test_transfer_reverts() public {
+        token.mint(alice, 1_000e18);
+        vm.prank(alice);
+        vm.expectRevert();
+        token.transfer(bob, 100e18);
+    }
+
+    function test_transferFrom_reverts() public {
+        token.mint(alice, 1_000e18);
+        vm.prank(alice);
+        token.approve(bob, 100e18);
+        vm.prank(bob);
+        vm.expectRevert();
+        token.transferFrom(alice, bob, 100e18);
+    }
+
+    // --- burn ---
+
+    function test_burn_owner_succeeds() public {
+        token.mint(alice, 1_000e18);
+        token.burn(alice, 400e18);
+        assertEq(token.balanceOf(alice), 600e18);
+    }
+}

--- a/contracts/test/TachiToken.t.sol
+++ b/contracts/test/TachiToken.t.sol
@@ -46,8 +46,6 @@ contract TachiTokenTest is Test {
 
     function test_transferFrom_reverts() public {
         token.mint(alice, 1_000e18);
-        vm.prank(alice);
-        token.approve(bob, 100e18);
         vm.prank(bob);
         vm.expectRevert(bytes("TachiToken: soulbound"));
         token.transferFrom(alice, bob, 100e18);
@@ -83,12 +81,12 @@ contract TachiTokenTest is Test {
         assertEq(token.balanceOf(alice), 1_000e18);
     }
 
-    // --- approve ---
+    // --- approve (Soulbound) ---
 
-    function test_approve_succeeds_even_though_transfer_blocked() public {
+    function test_approve_reverts() public {
         token.mint(alice, 1_000e18);
         vm.prank(alice);
+        vm.expectRevert(bytes("TachiToken: soulbound"));
         token.approve(bob, 500e18);
-        assertEq(token.allowance(alice, bob), 500e18);
     }
 }


### PR DESCRIPTION
## 什麼改動

實作 TachiToken Soulbound ERC-20 合約與 Foundry 單元測試。

## 為什麼

Phase 2 鏈上 mint 需要已部署的 Soulbound ERC-20 合約作為 \$TACHI 的鏈上載體。本票完成合約實作與測試，部署 Sepolia 另票處理。

closes #110

## Scope 對齊

- Source of truth：#110
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不部署合約到 Sepolia
  - 不實作後端 Claim / mint 串接
  - 不修改 DB schema 或後端 API
  - 不實作 Router Contract
  - 不進行合約升級性設計（proxy pattern 等）
  - 不實作前端 UI

## 超出範圍內容

補回 `contracts/foundry.toml`：原由 #125（commit 420e012）建立，因工具執行時誤刪導致本 branch 缺少此檔。內容與原始 commit 完全相同，不修改任何設定，僅確保 `forge build` / `forge test` 可正常執行。

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試（`forge test -v` 10 passed, 0 failed）

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 備註

純 Solidity contracts 層，無 Go backend contract 依賴。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 推出 Tachi 代币，固定最大供应量为 10 亿
  * 实现灵魂绑定机制，代币不可转让和授权
  * 仅限所有者执行代币铸造和销毁操作

* **测试**
  * 增加全面测试覆盖，验证供应上限、转账限制和销毁等功能

<!-- end of auto-generated comment: release notes by coderabbit.ai -->