### PR TITLE
[contract] Soulbound ERC-20 Sepolia 部署 + Etherscan 驗證

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ extensions/tachigo-demo-sidepanel/*.local
 contracts/out/
 contracts/cache/
 contracts/lib/
+contracts/broadcast/
+contracts/.env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,4 +30,4 @@ GOOGLE_REDIRECT_URL=http://localhost:8080/api/v1/auth/google/callback
 # ── CORS ──────────────────────────────────────────────────────────────────────
 # Comma-separated list of allowed origins
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174
-TACHI_CONTRACT_ADDRESS=   # 部署後填入
+TACHI_CONTRACT_ADDRESS=0xaB702A56fa95f7B5c8C1a47AB8348b2Bb74AE778

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,3 +30,4 @@ GOOGLE_REDIRECT_URL=http://localhost:8080/api/v1/auth/google/callback
 # ── CORS ──────────────────────────────────────────────────────────────────────
 # Comma-separated list of allowed origins
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174
+TACHI_CONTRACT_ADDRESS=   # 部署後填入

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,4 +30,4 @@ GOOGLE_REDIRECT_URL=http://localhost:8080/api/v1/auth/google/callback
 # ── CORS ──────────────────────────────────────────────────────────────────────
 # Comma-separated list of allowed origins
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174
-TACHI_CONTRACT_ADDRESS=0xaB702A56fa95f7B5c8C1a47AB8348b2Bb74AE778
+TACHI_CONTRACT_ADDRESS=   # 部署後填入

--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -1,0 +1,3 @@
+DEPLOYER_PRIVATE_KEY=0x...
+SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
+ETHERSCAN_API_KEY=YOUR_KEY

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -72,8 +72,22 @@ anvil
 
 ### Deploy
 
-```shell
-forge script script/<YourScript>.s.sol:<YourScriptContract> --rpc-url <your_rpc_url> --private-key <your_private_key>
+```bash
+# 複製環境變數範本
+cp .env.example .env
+# 填入 DEPLOYER_PRIVATE_KEY、SEPOLIA_RPC_URL、ETHERSCAN_API_KEY
+
+# 部署到 Sepolia（含 Etherscan 驗證）
+forge script script/Deploy.s.sol:Deploy \
+  --rpc-url $SEPOLIA_RPC_URL \
+  --broadcast \
+  --verify \
+  --etherscan-api-key $ETHERSCAN_API_KEY
+
+# 若部署時未加 --verify，事後單獨驗證
+forge verify-contract <CONTRACT_ADDRESS> src/TachiToken.sol:TachiToken \
+  --chain sepolia \
+  --etherscan-api-key $ETHERSCAN_API_KEY
 ```
 
 ### Cast

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../src/TachiToken.sol";
+
+contract Deploy is Script {
+    function run() external returns (TachiToken token) {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        token = new TachiToken();
+        vm.stopBroadcast();
+        console.log("TachiToken deployed at:", address(token));
+    }
+}

--- a/deployments/sepolia.json
+++ b/deployments/sepolia.json
@@ -1,7 +1,7 @@
 {
   "network": "sepolia",
-  "contractAddress": "0x0000000000000000000000000000000000000000",
-  "txHash": "0x",
-  "blockNumber": 0,
-  "deployedAt": "YYYY-MM-DDTHH:MM:SSZ"
+  "contractAddress": "0xaB702A56fa95f7B5c8C1a47AB8348b2Bb74AE778",
+  "txHash": "0x430580d0559da0771e42cfd6cf69be938989e2bcd8a2e235d9e78e1eb3fa5daa",
+  "blockNumber": 7877542,
+  "deployedAt": "2026-04-10T15:34:00Z"
 }

--- a/deployments/sepolia.json
+++ b/deployments/sepolia.json
@@ -1,0 +1,7 @@
+{
+  "network": "sepolia",
+  "contractAddress": "0x0000000000000000000000000000000000000000",
+  "txHash": "0x",
+  "blockNumber": 0,
+  "deployedAt": "YYYY-MM-DDTHH:MM:SSZ"
+}


### PR DESCRIPTION
## Summary

- 建立 `contracts/script/Deploy.s.sol` Foundry 部署腳本
- 部署 `TachiToken` 至 Sepolia（`0xaB702A56fa95f7B5c8C1a47AB8348b2Bb74AE778`）
- Etherscan 原始碼驗證通過 ✅
- 新增 `deployments/sepolia.json` 記錄部署資訊
- `.gitignore` 補上 `contracts/broadcast/`、`contracts/.env`

## Scope 對齊

- Source of truth: #111
- Depends on PR: none（#110 已合入 develop）
- Backend contract 是否已在 develop：是，`TachiToken.sol` 已在 develop

## 本 PR 明確不做

- 不修改 `TachiToken.sol`
- 不部署到 mainnet
- 不實作後端 mint / burn API 串接
- 不修改 DB schema 或後端 service
- 不建立前端 UI
- 不設計 proxy 升級機制
- 不修改 `backend/` 任何檔案（`TACHI_CONTRACT_ADDRESS` env var 另開 ticket 處理）

## Test plan

- [x] 本地 Anvil 測試：`forge script` 部署成功，`name()` / `symbol()` / `owner()` 回傳正確
- [x] Sepolia 部署成功，可在 [Etherscan](https://sepolia.etherscan.io/address/0xab702a56fa95f7b5c8c1a47ab8348b2bb74ae778) 查詢
- [x] Etherscan 驗證：`Pass - Verified`
- [x] 確認 `contracts/.env`、`contracts/broadcast/`、`contracts/cache/` 均在 `.gitignore`，私鑰不外洩

closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增智能合约部署脚本，支持Sepolia网络自动化部署。

* **文档**
  * 更新部署文档，包含详细的部署流程和合约验证步骤。

* **配置**
  * 增加环境变量配置示例和部署记录文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->