### PR TITLE
[discussion] relax scope police template requirements for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Lint
         run: docker compose run --no-deps --rm dashboard pnpm lint
 
+      - name: Test
+        run: docker compose run --no-deps --rm dashboard pnpm test
+
       - name: Build
         run: docker compose run --no-deps --rm dashboard pnpm build
 

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -31,6 +31,7 @@ jobs:
               isSameRepoHead &&
               pr.base?.ref === 'main' &&
               pr.head?.ref === 'develop'
+            const isDependabotPr = pr.user?.login === 'dependabot[bot]'
 
             const bypassLabels = new Set(['scope-exception'])
             const labels = (pr.labels || []).map((label) => label.name)
@@ -85,62 +86,65 @@ jobs:
 
             const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]']
             const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
-            if (!titlePrefix) {
-              policyFailures.push(
-                `PR title must start with one of: ${allowedPrefixes.join(', ')}. Current title: "${title}".`,
-              )
-            }
-
-            if (isReleasePromotionPr && titlePrefix !== '[release]') {
-              policyFailures.push('`develop -> main` release PR must use the `[release]` title prefix.')
-            }
-
-            if (!isReleasePromotionPr && titlePrefix === '[release]') {
-              policyFailures.push('`[release]` PR is reserved for formal `develop -> main` promotion PRs only.')
-            }
-
-            if (!isReleasePromotionPr && !/#\d+/.test(body)) {
-              policyFailures.push('PR body must reference at least one issue or PR number such as `#123`.')
-            }
-
-            if (!body.includes('Source of truth：') && !body.includes('Source of truth:')) {
-              policyFailures.push('PR body must include a `Source of truth` line in the Scope 對齊 section.')
-            }
-
-            if (!body.includes('本 PR 明確不做')) {
-              policyFailures.push('PR body must include a `本 PR 明確不做` section.')
-            }
-
             const dependsOnMatch = body.match(/Depends on PR[：:]\s*(.+)/i)
             const dependsOnRaw = dependsOnMatch?.[1]?.trim()
-            if (!dependsOnRaw) {
-              policyFailures.push('PR body must include a `Depends on PR` line with `none` or `#123`.')
-            }
-
             const dependsOnNone = dependsOnRaw?.toLowerCase() === 'none'
             const dependsOnPrMatch = dependsOnRaw?.match(/^#(\d+)$/)
-            if (dependsOnRaw && !dependsOnNone && !dependsOnPrMatch) {
-              policyFailures.push('`Depends on PR` must be `none` or a single PR number such as `#123`.')
-            }
-
             const backendContractYes = /Backend contract already in develop:[\s\S]*?- \[[xX]\] yes/i.test(body)
             const backendContractNo = /Backend contract already in develop:[\s\S]*?- \[[xX]\] no/i.test(body)
-            if (!backendContractYes && !backendContractNo) {
-              policyFailures.push('PR body must mark whether the backend contract is already in `develop`.')
-            }
-            if (backendContractYes && backendContractNo) {
-              policyFailures.push('`Backend contract already in develop` cannot select both yes and no.')
-            }
-            if (isReleasePromotionPr && !backendContractYes) {
-              policyFailures.push('Formal `[release]` PR must mark `Backend contract already in develop` as yes.')
-            }
-
             const stackedOnDependency = /If no, this PR is:[\s\S]*?- \[[xX]\] stacked on dependency branch/i.test(body)
             const intentionallyBlocked = /If no, this PR is:[\s\S]*?- \[[xX]\] intentionally blocked until dependency merges/i.test(body)
-            if (backendContractNo && !stackedOnDependency && !intentionallyBlocked) {
-              policyFailures.push(
-                'When backend contract is not yet in `develop`, PR body must mark this PR as stacked or intentionally blocked.',
-              )
+
+            if (!isDependabotPr) {
+              if (!titlePrefix) {
+                policyFailures.push(
+                  `PR title must start with one of: ${allowedPrefixes.join(', ')}. Current title: "${title}".`,
+                )
+              }
+
+              if (isReleasePromotionPr && titlePrefix !== '[release]') {
+                policyFailures.push('`develop -> main` release PR must use the `[release]` title prefix.')
+              }
+
+              if (!isReleasePromotionPr && titlePrefix === '[release]') {
+                policyFailures.push('`[release]` PR is reserved for formal `develop -> main` promotion PRs only.')
+              }
+
+              if (!isReleasePromotionPr && !/#\d+/.test(body)) {
+                policyFailures.push('PR body must reference at least one issue or PR number such as `#123`.')
+              }
+
+              if (!body.includes('Source of truth：') && !body.includes('Source of truth:')) {
+                policyFailures.push('PR body must include a `Source of truth` line in the Scope 對齊 section.')
+              }
+
+              if (!body.includes('本 PR 明確不做')) {
+                policyFailures.push('PR body must include a `本 PR 明確不做` section.')
+              }
+
+              if (!dependsOnRaw) {
+                policyFailures.push('PR body must include a `Depends on PR` line with `none` or `#123`.')
+              }
+
+              if (dependsOnRaw && !dependsOnNone && !dependsOnPrMatch) {
+                policyFailures.push('`Depends on PR` must be `none` or a single PR number such as `#123`.')
+              }
+
+              if (!backendContractYes && !backendContractNo) {
+                policyFailures.push('PR body must mark whether the backend contract is already in `develop`.')
+              }
+              if (backendContractYes && backendContractNo) {
+                policyFailures.push('`Backend contract already in develop` cannot select both yes and no.')
+              }
+              if (isReleasePromotionPr && !backendContractYes) {
+                policyFailures.push('Formal `[release]` PR must mark `Backend contract already in develop` as yes.')
+              }
+
+              if (backendContractNo && !stackedOnDependency && !intentionallyBlocked) {
+                policyFailures.push(
+                  'When backend contract is not yet in `develop`, PR body must mark this PR as stacked or intentionally blocked.',
+                )
+              }
             }
 
             if (titlePrefix === '[frontend]' && dependsOnPrMatch && backendContractNo) {
@@ -250,6 +254,13 @@ jobs:
               for (const warning of warnings) {
                 summaryLines.push(`- ${warning}`)
               }
+            }
+
+            if (isDependabotPr) {
+              summaryLines.push('')
+              summaryLines.push('### Dependabot Mode')
+              summaryLines.push('- Template policy checks are skipped for Dependabot maintenance PRs.')
+              summaryLines.push('- Scope, dependency, and size checks still apply.')
             }
 
             summaryLines.push('')

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,7 +9,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
@@ -38,6 +39,8 @@
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.2",
+    "jsdom": "^29.0.1"
   }
 }

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.2
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
@@ -84,12 +87,26 @@ importers:
       vite:
         specifier: ^8.0.1
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.4(@types/node@24.12.0)(jsdom@29.0.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.9':
+    resolution: {integrity: sha512-zd9c/Wdso6v1U7v6w3i/hbAr4K7NaSHImdpvmLt+Y9ea5BhilnIGNkfhOJ7FEIuPipAnE9tZeDOll05WDT0kgg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.9':
+    resolution: {integrity: sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -158,6 +175,46 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
@@ -204,6 +261,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -365,6 +431,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
@@ -460,6 +529,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -549,6 +624,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -568,6 +672,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -594,6 +702,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
@@ -616,6 +727,10 @@ packages:
 
   caniuse-lite@1.0.30001784:
     resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -653,8 +768,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -664,6 +787,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -687,6 +813,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -694,6 +824,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -764,9 +897,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -878,6 +1018,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -902,6 +1046,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -915,6 +1062,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1023,6 +1179,10 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lru-cache@11.3.3:
+    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1037,6 +1197,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1067,6 +1230,9 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1083,6 +1249,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1090,6 +1259,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1136,6 +1308,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1144,6 +1320,10 @@ packages:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1168,9 +1348,18 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1179,6 +1368,9 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -1190,9 +1382,35 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1221,6 +1439,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1274,14 +1496,83 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1302,6 +1593,22 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.9':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.0.9':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1403,6 +1710,34 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -1464,6 +1799,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -1571,6 +1908,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1644,6 +1983,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -1757,6 +2103,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)
 
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -1775,6 +2162,8 @@ snapshots:
       color-convert: 2.0.1
 
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
 
@@ -1801,6 +2190,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.13: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
@@ -1826,6 +2219,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001784: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -1860,11 +2255,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -1885,9 +2294,13 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
+  entities@6.0.1: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -1987,7 +2400,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2082,6 +2501,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -2099,6 +2524,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
@@ -2108,6 +2535,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.9
+      '@asamuzakjp/dom-selector': 7.0.9
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.3
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -2183,6 +2636,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lru-cache@11.3.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2196,6 +2651,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mime-db@1.52.0: {}
 
@@ -2219,6 +2676,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  obug@2.1.1: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2240,9 +2699,15 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -2277,6 +2742,8 @@ snapshots:
 
   react@19.2.4: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
@@ -2303,6 +2770,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -2317,7 +2788,13 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -2325,16 +2802,38 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -2362,6 +2861,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@7.24.7: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2387,11 +2888,64 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vitest@4.1.4(@types/node@24.12.0)(jsdom@29.0.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.0
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -4,6 +4,7 @@ import ProtectedRoute from '@/components/ProtectedRoute'
 import LoginPage from '@/pages/LoginPage'
 import DashboardPage from '@/pages/DashboardPage'
 import StreamersPage from '@/pages/StreamersPage'
+import StreamerDetailPage from '@/pages/StreamerDetailPage'
 import TransactionsPage from '@/pages/TransactionsPage'
 import SettingsPage from '@/pages/SettingsPage'
 
@@ -20,6 +21,7 @@ const router = createBrowserRouter([
         children: [
           { index: true, element: <DashboardPage /> },
           { path: 'streamers', element: <StreamersPage /> },
+          { path: 'streamers/:streamerId', element: <StreamerDetailPage /> },
           { path: 'transactions', element: <TransactionsPage /> },
           { path: 'settings', element: <SettingsPage /> },
         ],

--- a/dashboard/src/components/ui/skeleton.tsx
+++ b/dashboard/src/components/ui/skeleton.tsx
@@ -1,0 +1,8 @@
+import type { HTMLAttributes } from 'react'
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />
+}
+
+export { Skeleton }

--- a/dashboard/src/pages/StreamerDetailPage.tsx
+++ b/dashboard/src/pages/StreamerDetailPage.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getCurrentUserRole } from '@/services/auth'
+import {
+  getChannelConfig,
+  getStreamerStats,
+  type ChannelConfig,
+  type StreamerStats,
+} from '@/services/channels'
+
+function formatHours(seconds?: number) {
+  if (seconds === undefined) return '—'
+  return `${(seconds / 3600).toFixed(1)} 小時`
+}
+
+function formatMinutes(seconds?: number) {
+  if (seconds === undefined) return '—'
+  return `${Math.round(seconds / 60)} 分`
+}
+
+function formatNumber(value?: number, unit?: string) {
+  if (value === undefined) return '—'
+  return `${value.toLocaleString()}${unit ? ` ${unit}` : ''}`
+}
+
+function calcPerMinute(config: ChannelConfig | null) {
+  if (!config || config.seconds_per_point === 0) return '—'
+  return `${((60 / config.seconds_per_point) * config.multiplier).toFixed(1)} 點`
+}
+
+function TimeCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex-1 rounded-lg border border-border bg-secondary/30 p-4 text-center">
+      <p className="mb-1 text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-bold text-foreground">{value}</p>
+    </div>
+  )
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex-1 space-y-1 rounded-lg border border-border bg-secondary/30 p-5">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold text-foreground">{value}</p>
+    </div>
+  )
+}
+
+export default function StreamerDetailPage() {
+  const { streamerId } = useParams()
+  const navigate = useNavigate()
+  const role = getCurrentUserRole()
+  const [stats, setStats] = useState<StreamerStats | null>(null)
+  const [config, setConfig] = useState<ChannelConfig | null>(null)
+  const [loading, setLoading] = useState(Boolean(streamerId))
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (!streamerId) return
+
+    let mounted = true
+
+    getStreamerStats(streamerId)
+      .then(async ({ stats, channelId }) => {
+        if (!mounted) return
+        setStats(stats)
+
+        try {
+          const cfg = await getChannelConfig(channelId)
+          if (!mounted) return
+          setConfig(cfg)
+        } catch {
+          if (!mounted) return
+          setConfig(null)
+        }
+      })
+      .catch(() => {
+        if (!mounted) return
+        setError(true)
+      })
+      .finally(() => {
+        if (!mounted) return
+        setLoading(false)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [streamerId])
+
+  const timeCards = [
+    { label: '本次', value: formatHours(stats?.current_session_seconds) },
+    { label: '本日', value: formatHours(stats?.daily_seconds) },
+    { label: '本月', value: formatHours(stats?.monthly_seconds) },
+    { label: '年度', value: formatHours(stats?.yearly_seconds) },
+  ]
+
+  const metricCards = [
+    { label: '挖礦參與人數', value: formatNumber(stats?.unique_miners, '人') },
+    { label: '觀眾平均停留', value: formatMinutes(stats?.avg_session_seconds) },
+    { label: '總產出點數', value: formatNumber(stats?.total_token_minted, '點') },
+    { label: '可用點數總量', value: formatNumber(stats?.spendable_in_circulation, '點') },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {role !== 'streamer' && (
+            <button
+              onClick={() => navigate('/streamers')}
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              ← 返回列表
+            </button>
+          )}
+          <h1 className="text-2xl font-bold text-foreground">{streamerId}</h1>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" disabled>
+            空投
+          </Button>
+          <Button variant="outline" disabled>
+            調整倍率
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-28 w-full" />
+          <div className="grid gap-4 md:grid-cols-4">
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+            <Skeleton className="h-28 w-full" />
+          </div>
+          <Skeleton className="h-40 w-full" />
+        </div>
+      ) : error || !stats || !streamerId ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          無法載入頻道詳細資料
+        </div>
+      ) : (
+        <>
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              開台時數
+            </h2>
+            <div className="grid gap-3 md:grid-cols-4">
+              {timeCards.map((card) => (
+                <TimeCard key={card.label} label={card.label} value={card.value} />
+              ))}
+            </div>
+          </section>
+
+          <div className="grid gap-3 md:grid-cols-4">
+            {metricCards.map((card) => (
+              <MetricCard key={card.label} label={card.label} value={card.value} />
+            ))}
+          </div>
+
+          <section className="space-y-4 rounded-lg border border-border bg-secondary/30 p-6">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              挖礦倍率設定
+            </h2>
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">每秒點數基準</span>
+                <span className="font-medium text-foreground">
+                  {config ? `${config.seconds_per_point} 秒 / 點` : '—'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">目前倍率</span>
+                <span className="font-medium text-foreground">
+                  {config ? `${config.multiplier}x` : '—'}
+                </span>
+              </div>
+              <div className="mt-2 flex justify-between border-t border-border pt-2">
+                <span className="text-muted-foreground">每分鐘產出</span>
+                <span className="font-semibold text-primary">{calcPerMinute(config)}</span>
+              </div>
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/pages/StreamerDetailPage.tsx
+++ b/dashboard/src/pages/StreamerDetailPage.tsx
@@ -54,8 +54,8 @@ export default function StreamerDetailPage() {
   const role = getCurrentUserRole()
   const [stats, setStats] = useState<StreamerStats | null>(null)
   const [config, setConfig] = useState<ChannelConfig | null>(null)
-  const [loading, setLoading] = useState(Boolean(streamerId))
-  const [error, setError] = useState(false)
+  const [resolvedStreamerId, setResolvedStreamerId] = useState<string | null>(null)
+  const [failedStreamerId, setFailedStreamerId] = useState<string | null>(null)
 
   useEffect(() => {
     if (!streamerId) return
@@ -75,20 +75,23 @@ export default function StreamerDetailPage() {
           if (!mounted) return
           setConfig(null)
         }
+
+        if (!mounted) return
+        setFailedStreamerId(null)
+        setResolvedStreamerId(streamerId)
       })
       .catch(() => {
         if (!mounted) return
-        setError(true)
-      })
-      .finally(() => {
-        if (!mounted) return
-        setLoading(false)
+        setFailedStreamerId(streamerId)
       })
 
     return () => {
       mounted = false
     }
   }, [streamerId])
+
+  const loading = Boolean(streamerId) && resolvedStreamerId !== streamerId && failedStreamerId !== streamerId
+  const error = failedStreamerId === streamerId
 
   const timeCards = [
     { label: '本次', value: formatHours(stats?.current_session_seconds) },

--- a/dashboard/src/pages/StreamersPage.tsx
+++ b/dashboard/src/pages/StreamersPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
 import { getCurrentUserRole } from '@/services/auth'
-import { getStreamers, type Streamer } from '@/services/channels'
+import { getMyChannels, getStreamers, type Streamer } from '@/services/channels'
 
 export default function StreamersPage() {
   const navigate = useNavigate()
@@ -11,10 +11,15 @@ export default function StreamersPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
 
+  function openStreamer(streamerId: string) {
+    navigate(`/streamers/${streamerId}`)
+  }
+
   useEffect(() => {
     let mounted = true
+    const loadStreamers = role === 'streamer' ? getMyChannels : getStreamers
 
-    getStreamers()
+    loadStreamers()
       .then((data) => {
         if (!mounted) return
         setStreamers(data)
@@ -31,7 +36,7 @@ export default function StreamersPage() {
     return () => {
       mounted = false
     }
-  }, [])
+  }, [role])
 
   useEffect(() => {
     if (loading || role !== 'streamer') return
@@ -71,8 +76,17 @@ export default function StreamersPage() {
               {streamers.map((streamer, index) => (
                 <tr
                   key={streamer.id}
-                  className={`cursor-pointer border-b border-border transition-colors last:border-0 hover:bg-accent/30 ${index % 2 === 0 ? '' : 'bg-secondary/20'}`}
-                  onClick={() => navigate(`/streamers/${streamer.id}`)}
+                  tabIndex={0}
+                  role="button"
+                  aria-label={`查看 ${streamer.display_name || streamer.channel_id} 的詳細資料`}
+                  className={`cursor-pointer border-b border-border transition-colors last:border-0 hover:bg-accent/30 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary ${index % 2 === 0 ? '' : 'bg-secondary/20'}`}
+                  onClick={() => openStreamer(streamer.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      openStreamer(streamer.id)
+                    }
+                  }}
                 >
                   <td className="px-4 py-3 font-medium text-foreground">
                     {streamer.display_name || streamer.channel_id}

--- a/dashboard/src/pages/StreamersPage.tsx
+++ b/dashboard/src/pages/StreamersPage.tsx
@@ -1,3 +1,89 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getCurrentUserRole } from '@/services/auth'
+import { getStreamers, type Streamer } from '@/services/channels'
+
 export default function StreamersPage() {
-  return <h1 className="text-2xl font-bold text-foreground">實況主管理</h1>
+  const navigate = useNavigate()
+  const role = getCurrentUserRole()
+  const [streamers, setStreamers] = useState<Streamer[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+
+    getStreamers()
+      .then((data) => {
+        if (!mounted) return
+        setStreamers(data)
+      })
+      .catch(() => {
+        if (!mounted) return
+        setError(true)
+      })
+      .finally(() => {
+        if (!mounted) return
+        setLoading(false)
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (loading || role !== 'streamer') return
+    const first = streamers[0]
+    if (!first) return
+    navigate(`/streamers/${first.id}`, { replace: true })
+  }, [loading, navigate, role, streamers])
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-foreground">實況主管理</h1>
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-11 w-full" />
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          無法載入實況主資料
+        </div>
+      ) : streamers.length === 0 ? (
+        <div className="rounded-lg border border-border bg-secondary/20 px-4 py-8 text-center text-sm text-muted-foreground">
+          目前沒有可顯示的實況主資料
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-secondary/50">
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">實況主名稱</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Channel ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {streamers.map((streamer, index) => (
+                <tr
+                  key={streamer.id}
+                  className={`cursor-pointer border-b border-border transition-colors last:border-0 hover:bg-accent/30 ${index % 2 === 0 ? '' : 'bg-secondary/20'}`}
+                  onClick={() => navigate(`/streamers/${streamer.id}`)}
+                >
+                  <td className="px-4 py-3 font-medium text-foreground">
+                    {streamer.display_name || streamer.channel_id}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{streamer.channel_id}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
 }

--- a/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
+++ b/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
@@ -1,6 +1,6 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { MemoryRouter, Route, Routes } from 'react-router'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import StreamerDetailPage from '@/pages/StreamerDetailPage'
 
@@ -26,6 +26,26 @@ function RoutedApp() {
   )
 }
 
+function DetailRouteWithNavigation() {
+  const navigate = useNavigate()
+
+  return (
+    <>
+      <button onClick={() => navigate('/streamers/uuid-2')}>go-second</button>
+      <StreamerDetailPage />
+    </>
+  )
+}
+
+function NavigableRoutedApp() {
+  return (
+    <Routes>
+      <Route path="/streamers/:streamerId" element={<DetailRouteWithNavigation />} />
+      <Route path="/streamers" element={<div data-testid="list-page">list page</div>} />
+    </Routes>
+  )
+}
+
 async function renderAt(path: string) {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -35,6 +55,22 @@ async function renderAt(path: string) {
     root.render(
       <MemoryRouter initialEntries={[path]}>
         <RoutedApp />
+      </MemoryRouter>,
+    )
+  })
+
+  return { container, root }
+}
+
+async function renderNavigableAt(path: string) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[path]}>
+        <NavigableRoutedApp />
       </MemoryRouter>,
     )
   })
@@ -138,6 +174,57 @@ describe('StreamerDetailPage', () => {
     expect(container.textContent).toContain('1.5 小時')
     expect(container.textContent).toContain('挖礦倍率設定')
     expect(container.textContent).toContain('—')
+
+    cleanupRoot(root, container)
+  })
+
+  it('streamerId 變更時會先清掉舊資料並回到 loading 狀態', async () => {
+    let resolveSecond: ((value: { stats: typeof defaultStats; channelId: string }) => void) | null = null
+
+    getStreamerStatsMock.mockImplementation((streamerId: string) => {
+      if (streamerId === 'uuid-1') {
+        return Promise.resolve({
+          stats: defaultStats,
+          channelId: 'channel-1',
+        })
+      }
+
+      return new Promise((resolve) => {
+        resolveSecond = resolve
+      })
+    })
+
+    const { container, root } = await renderNavigableAt('/streamers/uuid-1')
+    await flush()
+    await flush()
+
+    expect(container.textContent).toContain('1.5 小時')
+
+    const navigateButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'go-second',
+    )
+    expect(navigateButton).toBeTruthy()
+
+    await act(async () => {
+      navigateButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(container.textContent).not.toContain('1.5 小時')
+    expect(container.textContent).toContain('調整倍率')
+
+    await act(async () => {
+      resolveSecond?.({
+        stats: {
+          ...defaultStats,
+          current_session_seconds: 7200,
+        },
+        channelId: 'channel-2',
+      })
+    })
+    await flush()
+    await flush()
+
+    expect(container.textContent).toContain('2.0 小時')
 
     cleanupRoot(root, container)
   })

--- a/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
+++ b/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
@@ -1,0 +1,144 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import StreamerDetailPage from '@/pages/StreamerDetailPage'
+
+const getStreamerStatsMock = vi.fn()
+const getChannelConfigMock = vi.fn()
+const getCurrentUserRoleMock = vi.fn()
+
+vi.mock('@/services/channels', () => ({
+  getStreamerStats: (...args: unknown[]) => getStreamerStatsMock(...args),
+  getChannelConfig: (...args: unknown[]) => getChannelConfigMock(...args),
+}))
+
+vi.mock('@/services/auth', () => ({
+  getCurrentUserRole: () => getCurrentUserRoleMock(),
+}))
+
+function RoutedApp() {
+  return (
+    <Routes>
+      <Route path="/streamers/:streamerId" element={<StreamerDetailPage />} />
+      <Route path="/streamers" element={<div data-testid="list-page">list page</div>} />
+    </Routes>
+  )
+}
+
+async function renderAt(path: string) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[path]}>
+        <RoutedApp />
+      </MemoryRouter>,
+    )
+  })
+
+  return { container, root }
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function cleanupRoot(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+}
+
+const defaultStats = {
+  current_session_seconds: 5400,
+  daily_seconds: 10800,
+  monthly_seconds: 28800,
+  yearly_seconds: 432000,
+  unique_miners: 1240,
+  avg_session_seconds: 600,
+  total_token_minted: 3200,
+  spendable_in_circulation: 1800,
+}
+
+const defaultConfig = {
+  channel_id: 'channel-1',
+  seconds_per_point: 30,
+  multiplier: 2,
+}
+
+describe('StreamerDetailPage', () => {
+  beforeEach(() => {
+    getStreamerStatsMock.mockReset()
+    getChannelConfigMock.mockReset()
+    getCurrentUserRoleMock.mockReset()
+    getCurrentUserRoleMock.mockReturnValue('admin')
+    getStreamerStatsMock.mockResolvedValue({
+      stats: defaultStats,
+      channelId: 'channel-1',
+    })
+    getChannelConfigMock.mockResolvedValue(defaultConfig)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('顯示秒數換算與倍率資訊，並顯示 action 按鈕', async () => {
+    const { container, root } = await renderAt('/streamers/uuid-1')
+    await flush()
+    await flush()
+
+    expect(container.textContent).toContain('1.5 小時')
+    expect(container.textContent).toContain('10 分')
+    expect(container.textContent).toContain('30 秒 / 點')
+    expect(container.textContent).toContain('2x')
+    expect(container.textContent).toContain('4.0 點')
+    expect(container.textContent).toContain('空投')
+    expect(container.textContent).toContain('調整倍率')
+
+    cleanupRoot(root, container)
+  })
+
+  it('streamer 角色不顯示返回列表按鈕', async () => {
+    getCurrentUserRoleMock.mockReturnValue('streamer')
+
+    const { container, root } = await renderAt('/streamers/uuid-1')
+    await flush()
+    await flush()
+
+    expect(container.textContent).not.toContain('返回列表')
+
+    cleanupRoot(root, container)
+  })
+
+  it('stats API 失敗時顯示整頁錯誤訊息', async () => {
+    getStreamerStatsMock.mockRejectedValue(new Error('boom'))
+
+    const { container, root } = await renderAt('/streamers/uuid-1')
+    await flush()
+
+    expect(container.textContent).toContain('無法載入頻道詳細資料')
+
+    cleanupRoot(root, container)
+  })
+
+  it('config API 失敗時仍顯示 stats，倍率區塊以破折號降級', async () => {
+    getChannelConfigMock.mockRejectedValue(new Error('config unavailable'))
+
+    const { container, root } = await renderAt('/streamers/uuid-1')
+    await flush()
+    await flush()
+
+    expect(container.textContent).toContain('1.5 小時')
+    expect(container.textContent).toContain('挖礦倍率設定')
+    expect(container.textContent).toContain('—')
+
+    cleanupRoot(root, container)
+  })
+})

--- a/dashboard/src/pages/__tests__/StreamersPage.test.tsx
+++ b/dashboard/src/pages/__tests__/StreamersPage.test.tsx
@@ -1,0 +1,116 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import StreamersPage from '@/pages/StreamersPage'
+
+const getStreamersMock = vi.fn()
+const getCurrentUserRoleMock = vi.fn()
+
+vi.mock('@/services/channels', () => ({
+  getStreamers: (...args: unknown[]) => getStreamersMock(...args),
+}))
+
+vi.mock('@/services/auth', () => ({
+  getCurrentUserRole: () => getCurrentUserRoleMock(),
+}))
+
+function RoutedApp() {
+  return (
+    <Routes>
+      <Route path="/streamers" element={<StreamersPage />} />
+      <Route path="/streamers/:streamerId" element={<div data-testid="detail-page">detail page</div>} />
+    </Routes>
+  )
+}
+
+async function renderAt(path: string) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[path]}>
+        <RoutedApp />
+      </MemoryRouter>,
+    )
+  })
+
+  return { container, root }
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function cleanupRoot(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+}
+
+describe('StreamersPage', () => {
+  beforeEach(() => {
+    getStreamersMock.mockReset()
+    getCurrentUserRoleMock.mockReset()
+    getCurrentUserRoleMock.mockReturnValue('admin')
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('顯示 API 回傳的實況主列表', async () => {
+    getStreamersMock.mockResolvedValue([
+      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+      { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
+    ])
+
+    const { container, root } = await renderAt('/streamers')
+    await flush()
+
+    expect(container.textContent).toContain('Alice')
+    expect(container.textContent).toContain('channel-2')
+
+    cleanupRoot(root, container)
+  })
+
+  it('streamer 角色載入後會直接導向自己的詳細頁', async () => {
+    getCurrentUserRoleMock.mockReturnValue('streamer')
+    getStreamersMock.mockResolvedValue([{ id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' }])
+
+    const { container, root } = await renderAt('/streamers')
+    await flush()
+    await flush()
+
+    expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toContain('detail page')
+
+    cleanupRoot(root, container)
+  })
+
+  it('API 失敗時顯示錯誤訊息', async () => {
+    getStreamersMock.mockRejectedValue(new Error('boom'))
+
+    const { container, root } = await renderAt('/streamers')
+    await flush()
+
+    expect(container.textContent).toContain('無法載入實況主資料')
+
+    cleanupRoot(root, container)
+  })
+
+  it('空列表時顯示無資料提示', async () => {
+    getStreamersMock.mockResolvedValue([])
+
+    const { container, root } = await renderAt('/streamers')
+    await flush()
+
+    expect(container.textContent).toContain('目前沒有可顯示的實況主資料')
+
+    cleanupRoot(root, container)
+  })
+})

--- a/dashboard/src/pages/__tests__/StreamersPage.test.tsx
+++ b/dashboard/src/pages/__tests__/StreamersPage.test.tsx
@@ -1,25 +1,33 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { MemoryRouter, Route, Routes } from 'react-router'
+import { MemoryRouter, Route, Routes, useParams } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import StreamersPage from '@/pages/StreamersPage'
 
 const getStreamersMock = vi.fn()
+const getMyChannelsMock = vi.fn()
 const getCurrentUserRoleMock = vi.fn()
 
 vi.mock('@/services/channels', () => ({
   getStreamers: (...args: unknown[]) => getStreamersMock(...args),
+  getMyChannels: (...args: unknown[]) => getMyChannelsMock(...args),
 }))
 
 vi.mock('@/services/auth', () => ({
   getCurrentUserRole: () => getCurrentUserRoleMock(),
 }))
 
+function DetailRouteProbe() {
+  const { streamerId } = useParams()
+
+  return <div data-testid="detail-page">{streamerId}</div>
+}
+
 function RoutedApp() {
   return (
     <Routes>
       <Route path="/streamers" element={<StreamersPage />} />
-      <Route path="/streamers/:streamerId" element={<div data-testid="detail-page">detail page</div>} />
+      <Route path="/streamers/:streamerId" element={<DetailRouteProbe />} />
     </Routes>
   )
 }
@@ -56,6 +64,7 @@ function cleanupRoot(root: Root, container: HTMLDivElement) {
 describe('StreamersPage', () => {
   beforeEach(() => {
     getStreamersMock.mockReset()
+    getMyChannelsMock.mockReset()
     getCurrentUserRoleMock.mockReset()
     getCurrentUserRoleMock.mockReturnValue('admin')
   })
@@ -79,15 +88,56 @@ describe('StreamersPage', () => {
     cleanupRoot(root, container)
   })
 
+  it('列表列可用 Enter 鍵進入詳細頁', async () => {
+    getStreamersMock.mockResolvedValue([
+      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+      { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
+    ])
+
+    const { container, root } = await renderAt('/streamers')
+    await flush()
+
+    const firstRow = container.querySelector('tbody tr')
+    expect(firstRow).toBeTruthy()
+
+    act(() => {
+      firstRow?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      )
+    })
+
+    expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toBe('uuid-1')
+
+    cleanupRoot(root, container)
+  })
+
   it('streamer 角色載入後會直接導向自己的詳細頁', async () => {
     getCurrentUserRoleMock.mockReturnValue('streamer')
-    getStreamersMock.mockResolvedValue([{ id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' }])
+    getMyChannelsMock.mockResolvedValue([{ id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' }])
 
     const { container, root } = await renderAt('/streamers')
     await flush()
     await flush()
 
-    expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toContain('detail page')
+    expect(getStreamersMock).not.toHaveBeenCalled()
+    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toBe('uuid-1')
+
+    cleanupRoot(root, container)
+  })
+
+  it('streamer 角色在沒有自己的頻道時停留於空狀態', async () => {
+    getCurrentUserRoleMock.mockReturnValue('streamer')
+    getMyChannelsMock.mockResolvedValue([])
+
+    const { container, root } = await renderAt('/streamers')
+    await flush()
+    await flush()
+
+    expect(getStreamersMock).not.toHaveBeenCalled()
+    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-testid="detail-page"]')).toBeNull()
+    expect(container.textContent).toContain('目前沒有可顯示的實況主資料')
 
     cleanupRoot(root, container)
   })

--- a/dashboard/src/services/__tests__/channels.test.ts
+++ b/dashboard/src/services/__tests__/channels.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import client from '@/services/api'
+import { getChannelConfig, getStreamerStats } from '@/services/channels'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+describe('channels service', () => {
+  beforeEach(() => {
+    vi.mocked(client.get).mockReset()
+  })
+
+  it('對 streamerId 做 URL encoding 後再查詢 stats', async () => {
+    vi.mocked(client.get).mockResolvedValue({
+      data: {
+        data: {
+          stats: {
+            current_session_seconds: 0,
+            daily_seconds: 0,
+            monthly_seconds: 0,
+            yearly_seconds: 0,
+            unique_miners: 0,
+            avg_session_seconds: 0,
+            total_token_minted: 0,
+            spendable_in_circulation: 0,
+          },
+          channel_id: 'channel-1',
+        },
+      },
+    })
+
+    await getStreamerStats('streamer/id')
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/dashboard/streamers/streamer%2Fid/stats')
+  })
+
+  it('對 channelId 做 URL encoding 後再查詢 config', async () => {
+    vi.mocked(client.get).mockResolvedValue({
+      data: {
+        data: {
+          config: {
+            channel_id: 'channel/1',
+            seconds_per_point: 60,
+            multiplier: 2,
+          },
+        },
+      },
+    })
+
+    await getChannelConfig('channel/1')
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/dashboard/channels/channel%2F1/config')
+  })
+})

--- a/dashboard/src/services/__tests__/channels.test.ts
+++ b/dashboard/src/services/__tests__/channels.test.ts
@@ -14,44 +14,53 @@ describe('channels service', () => {
   })
 
   it('對 streamerId 做 URL encoding 後再查詢 stats', async () => {
+    const stats = {
+      current_session_seconds: 0,
+      daily_seconds: 0,
+      monthly_seconds: 0,
+      yearly_seconds: 0,
+      unique_miners: 0,
+      avg_session_seconds: 0,
+      total_token_minted: 0,
+      spendable_in_circulation: 0,
+    }
+
     vi.mocked(client.get).mockResolvedValue({
       data: {
         data: {
-          stats: {
-            current_session_seconds: 0,
-            daily_seconds: 0,
-            monthly_seconds: 0,
-            yearly_seconds: 0,
-            unique_miners: 0,
-            avg_session_seconds: 0,
-            total_token_minted: 0,
-            spendable_in_circulation: 0,
-          },
+          stats,
           channel_id: 'channel-1',
         },
       },
     })
 
-    await getStreamerStats('streamer/id')
+    const result = await getStreamerStats('streamer/id')
 
     expect(client.get).toHaveBeenCalledWith('/api/v1/dashboard/streamers/streamer%2Fid/stats')
+    expect(result).toEqual({
+      stats,
+      channelId: 'channel-1',
+    })
   })
 
   it('對 channelId 做 URL encoding 後再查詢 config', async () => {
+    const config = {
+      channel_id: 'channel/1',
+      seconds_per_point: 60,
+      multiplier: 2,
+    }
+
     vi.mocked(client.get).mockResolvedValue({
       data: {
         data: {
-          config: {
-            channel_id: 'channel/1',
-            seconds_per_point: 60,
-            multiplier: 2,
-          },
+          config,
         },
       },
     })
 
-    await getChannelConfig('channel/1')
+    const result = await getChannelConfig('channel/1')
 
     expect(client.get).toHaveBeenCalledWith('/api/v1/dashboard/channels/channel%2F1/config')
+    expect(result).toEqual(config)
   })
 })

--- a/dashboard/src/services/auth.ts
+++ b/dashboard/src/services/auth.ts
@@ -3,6 +3,7 @@ import client, { setAuthToken, clearAuthToken } from '@/services/api'
 
 // 記憶體儲存，不 export
 let accessToken: string | null = null
+let currentUser: Record<string, unknown> | null = null
 
 interface LoginResponse {
   data: {
@@ -20,7 +21,9 @@ export async function login(email: string, password: string): Promise<void> {
     password,
   })
   accessToken = data.data.tokens.access_token
+  currentUser = data.data.user
   localStorage.setItem('refresh_token', data.data.tokens.refresh_token)
+  localStorage.setItem('current_user', JSON.stringify(data.data.user))
   setAuthToken(accessToken)
 }
 
@@ -30,12 +33,29 @@ export async function logout(): Promise<void> {
     await client.post('/api/v1/auth/logout', { refresh_token: refreshToken }).catch(() => {})
   }
   accessToken = null
+  currentUser = null
   localStorage.removeItem('refresh_token')
+  localStorage.removeItem('current_user')
   clearAuthToken()
 }
 
 export function isAuthenticated(): boolean {
   return accessToken !== null
+}
+
+export function getCurrentUserRole(): string | null {
+  if (currentUser && typeof currentUser.role === 'string') {
+    return currentUser.role
+  }
+  const stored = localStorage.getItem('current_user')
+  if (!stored) return null
+  try {
+    const parsed = JSON.parse(stored) as Record<string, unknown>
+    currentUser = parsed
+    return typeof parsed.role === 'string' ? parsed.role : null
+  } catch {
+    return null
+  }
 }
 
 export { isAxiosError }

--- a/dashboard/src/services/channels.ts
+++ b/dashboard/src/services/channels.ts
@@ -1,0 +1,57 @@
+import client from '@/services/api'
+
+type ApiResponse<T> = {
+  success: boolean
+  data: T
+}
+
+export interface Streamer {
+  id: string
+  user_id: string
+  agency_user_id?: string
+  channel_id: string
+  display_name: string
+}
+
+export interface StreamerStats {
+  current_session_seconds: number
+  daily_seconds: number
+  monthly_seconds: number
+  yearly_seconds: number
+  unique_miners: number
+  avg_session_seconds: number
+  total_token_minted: number
+  spendable_in_circulation: number
+}
+
+export interface ChannelConfig {
+  channel_id: string
+  seconds_per_point: number
+  multiplier: number
+}
+
+export interface StreamerStatsResponse {
+  stats: StreamerStats
+  channelId: string
+}
+
+export async function getStreamers(): Promise<Streamer[]> {
+  const { data } = await client.get<ApiResponse<{ streamers: Streamer[] }>>(
+    '/api/v1/dashboard/streamers',
+  )
+  return data.data.streamers
+}
+
+export async function getStreamerStats(streamerId: string): Promise<StreamerStatsResponse> {
+  const { data } = await client.get<ApiResponse<{ stats: StreamerStats; channel_id: string }>>(
+    `/api/v1/dashboard/streamers/${streamerId}/stats`,
+  )
+  return { stats: data.data.stats, channelId: data.data.channel_id }
+}
+
+export async function getChannelConfig(channelId: string): Promise<ChannelConfig> {
+  const { data } = await client.get<ApiResponse<{ config: ChannelConfig }>>(
+    `/api/v1/dashboard/channels/${channelId}/config`,
+  )
+  return data.data.config
+}

--- a/dashboard/src/services/channels.ts
+++ b/dashboard/src/services/channels.ts
@@ -42,16 +42,25 @@ export async function getStreamers(): Promise<Streamer[]> {
   return data.data.streamers
 }
 
+export async function getMyChannels(): Promise<Streamer[]> {
+  const { data } = await client.get<ApiResponse<{ channels: Streamer[] }>>(
+    '/api/v1/dashboard/streamers/channels',
+  )
+  return data.data.channels
+}
+
 export async function getStreamerStats(streamerId: string): Promise<StreamerStatsResponse> {
+  const encodedStreamerId = encodeURIComponent(streamerId)
   const { data } = await client.get<ApiResponse<{ stats: StreamerStats; channel_id: string }>>(
-    `/api/v1/dashboard/streamers/${streamerId}/stats`,
+    `/api/v1/dashboard/streamers/${encodedStreamerId}/stats`,
   )
   return { stats: data.data.stats, channelId: data.data.channel_id }
 }
 
 export async function getChannelConfig(channelId: string): Promise<ChannelConfig> {
+  const encodedChannelId = encodeURIComponent(channelId)
   const { data } = await client.get<ApiResponse<{ config: ChannelConfig }>>(
-    `/api/v1/dashboard/channels/${channelId}/config`,
+    `/api/v1/dashboard/channels/${encodedChannelId}/config`,
   )
   return data.data.config
 }

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+  },
+})

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -42,6 +42,24 @@ repo 目前有一個 GitHub Actions workflow：
 - `[contract]` PR 不可修改 `backend/` / `dashboard/` / `tachimint/`
 - `[frontend]` PR 若依賴尚未 merge 的 backend contract，會被 dependency gate 擋下
 
+### Dependabot maintenance PR
+
+對 `dependabot[bot]` 開的 maintenance PR，`PR Scope Police` 會保留真正有意義的自動檢查：
+
+- product surface 不可混雜
+- diff / changed files 不可超過硬上限
+- dependency gate 仍照常生效
+
+但不再要求 Dependabot PR 補齊人工模板欄位，例如：
+
+- title prefix
+- `Source of truth`
+- `Depends on PR`
+- `Backend contract already in develop`
+- `本 PR 明確不做`
+
+原因是這些欄位主要服務人工撰寫的 feature / release PR；對 Dependabot dependency bump 而言，持續人工補 metadata 成本高、訊號低，也容易讓 reviewer 浪費時間在固定格式而非實際風險。
+
 ## 正式 release PR
 
 以下情況視為正式支援的 release promotion PR，而不是 scope exception：


### PR DESCRIPTION
## 什麼改動

- 調整 `PR Scope Police`，讓 `dependabot[bot]` 開的 maintenance PR 不再被要求補人工 PR 模板欄位
- 保留 Dependabot PR 的 scope / diff size / dependency gate 檢查
- 更新 `docs/pr-scope-policy.md`，說明 Dependabot maintenance PR 的特例規則

## 為什麼

近期多張 Dependabot PR 雖然程式碼本身沒有風險，仍會固定因為 title / body 不符合人工模板而卡在 `Scope police`。這些欄位對人工 feature PR 有價值，但對 dependency bump 幾乎沒有額外訊號，反而造成 reviewer 每次都要手動補 metadata。

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：none（workflow / policy maintenance）
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分

## 本 PR 明確不做

- 不放寬 Dependabot PR 的 scope、dependency 或 diff size 檢查
- 不修改一般人工 feature / release PR 的模板要求
- 不改 Dependabot auto-merge policy
- 不修改產品程式碼

## 超出範圍內容

無

## 測試方式

- [ ] 本地測試過
- [ ] 有寫 / 更新測試

## 備註

- 這次只調整 policy workflow 與文件說明；實際 GitHub Actions 行為仍待 PR 上 workflow 執行驗證

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增流主详情页面，展示直播时数统计、参与者数据及挖矿倍率配置
  * 流主列表页面完全重新设计，支持数据驱动列表展示和导航功能
  * 新增骨架屏UI组件改进加载体验

* **测试**
  * 新增页面与API服务测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->