### PR TITLE
[discussion] relax scope police template requirements for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -31,6 +31,7 @@ jobs:
               isSameRepoHead &&
               pr.base?.ref === 'main' &&
               pr.head?.ref === 'develop'
+            const isDependabotPr = pr.user?.login === 'dependabot[bot]'
 
             const bypassLabels = new Set(['scope-exception'])
             const labels = (pr.labels || []).map((label) => label.name)
@@ -85,62 +86,65 @@ jobs:
 
             const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]']
             const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
-            if (!titlePrefix) {
-              policyFailures.push(
-                `PR title must start with one of: ${allowedPrefixes.join(', ')}. Current title: "${title}".`,
-              )
-            }
-
-            if (isReleasePromotionPr && titlePrefix !== '[release]') {
-              policyFailures.push('`develop -> main` release PR must use the `[release]` title prefix.')
-            }
-
-            if (!isReleasePromotionPr && titlePrefix === '[release]') {
-              policyFailures.push('`[release]` PR is reserved for formal `develop -> main` promotion PRs only.')
-            }
-
-            if (!isReleasePromotionPr && !/#\d+/.test(body)) {
-              policyFailures.push('PR body must reference at least one issue or PR number such as `#123`.')
-            }
-
-            if (!body.includes('Source of truth：') && !body.includes('Source of truth:')) {
-              policyFailures.push('PR body must include a `Source of truth` line in the Scope 對齊 section.')
-            }
-
-            if (!body.includes('本 PR 明確不做')) {
-              policyFailures.push('PR body must include a `本 PR 明確不做` section.')
-            }
-
             const dependsOnMatch = body.match(/Depends on PR[：:]\s*(.+)/i)
             const dependsOnRaw = dependsOnMatch?.[1]?.trim()
-            if (!dependsOnRaw) {
-              policyFailures.push('PR body must include a `Depends on PR` line with `none` or `#123`.')
-            }
-
             const dependsOnNone = dependsOnRaw?.toLowerCase() === 'none'
             const dependsOnPrMatch = dependsOnRaw?.match(/^#(\d+)$/)
-            if (dependsOnRaw && !dependsOnNone && !dependsOnPrMatch) {
-              policyFailures.push('`Depends on PR` must be `none` or a single PR number such as `#123`.')
-            }
-
             const backendContractYes = /Backend contract already in develop:[\s\S]*?- \[[xX]\] yes/i.test(body)
             const backendContractNo = /Backend contract already in develop:[\s\S]*?- \[[xX]\] no/i.test(body)
-            if (!backendContractYes && !backendContractNo) {
-              policyFailures.push('PR body must mark whether the backend contract is already in `develop`.')
-            }
-            if (backendContractYes && backendContractNo) {
-              policyFailures.push('`Backend contract already in develop` cannot select both yes and no.')
-            }
-            if (isReleasePromotionPr && !backendContractYes) {
-              policyFailures.push('Formal `[release]` PR must mark `Backend contract already in develop` as yes.')
-            }
-
             const stackedOnDependency = /If no, this PR is:[\s\S]*?- \[[xX]\] stacked on dependency branch/i.test(body)
             const intentionallyBlocked = /If no, this PR is:[\s\S]*?- \[[xX]\] intentionally blocked until dependency merges/i.test(body)
-            if (backendContractNo && !stackedOnDependency && !intentionallyBlocked) {
-              policyFailures.push(
-                'When backend contract is not yet in `develop`, PR body must mark this PR as stacked or intentionally blocked.',
-              )
+
+            if (!isDependabotPr) {
+              if (!titlePrefix) {
+                policyFailures.push(
+                  `PR title must start with one of: ${allowedPrefixes.join(', ')}. Current title: "${title}".`,
+                )
+              }
+
+              if (isReleasePromotionPr && titlePrefix !== '[release]') {
+                policyFailures.push('`develop -> main` release PR must use the `[release]` title prefix.')
+              }
+
+              if (!isReleasePromotionPr && titlePrefix === '[release]') {
+                policyFailures.push('`[release]` PR is reserved for formal `develop -> main` promotion PRs only.')
+              }
+
+              if (!isReleasePromotionPr && !/#\d+/.test(body)) {
+                policyFailures.push('PR body must reference at least one issue or PR number such as `#123`.')
+              }
+
+              if (!body.includes('Source of truth：') && !body.includes('Source of truth:')) {
+                policyFailures.push('PR body must include a `Source of truth` line in the Scope 對齊 section.')
+              }
+
+              if (!body.includes('本 PR 明確不做')) {
+                policyFailures.push('PR body must include a `本 PR 明確不做` section.')
+              }
+
+              if (!dependsOnRaw) {
+                policyFailures.push('PR body must include a `Depends on PR` line with `none` or `#123`.')
+              }
+
+              if (dependsOnRaw && !dependsOnNone && !dependsOnPrMatch) {
+                policyFailures.push('`Depends on PR` must be `none` or a single PR number such as `#123`.')
+              }
+
+              if (!backendContractYes && !backendContractNo) {
+                policyFailures.push('PR body must mark whether the backend contract is already in `develop`.')
+              }
+              if (backendContractYes && backendContractNo) {
+                policyFailures.push('`Backend contract already in develop` cannot select both yes and no.')
+              }
+              if (isReleasePromotionPr && !backendContractYes) {
+                policyFailures.push('Formal `[release]` PR must mark `Backend contract already in develop` as yes.')
+              }
+
+              if (backendContractNo && !stackedOnDependency && !intentionallyBlocked) {
+                policyFailures.push(
+                  'When backend contract is not yet in `develop`, PR body must mark this PR as stacked or intentionally blocked.',
+                )
+              }
             }
 
             if (titlePrefix === '[frontend]' && dependsOnPrMatch && backendContractNo) {
@@ -250,6 +254,13 @@ jobs:
               for (const warning of warnings) {
                 summaryLines.push(`- ${warning}`)
               }
+            }
+
+            if (isDependabotPr) {
+              summaryLines.push('')
+              summaryLines.push('### Dependabot Mode')
+              summaryLines.push('- Template policy checks are skipped for Dependabot maintenance PRs.')
+              summaryLines.push('- Scope, dependency, and size checks still apply.')
             }
 
             summaryLines.push('')

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -260,7 +260,8 @@ jobs:
               summaryLines.push('')
               summaryLines.push('### Dependabot Mode')
               summaryLines.push('- Template policy checks are skipped for Dependabot maintenance PRs.')
-              summaryLines.push('- Scope, dependency, and size checks still apply.')
+              summaryLines.push('- Scope and size checks still apply.')
+              summaryLines.push('- Dependency gate is not evaluated for Dependabot PRs.')
             }
 
             summaryLines.push('')

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -42,6 +42,24 @@ repo 目前有一個 GitHub Actions workflow：
 - `[contract]` PR 不可修改 `backend/` / `dashboard/` / `tachimint/`
 - `[frontend]` PR 若依賴尚未 merge 的 backend contract，會被 dependency gate 擋下
 
+### Dependabot maintenance PR
+
+對 `dependabot[bot]` 開的 maintenance PR，`PR Scope Police` 會保留真正有意義的自動檢查：
+
+- product surface 不可混雜
+- diff / changed files 不可超過硬上限
+- dependency gate 仍照常生效
+
+但不再要求 Dependabot PR 補齊人工模板欄位，例如：
+
+- title prefix
+- `Source of truth`
+- `Depends on PR`
+- `Backend contract already in develop`
+- `本 PR 明確不做`
+
+原因是這些欄位主要服務人工撰寫的 feature / release PR；對 Dependabot dependency bump 而言，持續人工補 metadata 成本高、訊號低，也容易讓 reviewer 浪費時間在固定格式而非實際風險。
+
 ## 正式 release PR
 
 以下情況視為正式支援的 release promotion PR，而不是 scope exception：

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -48,9 +48,11 @@ repo 目前有一個 GitHub Actions workflow：
 
 - product surface 不可混雜
 - diff / changed files 不可超過硬上限
-- dependency gate 仍照常生效
+- 不再要求人工模板欄位
 
-但不再要求 Dependabot PR 補齊人工模板欄位，例如：
+Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的 dependency gate。這條 gate 依賴人工填寫的 PR 模板欄位（例如 `Depends on PR` 與 `Backend contract already in develop`），而這次規則調整的目的正是不要再要求 bot 補這類 metadata。
+
+因此 Dependabot PR 目前只保留 scope / size 類型的自動檢查，不再要求補齊人工模板欄位，例如：
 
 - title prefix
 - `Source of truth`


### PR DESCRIPTION
## 什麼改動

- 調整 `PR Scope Police`，讓 `dependabot[bot]` 開的 maintenance PR 不再被要求補人工 PR 模板欄位
- 保留 Dependabot PR 的 scope / diff size / dependency gate 檢查
- 更新 `docs/pr-scope-policy.md`，說明 Dependabot maintenance PR 的特例規則

## 為什麼

近期多張 Dependabot PR 雖然程式碼本身沒有風險，仍會固定因為 title / body 不符合人工模板而卡在 `Scope police`。這些欄位對人工 feature PR 有價值，但對 dependency bump 幾乎沒有額外訊號，反而造成 reviewer 每次都要手動補 metadata。

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：#177（workflow / policy maintenance）
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分

## 本 PR 明確不做

- 不放寬 Dependabot PR 的 scope、dependency 或 diff size 檢查
- 不修改一般人工 feature / release PR 的模板要求
- 不改 Dependabot auto-merge policy
- 不修改產品程式碼

## 超出範圍內容

無

## 測試方式

- [ ] 本地測試過
- [ ] 有寫 / 更新測試

## 備註

- 這次只調整 policy workflow 與文件說明；實際 GitHub Actions 行為仍待 PR 上 workflow 執行驗證


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档更新**
  * 更新了PR范围策略文档，说明Dependabot维护PR的不同处理方式。

* **其他改进**
  * 调整了PR范围检查工作流，对Dependabot自动化PR采用简化验证流程，重点关注代码范围和体量限制，同时豁免部分手动模板要求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->