### PR TITLE
[backend] TACHI_CONTRACT_ADDRESS / SEPOLIA_SIGNER_KEY 環境設定與 owner 策略文件化

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,7 +36,7 @@ TACHI_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
 # Purpose: signs transactions on behalf of the backend (e.g. future mint calls) on Sepolia testnet.
 # Management: use a dedicated testnet-only wallet; rotate if exposed.
 # WARNING: never commit a real private key. Use a secrets manager or hardware wallet in production.
-SEPOLIA_SIGNER_KEY=replace-with-sepolia-signer-private-key
+SEPOLIA_SIGNER_KEY=
 
 # ── CORS ──────────────────────────────────────────────────────────────────────
 # Comma-separated list of allowed origins

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,12 +28,14 @@ GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URL=http://localhost:8080/api/v1/auth/google/callback
 
 # ── Tachi Contract ────────────────────────────────────────────────────────────
-# Contract address used by upcoming backend contract integration.
-# Verification note: as of issue #175, backend/internal/config/config.go does not load TACHI_CONTRACT_ADDRESS yet.
+# Loaded by backend/internal/config/config.go (Config.Contract.TachiContractAddress).
+# Set to the deployed TachiToken address on Sepolia; see deployments/sepolia.json.
 TACHI_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
 
-# Sepolia signer private key for transaction signing in non-production environments only.
-# Never commit a real key. In production, store signing credentials in a secrets manager or use a hardware wallet.
+# Loaded by backend/internal/config/config.go (Config.Contract.SepoliaSignerKey).
+# Purpose: signs transactions on behalf of the backend (e.g. future mint calls) on Sepolia testnet.
+# Management: use a dedicated testnet-only wallet; rotate if exposed.
+# WARNING: never commit a real private key. Use a secrets manager or hardware wallet in production.
 SEPOLIA_SIGNER_KEY=replace-with-sepolia-signer-private-key
 
 # ── CORS ──────────────────────────────────────────────────────────────────────

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,6 +27,15 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URL=http://localhost:8080/api/v1/auth/google/callback
 
+# ── Tachi Contract ────────────────────────────────────────────────────────────
+# Contract address used by upcoming backend contract integration.
+# Verification note: as of issue #175, backend/internal/config/config.go does not load TACHI_CONTRACT_ADDRESS yet.
+TACHI_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
+
+# Sepolia signer private key for transaction signing in non-production environments only.
+# Never commit a real key. In production, store signing credentials in a secrets manager or use a hardware wallet.
+SEPOLIA_SIGNER_KEY=replace-with-sepolia-signer-private-key
+
 # ── CORS ──────────────────────────────────────────────────────────────────────
 # Comma-separated list of allowed origins
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -13,6 +13,12 @@ type Config struct {
 	OAuth    OAuthConfig
 	SMTP     SMTPConfig
 	App      AppConfig
+	Contract ContractConfig
+}
+
+type ContractConfig struct {
+	TachiContractAddress string // TACHI_CONTRACT_ADDRESS
+	SepoliaSignerKey     string // SEPOLIA_SIGNER_KEY — never log or expose
 }
 
 type SMTPConfig struct {
@@ -102,6 +108,10 @@ func Load() *Config {
 				ClientSecret: getEnv("GOOGLE_CLIENT_SECRET", ""),
 				RedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:8080/api/v1/auth/google/callback"),
 			},
+		},
+		Contract: ContractConfig{
+			TachiContractAddress: getEnv("TACHI_CONTRACT_ADDRESS", ""),
+			SepoliaSignerKey:     getEnv("SEPOLIA_SIGNER_KEY", ""),
 		},
 	}
 }

--- a/deployments/sepolia.json
+++ b/deployments/sepolia.json
@@ -1,0 +1,8 @@
+{
+  "network": "sepolia",
+  "contractAddress": "0xaB702A56fa95f7B5c8C1a47AB8348b2Bb74AE778",
+  "txHash": "0x430580d0559da0771e42cfd6cf69be938989e2bcd8a2e235d9e78e1eb3fa5daa",
+  "blockNumber": 7877542,
+  "deployedAt": "2026-04-10T15:34:00Z",
+  "ownerStrategy": "MVP owner = deployer wallet"
+}


### PR DESCRIPTION
## 什麼改動

- `backend/internal/config/config.go` 新增 `ContractConfig`，`Load()` 載入 `TACHI_CONTRACT_ADDRESS` / `SEPOLIA_SIGNER_KEY`
- `backend/.env.example` 補上兩個 env var 的佔位說明與安全注意事項
- `deployments/sepolia.json` 新建，記錄 Sepolia 部署資訊與 `ownerStrategy`（MVP owner = deployer wallet）

## 為什麼

#174（Sepolia 部署）完成後，後端需能讀取合約地址；owner 策略與 signer key 管理方式需在文件中明確記錄，以利後續 mint service 實作。這是 #111 的剩餘完成條件。

closes #175

> 備註：`deployments/sepolia.json` 在 #174 也會建立，合併順序應先 #174 再本 PR，否則需手動解 conflict。#111 需等兩支 PR 都 merge 後才完全關閉。

## Scope 對齊

- Source of truth：#175
- Depends on PR：none
- Backend contract already in develop:
  - [ ] yes
  - [x] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [x] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作 mint / burn API 串接
  - 不修改 DB schema 或 service logic
  - 不部署到 mainnet
  - 不引入 Defender Relayer 或 multisig

## 測試方式

- [x] `go build ./...` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加对 Sepolia 测试网络上智能合约部署与交互的支持。

* **配置更新**
  * 扩展了配置项，新增合约地址和 Sepolia 交易签名密钥配置。
  * 新增 Sepolia 网络的部署元数据记录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->