### PR TITLE
[discussion] add Codex PR review optimization guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,46 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - 只列出關鍵變更（檔案名稱 + 一行說明），不貼完整 diff
 - 測試結果只報 pass/fail 數量與失敗原因，不貼完整 log
 - 遇到錯誤：先給出診斷與建議修法，再問是否繼續
+
+## PR Review 最小化規則
+
+目標：降低 Codex 在 PR review 的 token 使用量，同時維持 blocker 導向的審查品質。
+
+### Review policy
+
+- 預設先做輕量 review：先看 PR 描述、changed files、checks、未解 review thread，再決定是否深入讀碼
+- 優先找 blocker、regression、scope violation、缺失的必要測試；不要先做全面 code walkthrough
+- 若前一輪 blocker 已解除，優先更新 merge 判斷，不重做整份 review
+
+### Scope control
+
+- 只審查 PR changed files 與直接相關的最小必要上下文
+- 不主動延伸到未變更檔案，除非：
+  - 這次改動明確依賴該檔案行為
+  - review comment 指向跨檔案整合風險
+  - 需要驗證是否真的有 regression
+- 對 scope 外議題，直接標示為 follow-up issue / wrong PR，不展開長篇分析
+
+### Output constraints
+
+- findings 優先，摘要次之
+- 單次 review 以 3 個 finding 為上限；若沒有 blocker，直接明講 `no blocker found`
+- 每個 finding 只寫：
+  - 檔案 / 位置
+  - 風險一句
+  - 為什麼構成 blocker 或 non-blocker 一句
+- 不重述 PR 全貌，不貼大段 diff，不列與 merge 無關的觀察清單
+
+### Avoid unnecessary explanation
+
+- 不解釋顯而易見的程式碼流程
+- 不為了展現覆蓋率而列出已檢查但無問題的檔案
+- 不重複前一輪已成立的結論，除非新 commit 改變判斷
+- 對 minor / nit / future work，除非使用者明問，否則一句帶過即可
+
+### Escalate deeper review when
+
+- PR 涉及 auth、權限、金流、私鑰、contract interaction、schema migration、刪資料風險
+- CI fail、review thread 指向實際行為回歸、或 PR 描述與 diff 明顯不一致
+- changed files 雖少，但跨 service boundary、環境設定、部署流程或 release 流程
+- 使用者明確要求 full review / deep dive / second pass


### PR DESCRIPTION
## 什麼改動

- 在 `AGENTS.md` 增補一段專門給 Codex 使用的 PR review 最小化規則
- 收斂 review policy、scope control、output constraints、finding 數量上限與 deeper review escalation 條件
- 保留原本 repo 規範，只做附加式補充

## 為什麼

這次希望把「審 PR 時如何節省 token、降低不必要輸出、維持 blocker 導向 review」寫成固定規則，減少每次 review 都重新描述一次審查風格。

refs #179

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：#179
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分

## 本 PR 明確不做

- 不修改任何產品程式碼或 workflow 行為
- 不調整 branch protection / CI 設定
- 不改 repo 既有 Git / scope 規範，只補 Codex review 指引

## 超出範圍內容

無

## 測試方式

- [ ] 本地測試過
- [ ] 有寫 / 更新測試

## 備註

- 這次只更新 repository guidance，沒有新增 runtime behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文件更新**
  * 新增 PR 審查最小化規則文件，明確定義審查範疇限制、輸出格式約束（含 finding 數量限制與標準化欄位），以及在認證、權限、金流、合約互動、資料刪除等關鍵領域升級深入審查的觸發條件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->