### PR TITLE
[backend] Internal API — tachiya 點數查詢 endpoint (Demo)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,6 +21,10 @@ TWITCH_REDIRECT_URL=http://localhost:8080/api/v1/auth/twitch/callback
 # Found in the Extension dashboard → "Extension Secret" (base64-encoded)
 TWITCH_EXTENSION_SECRET=
 
+# ── Internal API ──────────────────────────────────────────────────────────────
+# Shared secret for tachiya -> tachigo server-to-server internal requests.
+TACHIYA_INTERNAL_SHARED_SECRET=
+
 # ── Google OAuth ──────────────────────────────────────────────────────────────
 # Register at https://console.cloud.google.com/apis/credentials
 GOOGLE_CLIENT_ID=

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -131,7 +131,23 @@ func main() {
 		allowedOrigins = strings.Split(originsEnv, ",")
 	}
 
-	r := router.New(authSvc, userSvc, addrSvc, extSvc, emailAuthSvc, watchSvc, channelConfigSvc, pointsSvc, airdropSvc, streamerSvc, agencySvc, claimSvc, agencyH, allowedOrigins)
+	r := router.New(
+		authSvc,
+		userSvc,
+		addrSvc,
+		extSvc,
+		emailAuthSvc,
+		watchSvc,
+		channelConfigSvc,
+		pointsSvc,
+		airdropSvc,
+		streamerSvc,
+		agencySvc,
+		claimSvc,
+		agencyH,
+		allowedOrigins,
+		router.InternalRouterConfig{DB: db, Config: cfg},
+	)
 
 	addr := ":" + cfg.Server.Port
 	log.Printf("server starting on %s (env=%s)", addr, cfg.Server.Env)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -14,11 +14,16 @@ type Config struct {
 	SMTP     SMTPConfig
 	App      AppConfig
 	Contract ContractConfig
+	Internal InternalConfig
 }
 
 type ContractConfig struct {
 	TachiContractAddress string // TACHI_CONTRACT_ADDRESS
 	SepoliaSignerKey     string // SEPOLIA_SIGNER_KEY — never log or expose
+}
+
+type InternalConfig struct {
+	TachiyaSharedSecret string // TACHIYA_INTERNAL_SHARED_SECRET
 }
 
 type SMTPConfig struct {
@@ -112,6 +117,9 @@ func Load() *Config {
 		Contract: ContractConfig{
 			TachiContractAddress: getEnv("TACHI_CONTRACT_ADDRESS", ""),
 			SepoliaSignerKey:     getEnv("SEPOLIA_SIGNER_KEY", ""),
+		},
+		Internal: InternalConfig{
+			TachiyaSharedSecret: getEnv("TACHIYA_INTERNAL_SHARED_SECRET", ""),
 		},
 	}
 }

--- a/backend/internal/handlers/internal_points_handler.go
+++ b/backend/internal/handlers/internal_points_handler.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+type InternalPointsHandler struct {
+	db *gorm.DB
+}
+
+func NewInternalPointsHandler(db *gorm.DB) *InternalPointsHandler {
+	return &InternalPointsHandler{db: db}
+}
+
+func (h *InternalPointsHandler) GetUserPointsBalance(c *gin.Context) {
+	email := c.Query("email")
+	if email == "" {
+		badRequest(c, "email is required")
+		return
+	}
+
+	var user models.User
+	if err := h.db.Where("email = ?", email).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			notFound(c, "user not found")
+			return
+		}
+		internal(c)
+		return
+	}
+
+	var balance struct {
+		SpendableBalance int64 `gorm:"column:spendable_balance"`
+		CumulativeTotal  int64 `gorm:"column:cumulative_total"`
+	}
+	if err := h.db.Raw(`
+		SELECT
+			COALESCE(SUM(spendable_balance), 0) AS spendable_balance,
+			COALESCE(SUM(cumulative_total), 0) AS cumulative_total
+		FROM points_ledgers
+		WHERE user_id = ?
+	`, user.ID).Scan(&balance).Error; err != nil {
+		internal(c)
+		return
+	}
+
+	ok(c, gin.H{
+		"user_id":           user.ID,
+		"email":             email,
+		"spendable_balance": balance.SpendableBalance,
+		"cumulative_total":  balance.CumulativeTotal,
+	})
+}

--- a/backend/internal/handlers/internal_points_handler.go
+++ b/backend/internal/handlers/internal_points_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -18,14 +19,14 @@ func NewInternalPointsHandler(db *gorm.DB) *InternalPointsHandler {
 }
 
 func (h *InternalPointsHandler) GetUserPointsBalance(c *gin.Context) {
-	email := c.Query("email")
+	email := strings.ToLower(strings.TrimSpace(c.Query("email")))
 	if email == "" {
 		badRequest(c, "email is required")
 		return
 	}
 
 	var user models.User
-	if err := h.db.Where("email = ?", email).First(&user).Error; err != nil {
+	if err := h.db.Where("LOWER(email) = ?", email).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			notFound(c, "user not found")
 			return
@@ -51,7 +52,7 @@ func (h *InternalPointsHandler) GetUserPointsBalance(c *gin.Context) {
 
 	ok(c, gin.H{
 		"user_id":           user.ID,
-		"email":             email,
+		"email":             user.Email,
 		"spendable_balance": balance.SpendableBalance,
 		"cumulative_total":  balance.CumulativeTotal,
 	})

--- a/backend/internal/handlers/internal_points_handler_test.go
+++ b/backend/internal/handlers/internal_points_handler_test.go
@@ -1,0 +1,70 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tachigo/tachigo/internal/handlers"
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+func TestInternalPointsHandler_NormalizesEmailQueryAndReturnsCanonicalEmail(t *testing.T) {
+	env := newTestEnv(t)
+
+	canonicalEmail := "viewer@example.com"
+	user := &models.User{
+		Username: stringPtr("viewer"),
+		Email:    &canonicalEmail,
+	}
+	if err := env.db.Create(user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	if err := env.db.Create(&models.PointsLedger{
+		UserID:           user.ID,
+		ChannelID:        "ch_one",
+		SpendableBalance: 40,
+		CumulativeTotal:  50,
+	}).Error; err != nil {
+		t.Fatalf("create ledger 1: %v", err)
+	}
+	if err := env.db.Create(&models.PointsLedger{
+		UserID:           user.ID,
+		ChannelID:        "ch_two",
+		SpendableBalance: 60,
+		CumulativeTotal:  70,
+	}).Error; err != nil {
+		t.Fatalf("create ledger 2: %v", err)
+	}
+
+	r := gin.New()
+	r.GET("/api/v1/internal/tachiya/users/points/balance", handlers.NewInternalPointsHandler(env.db).GetUserPointsBalance)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/internal/tachiya/users/points/balance?email=%20Viewer@Example.com%20", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resp := parseBody(t, rec.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+
+	if data["email"] != canonicalEmail {
+		t.Fatalf("want canonical email %q, got %v", canonicalEmail, data["email"])
+	}
+	if data["spendable_balance"] != float64(100) {
+		t.Fatalf("want spendable_balance 100, got %v", data["spendable_balance"])
+	}
+	if data["cumulative_total"] != float64(120) {
+		t.Fatalf("want cumulative_total 120, got %v", data["cumulative_total"])
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/backend/internal/middleware/internal_auth.go
+++ b/backend/internal/middleware/internal_auth.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"crypto/subtle"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tachigo/tachigo/internal/config"
+)
+
+const tachiyaInternalSecretHeader = "X-Tachiya-Internal-Secret"
+
+func TachiyaInternalAuth(cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		expected := cfg.Internal.TachiyaSharedSecret
+		actual := c.GetHeader(tachiyaInternalSecretHeader)
+
+		if expected == "" || actual == "" || subtle.ConstantTimeCompare([]byte(actual), []byte(expected)) != 1 {
+			c.AbortWithStatusJSON(401, gin.H{"success": false, "error": "invalid internal secret"})
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -4,12 +4,19 @@ import (
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
+	"gorm.io/gorm"
 
+	"github.com/tachigo/tachigo/internal/config"
 	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/middleware"
 	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
+
+type InternalRouterConfig struct {
+	DB     *gorm.DB
+	Config *config.Config
+}
 
 func New(
 	authSvc *services.AuthService,
@@ -26,6 +33,7 @@ func New(
 	claimSvc *services.ClaimService,
 	agencyHandler *handlers.AgencyHandler,
 	allowedOrigins []string,
+	internalRouterConfig ...InternalRouterConfig,
 ) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
@@ -159,6 +167,15 @@ func New(
 	dashboardAirdrop.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
 	{
 		dashboardAirdrop.POST("/airdrop", airdropH.Airdrop)
+	}
+
+	if len(internalRouterConfig) > 0 && internalRouterConfig[0].DB != nil && internalRouterConfig[0].Config != nil {
+		internalPointsH := handlers.NewInternalPointsHandler(internalRouterConfig[0].DB)
+		internal := v1.Group("/internal/tachiya")
+		internal.Use(middleware.TachiyaInternalAuth(internalRouterConfig[0].Config))
+		{
+			internal.GET("/users/points/balance", internalPointsH.GetUserPointsBalance)
+		}
 	}
 
 	// ── Agency management ─────────────────────────────────────────────────

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -169,7 +169,10 @@ func New(
 		dashboardAirdrop.POST("/airdrop", airdropH.Airdrop)
 	}
 
-	if len(internalRouterConfig) > 0 && internalRouterConfig[0].DB != nil && internalRouterConfig[0].Config != nil {
+	if len(internalRouterConfig) > 0 &&
+		internalRouterConfig[0].DB != nil &&
+		internalRouterConfig[0].Config != nil &&
+		internalRouterConfig[0].Config.Internal.TachiyaSharedSecret != "" {
 		internalPointsH := handlers.NewInternalPointsHandler(internalRouterConfig[0].DB)
 		internal := v1.Group("/internal/tachiya")
 		internal.Use(middleware.TachiyaInternalAuth(internalRouterConfig[0].Config))

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -465,3 +465,91 @@ func TestInternalRouter_SkipsRouteWhenSharedSecretMissing(t *testing.T) {
 		t.Fatalf("want 404 when internal secret missing, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestInternalRouter_WithSecretSet_MiddlewareRejectsAndRouteRegistered(t *testing.T) {
+	dbName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", dbName)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db handle: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("enable foreign keys: %v", err)
+	}
+	if err := migrateTestDB(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	const secret = "test-internal-secret"
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			AccessSecret:  "test-access-secret-at-least-32-chars!",
+			RefreshSecret: "test-refresh-secret",
+			AccessTTL:     15 * time.Minute,
+			RefreshTTL:    30 * 24 * time.Hour,
+		},
+		App:      config.AppConfig{FrontendURL: "http://localhost:3000"},
+		Internal: config.InternalConfig{TachiyaSharedSecret: secret},
+	}
+
+	authSvc := services.NewAuthService(db, cfg)
+	userSvc := services.NewUserService(db)
+	addrSvc := services.NewAddressService(db)
+	emailAuthSvc := services.NewEmailAuthService(db, cfg, &mockMailer{})
+	extSvc := services.NewExtensionService(db, cfg, authSvc)
+	watchSvc := services.NewWatchService(db)
+	channelConfigSvc := services.NewChannelConfigService(db)
+	pointsSvc := services.NewPointsService(db, watchSvc)
+	airdropSvc := services.NewAirdropService(db, pointsSvc, channelConfigSvc)
+	streamerSvc := services.NewStreamerService(db, pointsSvc)
+	agencySvc := services.NewAgencyService(db)
+	claimSvc := services.NewClaimService(db)
+	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
+
+	engine := router.New(
+		authSvc,
+		userSvc,
+		addrSvc,
+		extSvc,
+		emailAuthSvc,
+		watchSvc,
+		channelConfigSvc,
+		pointsSvc,
+		airdropSvc,
+		streamerSvc,
+		agencySvc,
+		claimSvc,
+		agencyHandler,
+		[]string{"http://localhost:3000"},
+		router.InternalRouterConfig{DB: db, Config: cfg},
+	)
+
+	const path = "/api/v1/internal/tachiya/users/points/balance?email=nobody@example.com"
+
+	// Without the secret header: middleware should reject with 401.
+	reqNoHeader := httptest.NewRequest(http.MethodGet, path, nil)
+	recNoHeader := httptest.NewRecorder()
+	engine.ServeHTTP(recNoHeader, reqNoHeader)
+	if recNoHeader.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 without secret header, got %d: %s", recNoHeader.Code, recNoHeader.Body.String())
+	}
+
+	// With the correct secret header: route is registered; unknown user → 404 from handler.
+	reqWithHeader := httptest.NewRequest(http.MethodGet, path, nil)
+	reqWithHeader.Header.Set("X-Tachiya-Internal-Secret", secret)
+	recWithHeader := httptest.NewRecorder()
+	engine.ServeHTTP(recWithHeader, reqWithHeader)
+	if recWithHeader.Code != http.StatusNotFound {
+		t.Fatalf("want 404 (user not found) with valid secret header, got %d: %s", recWithHeader.Code, recWithHeader.Body.String())
+	}
+}

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -73,7 +73,6 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 			FrontendURL: "http://localhost:3000",
 		},
 	}
-
 	authSvc := services.NewAuthService(db, cfg)
 	userSvc := services.NewUserService(db)
 	addrSvc := services.NewAddressService(db)
@@ -387,5 +386,82 @@ func TestDashboardRouter_AgencyNonOwnedChannelConfigForbidden(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("want 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInternalRouter_SkipsRouteWhenSharedSecretMissing(t *testing.T) {
+	dbName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", dbName)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db handle: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("enable foreign keys: %v", err)
+	}
+	if err := migrateTestDB(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			AccessSecret:  "test-access-secret-at-least-32-chars!",
+			RefreshSecret: "test-refresh-secret",
+			AccessTTL:     15 * time.Minute,
+			RefreshTTL:    30 * 24 * time.Hour,
+		},
+		App: config.AppConfig{
+			FrontendURL: "http://localhost:3000",
+		},
+	}
+
+	authSvc := services.NewAuthService(db, cfg)
+	userSvc := services.NewUserService(db)
+	addrSvc := services.NewAddressService(db)
+	emailAuthSvc := services.NewEmailAuthService(db, cfg, &mockMailer{})
+	extSvc := services.NewExtensionService(db, cfg, authSvc)
+	watchSvc := services.NewWatchService(db)
+	channelConfigSvc := services.NewChannelConfigService(db)
+	pointsSvc := services.NewPointsService(db, watchSvc)
+	airdropSvc := services.NewAirdropService(db, pointsSvc, channelConfigSvc)
+	streamerSvc := services.NewStreamerService(db, pointsSvc)
+	agencySvc := services.NewAgencyService(db)
+	claimSvc := services.NewClaimService(db)
+	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
+
+	engine := router.New(
+		authSvc,
+		userSvc,
+		addrSvc,
+		extSvc,
+		emailAuthSvc,
+		watchSvc,
+		channelConfigSvc,
+		pointsSvc,
+		airdropSvc,
+		streamerSvc,
+		agencySvc,
+		claimSvc,
+		agencyHandler,
+		[]string{"http://localhost:3000"},
+		router.InternalRouterConfig{DB: db, Config: cfg},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/internal/tachiya/users/points/balance?email=viewer@example.com", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404 when internal secret missing, got %d: %s", rec.Code, rec.Body.String())
 	}
 }


### PR DESCRIPTION
## 什麼改動

- 新增 `GET /api/v1/internal/tachiya/users/points/balance?email=xxx`
- 新增 `internal/middleware/internal_auth.go` — 驗證 `X-Tachiya-Internal-Secret` header
- 新增 `internal/handlers/internal_points_handler.go` — 查 email → user → points_ledgers 加總
- `config.go` 新增 `Internal.TachiyaSharedSecret`
- `main.go` / `router.go` 注入並掛載 route

## 為什麼

- Source issue: #183
- refs #183
- closes #183

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：#183
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不串接 Twitch ID
  - 不實作 rate limiting
  - 不加測試（Demo 用）

## 超出範圍內容

- 無

## 測試方式

```bash
curl -H "X-Tachiya-Internal-Secret: demo-internal-secret-2026" \
  "http://localhost:8080/api/v1/internal/tachiya/users/points/balance?email=demo@tachigo.io"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 添加受认证保护的内部 API：按邮箱查询用户积分余额（邮箱会归一化，返回可用余额与累计总额）。
* **Chores**
  * 新增内部共享密钥环境变量支持（用于内部服务间认证）。
* **Tests**
  * 增加内部端点与中间件相关测试，覆盖路由注册、认证流程与余额聚合验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->