### PR TITLE
[backend] SpendService — 呼叫合約 burn() 換折價券

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -139,6 +139,7 @@ func main() {
 		}
 	}
 	claimSvc := services.NewClaimService(db, cfg.Contract, ethClient)
+	spendSvc := services.NewSpendService(db, cfg.Contract, ethClient)
 	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	// CORS origins from env, default to localhost for dev
@@ -161,6 +162,7 @@ func main() {
 		streamerSvc,
 		agencySvc,
 		claimSvc,
+		spendSvc,
 		agencyH,
 		allowedOrigins,
 		router.InternalRouterConfig{DB: db, Config: cfg},

--- a/backend/internal/contract/tachi_token.go
+++ b/backend/internal/contract/tachi_token.go
@@ -125,3 +125,90 @@ func (t *TachiToken) Mint(ctx context.Context, toAddr common.Address, amount *bi
 
 	return signedTx.Hash().Hex(), nil
 }
+
+func (t *TachiToken) Burn(ctx context.Context, fromAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.client == nil {
+		return "", fmt.Errorf("eth client is nil")
+	}
+	if signerKey == nil {
+		return "", fmt.Errorf("signer key is nil")
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return "", fmt.Errorf("amount must be greater than zero")
+	}
+
+	fromSignerAddr := crypto.PubkeyToAddress(signerKey.PublicKey)
+	data, err := t.abi.Pack("burn", fromAddr, amount)
+	if err != nil {
+		return "", fmt.Errorf("pack burn calldata: %w", err)
+	}
+
+	chainID, err := t.client.ChainID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get chain ID: %w", err)
+	}
+
+	nonce, err := t.client.PendingNonceAt(ctx, fromSignerAddr)
+	if err != nil {
+		return "", fmt.Errorf("get pending nonce: %w", err)
+	}
+
+	tipCap, err := t.client.SuggestGasTipCap(ctx)
+	if err != nil {
+		return "", fmt.Errorf("suggest gas tip cap: %w", err)
+	}
+
+	header, err := t.client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("get latest header: %w", err)
+	}
+	if header.BaseFee == nil {
+		return "", fmt.Errorf("latest header missing base fee")
+	}
+
+	feeCap := new(big.Int).Mul(header.BaseFee, big.NewInt(2))
+	feeCap.Add(feeCap, tipCap)
+
+	callMsg := ethereum.CallMsg{
+		From:      fromSignerAddr,
+		To:        &t.address,
+		GasFeeCap: feeCap,
+		GasTipCap: tipCap,
+		Data:      data,
+	}
+	gasLimit, err := t.client.EstimateGas(ctx, callMsg)
+	if err != nil {
+		return "", fmt.Errorf("estimate gas: %w", err)
+	}
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: tipCap,
+		GasFeeCap: feeCap,
+		Gas:       gasLimit,
+		To:        &t.address,
+		Data:      data,
+	})
+
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), signerKey)
+	if err != nil {
+		return "", fmt.Errorf("sign burn tx: %w", err)
+	}
+
+	if err := t.client.SendTransaction(ctx, signedTx); err != nil {
+		return "", fmt.Errorf("send burn tx: %w", err)
+	}
+	receipt, err := bind.WaitMined(ctx, t.client, signedTx)
+	if err != nil {
+		return "", fmt.Errorf("wait burn receipt: %w", err)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return "", fmt.Errorf("burn tx failed: %s", signedTx.Hash().Hex())
+	}
+
+	return signedTx.Hash().Hex(), nil
+}

--- a/backend/internal/contract/tachi_token.go
+++ b/backend/internal/contract/tachi_token.go
@@ -204,7 +204,9 @@ func (t *TachiToken) Burn(ctx context.Context, fromAddr common.Address, amount *
 	}
 	receipt, err := bind.WaitMined(ctx, t.client, signedTx)
 	if err != nil {
-		return "", fmt.Errorf("wait burn receipt: %w", err)
+		// Return txHash so callers can distinguish "tx broadcast but receipt unknown"
+		// from "tx never sent". Do NOT roll back DB based on this error alone.
+		return signedTx.Hash().Hex(), fmt.Errorf("wait burn receipt: %w", err)
 	}
 	if receipt.Status != types.ReceiptStatusSuccessful {
 		return "", fmt.Errorf("burn tx failed: %s", signedTx.Hash().Hex())

--- a/backend/internal/handlers/spend_handler.go
+++ b/backend/internal/handlers/spend_handler.go
@@ -19,7 +19,7 @@ func NewSpendHandler(spendSvc *services.SpendService) *SpendHandler {
 }
 
 type redeemRequest struct {
-	Amount int64 `json:"amount"`
+	Amount int64 `json:"amount" binding:"required,min=1"`
 }
 
 type redeemResponse struct {
@@ -51,10 +51,6 @@ func (h *SpendHandler) Redeem(c *gin.Context) {
 		badRequest(c, "invalid request body: "+err.Error())
 		return
 	}
-	if req.Amount <= 0 {
-		badRequest(c, "amount must be > 0")
-		return
-	}
 
 	newBalance, err := h.spendSvc.Redeem(c.Request.Context(), userID, req.Amount)
 	if err != nil {
@@ -70,6 +66,7 @@ func (h *SpendHandler) Redeem(c *gin.Context) {
 			badRequest(c, err.Error())
 			return
 		}
+		// ErrSpendContractConfig is a server-side misconfiguration; intentionally falls through to internal(c).
 		internal(c)
 		return
 	}

--- a/backend/internal/handlers/spend_handler.go
+++ b/backend/internal/handlers/spend_handler.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+type SpendHandler struct {
+	spendSvc *services.SpendService
+}
+
+func NewSpendHandler(spendSvc *services.SpendService) *SpendHandler {
+	return &SpendHandler{spendSvc: spendSvc}
+}
+
+type redeemRequest struct {
+	Amount int64 `json:"amount"`
+}
+
+type redeemResponse struct {
+	Balance int64 `json:"balance"`
+}
+
+// Redeem godoc
+// @Summary      Burn $TACHI to redeem a discount coupon
+// @Tags         spend
+// @Accept       json
+// @Produce      json
+// @Param        body body redeemRequest true "Amount to burn (must be > 0)"
+// @Success      200 {object} Response{data=redeemResponse}
+// @Failure      400 {object} Response
+// @Failure      401 {object} Response
+// @Failure      500 {object} Response
+// @Security     BearerAuth
+// @Router       /spend/redeem [post]
+func (h *SpendHandler) Redeem(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+
+	var req redeemRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		badRequest(c, "invalid request body: "+err.Error())
+		return
+	}
+	if req.Amount <= 0 {
+		badRequest(c, "amount must be > 0")
+		return
+	}
+
+	newBalance, err := h.spendSvc.Redeem(c.Request.Context(), userID, req.Amount)
+	if err != nil {
+		if errors.Is(err, services.ErrSpendInsufficientBalance) {
+			badRequest(c, err.Error())
+			return
+		}
+		if errors.Is(err, services.ErrSpendWalletNotLinked) {
+			badRequest(c, err.Error())
+			return
+		}
+		if errors.Is(err, services.ErrSpendAmountInvalid) {
+			badRequest(c, err.Error())
+			return
+		}
+		internal(c)
+		return
+	}
+
+	ok(c, redeemResponse{Balance: newBalance})
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -31,6 +31,7 @@ func New(
 	streamerSvc *services.StreamerService,
 	agencySvc *services.AgencyService,
 	claimSvc *services.ClaimService,
+	spendSvc *services.SpendService,
 	agencyHandler *handlers.AgencyHandler,
 	allowedOrigins []string,
 	internalRouterConfig ...InternalRouterConfig,
@@ -49,6 +50,7 @@ func New(
 	pointsH := handlers.NewPointsHandler(pointsSvc)
 	streamerH := handlers.NewStreamerHandler(streamerSvc)
 	claimH := handlers.NewClaimHandler(claimSvc)
+	spendH := handlers.NewSpendHandler(spendSvc)
 	airdropH := handlers.NewAirdropHandler(airdropSvc, agencySvc, streamerSvc)
 
 	r.GET("/health", func(c *gin.Context) {
@@ -115,6 +117,9 @@ func New(
 		// T-Point → $TACHI claim
 		protected.POST("users/me/points/claim", claimH.Claim)
 		protected.GET("users/me/tachi/balance", claimH.GetTachiBalance)
+
+		// $TACHI spend (burn)
+		protected.POST("spend/redeem", spendH.Redeem)
 
 		// User profile
 		protected.GET("users/me", userH.Me)

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -85,6 +85,7 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
+	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(
@@ -100,6 +101,7 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 		streamerSvc,
 		agencySvc,
 		claimSvc,
+		spendSvc,
 		agencyHandler,
 		[]string{"http://localhost:3000"},
 	)
@@ -436,7 +438,8 @@ func TestInternalRouter_SkipsRouteWhenSharedSecretMissing(t *testing.T) {
 	airdropSvc := services.NewAirdropService(db, pointsSvc, channelConfigSvc)
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	agencySvc := services.NewAgencyService(db)
-	claimSvc := services.NewClaimService(db)
+	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
+	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(
@@ -452,6 +455,7 @@ func TestInternalRouter_SkipsRouteWhenSharedSecretMissing(t *testing.T) {
 		streamerSvc,
 		agencySvc,
 		claimSvc,
+		spendSvc,
 		agencyHandler,
 		[]string{"http://localhost:3000"},
 		router.InternalRouterConfig{DB: db, Config: cfg},
@@ -513,7 +517,8 @@ func TestInternalRouter_WithSecretSet_MiddlewareRejectsAndRouteRegistered(t *tes
 	airdropSvc := services.NewAirdropService(db, pointsSvc, channelConfigSvc)
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	agencySvc := services.NewAgencyService(db)
-	claimSvc := services.NewClaimService(db)
+	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
+	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(
@@ -529,6 +534,7 @@ func TestInternalRouter_WithSecretSet_MiddlewareRejectsAndRouteRegistered(t *tes
 		streamerSvc,
 		agencySvc,
 		claimSvc,
+		spendSvc,
 		agencyHandler,
 		[]string{"http://localhost:3000"},
 		router.InternalRouterConfig{DB: db, Config: cfg},

--- a/backend/internal/services/spend_service.go
+++ b/backend/internal/services/spend_service.go
@@ -81,7 +81,13 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, amount int6
 
 	burnCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if _, err := s.burnCaller.BurnOnChain(burnCtx, reservation.fromAddr, reservation.amount); err != nil {
+	txHash, err := s.burnCaller.BurnOnChain(burnCtx, reservation.fromAddr, reservation.amount)
+	if err != nil {
+		if txHash != "" {
+			// Tx was broadcast but receipt is unknown (e.g. context deadline, RPC error).
+			// Do NOT roll back: the chain may have already burned the tokens.
+			return 0, fmt.Errorf("burn tx broadcast (txHash=%s) but receipt unknown: %w", txHash, err)
+		}
 		rollbackErr := s.db.Transaction(func(tx *gorm.DB) error {
 			return s.rollbackSpendReservation(tx, userID, reservation.amount)
 		})

--- a/backend/internal/services/spend_service.go
+++ b/backend/internal/services/spend_service.go
@@ -1,0 +1,178 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/tachigo/tachigo/internal/config"
+	contractpkg "github.com/tachigo/tachigo/internal/contract"
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+var (
+	ErrSpendAmountInvalid       = errors.New("spend amount must be greater than zero")
+	ErrSpendInsufficientBalance = errors.New("insufficient tachi balance")
+	ErrSpendWalletNotLinked     = errors.New("web3 wallet not linked")
+	ErrSpendContractConfig      = errors.New("spend contract config is incomplete")
+)
+
+// BurnCaller abstracts the on-chain burn call; replaced with a mock in tests.
+type BurnCaller interface {
+	BurnOnChain(ctx context.Context, fromAddr string, amount int64) (txHash string, err error)
+}
+
+type SpendService struct {
+	db          *gorm.DB
+	contractCfg config.ContractConfig
+	tachiToken  *contractpkg.TachiToken
+	burnCaller  BurnCaller
+}
+
+type spendReservation struct {
+	fromAddr   string
+	amount     int64
+	newBalance int64
+}
+
+func NewSpendService(db *gorm.DB, contractCfg config.ContractConfig, ethClient *ethclient.Client) *SpendService {
+	svc := &SpendService{
+		db:          db,
+		contractCfg: contractCfg,
+	}
+	if ethClient != nil && contractCfg.TachiContractAddress != "" && contractCfg.SepoliaSignerKey != "" {
+		if common.IsHexAddress(contractCfg.TachiContractAddress) {
+			t, err := contractpkg.NewTachiToken(common.HexToAddress(contractCfg.TachiContractAddress), ethClient)
+			if err == nil {
+				svc.tachiToken = t
+			}
+		}
+	}
+	svc.burnCaller = svc
+	return svc
+}
+
+// SetBurnCallerForTest replaces the burn caller; use only in tests.
+func (s *SpendService) SetBurnCallerForTest(bc BurnCaller) { s.burnCaller = bc }
+
+// Redeem burns `amount` $TACHI from the user's on-chain wallet and deducts
+// the same amount from tachi_balances. Returns the new balance.
+func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, amount int64) (int64, error) {
+	if amount <= 0 {
+		return 0, ErrSpendAmountInvalid
+	}
+
+	var reservation spendReservation
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		reservation, err = s.reserveSpend(tx, userID, amount)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	burnCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if _, err := s.burnCaller.BurnOnChain(burnCtx, reservation.fromAddr, reservation.amount); err != nil {
+		rollbackErr := s.db.Transaction(func(tx *gorm.DB) error {
+			return s.rollbackSpendReservation(tx, userID, reservation.amount)
+		})
+		if rollbackErr != nil {
+			return 0, fmt.Errorf("%w; rollback spend reservation: %v", err, rollbackErr)
+		}
+		return 0, err
+	}
+
+	return reservation.newBalance, nil
+}
+
+func (s *SpendService) reserveSpend(tx *gorm.DB, userID uuid.UUID, amount int64) (spendReservation, error) {
+	var tb models.TachiBalance
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("user_id = ?", userID).
+		First(&tb).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return spendReservation{}, ErrSpendInsufficientBalance
+		}
+		return spendReservation{}, err
+	}
+	if tb.Balance < amount {
+		return spendReservation{}, ErrSpendInsufficientBalance
+	}
+
+	fromAddr, err := s.resolveWalletAddress(tx, userID)
+	if err != nil {
+		return spendReservation{}, err
+	}
+
+	newBalance := tb.Balance - amount
+	if err := tx.Model(&models.TachiBalance{}).
+		Where("user_id = ?", userID).
+		Updates(map[string]interface{}{
+			"balance":    newBalance,
+			"updated_at": time.Now(),
+		}).Error; err != nil {
+		return spendReservation{}, err
+	}
+
+	return spendReservation{
+		fromAddr:   fromAddr,
+		amount:     amount,
+		newBalance: newBalance,
+	}, nil
+}
+
+func (s *SpendService) rollbackSpendReservation(tx *gorm.DB, userID uuid.UUID, amount int64) error {
+	return tx.Model(&models.TachiBalance{}).
+		Where("user_id = ?", userID).
+		Updates(map[string]interface{}{
+			"balance":    gorm.Expr("balance + ?", amount),
+			"updated_at": time.Now(),
+		}).Error
+}
+
+func (s *SpendService) resolveWalletAddress(db *gorm.DB, userID uuid.UUID) (string, error) {
+	var authProvider models.AuthProvider
+	err := db.Where("user_id = ? AND provider = ?", userID, models.ProviderWeb3).
+		Order("created_at ASC").
+		First(&authProvider).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", ErrSpendWalletNotLinked
+		}
+		return "", err
+	}
+	if !common.IsHexAddress(authProvider.ProviderID) {
+		return "", fmt.Errorf("invalid linked wallet address: %s", authProvider.ProviderID)
+	}
+	return common.HexToAddress(authProvider.ProviderID).Hex(), nil
+}
+
+// BurnOnChain implements BurnCaller using the real TachiToken contract.
+func (s *SpendService) BurnOnChain(ctx context.Context, fromAddr string, amount int64) (string, error) {
+	if s.tachiToken == nil {
+		return "", ErrSpendContractConfig
+	}
+	if !common.IsHexAddress(fromAddr) {
+		return "", fmt.Errorf("invalid wallet address: %s", fromAddr)
+	}
+	if amount <= 0 {
+		return "", ErrSpendAmountInvalid
+	}
+
+	signerKey, err := parseSignerKey(s.contractCfg.SepoliaSignerKey)
+	if err != nil {
+		return "", err
+	}
+
+	return s.tachiToken.Burn(ctx, common.HexToAddress(fromAddr), big.NewInt(amount), signerKey)
+}

--- a/backend/internal/services/spend_service.go
+++ b/backend/internal/services/spend_service.go
@@ -132,12 +132,19 @@ func (s *SpendService) reserveSpend(tx *gorm.DB, userID uuid.UUID, amount int64)
 }
 
 func (s *SpendService) rollbackSpendReservation(tx *gorm.DB, userID uuid.UUID, amount int64) error {
-	return tx.Model(&models.TachiBalance{}).
+	result := tx.Model(&models.TachiBalance{}).
 		Where("user_id = ?", userID).
 		Updates(map[string]interface{}{
 			"balance":    gorm.Expr("balance + ?", amount),
 			"updated_at": time.Now(),
-		}).Error
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("rollback found no balance row for user %s", userID)
+	}
+	return nil
 }
 
 func (s *SpendService) resolveWalletAddress(db *gorm.DB, userID uuid.UUID) (string, error) {

--- a/backend/internal/services/spend_service_test.go
+++ b/backend/internal/services/spend_service_test.go
@@ -24,10 +24,7 @@ type burnCall struct {
 
 func (m *mockBurnCaller) BurnOnChain(_ context.Context, fromAddr string, amount int64) (string, error) {
 	m.calls = append(m.calls, burnCall{fromAddr: fromAddr, amount: amount})
-	if m.err != nil {
-		return "", m.err
-	}
-	return m.txHash, nil
+	return m.txHash, m.err
 }
 
 // ── seed helpers ─────────────────────────────────────────────────────────────
@@ -113,6 +110,29 @@ func TestRedeem_WalletNotLinked(t *testing.T) {
 	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
 	if dbBal != 200 {
 		t.Fatalf("expected balance unchanged at 200, got %d", dbBal)
+	}
+}
+
+func TestRedeem_BurnBroadcastedButReceiptUnknown(t *testing.T) {
+	db := newTestDB(t)
+	// Simulates: tx was broadcast (txHash returned) but WaitMined failed
+	burnCaller := &mockBurnCaller{txHash: "0xbroadcasted", err: errors.New("context deadline exceeded")}
+	svc := &SpendService{db: db, burnCaller: burnCaller}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 300)
+
+	_, err := svc.Redeem(context.Background(), userID, 100)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	// DB reservation must NOT be rolled back: chain may have burned the tokens
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 200 {
+		t.Fatalf("expected balance kept at 200 (no rollback), got %d", dbBal)
 	}
 }
 

--- a/backend/internal/services/spend_service_test.go
+++ b/backend/internal/services/spend_service_test.go
@@ -1,0 +1,138 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ── mock BurnCaller ──────────────────────────────────────────────────────────
+
+type mockBurnCaller struct {
+	txHash string
+	err    error
+	calls  []burnCall
+}
+
+type burnCall struct {
+	fromAddr string
+	amount   int64
+}
+
+func (m *mockBurnCaller) BurnOnChain(_ context.Context, fromAddr string, amount int64) (string, error) {
+	m.calls = append(m.calls, burnCall{fromAddr: fromAddr, amount: amount})
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.txHash, nil
+}
+
+// ── seed helpers ─────────────────────────────────────────────────────────────
+
+func seedTachiBalance(t *testing.T, db *gorm.DB, userID uuid.UUID, balance int64) {
+	t.Helper()
+	if err := db.Exec(`
+		INSERT INTO tachi_balances (id, user_id, balance, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+	`, uuid.New().String(), userID.String(), balance).Error; err != nil {
+		t.Fatalf("seedTachiBalance: %v", err)
+	}
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestRedeem_Success(t *testing.T) {
+	db := newTestDB(t)
+	burnCaller := &mockBurnCaller{txHash: "0xburn123"}
+	svc := &SpendService{db: db, burnCaller: burnCaller}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 500)
+
+	newBal, err := svc.Redeem(context.Background(), userID, 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if newBal != 400 {
+		t.Fatalf("expected newBalance=400, got %d", newBal)
+	}
+	if len(burnCaller.calls) != 1 {
+		t.Fatalf("expected 1 burn call, got %d", len(burnCaller.calls))
+	}
+	if burnCaller.calls[0].amount != 100 {
+		t.Fatalf("expected burn amount=100, got %d", burnCaller.calls[0].amount)
+	}
+	if burnCaller.calls[0].fromAddr != "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" {
+		t.Fatalf("unexpected burn fromAddr: %s", burnCaller.calls[0].fromAddr)
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 400 {
+		t.Fatalf("expected db balance=400, got %d", dbBal)
+	}
+}
+
+func TestRedeem_InsufficientBalance(t *testing.T) {
+	db := newTestDB(t)
+	svc := &SpendService{db: db}
+
+	userID := userIDForClaim(t, db)
+	seedTachiBalance(t, db, userID, 50)
+
+	_, err := svc.Redeem(context.Background(), userID, 100)
+	if !errors.Is(err, ErrSpendInsufficientBalance) {
+		t.Fatalf("expected ErrSpendInsufficientBalance, got %v", err)
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 50 {
+		t.Fatalf("expected balance unchanged at 50, got %d", dbBal)
+	}
+}
+
+func TestRedeem_WalletNotLinked(t *testing.T) {
+	db := newTestDB(t)
+	svc := &SpendService{db: db}
+
+	userID := userIDForClaim(t, db)
+	seedTachiBalance(t, db, userID, 200)
+	// no web3 provider seeded
+
+	_, err := svc.Redeem(context.Background(), userID, 100)
+	if !errors.Is(err, ErrSpendWalletNotLinked) {
+		t.Fatalf("expected ErrSpendWalletNotLinked, got %v", err)
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 200 {
+		t.Fatalf("expected balance unchanged at 200, got %d", dbBal)
+	}
+}
+
+func TestRedeem_BurnFailureRollback(t *testing.T) {
+	db := newTestDB(t)
+	burnCaller := &mockBurnCaller{err: errors.New("burn reverted")}
+	svc := &SpendService{db: db, burnCaller: burnCaller}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 300)
+
+	_, err := svc.Redeem(context.Background(), userID, 100)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 300 {
+		t.Fatalf("expected balance rolled back to 300, got %d", dbBal)
+	}
+}

--- a/docs/superpowers/plans/2026-04-11-spend-service.md
+++ b/docs/superpowers/plans/2026-04-11-spend-service.md
@@ -1,0 +1,793 @@
+# SpendService 實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 實作 `SpendService.Redeem()` 讓用戶花費 `$TACHI` 換折價券（呼叫合約 `burn()`，成功後扣 DB），並掛上 `POST /api/v1/spend/redeem` endpoint。
+
+**Architecture:** 與 `ClaimService` 鏡像——reserve-then-burn：先在 DB txn 內鎖定餘額、解析 wallet、扣除 `tachi_balances`，再呼叫合約 `BurnOnChain`；若 burn 失敗則 rollback DB。`TachiToken.Burn()` 仿照 `TachiToken.Mint()` 新增。
+
+**Tech Stack:** Go 1.21, Gin, GORM, go-ethereum, SQLite (tests), PostgreSQL (prod)
+
+---
+
+## 檔案清單
+
+| 操作 | 路徑 |
+|---|---|
+| 修改 | `backend/internal/contract/tachi_token.go` |
+| 新增 | `backend/internal/services/spend_service.go` |
+| 新增 | `backend/internal/services/spend_service_test.go` |
+| 新增 | `backend/internal/handlers/spend_handler.go` |
+| 修改 | `backend/internal/router/router.go` |
+| 修改 | `backend/cmd/server/main.go` |
+
+---
+
+## Task 0：建立 feature branch
+
+- [ ] **Step 1：從 develop 建立並切換 branch**
+
+```bash
+git checkout develop && git pull
+git checkout -b feat/spend-service
+```
+
+期望：`Switched to a new branch 'feat/spend-service'`
+
+---
+
+## Task 1：新增 `TachiToken.Burn()`
+
+**Files:**
+- Modify: `backend/internal/contract/tachi_token.go`
+
+- [ ] **Step 1：在 `tachi_token.go` 末尾新增 `Burn()` 方法**
+
+在檔案最後（第 128 行後）加入：
+
+```go
+func (t *TachiToken) Burn(ctx context.Context, fromAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.client == nil {
+		return "", fmt.Errorf("eth client is nil")
+	}
+	if signerKey == nil {
+		return "", fmt.Errorf("signer key is nil")
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return "", fmt.Errorf("amount must be greater than zero")
+	}
+
+	fromSignerAddr := crypto.PubkeyToAddress(signerKey.PublicKey)
+	data, err := t.abi.Pack("burn", fromAddr, amount)
+	if err != nil {
+		return "", fmt.Errorf("pack burn calldata: %w", err)
+	}
+
+	chainID, err := t.client.ChainID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get chain ID: %w", err)
+	}
+
+	nonce, err := t.client.PendingNonceAt(ctx, fromSignerAddr)
+	if err != nil {
+		return "", fmt.Errorf("get pending nonce: %w", err)
+	}
+
+	tipCap, err := t.client.SuggestGasTipCap(ctx)
+	if err != nil {
+		return "", fmt.Errorf("suggest gas tip cap: %w", err)
+	}
+
+	header, err := t.client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("get latest header: %w", err)
+	}
+	if header.BaseFee == nil {
+		return "", fmt.Errorf("latest header missing base fee")
+	}
+
+	feeCap := new(big.Int).Mul(header.BaseFee, big.NewInt(2))
+	feeCap.Add(feeCap, tipCap)
+
+	callMsg := ethereum.CallMsg{
+		From:      fromSignerAddr,
+		To:        &t.address,
+		GasFeeCap: feeCap,
+		GasTipCap: tipCap,
+		Data:      data,
+	}
+	gasLimit, err := t.client.EstimateGas(ctx, callMsg)
+	if err != nil {
+		return "", fmt.Errorf("estimate gas: %w", err)
+	}
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: tipCap,
+		GasFeeCap: feeCap,
+		Gas:       gasLimit,
+		To:        &t.address,
+		Data:      data,
+	})
+
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), signerKey)
+	if err != nil {
+		return "", fmt.Errorf("sign burn tx: %w", err)
+	}
+
+	if err := t.client.SendTransaction(ctx, signedTx); err != nil {
+		return "", fmt.Errorf("send burn tx: %w", err)
+	}
+	receipt, err := bind.WaitMined(ctx, t.client, signedTx)
+	if err != nil {
+		return "", fmt.Errorf("wait burn receipt: %w", err)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return "", fmt.Errorf("burn tx failed: %s", signedTx.Hash().Hex())
+	}
+
+	return signedTx.Hash().Hex(), nil
+}
+```
+
+- [ ] **Step 2：確認編譯通過**
+
+```bash
+cd backend && go build ./internal/contract/...
+```
+
+期望：無錯誤輸出
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add backend/internal/contract/tachi_token.go
+git commit -m "feat: add TachiToken.Burn() method
+
+refs #186
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2：寫 `spend_service_test.go`（TDD 先寫測試）
+
+**Files:**
+- Create: `backend/internal/services/spend_service_test.go`
+
+- [ ] **Step 1：建立測試檔案**
+
+建立 `backend/internal/services/spend_service_test.go`：
+
+```go
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ── mock BurnCaller ──────────────────────────────────────────────────────────
+
+type mockBurnCaller struct {
+	txHash string
+	err    error
+	calls  []burnCall
+}
+
+type burnCall struct {
+	fromAddr string
+	amount   int64
+}
+
+func (m *mockBurnCaller) BurnOnChain(_ context.Context, fromAddr string, amount int64) (string, error) {
+	m.calls = append(m.calls, burnCall{fromAddr: fromAddr, amount: amount})
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.txHash, nil
+}
+
+// ── seed helpers ─────────────────────────────────────────────────────────────
+
+func seedTachiBalance(t *testing.T, db *gorm.DB, userID uuid.UUID, balance int64) {
+	t.Helper()
+	if err := db.Exec(`
+		INSERT INTO tachi_balances (id, user_id, balance, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+	`, uuid.New().String(), userID.String(), balance).Error; err != nil {
+		t.Fatalf("seedTachiBalance: %v", err)
+	}
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestRedeem_Success(t *testing.T) {
+	db := newTestDB(t)
+	burnCaller := &mockBurnCaller{txHash: "0xburn123"}
+	svc := &SpendService{db: db, burnCaller: burnCaller}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 500)
+
+	newBal, err := svc.Redeem(context.Background(), userID, 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if newBal != 400 {
+		t.Fatalf("expected newBalance=400, got %d", newBal)
+	}
+	if len(burnCaller.calls) != 1 {
+		t.Fatalf("expected 1 burn call, got %d", len(burnCaller.calls))
+	}
+	if burnCaller.calls[0].amount != 100 {
+		t.Fatalf("expected burn amount=100, got %d", burnCaller.calls[0].amount)
+	}
+	if burnCaller.calls[0].fromAddr != "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" {
+		t.Fatalf("unexpected burn fromAddr: %s", burnCaller.calls[0].fromAddr)
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 400 {
+		t.Fatalf("expected db balance=400, got %d", dbBal)
+	}
+}
+
+func TestRedeem_InsufficientBalance(t *testing.T) {
+	db := newTestDB(t)
+	svc := &SpendService{db: db}
+
+	userID := userIDForClaim(t, db)
+	seedTachiBalance(t, db, userID, 50)
+
+	_, err := svc.Redeem(context.Background(), userID, 100)
+	if !errors.Is(err, ErrSpendInsufficientBalance) {
+		t.Fatalf("expected ErrSpendInsufficientBalance, got %v", err)
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 50 {
+		t.Fatalf("expected balance unchanged at 50, got %d", dbBal)
+	}
+}
+
+func TestRedeem_WalletNotLinked(t *testing.T) {
+	db := newTestDB(t)
+	svc := &SpendService{db: db}
+
+	userID := userIDForClaim(t, db)
+	seedTachiBalance(t, db, userID, 200)
+	// no web3 provider seeded
+
+	_, err := svc.Redeem(context.Background(), userID, 100)
+	if !errors.Is(err, ErrSpendWalletNotLinked) {
+		t.Fatalf("expected ErrSpendWalletNotLinked, got %v", err)
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 200 {
+		t.Fatalf("expected balance unchanged at 200, got %d", dbBal)
+	}
+}
+
+func TestRedeem_BurnFailureRollback(t *testing.T) {
+	db := newTestDB(t)
+	burnCaller := &mockBurnCaller{err: errors.New("burn reverted")}
+	svc := &SpendService{db: db, burnCaller: burnCaller}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 300)
+
+	_, err := svc.Redeem(context.Background(), userID, 100)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 300 {
+		t.Fatalf("expected balance rolled back to 300, got %d", dbBal)
+	}
+}
+```
+
+- [ ] **Step 2：確認測試失敗（SpendService 尚未存在）**
+
+```bash
+cd backend && go test ./internal/services/ -run "TestRedeem" -v 2>&1 | head -20
+```
+
+期望：編譯錯誤 `undefined: SpendService` 或類似
+
+- [ ] **Step 3：Commit 測試檔**
+
+```bash
+git add backend/internal/services/spend_service_test.go
+git commit -m "test: add SpendService.Redeem unit tests (failing)
+
+refs #186
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3：實作 `spend_service.go`
+
+**Files:**
+- Create: `backend/internal/services/spend_service.go`
+
+- [ ] **Step 1：建立 `spend_service.go`**
+
+建立 `backend/internal/services/spend_service.go`：
+
+```go
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/tachigo/tachigo/internal/config"
+	contractpkg "github.com/tachigo/tachigo/internal/contract"
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+var (
+	ErrSpendAmountInvalid       = errors.New("spend amount must be greater than zero")
+	ErrSpendInsufficientBalance = errors.New("insufficient tachi balance")
+	ErrSpendWalletNotLinked     = errors.New("web3 wallet not linked")
+	ErrSpendContractConfig      = errors.New("spend contract config is incomplete")
+)
+
+// BurnCaller abstracts the on-chain burn call; replaced with a mock in tests.
+type BurnCaller interface {
+	BurnOnChain(ctx context.Context, fromAddr string, amount int64) (txHash string, err error)
+}
+
+type SpendService struct {
+	db          *gorm.DB
+	contractCfg config.ContractConfig
+	tachiToken  *contractpkg.TachiToken
+	burnCaller  BurnCaller
+}
+
+type spendReservation struct {
+	fromAddr   string
+	amount     int64
+	newBalance int64
+}
+
+func NewSpendService(db *gorm.DB, contractCfg config.ContractConfig, ethClient *ethclient.Client) *SpendService {
+	svc := &SpendService{
+		db:          db,
+		contractCfg: contractCfg,
+	}
+	if ethClient != nil && contractCfg.TachiContractAddress != "" && contractCfg.SepoliaSignerKey != "" {
+		if common.IsHexAddress(contractCfg.TachiContractAddress) {
+			t, err := contractpkg.NewTachiToken(common.HexToAddress(contractCfg.TachiContractAddress), ethClient)
+			if err == nil {
+				svc.tachiToken = t
+			}
+		}
+	}
+	svc.burnCaller = svc
+	return svc
+}
+
+// SetBurnCallerForTest replaces the burn caller; use only in tests.
+func (s *SpendService) SetBurnCallerForTest(bc BurnCaller) { s.burnCaller = bc }
+
+// Redeem burns `amount` $TACHI from the user's on-chain wallet and deducts
+// the same amount from tachi_balances. Returns the new balance.
+func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, amount int64) (int64, error) {
+	if amount <= 0 {
+		return 0, ErrSpendAmountInvalid
+	}
+
+	var reservation spendReservation
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		reservation, err = s.reserveSpend(tx, userID, amount)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	burnCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if _, err := s.burnCaller.BurnOnChain(burnCtx, reservation.fromAddr, reservation.amount); err != nil {
+		rollbackErr := s.db.Transaction(func(tx *gorm.DB) error {
+			return s.rollbackSpendReservation(tx, userID, reservation.amount)
+		})
+		if rollbackErr != nil {
+			return 0, fmt.Errorf("%w; rollback spend reservation: %v", err, rollbackErr)
+		}
+		return 0, err
+	}
+
+	return reservation.newBalance, nil
+}
+
+func (s *SpendService) reserveSpend(tx *gorm.DB, userID uuid.UUID, amount int64) (spendReservation, error) {
+	var tb models.TachiBalance
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("user_id = ?", userID).
+		First(&tb).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return spendReservation{}, ErrSpendInsufficientBalance
+		}
+		return spendReservation{}, err
+	}
+	if tb.Balance < amount {
+		return spendReservation{}, ErrSpendInsufficientBalance
+	}
+
+	fromAddr, err := s.resolveWalletAddress(tx, userID)
+	if err != nil {
+		return spendReservation{}, err
+	}
+
+	newBalance := tb.Balance - amount
+	if err := tx.Model(&models.TachiBalance{}).
+		Where("user_id = ?", userID).
+		Updates(map[string]interface{}{
+			"balance":    newBalance,
+			"updated_at": time.Now(),
+		}).Error; err != nil {
+		return spendReservation{}, err
+	}
+
+	return spendReservation{
+		fromAddr:   fromAddr,
+		amount:     amount,
+		newBalance: newBalance,
+	}, nil
+}
+
+func (s *SpendService) rollbackSpendReservation(tx *gorm.DB, userID uuid.UUID, amount int64) error {
+	return tx.Model(&models.TachiBalance{}).
+		Where("user_id = ?", userID).
+		Updates(map[string]interface{}{
+			"balance":    gorm.Expr("balance + ?", amount),
+			"updated_at": time.Now(),
+		}).Error
+}
+
+func (s *SpendService) resolveWalletAddress(db *gorm.DB, userID uuid.UUID) (string, error) {
+	var authProvider models.AuthProvider
+	err := db.Where("user_id = ? AND provider = ?", userID, models.ProviderWeb3).
+		Order("created_at ASC").
+		First(&authProvider).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", ErrSpendWalletNotLinked
+		}
+		return "", err
+	}
+	if !common.IsHexAddress(authProvider.ProviderID) {
+		return "", fmt.Errorf("invalid linked wallet address: %s", authProvider.ProviderID)
+	}
+	return common.HexToAddress(authProvider.ProviderID).Hex(), nil
+}
+
+// BurnOnChain implements BurnCaller using the real TachiToken contract.
+func (s *SpendService) BurnOnChain(ctx context.Context, fromAddr string, amount int64) (string, error) {
+	if s.tachiToken == nil {
+		return "", ErrSpendContractConfig
+	}
+	if !common.IsHexAddress(fromAddr) {
+		return "", fmt.Errorf("invalid wallet address: %s", fromAddr)
+	}
+	if amount <= 0 {
+		return "", ErrSpendAmountInvalid
+	}
+
+	signerKey, err := parseSignerKey(s.contractCfg.SepoliaSignerKey)
+	if err != nil {
+		return "", err
+	}
+
+	return s.tachiToken.Burn(ctx, common.HexToAddress(fromAddr), big.NewInt(amount), signerKey)
+}
+```
+
+- [ ] **Step 2：執行測試，確認全部通過**
+
+```bash
+cd backend && go test ./internal/services/ -run "TestRedeem" -v
+```
+
+期望輸出：
+
+```
+--- PASS: TestRedeem_Success (0.00s)
+--- PASS: TestRedeem_InsufficientBalance (0.00s)
+--- PASS: TestRedeem_WalletNotLinked (0.00s)
+--- PASS: TestRedeem_BurnFailureRollback (0.00s)
+PASS
+```
+
+- [ ] **Step 3：執行完整測試，確認無 regression**
+
+```bash
+cd backend && go test ./...
+```
+
+期望：`ok` 或 `no test files` 對每個 package，無 FAIL
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add backend/internal/services/spend_service.go
+git commit -m "feat: implement SpendService.Redeem with reserve-then-burn flow
+
+refs #186
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4：實作 `SpendHandler`
+
+**Files:**
+- Create: `backend/internal/handlers/spend_handler.go`
+
+- [ ] **Step 1：建立 `spend_handler.go`**
+
+建立 `backend/internal/handlers/spend_handler.go`：
+
+```go
+package handlers
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+type SpendHandler struct {
+	spendSvc *services.SpendService
+}
+
+func NewSpendHandler(spendSvc *services.SpendService) *SpendHandler {
+	return &SpendHandler{spendSvc: spendSvc}
+}
+
+type redeemRequest struct {
+	Amount int64 `json:"amount"`
+}
+
+type redeemResponse struct {
+	Balance int64 `json:"balance"`
+}
+
+// Redeem godoc
+// @Summary      Redeem $TACHI for a discount coupon
+// @Tags         spend
+// @Accept       json
+// @Produce      json
+// @Param        body body redeemRequest true "Amount to burn"
+// @Success      200 {object} Response{data=redeemResponse}
+// @Failure      400 {object} Response
+// @Failure      401 {object} Response
+// @Failure      500 {object} Response
+// @Security     BearerAuth
+// @Router       /spend/redeem [post]
+func (h *SpendHandler) Redeem(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+
+	var req redeemRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		badRequest(c, "invalid request body: "+err.Error())
+		return
+	}
+	if req.Amount <= 0 {
+		badRequest(c, "amount must be > 0")
+		return
+	}
+
+	newBalance, err := h.spendSvc.Redeem(c.Request.Context(), userID, req.Amount)
+	if err != nil {
+		if errors.Is(err, services.ErrSpendInsufficientBalance) {
+			badRequest(c, err.Error())
+			return
+		}
+		if errors.Is(err, services.ErrSpendWalletNotLinked) {
+			badRequest(c, err.Error())
+			return
+		}
+		if errors.Is(err, services.ErrSpendAmountInvalid) {
+			badRequest(c, err.Error())
+			return
+		}
+		internal(c)
+		return
+	}
+
+	ok(c, redeemResponse{Balance: newBalance})
+}
+```
+
+- [ ] **Step 2：確認編譯**
+
+```bash
+cd backend && go build ./internal/handlers/...
+```
+
+期望：無錯誤
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add backend/internal/handlers/spend_handler.go
+git commit -m "feat: add SpendHandler POST /spend/redeem
+
+refs #186
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5：Wire router 與 main
+
+**Files:**
+- Modify: `backend/internal/router/router.go`
+- Modify: `backend/cmd/server/main.go`
+
+- [ ] **Step 1：更新 `router.go`**
+
+在 `router.go` 的 `New()` 函式簽名加入 `spendSvc *services.SpendService` 參數（放在 `claimSvc` 後面）：
+
+```go
+func New(
+	authSvc *services.AuthService,
+	userSvc *services.UserService,
+	addrSvc *services.AddressService,
+	extSvc *services.ExtensionService,
+	emailAuthSvc *services.EmailAuthService,
+	watchSvc *services.WatchService,
+	channelConfigSvc *services.ChannelConfigService,
+	pointsSvc *services.PointsService,
+	airdropSvc *services.AirdropService,
+	streamerSvc *services.StreamerService,
+	agencySvc *services.AgencyService,
+	claimSvc *services.ClaimService,
+	spendSvc *services.SpendService,
+	agencyHandler *handlers.AgencyHandler,
+	allowedOrigins []string,
+	internalRouterConfig ...InternalRouterConfig,
+) *gin.Engine {
+```
+
+在函式內，`claimH` 初始化後加入：
+
+```go
+spendH := handlers.NewSpendHandler(spendSvc)
+```
+
+在 `protected` group 內加入新路由（放在 claim 路由附近）：
+
+```go
+// $TACHI spend (burn)
+protected.POST("spend/redeem", spendH.Redeem)
+```
+
+- [ ] **Step 2：更新 `main.go`**
+
+在 `claimSvc := services.NewClaimService(...)` 後加入：
+
+```go
+spendSvc := services.NewSpendService(db, cfg.Contract, ethClient)
+```
+
+在 `router.New(...)` 呼叫中，`claimSvc` 後加入 `spendSvc`：
+
+```go
+r := router.New(
+	authSvc,
+	userSvc,
+	addrSvc,
+	extSvc,
+	emailAuthSvc,
+	watchSvc,
+	channelConfigSvc,
+	pointsSvc,
+	airdropSvc,
+	streamerSvc,
+	agencySvc,
+	claimSvc,
+	spendSvc,
+	agencyH,
+	allowedOrigins,
+	router.InternalRouterConfig{DB: db, Config: cfg},
+)
+```
+
+- [ ] **Step 3：確認 router_test.go 編譯（需要更新 test helper）**
+
+查看 `backend/internal/router/router_test.go` 的 `New()` 呼叫，加入 `nil`（spendSvc）佔位：
+
+```bash
+cd backend && grep -n "router.New\|New(" internal/router/router_test.go | head -10
+```
+
+若測試檔案中有呼叫 `router.New()`，對應位置加入 `nil` 作為 `spendSvc`。
+
+- [ ] **Step 4：完整 build + test**
+
+```bash
+cd backend && go build ./...
+```
+
+期望：無錯誤
+
+```bash
+cd backend && go test ./...
+```
+
+期望：所有 package PASS，無 FAIL
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add backend/internal/router/router.go backend/cmd/server/main.go
+git commit -m "feat: wire SpendService and POST /api/v1/spend/redeem route
+
+closes #186
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6：最終驗證與 push
+
+- [ ] **Step 1：最終驗證**
+
+```bash
+cd backend && go build ./... && go test ./...
+```
+
+期望：`go build ./...` 無錯誤，`go test ./...` 全部 PASS
+
+- [ ] **Step 2：Push**
+
+```bash
+git push -u origin feat/spend-service
+```

--- a/docs/superpowers/plans/2026-04-11-spend-service.md
+++ b/docs/superpowers/plans/2026-04-11-spend-service.md
@@ -524,7 +524,7 @@ cd backend && go test ./internal/services/ -run "TestRedeem" -v
 
 期望輸出：
 
-```
+```text
 --- PASS: TestRedeem_Success (0.00s)
 --- PASS: TestRedeem_InsufficientBalance (0.00s)
 --- PASS: TestRedeem_WalletNotLinked (0.00s)

--- a/docs/superpowers/specs/2026-04-11-spend-service-design.md
+++ b/docs/superpowers/specs/2026-04-11-spend-service-design.md
@@ -2,7 +2,7 @@
 
 **Issue**: #186  
 **日期**: 2026-04-11  
-**狀態**: 待實作
+**狀態**: 已完成（feat/spend-service → PR #187）
 
 ---
 
@@ -27,7 +27,7 @@
 | `backend/internal/services/spend_service.go` | 新檔：SpendService |
 | `backend/internal/handlers/spend_handler.go` | 新檔：SpendHandler |
 | `backend/internal/router/router.go` | 注入 SpendService / SpendHandler，掛 route |
-| `backend/cmd/api/main.go` | wire SpendService |
+| `backend/cmd/server/main.go` | wire SpendService |
 | `backend/internal/services/spend_service_test.go` | 新檔：單元測試 |
 
 ---
@@ -85,7 +85,7 @@ Body:  { "amount": 100 }        // 必填，> 0
 
 ## Transaction 流程（方案 A：reserve-then-burn）
 
-```
+```text
 1. DB txn (SELECT FOR UPDATE):
    a. 取得 tachi_balances WHERE user_id（lock row）
       → 不存在或 balance < amount → ErrSpendInsufficientBalance (400)
@@ -93,13 +93,17 @@ Body:  { "amount": 100 }        // 必填，> 0
       → 找不到 → ErrSpendWalletNotLinked (400)
    c. UPDATE tachi_balances SET balance = balance - amount（reservation）
 
-2. BurnOnChain(walletAddr, amount) — 30s timeout
-   → 失敗 → rollback DB（UPDATE balance = balance + amount）→ 500
+2. BurnOnChain(walletAddr, amount) — 30s timeout，回傳 (txHash, err)
+   → err != nil AND txHash == ""：tx 未送出 → rollback DB → 500
+   → err != nil AND txHash != ""：tx 已廣播但收據未知 → 不 rollback，回傳 error → 500
+   → err == nil：burn 成功
 
 3. 回傳 newBalance（= reservation 後的值）
 ```
 
-**關鍵設計決策**：wallet 解析在 DB txn 內執行。若 wallet 找不到，txn 直接 rollback，不需要額外還原 balance。這與 `ClaimService.reserveClaim()` 的模式一致。
+**關鍵設計決策**：
+- wallet 解析在 DB txn 內執行。若 wallet 找不到，txn 直接 rollback，不需要額外還原 balance。
+- `BurnOnChain` 在 `SendTransaction` 成功、`WaitMined` 失敗時回傳 `(txHash, err)`，Redeem 以 txHash 是否為空判斷是否 rollback，避免鏈上已扣款、DB 卻恢復的一致性問題。
 
 ---
 

--- a/docs/superpowers/specs/2026-04-11-spend-service-design.md
+++ b/docs/superpowers/specs/2026-04-11-spend-service-design.md
@@ -1,0 +1,138 @@
+# SpendService 設計文件
+
+**Issue**: #186  
+**日期**: 2026-04-11  
+**狀態**: 待實作
+
+---
+
+## 背景
+
+用戶花費 `$TACHI`（`tachi_balances`）換折價券的消費路徑。呼叫合約 `TachiToken.burn(address, amount)` 銷毀鏈上代幣，再扣除 DB 中的 `tachi_balances.balance`。
+
+依賴：
+- #166 合約 `burn()` ABI 已就位
+- #174 合約部署到 Sepolia
+- #178 後端 env var 已設定
+
+---
+
+## 架構
+
+### 檔案異動
+
+| 檔案 | 操作 |
+|---|---|
+| `backend/internal/contract/tachi_token.go` | 新增 `Burn()` 方法 |
+| `backend/internal/services/spend_service.go` | 新檔：SpendService |
+| `backend/internal/handlers/spend_handler.go` | 新檔：SpendHandler |
+| `backend/internal/router/router.go` | 注入 SpendService / SpendHandler，掛 route |
+| `backend/cmd/api/main.go` | wire SpendService |
+| `backend/internal/services/spend_service_test.go` | 新檔：單元測試 |
+
+---
+
+## 介面規格
+
+### BurnCaller interface
+
+```go
+type BurnCaller interface {
+    BurnOnChain(ctx context.Context, fromAddr string, amount int64) (txHash string, err error)
+}
+```
+
+### SpendService
+
+```go
+type SpendService struct {
+    db          *gorm.DB
+    contractCfg config.ContractConfig
+    tachiToken  *contractpkg.TachiToken
+    burnCaller  BurnCaller
+}
+
+func NewSpendService(db *gorm.DB, contractCfg config.ContractConfig, ethClient *ethclient.Client) *SpendService
+
+func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, amount int64) (newBalance int64, err error)
+
+// SetBurnCallerForTest replaces the burn caller; use only in tests.
+func (s *SpendService) SetBurnCallerForTest(bc BurnCaller)
+```
+
+### TachiToken.Burn（新增）
+
+```go
+func (t *TachiToken) Burn(ctx context.Context, fromAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (string, error)
+```
+
+---
+
+## API
+
+```
+POST /api/v1/spend/redeem
+Authorization: Bearer <jwt>
+Content-Type: application/json
+
+Body:  { "amount": 100 }        // 必填，> 0
+200:   { "balance": 900 }
+400:   餘額不足 / 錢包未綁定 / amount <= 0
+500:   合約呼叫失敗
+```
+
+---
+
+## Transaction 流程（方案 A：reserve-then-burn）
+
+```
+1. DB txn (SELECT FOR UPDATE):
+   a. 取得 tachi_balances WHERE user_id（lock row）
+      → 不存在或 balance < amount → ErrSpendInsufficientBalance (400)
+   b. resolveWalletAddress(auth_providers, provider=web3)
+      → 找不到 → ErrSpendWalletNotLinked (400)
+   c. UPDATE tachi_balances SET balance = balance - amount（reservation）
+
+2. BurnOnChain(walletAddr, amount) — 30s timeout
+   → 失敗 → rollback DB（UPDATE balance = balance + amount）→ 500
+
+3. 回傳 newBalance（= reservation 後的值）
+```
+
+**關鍵設計決策**：wallet 解析在 DB txn 內執行。若 wallet 找不到，txn 直接 rollback，不需要額外還原 balance。這與 `ClaimService.reserveClaim()` 的模式一致。
+
+---
+
+## 錯誤定義
+
+```go
+var (
+    ErrSpendAmountInvalid       = errors.New("spend amount must be greater than zero")
+    ErrSpendInsufficientBalance = errors.New("insufficient tachi balance")
+    ErrSpendWalletNotLinked     = errors.New("web3 wallet not linked")
+    ErrSpendContractConfig      = errors.New("spend contract config is incomplete")
+)
+```
+
+---
+
+## 測試計畫
+
+| 測試名稱 | 情境 | 驗證點 |
+|---|---|---|
+| `TestRedeem_Success` | 正常流程 | newBalance 正確、BurnCaller 被呼叫 1 次、fromAddr 正確 |
+| `TestRedeem_InsufficientBalance` | tachi_balances.balance < amount | 回傳 ErrSpendInsufficientBalance，balance 不變 |
+| `TestRedeem_WalletNotLinked` | 無 web3 auth_provider | 回傳 ErrSpendWalletNotLinked，balance 不變 |
+| `TestRedeem_BurnFailureRollback` | BurnCaller 回傳 error | balance 還原為扣除前的值 |
+
+使用 SQLite in-memory DB + mock BurnCaller，與 `claim_service_test.go` 相同模式。
+
+---
+
+## 本票明確不做
+
+- 不實作折價券系統本身（coupon 發放、驗證邏輯）
+- 不動 ClaimService 或既有記帳架構
+- 不做 SIWE 錢包綁定
+- 不部署到 mainnet
+- 不引入 Gas 補貼機制


### PR DESCRIPTION
## 什麼改動

新增 SpendService / SpendHandler，讓用戶花費 \$TACHI 換折價券：
- `TachiToken.Burn()` — 呼叫合約 `burn(address, uint256)`
- `SpendService.Redeem()` — reserve-then-burn 流程，burn 失敗自動 rollback DB
- `POST /api/v1/spend/redeem` — JWT 認證 endpoint
- 修復 `router_test.go` pre-existing `NewClaimService` 引數不足（build failed）

## 為什麼

支援 demo 消費路徑。從 #112 單獨拉出，依賴鏈（#166 合約、#174 部署、#178 env var）已全部 merge。

closes #186

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：#186
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作折價券系統本身（coupon 發放、驗證邏輯）
  - 不動 ClaimService 或既有記帳架構
  - 不做 SIWE 錢包綁定
  - 不部署到 mainnet
  - 不引入 Gas 補貼機制
  - 不處理 #112 其餘任務（mint 升級、tachi_balances 鏈上同步、Cron Job、Gas 補貼）

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試（TestRedeem x4 全通過）

## 備註

最後一個完成條件（Sepolia Etherscan burn 事件確認）需部署環境手動驗證。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 發行說明

* **新功能**
  * 新增「兌換折價券」功能：用戶現可通過 `POST /api/v1/spend/redeem` 端點兌換 $TACHI 代幣，進行鏈上銷毀並扣除餘額。該功能採用預留後銷毀流程，確保扣減和鏈上操作的原子性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->