### PR TITLE
[backend] fix: SQLite per-connection pragma in concurrent airdrop test

### DIFF
--- a/backend/internal/services/airdrop_service_test.go
+++ b/backend/internal/services/airdrop_service_test.go
@@ -494,7 +494,12 @@ func newConcurrentTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 
 	dbPath := t.TempDir() + "/airdrop-concurrency.db"
-	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+	// PRAGMAs in the DSN are applied per-connection by the SQLite driver, so
+	// every connection in the pool gets busy_timeout, WAL mode, and foreign
+	// keys — unlike executing PRAGMA statements after Open, which only affects
+	// the single connection that runs the query.
+	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=on"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger:         logger.Default.LogMode(logger.Silent),
 		TranslateError: true,
 	})
@@ -508,17 +513,6 @@ func newConcurrentTestDB(t *testing.T) *gorm.DB {
 	}
 	sqlDB.SetMaxOpenConns(8)
 	sqlDB.SetMaxIdleConns(8)
-
-	pragmas := []string{
-		`PRAGMA foreign_keys = ON`,
-		`PRAGMA journal_mode = WAL`,
-		`PRAGMA busy_timeout = 5000`,
-	}
-	for _, stmt := range pragmas {
-		if err := db.Exec(stmt).Error; err != nil {
-			t.Fatalf("apply pragma %q: %v", stmt, err)
-		}
-	}
 
 	if err := migrateTestDB(db); err != nil {
 		t.Fatalf("migrate concurrent test db: %v", err)


### PR DESCRIPTION
## 什麼改動

`newConcurrentTestDB` 原本用 `PRAGMA` SQL 語句設定 `busy_timeout`、`journal_mode`、`foreign_keys`，但這些設定只作用於執行該語句的單一 connection。設了 `SetMaxOpenConns(8)` 後，pool 裡其他 connection 缺少這些設定，concurrent goroutine 在 CI 環境下會直接拿到 "database is locked" 錯誤，導致 `TestAirdrop_ConcurrentExecute_DoesNotExceedDailyLimit` 偶發失敗。

改成把設定放進 DSN（`?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=on`），SQLite driver 每次開啟新 connection 時自動套用。

## 為什麼

CI 後端測試偶發失敗，根本原因是 SQLite pragma per-connection 問題，與 #70 的 airdrop service 實作相關。

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：issue #70
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - airdrop service 邏輯修改
  - schema / migration 異動
  - 其他 service 測試異動

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

執行：
```
docker compose run --no-deps --rm app go test ./internal/services/ -run TestAirdrop_ConcurrentExecute_DoesNotExceedDailyLimit -v -count=3
```

3 次全數 PASS，無 "database is locked" 錯誤。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 优化了测试数据库的 SQLite 连接配置方式，以提高测试的可靠性和性能。

---

**注：** 此版本不包含面向用户的新功能或修复。所有更改都是内部测试基础设施的改进。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->