### PR TITLE
[frontend] Claim API 串接

### DIFF
--- a/tachimint/src/App.tsx
+++ b/tachimint/src/App.tsx
@@ -6,6 +6,8 @@ import { useHeartbeat } from './hooks/useHeartbeat'
 import { useClickBoost } from './hooks/useClickBoost'
 import { claimPoints, getTachiBalance } from './services/api'
 
+type ClaimErrorKey = 'loadBalanceFailed' | 'claimFailed'
+
 export default function App() {
   const { t } = useTranslation()
   const { context, jwt, products, bitsEnabled, authError, backendReady } = useTwitch()
@@ -13,7 +15,7 @@ export default function App() {
   const isViewer = context?.role === 'viewer'
   const [tachiBalance, setTachiBalance] = useState<number | null>(null)
   const [claimStatus, setClaimStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle')
-  const [claimError, setClaimError] = useState<string | null>(null)
+  const [claimError, setClaimError] = useState<ClaimErrorKey | null>(null)
   const { balance, gain, isAnimating, syncBalance } = useHeartbeat(context?.channelId, {
     enabled: isViewer && backendReady,
   })
@@ -48,7 +50,7 @@ export default function App() {
       .catch(() => {
         if (!isDisposed) {
           setClaimStatus('error')
-          setClaimError('Unable to load $TACHI balance.')
+          setClaimError('loadBalanceFailed')
         }
       })
 
@@ -72,7 +74,7 @@ export default function App() {
       setClaimStatus('success')
     } catch {
       setClaimStatus('error')
-      setClaimError('Claim failed. Please try again.')
+      setClaimError('claimFailed')
     }
   }, [backendReady, balance, claimStatus, isViewer, syncBalance])
 
@@ -126,16 +128,18 @@ export default function App() {
             onClick={handleClaim}
             disabled={!backendReady || claimStatus === 'pending' || !balance || balance <= 0}
           >
-            {claimStatus === 'pending' ? 'Claiming...' : 'Claim'}
+            {claimStatus === 'pending' ? t('claim.actions.claiming') : t('claim.actions.claim')}
           </button>
         </section>
 
         {claimStatus === 'success' && (
-          <p className="ext-success-text">Claim complete.</p>
+          <p className="ext-success-text">{t('claim.status.complete')}</p>
         )}
 
         {claimStatus === 'error' && (
-          <p className="ext-error">{claimError ?? 'Claim failed.'}</p>
+          <p className="ext-error">
+            {t(`claim.errors.${claimError ?? 'claimFailed'}`)}
+          </p>
         )}
 
         <section className="ext-mine">

--- a/tachimint/src/App.tsx
+++ b/tachimint/src/App.tsx
@@ -1,14 +1,19 @@
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTwitch } from './hooks/useTwitch'
 import { useBits } from './hooks/useBits'
 import { useHeartbeat } from './hooks/useHeartbeat'
 import { useClickBoost } from './hooks/useClickBoost'
+import { claimPoints, getTachiBalance } from './services/api'
 
 export default function App() {
   const { t } = useTranslation()
   const { context, jwt, products, bitsEnabled, authError, backendReady } = useTwitch()
   const { buyWithBits, status, error } = useBits(jwt)
   const isViewer = context?.role === 'viewer'
+  const [tachiBalance, setTachiBalance] = useState<number | null>(null)
+  const [claimStatus, setClaimStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle')
+  const [claimError, setClaimError] = useState<string | null>(null)
   const { balance, gain, isAnimating, syncBalance } = useHeartbeat(context?.channelId, {
     enabled: isViewer && backendReady,
   })
@@ -18,6 +23,58 @@ export default function App() {
     isAnimating: clickAnimating,
     gain: clickGain,
   } = useClickBoost(context?.channelId, isViewer && backendReady, syncBalance)
+
+  useEffect(() => {
+    if (!isViewer || !backendReady) {
+      const resetTimer = window.setTimeout(() => {
+        setTachiBalance(null)
+        setClaimStatus('idle')
+        setClaimError(null)
+      }, 0)
+      return () => {
+        window.clearTimeout(resetTimer)
+      }
+    }
+
+    let isDisposed = false
+    getTachiBalance()
+      .then((nextBalance) => {
+        if (!isDisposed) {
+          setTachiBalance(nextBalance)
+          setClaimStatus('idle')
+          setClaimError(null)
+        }
+      })
+      .catch(() => {
+        if (!isDisposed) {
+          setClaimStatus('error')
+          setClaimError('Unable to load $TACHI balance.')
+        }
+      })
+
+    return () => {
+      isDisposed = true
+    }
+  }, [backendReady, isViewer])
+
+  const handleClaim = useCallback(async () => {
+    if (!isViewer || !backendReady || claimStatus === 'pending' || !balance || balance <= 0) {
+      return
+    }
+
+    setClaimStatus('pending')
+    setClaimError(null)
+
+    try {
+      const result = await claimPoints()
+      setTachiBalance(result.tachiBalance)
+      syncBalance(0)
+      setClaimStatus('success')
+    } catch {
+      setClaimStatus('error')
+      setClaimError('Claim failed. Please try again.')
+    }
+  }, [backendReady, balance, claimStatus, isViewer, syncBalance])
 
   if (!context) {
     return (
@@ -58,6 +115,28 @@ export default function App() {
             <span className="ext-balance-gain">+{gain.toLocaleString()} {t('common.points')}</span>
           )}
         </section>
+
+        <section className="ext-claim">
+          <div>
+            <span className="ext-claim__label">$TACHI</span>
+            <strong className="ext-claim__value">{tachiBalance?.toLocaleString() ?? '—'}</strong>
+          </div>
+          <button
+            className="ext-btn ext-btn--claim"
+            onClick={handleClaim}
+            disabled={!backendReady || claimStatus === 'pending' || !balance || balance <= 0}
+          >
+            {claimStatus === 'pending' ? 'Claiming...' : 'Claim'}
+          </button>
+        </section>
+
+        {claimStatus === 'success' && (
+          <p className="ext-success-text">Claim complete.</p>
+        )}
+
+        {claimStatus === 'error' && (
+          <p className="ext-error">{claimError ?? 'Claim failed.'}</p>
+        )}
 
         <section className="ext-mine">
           <div className="ext-mine__wrap">

--- a/tachimint/src/i18n/locales/en/common.json
+++ b/tachimint/src/i18n/locales/en/common.json
@@ -7,5 +7,18 @@
     "retry": "Retry",
     "initializing": "Initializing...",
     "points": "points"
+  },
+  "claim": {
+    "actions": {
+      "claim": "Claim",
+      "claiming": "Claiming..."
+    },
+    "status": {
+      "complete": "Claim complete."
+    },
+    "errors": {
+      "loadBalanceFailed": "Unable to load $TACHI balance.",
+      "claimFailed": "Claim failed. Please try again."
+    }
   }
 }

--- a/tachimint/src/i18n/locales/zh-CN/common.json
+++ b/tachimint/src/i18n/locales/zh-CN/common.json
@@ -7,5 +7,18 @@
     "retry": "重试",
     "initializing": "初始化中...",
     "points": "点"
+  },
+  "claim": {
+    "actions": {
+      "claim": "领取",
+      "claiming": "领取中..."
+    },
+    "status": {
+      "complete": "领取完成。"
+    },
+    "errors": {
+      "loadBalanceFailed": "无法加载 $TACHI 余额。",
+      "claimFailed": "领取失败，请再试一次。"
+    }
   }
 }

--- a/tachimint/src/i18n/locales/zh-TW/common.json
+++ b/tachimint/src/i18n/locales/zh-TW/common.json
@@ -7,5 +7,18 @@
     "retry": "重試",
     "initializing": "初始化中...",
     "points": "點"
+  },
+  "claim": {
+    "actions": {
+      "claim": "提領",
+      "claiming": "提領中..."
+    },
+    "status": {
+      "complete": "提領完成。"
+    },
+    "errors": {
+      "loadBalanceFailed": "無法載入 $TACHI 餘額。",
+      "claimFailed": "提領失敗，請再試一次。"
+    }
   }
 }

--- a/tachimint/src/index.css
+++ b/tachimint/src/index.css
@@ -144,6 +144,47 @@ p  { margin: 0; }
   100% { opacity: 0; transform: translateY(-10px); }
 }
 
+/* ── Claim ─────────────────────────────────────────────────────────────────── */
+.ext-claim {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.ext-claim__label {
+  display: block;
+  font-size: 11px;
+  color: var(--text);
+}
+
+.ext-claim__value {
+  display: block;
+  color: var(--text-h);
+  font-size: 16px;
+}
+
+.ext-btn--claim {
+  padding: 6px 12px;
+  background: var(--success);
+  color: #06120a;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.ext-btn--claim:hover:not(:disabled) { background: #20e06e; }
+
+.ext-success-text {
+  font-size: 12px;
+  color: var(--success);
+  margin-bottom: 8px;
+}
+
 /* ── Mining character ───────────────────────────────────────────────────────── */
 .ext-mine {
   display: flex;

--- a/tachimint/src/services/api.test.ts
+++ b/tachimint/src/services/api.test.ts
@@ -209,6 +209,78 @@ test('sendClick ensures the watch session exists before sending click rewards', 
   )
 })
 
+test('claimPoints claims viewer points then refreshes tachi balance', async () => {
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/users/me/points/claim') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { tachi_balance: 12 } }))
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/users/me/tachi/balance') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { tachi_balance: 12 } }))
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+
+      try {
+        const api = await import(`./api.ts?claim=${Date.now()}`)
+
+        api.setAuthToken('tachigo-access-token')
+        const claimed = await api.claimPoints()
+        const balance = await api.getTachiBalance()
+
+        assert.deepEqual(claimed, { tachiBalance: 12 })
+        assert.equal(balance, 12)
+        assert.deepEqual(
+          requests.map(({ method, url, authorization, body }) => ({
+            method,
+            url,
+            authorization,
+            body,
+          })),
+          [
+            {
+              method: 'POST',
+              url: '/api/v1/users/me/points/claim',
+              authorization: 'Bearer tachigo-access-token',
+              body: { amount: 0 },
+            },
+            {
+              method: 'GET',
+              url: '/api/v1/users/me/tachi/balance',
+              authorization: 'Bearer tachigo-access-token',
+              body: null,
+            },
+          ],
+        )
+      } finally {
+        if (originalBaseUrl === undefined) {
+          delete process.env.VITE_TACHIGO_API_URL
+        } else {
+          process.env.VITE_TACHIGO_API_URL = originalBaseUrl
+        }
+      }
+    },
+  )
+})
+
 test('sendHeartbeat re-authenticates after 401 and falls back to previous balance when balance read fails', async () => {
   let heartbeatAttempts = 0
 

--- a/tachimint/src/services/api.ts
+++ b/tachimint/src/services/api.ts
@@ -116,6 +116,10 @@ interface HeartbeatResponse {
   balance: number
 }
 
+interface TachiBalanceResponse {
+  tachiBalance: number
+}
+
 function parsePointsEarnedFromPayload(payload: unknown): number | null {
   if (!payload || typeof payload !== 'object') {
     return null
@@ -152,6 +156,23 @@ function parseBalanceFromPayload(payload: unknown): number {
   return value
 }
 
+function parseTachiBalanceFromPayload(payload: unknown): number {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid tachi balance response')
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = payload as any
+  const direct = raw.tachi_balance
+  const nested = raw.data?.tachi_balance
+  const value = typeof direct === 'number' ? direct : typeof nested === 'number' ? nested : null
+  if (typeof value !== 'number') {
+    throw new Error('Tachi balance response missing tachi_balance')
+  }
+
+  return value
+}
+
 interface ClickResponse {
   balance: number
   delta: number
@@ -180,6 +201,21 @@ export async function sendClick(channelId: string): Promise<ClickResponse> {
       config,
     ))
   return data.data
+}
+
+export async function getTachiBalance(): Promise<number> {
+  const { data } = await runWithAuthRecovery((config) => client.get('/api/v1/users/me/tachi/balance', config))
+
+  return parseTachiBalanceFromPayload(data)
+}
+
+export async function claimPoints(amount = 0): Promise<TachiBalanceResponse> {
+  const { data } = await runWithAuthRecovery((config) =>
+    client.post('/api/v1/users/me/points/claim', { amount }, config))
+
+  return {
+    tachiBalance: parseTachiBalanceFromPayload(data),
+  }
 }
 
 export async function sendHeartbeat(


### PR DESCRIPTION
## 什麼改動
- 在 tachimint API client 新增 Claim 與 $TACHI balance 查詢方法
- 在 sidepanel 顯示 `$TACHI` balance，Claim 按鈕改為呼叫 backend claim all
- 補 API client 測試，驗證 claim / balance request path、Authorization 與 response parsing

## 為什麼
tachimint sidepanel 目前 Claim 行為仍停留在本地 state，需要依 #190 改為串接已落地的 backend Claim API。

closes #190

## Release Context
- Release type：`n/a`

## Scope 對齊
- Source of truth：#190
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 dashboard
  - 不修改 backend contract
  - 不改 Extension Demo #180 的 ClaimPanel / HUD 視覺
  - 不串接鏈上合約

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

已執行：
- `pnpm --dir tachimint check:i18n`
- `pnpm --dir tachimint lint`
- `pnpm --dir tachimint build`
- `node --experimental-strip-types --test tachimint/src/services/api.test.ts`

## 備註
此 PR 基於本機 `develop` 建立的 `feat/tachimint-claim-api` branch。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 新增 $TACHI 代币余额展示和领取功能，用户可以实时查看当前余额并通过专属按钮进行领取，系统支持成功和失败状态提示

## 本地化
* 为英文、简体中文和繁体中文添加了领取功能相关的语言本地化支持

<!-- end of auto-generated comment: release notes by coderabbit.ai -->