### PR TITLE
[backend] 修正 $TACHI 鏈上最小單位換算

### DIFF
--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"math/big"
 	"strings"
 	"time"
 
@@ -146,7 +145,7 @@ func (s *ClaimService) MintOnChain(ctx context.Context, toAddr string, amount in
 	}
 
 	// TODO: wait for receipt status == 1 before committing DB (fire-and-forget for now)
-	return s.tachiToken.Mint(ctx, common.HexToAddress(toAddr), big.NewInt(amount), signerKey)
+	return s.tachiToken.Mint(ctx, common.HexToAddress(toAddr), tachiWholeTokensToRawUnits(amount), signerKey)
 }
 
 func (s *ClaimService) reserveClaim(tx *gorm.DB, userID uuid.UUID, amount int64) (claimReservation, error) {

--- a/backend/internal/services/spend_service.go
+++ b/backend/internal/services/spend_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -187,5 +186,5 @@ func (s *SpendService) BurnOnChain(ctx context.Context, fromAddr string, amount 
 		return "", err
 	}
 
-	return s.tachiToken.Burn(ctx, common.HexToAddress(fromAddr), big.NewInt(amount), signerKey)
+	return s.tachiToken.Burn(ctx, common.HexToAddress(fromAddr), tachiWholeTokensToRawUnits(amount), signerKey)
 }

--- a/backend/internal/services/token_units.go
+++ b/backend/internal/services/token_units.go
@@ -1,0 +1,9 @@
+package services
+
+import "math/big"
+
+var tachiTokenRawUnit = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+func tachiWholeTokensToRawUnits(amount int64) *big.Int {
+	return new(big.Int).Mul(big.NewInt(amount), tachiTokenRawUnit)
+}

--- a/backend/internal/services/token_units_test.go
+++ b/backend/internal/services/token_units_test.go
@@ -1,0 +1,18 @@
+package services
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestTachiWholeTokensToRawUnits(t *testing.T) {
+	got := tachiWholeTokensToRawUnits(100)
+	want, ok := new(big.Int).SetString("100000000000000000000", 10)
+	if !ok {
+		t.Fatal("invalid expected raw unit amount")
+	}
+
+	if got.Cmp(want) != 0 {
+		t.Fatalf("expected 100 $TACHI to equal %s raw units, got %s", want.String(), got.String())
+	}
+}


### PR DESCRIPTION
## 什麼改動

- 新增 `$TACHI` 整枚數量轉 ERC-20 raw units 的 backend helper（`amount * 1e18`）
- `ClaimService.MintOnChain()` 呼叫 `mint()` 前改用 raw units
- `SpendService.BurnOnChain()` 呼叫 `burn()` 前改用 raw units
- 補測試鎖定 `100 $TACHI = 100000000000000000000` raw units

## 為什麼

demo 顯示 `100 $TACHI` 時，backend 先前直接 `big.NewInt(amount)` 會把 `100` 當成 ERC-20 最小單位，Sepolia / explorer 看起來會像 mint 或 burn 了極小數量。

refs #192

## Scope 對齊

- Source of truth：#192
- Depends on PR：none
- Related：#113、#166、#173、#187、#190/#191
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 frontend amount contract
  - 不修改 DB schema
  - 不修改合約 ABI 或部署設定
  - 不處理 Swagger docs / airdrop handler 既有測試失敗

## 測試方式

- [x] TDD red：新增 `TestTachiWholeTokensToRawUnits` 後先因 `undefined: tachiWholeTokensToRawUnits` 失敗
- [x] `env GOCACHE=/tmp/tachigo-go-cache go test ./internal/services -count=1` 通過
- [ ] `env GOCACHE=/tmp/tachigo-go-cache go test ./...` 目前未全綠，失敗在既有/其他範圍：
  - `docs`: `TestSwaggerDoc_UsesGlobalBearerAuthAndPublicOverrides` root security 為 nil
  - `internal/handlers`: airdrop handler 測試回 `no active viewers`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复代币铸造和销毁操作中的金额换算问题，现已确保链上交易时使用正确的数值规模。

* **Tests**
  * 新增单元测试验证代币数量单位转换功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->