### PR TITLE
[backend] Demo wallet binding helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,49 @@ Key backend variables:
 | `GOOGLE_CLIENT_SECRET`    | From Google Cloud Console              |
 | `JWT_ACCESS_SECRET`       | Random string ≥ 32 chars               |
 | `JWT_REFRESH_SECRET`      | Random string ≥ 32 chars               |
+| `TACHI_CONTRACT_ADDRESS`  | Sepolia TachiToken contract address    |
+| `SEPOLIA_SIGNER_KEY`      | Backend signer key for TACHI mint/burn |
+
+### Demo wallet binding
+
+This is a demo-only helper for the current no-MetaMask flow. Remove it once the real wallet connection flow is in place.
+
+The demo panel does not connect MetaMask. For on-chain claim demos, the backend pays Sepolia gas and the viewer must be pre-linked to a recipient wallet.
+
+Use this checklist on the demo machine:
+
+```env
+TACHI_CONTRACT_ADDRESS=0xaB702A56fa95f7B5c8C1a47AB8348b2Bb74AE778
+SEPOLIA_SIGNER_KEY=<private key for 0xdC9DEf814AFCeC17096FA826cF69ee270233e116>
+```
+
+Before starting the backend, confirm the signer address without printing the private key:
+
+```bash
+cast wallet address --private-key "$SEPOLIA_SIGNER_KEY"
+```
+
+Expected owner/signer address:
+
+```text
+0xdC9DEf814AFCeC17096FA826cF69ee270233e116
+```
+
+That wallet must have Sepolia ETH for gas. Then pre-link a viewer to a recipient wallet before pressing claim:
+
+```bash
+cd backend
+go run ./cmd/demo/link-wallet --email viewer@example.com --wallet 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+When running the command from the host against Docker Compose Postgres, make sure `DATABASE_URL` points at `localhost:5433`.
+
+You can also target a user UUID:
+
+```bash
+cd backend
+go run ./cmd/demo/link-wallet --user-id <viewer-user-id> --wallet <recipient-wallet-address>
+```
 
 ## Architecture
 

--- a/backend/cmd/demo/link-wallet/main.go
+++ b/backend/cmd/demo/link-wallet/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/joho/godotenv"
+
+	"github.com/tachigo/tachigo/internal/config"
+	"github.com/tachigo/tachigo/internal/database"
+	"github.com/tachigo/tachigo/internal/demo"
+)
+
+func main() {
+	var input demo.LinkDemoWalletInput
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [flags]\n\nDemo-only helper for the current no-MetaMask flow. Remove it once the real wallet connection flow is in place.\n\n", flag.CommandLine.Name())
+		flag.PrintDefaults()
+	}
+	flag.StringVar(&input.UserID, "user-id", "", "demo viewer user UUID")
+	flag.StringVar(&input.Email, "email", "", "demo viewer email")
+	flag.StringVar(&input.WalletAddress, "wallet", "", "demo recipient wallet address")
+	flag.Parse()
+
+	_ = godotenv.Load()
+	cfg := config.Load()
+	db := database.Connect(cfg.Database.DSN)
+
+	linked, err := demo.LinkDemoWallet(context.Background(), db, input)
+	if err != nil {
+		log.Fatalf("link demo wallet: %v", err)
+	}
+
+	fmt.Printf("linked demo wallet: user_id=%s wallet=%s\n", linked.UserID, linked.WalletAddress)
+}

--- a/backend/internal/demo/wallet_linker.go
+++ b/backend/internal/demo/wallet_linker.go
@@ -1,0 +1,88 @@
+package demo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+var (
+	ErrDemoUserSelectorRequired = errors.New("user_id or email is required")
+	ErrDemoUserNotFound         = errors.New("demo user not found")
+	ErrInvalidWalletAddress     = errors.New("invalid wallet address")
+)
+
+type LinkDemoWalletInput struct {
+	UserID        string
+	Email         string
+	WalletAddress string
+}
+
+type LinkedDemoWallet struct {
+	UserID        uuid.UUID
+	WalletAddress string
+}
+
+func LinkDemoWallet(ctx context.Context, db *gorm.DB, input LinkDemoWalletInput) (LinkedDemoWallet, error) {
+	if !common.IsHexAddress(input.WalletAddress) {
+		return LinkedDemoWallet{}, ErrInvalidWalletAddress
+	}
+
+	walletAddress := common.HexToAddress(input.WalletAddress).Hex()
+
+	var user models.User
+	if err := findDemoUser(ctx, db, input, &user); err != nil {
+		return LinkedDemoWallet{}, err
+	}
+
+	if err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var provider models.AuthProvider
+		err := tx.Where("user_id = ? AND provider = ?", user.ID, models.ProviderWeb3).
+			Order("created_at ASC").
+			First(&provider).Error
+		if err == nil {
+			return tx.Model(&provider).Update("provider_id", walletAddress).Error
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		return tx.Create(&models.AuthProvider{
+			UserID:     user.ID,
+			Provider:   models.ProviderWeb3,
+			ProviderID: walletAddress,
+		}).Error
+	}); err != nil {
+		return LinkedDemoWallet{}, err
+	}
+
+	return LinkedDemoWallet{UserID: user.ID, WalletAddress: walletAddress}, nil
+}
+
+func findDemoUser(ctx context.Context, db *gorm.DB, input LinkDemoWalletInput, user *models.User) error {
+	query := db.WithContext(ctx)
+	switch {
+	case input.UserID != "":
+		userID, err := uuid.Parse(input.UserID)
+		if err != nil {
+			return fmt.Errorf("parse user_id: %w", err)
+		}
+		query = query.Where("id = ?", userID)
+	case input.Email != "":
+		query = query.Where("email = ?", input.Email)
+	default:
+		return ErrDemoUserSelectorRequired
+	}
+
+	err := query.First(user).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return ErrDemoUserNotFound
+	}
+	return err
+}

--- a/backend/internal/demo/wallet_linker_test.go
+++ b/backend/internal/demo/wallet_linker_test.go
@@ -1,0 +1,148 @@
+package demo
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+func newWalletLinkerTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			username TEXT,
+			email TEXT UNIQUE,
+			password_hash TEXT,
+			avatar_url TEXT,
+			role TEXT,
+			is_active BOOLEAN,
+			email_verified BOOLEAN,
+			created_at DATETIME,
+			updated_at DATETIME,
+			deleted_at DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("create users: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE auth_providers (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			provider TEXT NOT NULL,
+			provider_id TEXT NOT NULL,
+			access_token TEXT,
+			refresh_token TEXT,
+			token_expires_at DATETIME,
+			metadata TEXT,
+			created_at DATETIME,
+			updated_at DATETIME,
+			deleted_at DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("create auth_providers: %v", err)
+	}
+	return db
+}
+
+func seedDemoUser(t *testing.T, db *gorm.DB, email string) uuid.UUID {
+	t.Helper()
+
+	user := &models.User{
+		Email: &email,
+		Role:  models.RoleViewer,
+	}
+	if err := db.Create(user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return user.ID
+}
+
+func TestLinkDemoWalletCreatesWeb3ProviderByEmail(t *testing.T) {
+	db := newWalletLinkerTestDB(t)
+	userID := seedDemoUser(t, db, "viewer@example.com")
+
+	linked, err := LinkDemoWallet(context.Background(), db, LinkDemoWalletInput{
+		Email:         "viewer@example.com",
+		WalletAddress: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+	})
+	if err != nil {
+		t.Fatalf("LinkDemoWallet: %v", err)
+	}
+	if linked.UserID != userID {
+		t.Fatalf("expected userID %s, got %s", userID, linked.UserID)
+	}
+	if linked.WalletAddress != "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" {
+		t.Fatalf("expected checksummed address, got %s", linked.WalletAddress)
+	}
+
+	var providers []models.AuthProvider
+	if err := db.Where("user_id = ? AND provider = ?", userID, models.ProviderWeb3).Find(&providers).Error; err != nil {
+		t.Fatalf("query providers: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("expected 1 web3 provider, got %d", len(providers))
+	}
+	if providers[0].ProviderID != linked.WalletAddress {
+		t.Fatalf("expected provider_id %s, got %s", linked.WalletAddress, providers[0].ProviderID)
+	}
+}
+
+func TestLinkDemoWalletUpdatesExistingWeb3Provider(t *testing.T) {
+	db := newWalletLinkerTestDB(t)
+	userID := seedDemoUser(t, db, "viewer@example.com")
+	oldAddress := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+	if err := db.Create(&models.AuthProvider{
+		UserID:     userID,
+		Provider:   models.ProviderWeb3,
+		ProviderID: oldAddress,
+	}).Error; err != nil {
+		t.Fatalf("seed provider: %v", err)
+	}
+
+	linked, err := LinkDemoWallet(context.Background(), db, LinkDemoWalletInput{
+		UserID:        userID.String(),
+		WalletAddress: "0x000000000000000000000000000000000000dEaD",
+	})
+	if err != nil {
+		t.Fatalf("LinkDemoWallet: %v", err)
+	}
+	if linked.WalletAddress != "0x000000000000000000000000000000000000dEaD" {
+		t.Fatalf("expected updated wallet, got %s", linked.WalletAddress)
+	}
+
+	var providers []models.AuthProvider
+	if err := db.Where("user_id = ? AND provider = ?", userID, models.ProviderWeb3).Find(&providers).Error; err != nil {
+		t.Fatalf("query providers: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("expected existing provider to be updated, got %d rows", len(providers))
+	}
+	if providers[0].ProviderID != linked.WalletAddress {
+		t.Fatalf("expected provider_id %s, got %s", linked.WalletAddress, providers[0].ProviderID)
+	}
+}
+
+func TestLinkDemoWalletRejectsInvalidWalletAddress(t *testing.T) {
+	db := newWalletLinkerTestDB(t)
+	seedDemoUser(t, db, "viewer@example.com")
+
+	_, err := LinkDemoWallet(context.Background(), db, LinkDemoWalletInput{
+		Email:         "viewer@example.com",
+		WalletAddress: "not-a-wallet",
+	})
+	if !errors.Is(err, ErrInvalidWalletAddress) {
+		t.Fatalf("expected ErrInvalidWalletAddress, got %v", err)
+	}
+}


### PR DESCRIPTION
## 什麼改動
新增 demo-only wallet binding helper，讓目前未接 MetaMask 的 demo flow 可以先把 viewer 預綁到 recipient wallet，再走現有 backend claim -> on-chain mint 流程。

- 新增 `backend/internal/demo` wallet linking service
- 新增 `backend/cmd/demo/link-wallet` CLI
- 新增 wallet linking 單元測試
- 補 README demo 機器設定 checklist

## 為什麼
refs #191

目前 demo 前端沒有接小狐狸，viewer 沒有 linked web3 wallet 時，claim 會卡在 `web3 wallet not linked`，無法進入鏈上 mint。此 PR 只為 demo 提供預先綁定 viewer wallet 的操作工具。

## Release Context
- Release type：`n/a`

## Scope 對齊
- Source of truth：#191
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不接 MetaMask
  - 不新增正式 wallet connection flow
  - 不改 claim / mint 正式流程
  - 不改合約 owner / deploy 流程

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

```bash
cd backend
go test -count=1 ./internal/demo ./cmd/demo/link-wallet
```

已知：`go test ./...` 目前在既有 `internal/handlers` airdrop handler 測試失敗，錯誤為 `no active viewers`，不屬於本 PR scope。

## 備註
這是 demo-only helper，README 與 CLI usage 都已註記：等真正 wallet connection flow 上線後要移除此功能。

Demo 機器需要填：

```env
TACHI_CONTRACT_ADDRESS=0xaB702A56fa95f7B5c8C1a47AB8348b2Bb74AE778
SEPOLIA_SIGNER_KEY=<private key for 0xdC9DEf814AFCeC17096FA826cF69ee270233e116>
```

合約 owner / backend signer address：

```text
0xdC9DEf814AFCeC17096FA826cF69ee270233e116
```

該 signer wallet 需要有 Sepolia ETH 付 gas。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加演示钱包绑定功能，支持通过用户 ID 或邮箱将钱包地址关联到演示用户。

* **文档**
  * 更新 README，添加后端环境变量说明（`TACHI_CONTRACT_ADDRESS` 和 `SEPOLIA_SIGNER_KEY`）。
  * 新增演示钱包绑定部分文档，包含使用说明和示例命令。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->