### PR TITLE
[discussion] Sepolia Claim/Mint MVP 規劃文件

### DIFF
--- a/docs/tachimint-loyalty-claim-boundary.md
+++ b/docs/tachimint-loyalty-claim-boundary.md
@@ -1,0 +1,143 @@
+# Tachimint 與 Claim Flow 邊界說明
+
+> 用途：快速對齊產品方向，避免把 `tachimint` 的忠誠點數累積流程，和平台幣兌換流程混在一起。
+> 定位：討論用短文件，不是正式 architecture source of truth。
+
+---
+
+## 1. 一句話版本
+
+`tachimint` 負責讓觀眾在 Twitch Extension 內累積忠誠點數 `T-Point`；另一個獨立按鈕或入口，負責把 `T-Point` 兌換成平台幣 `$TACHI`。
+
+---
+
+## 2. 產品邊界
+
+### `tachimint` 要負責的事
+
+- 顯示目前 `T-Point` 餘額
+- 透過 heartbeat 累積觀看點數
+- 透過互動按鈕提供額外點數回饋
+- 顯示 Bits 商品與互動狀態
+- 維持小尺寸、快速瞥視的 extension panel 體驗
+
+### `tachimint` 不應該優先承擔的事
+
+- 完整 wallet 連接流程
+- 鏈上交易細節
+- 複雜的 claim / redeem 多步驟流程
+- 平台幣資產管理頁
+- 一整套 web3 dApp 體驗
+
+---
+
+## 3. Claim 按鈕應該代表什麼
+
+這個按鈕的意義是：
+
+- 把已累積的 `T-Point` 轉換成平台幣 `$TACHI`
+- 它是「兌換入口」，不是「繼續累積點數的互動」
+
+因此，Claim Flow 應被視為獨立能力：
+
+- 可以從 extension 內放一個入口按鈕進去
+- 也可以導向另一個更適合完成兌換的畫面
+- 但它的產品責任，和 `tachimint` 的點數累積責任要分開看
+
+---
+
+## 4. 最推薦的拆法
+
+### A. Extension 主畫面
+
+重點放在：
+
+- 你現在有多少 `T-Point`
+- 你現在能不能繼續挖 / 累積
+- 你現在能不能買 Bits 商品
+
+### B. Claim 入口
+
+提供一個清楚但不喧賓奪主的按鈕，例如：
+
+- `Claim $TACHI`
+- `兌換平台幣`
+- `Convert Points`
+
+### C. Claim 畫面 / 流程
+
+重點放在：
+
+- 你目前可兌換多少 `T-Point`
+- 兌換後會得到多少 `$TACHI`
+- 這次 claim 是否只是 DB 記帳，或已經觸發鏈上 mint
+- 成功 / 失敗 / wallet 狀態
+
+---
+
+## 5. Phase 1 / Phase 2 切法
+
+### Phase 1
+
+先做：
+
+- `tachimint` 持續累積 `T-Point`
+- Claim 按鈕呼叫後端 claim API
+- 後端把 `T-Point` 轉進 `tachi_balances`
+- 先不碰鏈上 mint
+
+這一階段的使用者理解可以是：
+
+- `T-Point` 是忠誠點數
+- `$TACHI` 是平台內記帳的可兌換平台幣
+
+### Phase 2
+
+再升級：
+
+- claim 與 wallet 綁定
+- 接 Sepolia / 合約 mint
+- 將 `$TACHI` 從 DB-only 餘額升級成鏈上平台幣流程
+
+這一階段才需要處理：
+
+- wallet UX
+- 合約部署
+- 簽章 / relayer / gas
+- on-chain 成功與失敗狀態
+
+---
+
+## 6. UI 設計上的意思
+
+如果照這個方向，UI 上應該這樣理解：
+
+- `tachimint` 是 loyalty points panel
+- Claim 是 secondary action，不是主互動
+- 主視覺仍應放在點數累積，而不是放在 web3 錢包操作
+- 若 claim 流程開始變複雜，就應考慮抽到獨立頁面，而不是一直塞進 extension panel
+
+---
+
+## 7. 對實作者最重要的結論
+
+- 不要把 `tachimint` 直接做成錢包 dApp
+- 先把 `T-Point` 累積體驗做清楚
+- 把 claim 視為「另一個能力入口」
+- Phase 1 先跑通 DB-only claim
+- Phase 2 再接 Sepolia
+
+---
+
+## 8. 可直接拿去討論的版本
+
+```text
+Tachigo 的產品拆分應該是：
+
+1. `tachimint` 專注在 Twitch Extension 內的忠誠點數累積體驗
+2. Claim 按鈕是把 `T-Point` 兌換成 `$TACHI` 的入口
+3. Phase 1 先做 DB-only claim，不讓 extension 承擔完整 web3 流程
+4. Phase 2 再把 claim 升級成 Sepolia / on-chain mint
+
+這樣可以保持 extension 輕量，也能讓平台幣流程獨立演進。
+```

--- a/plans/sepolia-claim-mint-issue-breakdown.md
+++ b/plans/sepolia-claim-mint-issue-breakdown.md
@@ -1,0 +1,260 @@
+# Sepolia Claim / Mint MVP 建議出票順序
+
+> 用途：把 `plans/sepolia-claim-mint-mvp.md` 拆成可實際建立 issue / PR 的順序。
+> 原則：先跑通 Sepolia MVP，不把主網、Router Contract、完整 dApp UX 混進來。
+
+---
+
+## 1. 建議順序總覽
+
+1. 合約 review 收尾
+2. Sepolia 部署腳本與部署文件
+3. Account linking 與 claim target address 規格
+4. claim idempotency 設計與 job 記錄 schema（**先於 mint service**）
+5. 後端 Sepolia mint service
+6. `claim-sepolia` API
+7. 前端最小 claim 入口
+8. E2E 驗證與文件更新
+
+---
+
+## 2. 建議 issue 拆法
+
+## Issue 1: Soulbound ERC-20 review 收尾
+
+### 目標
+
+讓 `TachiToken` 合約語意完整，可作為 Sepolia MVP 的鏈上載體。
+
+### 範圍
+
+- 修正 review feedback
+- 確認 soulbound 語意完整
+- 補測試
+
+### 完成條件
+
+- `forge test` 全綠
+- 合約 review 結束
+- 可進入部署準備
+
+---
+
+## Issue 2: Sepolia 部署腳本與部署文件
+
+### 目標
+
+讓團隊能一致地把 `TachiToken` 部署到 Sepolia，並保留 deploy 資訊。
+
+### 範圍
+
+- Foundry deploy script
+- deploy 參數說明
+- owner / signer 策略記錄
+- Sepolia contract address 記錄方式
+
+### 完成條件
+
+- 可用指令完成部署
+- 有 contract address / chain id / tx hash
+- 文件可重現部署流程
+- **owner 策略已明確記錄（MVP = deployer wallet，私鑰透過環境變數管理）**
+
+---
+
+## Issue 3: Account linking 與 claim target address 規格
+
+### 目標
+
+定義並實作「Twitch user ↔ wallet address」的關聯機制，讓後端 claim 時能穩定取得目標地址。
+
+### 背景
+
+目前 repo 有兩套獨立的 user record：
+- Twitch Extension JWT 路徑（tachimint viewer）
+- Web3 SIWE 路徑（`/auth/web3/nonce` + `/auth/web3/verify`）
+
+claim 的前提是「知道哪個 Twitch viewer 對應到哪個 wallet address」，這需要明確的 linking 流程。
+
+### 範圍
+
+- 決定 account linking 觸發的畫面與時機（建議：dashboard 或獨立頁面，不在 extension 內）
+- 定義 linking API（Twitch user ↔ Web3 provider 關聯）
+- 確認或補最小 schema（`auth_providers` 是否足夠，或需要新的關聯欄位）
+- 定義使用者主 wallet address 規則（MVP 先只取一個主地址）
+- 決定沒有綁定 wallet 時 API / 前端的處理方式
+
+### 完成條件
+
+- account linking 流程有明確規格（畫面 + API）
+- 後端 service 可穩定取得 claim target address
+- 未綁定 wallet 的錯誤路徑有明確定義
+
+---
+
+## Issue 4: claim idempotency 設計與 job 記錄 schema
+
+### 目標
+
+在實作 mint service 與 claim API 之前，先定義 idempotency 機制與 job 記錄結構，避免後續 API 上線後再補時留下 double mint 風險窗口。
+
+### 範圍
+
+- 定義 idempotency key 規格（request id 來源、格式）
+- 設計 `mint_jobs`（或 claim status）資料表 schema
+- 定義 tx hash 與 userID / amount 的對應關係
+- 定義 reserve → pending → settled / failed 狀態機
+
+### 完成條件
+
+- schema migration 可執行
+- 狀態機有明確定義（含失敗解凍路徑）
+- 後續 mint service 與 claim API 可直接依此實作
+
+---
+
+## Issue 5: 後端 Sepolia mint service
+
+### 目標
+
+讓後端能安全呼叫 Sepolia 合約 `mint(to, amount)`，並整合 Issue 4 定義的 job 記錄。
+
+### 範圍
+
+- EVM client / signer 初始化
+- env 設定（`SEPOLIA_RPC_URL`、`SEPOLIA_CHAIN_ID`、`TACHI_TOKEN_ADDRESS`、`SEPOLIA_SIGNER_KEY`）
+- 合約呼叫封裝
+- tx hash 回傳
+- 寫入 mint_jobs 記錄
+
+### 完成條件
+
+- 可從後端成功送出 Sepolia mint
+- 能取得 tx hash
+- 失敗可回報明確錯誤
+- mint_jobs 狀態正確更新
+
+---
+
+## Issue 6: `claim-sepolia` API
+
+### 目標
+
+新增一條明確的 API，讓使用者把 `T-Point` 兌換成 Sepolia `$TACHI`。
+
+### 建議路徑
+
+- `POST /users/me/tachi/claim-sepolia`
+
+### 範圍
+
+- 驗證 spendable balance
+- 取得 wallet address（依賴 Issue 3 的 linking 規格）
+- DB reserve（spendable → reserved）
+- 呼叫 mint service（Issue 5）
+- tx confirmed → DB settle；tx failed → DB 解凍
+- 回傳 claim 結果與 tx hash
+
+### 完成條件
+
+- API 可用
+- success / insufficient balance / wallet missing / chain error 都有明確回應
+- 重送相同 idempotency key 不會 double mint
+
+---
+
+## Issue 7: 前端最小 claim 入口
+
+### 目標
+
+讓使用者有地方發起 claim，但不把 `tachimint` 變成完整 wallet dApp。
+
+### 建議做法
+
+- 先放 dashboard 或獨立頁面
+- extension 只保留 secondary 入口或暫不處理
+
+### 範圍
+
+- 顯示可 claim 點數
+- 顯示 wallet address
+- Claim 按鈕
+- pending / success / error
+- explorer link
+
+### 完成條件
+
+- 使用者能從 UI 發起 claim
+- 成功後能看到 tx hash / Sepolia 結果
+
+---
+
+## Issue 8: E2E 驗證與文件更新
+
+### 目標
+
+確認整條 Sepolia MVP 流程可跑通，並把文件補齊。
+
+### 驗證流程
+
+1. viewer 累積 `T-Point`
+2. 使用者登入並有 wallet address
+3. 發起 claim
+4. DB 餘額扣除正確
+5. `tachi_balances` 更新正確
+6. Sepolia token balance 增加正確
+7. explorer 可查到 tx
+
+### 完成條件
+
+- 有一份手動驗證結果
+- 文件更新完成
+
+---
+
+## 3. 建議 PR 範圍
+
+### PR A: contracts only
+
+- Issue 1
+- Issue 2
+
+### PR B: backend linking + idempotency schema
+
+- Issue 3
+- Issue 4
+
+### PR C: backend mint + claim API
+
+- Issue 5
+- Issue 6
+
+### PR D: frontend claim UI
+
+- Issue 7
+
+### PR E: docs / verification
+
+- Issue 8
+
+---
+
+## 4. 建議不要混在同一輪的內容
+
+- Router Contract
+- 主網部署
+- claim fee burn
+- treasury reclaim
+- 多鏈支援
+- extension 內完整 wallet UX
+- 大規模 dashboard redesign
+
+---
+
+## 5. 最短里程碑定義
+
+如果要用一句話定義這個里程碑：
+
+```text
+使用者已能把在 tachimint 累積的 T-Point，透過平台 claim 流程，成功兌換成 Sepolia 上的 $TACHI。
+```

--- a/plans/sepolia-claim-mint-mvp.md
+++ b/plans/sepolia-claim-mint-mvp.md
@@ -1,0 +1,354 @@
+# Sepolia Claim / Mint MVP 計畫
+
+> 狀態：規劃中
+> 最後更新：2026-04-10
+> 目標：讓使用者可以把 `T-Point` 兌換成鏈上 `$TACHI`，先跑通 **Sepolia 測試網 MVP**。
+> 前置：watch-to-points 已完成、DB-only claim 已存在、Web3 nonce/signature auth 已存在、Soulbound ERC-20 合約另由合約 PR 推進中。
+
+---
+
+## 1. 這份計畫要解決什麼
+
+目前專案已經有兩段基礎：
+
+1. `tachimint` 內累積 `T-Point`
+2. 後端 DB-only claim，將 `T-Point` 轉入 `tachi_balances`
+
+但還沒有真正跑通：
+
+- wallet 綁定 / claim 對應哪個地址
+- Sepolia 合約部署
+- 後端或使用者觸發鏈上 mint
+- 前端 claim UI / 成功失敗回饋
+
+這份計畫的目標不是直接做完整 Phase 2，而是先讓整條「`T-Point` → claim → Sepolia `$TACHI`」能在測試網跑通。
+
+---
+
+## 2. 範圍定義
+
+### 本計畫包含
+
+- Soulbound ERC-20 合約在 Sepolia 部署
+- 決定 claim 的最短執行模型
+- 後端保存 / 取得使用者 wallet address
+- claim API 與 on-chain mint 串接
+- 最小可用的前端 claim 入口
+- 端到端驗證流程
+
+### 本計畫不包含
+
+- 主網部署
+- Router Contract 完整設計
+- 1% claim fee burn
+- 7 日未 claim 回收
+- 多種鏈支援
+- 完整錢包資產管理頁
+- 大範圍 UI redesign
+
+---
+
+## 3. MVP 架構決策
+
+### 建議採用的最短路徑
+
+先做 **Server-mediated mint on Sepolia**：
+
+```text
+viewer 累積 T-Point
+  → 前端發起 claim
+  → 後端檢查 spendable_balance
+  → 後端扣除 DB 餘額
+  → 後端呼叫已部署的 TachiToken.mint(to, amount)
+  → 成功後回寫 mint result / tx hash
+  → 前端顯示 Sepolia claim 成功
+```
+
+### 為什麼先不用「使用者自己呼叫合約 claim」
+
+- 目前 repo 雖有 wallet auth 基礎，但還沒有完整 claim signature / on-chain claim contract 設計
+- 若直接做 user-side contract call，會多出：
+  - claim message spec
+  - replay protection
+  - 合約 claim 驗證邏輯
+  - 前端 wallet transaction UX
+- 對 Sepolia MVP 來說，這會讓 scope 膨脹太多
+
+### 這個決策的 tradeoff
+
+優點：
+
+- 最快跑通
+- 可以驗證 tokenomics 與鏈上資料流
+- 前後端都較容易控制錯誤處理
+
+缺點：
+
+- 後端需要持有 deployer / owner 私鑰或 relayer
+- 不是最終主網模型
+- 之後升級成 Router Contract 時要再重構一次
+
+---
+
+## 4. 必要前置條件
+
+### A. 合約層
+
+- `TachiToken.sol` 合約通過 review
+- Foundry 測試通過
+- 決定 owner 是：
+  - 暫時用 deployer wallet
+  - 或 Defender Relayer / 專用 hot wallet
+
+### B. 後端層
+
+- claim API 行為與 DB transaction 再確認
+- 能保存使用者 wallet address
+- 能安全讀取 Sepolia RPC 與 signer 設定
+
+> **決策：MVP owner 策略**
+> Sepolia MVP 階段使用 deployer wallet + 環境變數管理私鑰（`SEPOLIA_SIGNER_KEY`），不引入 Defender Relayer 等外部服務。主網再評估升級策略。
+
+### C. 前端層
+
+- 有 wallet connect / wallet link 最小入口
+- 有 claim 成功 / 失敗 UI
+
+---
+
+## 5. 工作拆解
+
+## 5.1 合約與部署
+
+### 目標
+
+讓 `$TACHI` Soulbound ERC-20 可部署到 Sepolia，並取得正式合約地址供後端與前端使用。
+
+### 任務
+
+- [ ] 完成 `TachiToken` review feedback
+- [ ] 補 deploy script
+- [ ] 定義部署參數與 owner 策略
+- [ ] 部署到 Sepolia
+- [ ] 記錄 contract address、chain id、deploy tx hash
+- [ ] 補一份部署操作說明文件
+
+### 交付物
+
+- `contracts/script/...`
+- Sepolia contract address
+- 部署說明文件
+
+---
+
+## 5.2 Wallet 綁定資料模型
+
+### 目標
+
+讓每個使用者有明確的 claim 目標地址。
+
+### 重要前提：Twitch user 與 Web3 user 的 account linking
+
+目前 repo 有兩套獨立的 user record：
+- Twitch Extension JWT 路徑（`tachimint` 用戶，Twitch viewer）
+- Web3 SIWE 路徑（`/auth/web3/nonce` + `/auth/web3/verify`，錢包登入）
+
+claim 的前提是「知道哪個 Twitch viewer 對應到哪個 wallet address」，因此必須先決定 **account linking 在哪個畫面、哪個時機完成**，這不是單純查現有資料就能解決的問題。
+
+> **決策：MVP account linking 策略**
+> Sepolia MVP 建議採用最簡單的 linking 流程：使用者在 dashboard 或獨立頁面先完成 SIWE 登入，後端將 Web3 provider 與 Twitch user record 關聯。Twitch Extension 本身不做 wallet 連線流程，避免 extension 變成 dApp。
+
+### 建議做法
+
+優先沿用既有 Web3 auth/provider 資料，不另外發明新表；若現有 `auth_providers` 已可穩定取到 wallet address，就直接複用。
+
+### 任務
+
+- [ ] 決定 account linking 流程（哪個畫面 / API 觸發 Twitch user ↔ wallet address 關聯）
+- [ ] 確認目前登入後如何取得使用者 wallet address
+- [ ] 確認是否允許一人多地址；Sepolia MVP 建議先只取一個主地址
+- [ ] 決定 claim 預設地址來源
+- [ ] 若現有資料結構不足，再補最小 schema / service
+
+### 交付物
+
+- wallet address 來源規格
+- 後端可讀取的 `claim target address`
+
+---
+
+## 5.3 後端 Claim → Mint 串接
+
+### 目標
+
+讓 claim 不只是 DB 記帳，而是會產生 Sepolia mint transaction。
+
+### 核心決策
+
+MVP 建議新增新的 claim 路徑，而不是直接改壞既有 DB-only claim：
+
+- `POST /users/me/tachi/claim-sepolia`
+
+或保留原 API，但加 mode flag。前者比較乾淨。
+
+### 後端任務
+
+- [ ] 新增 Sepolia mint service
+- [ ] 包裝合約呼叫：`mint(address to, uint256 amount)`
+- [ ] 定義 env：
+  - `SEPOLIA_RPC_URL`
+  - `SEPOLIA_CHAIN_ID`
+  - `TACHI_TOKEN_ADDRESS`
+  - signer private key 或 relayer 設定
+- [ ] claim transaction 與 mint transaction 的一致性策略
+- [ ] 儲存 tx hash / mint result
+- [ ] 失敗回滾策略
+
+### 一致性建議
+
+先採三步驟保守策略：
+
+```text
+① DB: spendable_balance → reserved
+   （減少 spendable，但尚未 settled；防止重複提交）
+② on-chain: 送出 mint tx，等待 tx confirmed
+③-A tx confirmed → DB: reserved 轉 settled，tachi_balances 更新，寫入 tx hash
+③-B tx failed    → DB: reserved 解凍，回原 spendable，回報錯誤
+```
+
+> **注意**：不可先 mint 再扣 DB。若 DB 在 step ③-A 失敗，使用者鏈上已有幣但 DB 未扣帳，會造成資產與帳本不一致。reserve 機制確保「扣帳意圖」在送鏈前就已鎖定。
+
+理由：
+
+- 先 reserve 確保同一筆 T-Point 不會被重複 claim
+- 鏈上成功後再 settle，確保帳本與鏈上狀態一致
+- 失敗可安全解凍，使用者不會損失資產
+
+### 風險
+
+- 鏈上交易 pending 時，API timeout / retry 行為要小心
+- 需要 idempotency，避免重送造成 double mint
+
+### 建議最小保護
+
+- [ ] claim request id / idempotency key
+- [ ] `mint_jobs` 或 claim status 記錄表
+- [ ] tx hash 與 userID / amount 對應
+
+---
+
+## 5.4 前端 Claim 入口
+
+### 目標
+
+讓使用者看得到「把忠誠點數兌換成平台幣」的明確入口。
+
+### UI 原則
+
+- `tachimint` 仍以 loyalty points panel 為主
+- Claim 是 secondary action
+- 若 wallet / claim 流程太複雜，可導到另一個頁面完成
+
+### 最短 UI 任務
+
+- [ ] 顯示目前可 claim 的 `T-Point`
+- [ ] 顯示已綁定的 wallet address
+- [ ] Claim 按鈕
+- [ ] pending / success / error 狀態
+- [ ] 成功後顯示 Sepolia tx hash 或 explorer link
+
+### 技術選項
+
+Option A：
+- claim UI 放在 dashboard 或獨立 web 頁面
+
+Option B：
+- extension 內只放 claim 入口，點下去導到外部頁面
+
+MVP 建議：
+
+- **先不要把完整 wallet UX 塞進 `tachimint`**
+- 先做 dashboard / 獨立頁面 claim，比較不會把 extension 膨脹成 dApp
+
+---
+
+## 5.5 驗證與觀測
+
+### 必要驗證
+
+- [ ] 用戶能累積 `T-Point`
+- [ ] 用戶能綁定 / 辨識 wallet address
+- [ ] claim 成功後：
+  - DB 餘額扣除正確
+  - `tachi_balances` 更新正確
+  - Sepolia token balance 增加正確
+- [ ] tx hash 可追到 explorer
+- [ ] 重送 claim request 不會 double mint
+
+### 失敗情境
+
+- [ ] wallet address 不存在
+- [ ] claim amount > spendable balance
+- [ ] signer / relayer 無法送交易
+- [ ] contract revert
+- [ ] RPC timeout / nonce 問題
+
+---
+
+## 6. 建議切票順序
+
+### Phase A: 合約可部署
+
+1. Soulbound ERC-20 review 修正
+2. Sepolia deploy script
+3. 部署文件 + deploy 結果
+
+### Phase B: 鏈下資料對齊
+
+4. wallet address 來源確認
+5. claim target address 規格
+6. claim idempotency / job 設計
+
+### Phase C: 後端串鏈
+
+7. Sepolia mint service
+8. claim-sepolia API
+9. tx hash / claim status persistence
+
+### Phase D: 前端入口
+
+10. 最小 claim UI
+11. success / error / explorer link
+
+### Phase E: 驗證
+
+12. E2E 手動驗證
+13. 文件更新
+
+---
+
+## 7. 成功定義
+
+Sepolia MVP 完成的標準：
+
+- 使用者先在平台累積 `T-Point`
+- 使用者有一個可識別的 wallet address
+- 使用者觸發 claim 後
+  - DB 正確扣除對應 `T-Point`
+  - `tachi_balances` 正確更新
+  - Sepolia 上的 `$TACHI` 成功 mint 到該地址
+  - 前端可看到成功結果與 tx hash
+
+---
+
+## 8. 本計畫後的下一步
+
+Sepolia MVP 跑通後，再決定是否進入真正的 Phase 2：
+
+- Router Contract
+- user-side claim signature model
+- claim fee burn
+- treasury / reclaim
+- 主網部署
+
+在 Sepolia MVP 前，不建議先把這些一起混進同一輪。


### PR DESCRIPTION
## 背景

整理 Sepolia Claim/Mint MVP 的規劃文件，以及 tachimint 與 Claim Flow 的產品邊界說明。這些文件是 Phase 2 實作前的對齊基礎。

## 本 PR 包含

- `docs/tachimint-loyalty-claim-boundary.md` — T-Point vs \$TACHI 產品邊界說明，避免把忠誠點數累積和平台幣兌換流程混在一起
- `plans/sepolia-claim-mint-mvp.md` — Sepolia MVP 完整計畫（wallet 綁定、合約部署、mint 串接、前端入口）
- `plans/sepolia-claim-mint-issue-breakdown.md` — 建議出票順序，可直接拿來開 issue

## 本 PR 明確不做

- 不包含任何實作程式碼
- 不開對應的 issue（後續另行處理）
- 不修改現有 docs/ 或 plans/ 文件

## Scope 對齊

Source of truth：本地規劃文件（未 commit）

Depends on PR：none

Backend contract already in develop：
- [x] yes
- [ ] no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification documents defining the product boundaries and scope for the upcoming T-Point claim functionality
  * Added detailed architecture and development roadmap for implementing claim and on-chain minting features across testing environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->