### PR TITLE
[discussion] Define tachimint Chrome sidepanel migration decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tachigo
 
-Twitch extension + Web3 rewards platform.
+Chrome sidepanel extension + Web3 rewards platform.
 Viewers spend Bits to earn on-chain tokens; streamers manage rewards from the dashboard.
 
 ## Structure
@@ -8,7 +8,7 @@ Viewers spend Bits to earn on-chain tokens; streamers manage rewards from the da
 ```
 tachigo/
 ├── backend/      # Go API (Gin + GORM + PostgreSQL)
-├── tachimint/    # Twitch Extension frontend (React + TypeScript + Vite)
+├── tachimint/    # Chrome sidepanel frontend (React + TypeScript + Vite)
 └── dashboard/    # Admin dashboard (React + TypeScript + Vite)
 ```
 
@@ -62,8 +62,8 @@ docker compose run --no-deps --rm app go test ./...
 ### Frontend (`tachimint/`)
 
 - Hot reload via Vite HMR
-- `window.Twitch.ext` is mocked in dev mode — no Twitch Developer Rig needed
-- Open http://localhost:5173 to see the extension panel
+- current migration direction is Chrome sidepanel runtime
+- Twitch identity / extension auth related flows are still retained during the migration stage
 
 ```bash
 docker compose run --no-deps --rm frontend npm run build   # production build
@@ -143,6 +143,7 @@ go run ./cmd/demo/link-wallet --user-id <viewer-user-id> --wallet <recipient-wal
 ## Architecture
 
 See [docs/architecture.md](docs/architecture.md) for the full system diagram.
+For the current frontend migration decision, see [docs/tachimint-chrome-sidepanel-migration.md](docs/tachimint-chrome-sidepanel-migration.md).
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 │                           CLIENT LAYER                             │
 │                                                                    │
 │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
-│  │ Twitch Extension │  │  Dashboard [TBD] │  │  Wallet [Phs.2]  │  │
+│  │ Chrome Sidepanel │  │  Dashboard [TBD] │  │  Wallet [Phs.2]  │  │
 │  │   (tachimint)    │  │  Agency/Streamer │  │  Claim on-chain  │  │
 │  │ React+TypeScript │  │  Mgmt Interface  │  │                  │  │
 │  └────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘  │
@@ -50,6 +50,8 @@
 ```
 
 ## 主要資料流
+
+> 補充：`tachimint` 的前端 runtime 方向已定為 Chrome sidepanel extension；本階段 viewer identity 與既有 API contract 仍沿用 Twitch / extension auth 流程。詳見 [docs/tachimint-chrome-sidepanel-migration.md](tachimint-chrome-sidepanel-migration.md)。
 
 ```
 觀眾觀看直播（定時 Heartbeat）

--- a/docs/chrome-extension-terminology-audit.md
+++ b/docs/chrome-extension-terminology-audit.md
@@ -1,20 +1,21 @@
 # Chrome Extension 名詞盤點
 
 > 用途：盤點 repo 內 `Chrome Extension`、`Twitch Extension` 與泛用 `extension` 命名的混用情況。
-> 狀態：盤點文件，不是 migration spec，也不是「已完成 Chrome Extension 轉換」的宣告。
-> 最後更新：2026-04-10
+> 狀態：盤點文件；Chrome sidepanel migration 方向已定案，但本文件本身不是完整實作 spec。
+> 最後更新：2026-04-16
 
 ---
 
 ## 1. 目前可確認的 source of truth
 
-依目前 repo 既有文件與程式碼現況，可先確認以下事實：
+依目前 repo 既有文件、程式碼現況與已定案 migration decision，可先確認以下事實：
 
-1. `tachimint` 的可運作實作目前仍是 **Twitch-hosted extension runtime**
-2. 前端與後端仍依賴 `window.Twitch.ext`、`extension_jwt`、Twitch helper script 等流程
-3. 若要正式改成 Chrome Extension，必須先有獨立的架構決策或 migration spec
+1. `tachimint` 的既有可運作實作是 **Twitch-hosted extension runtime**
+2. `tachimint` 的新方向已定為 **Chrome sidepanel extension runtime**
+3. 本階段前端與後端仍依賴 `window.Twitch.ext`、`extension_jwt`、Twitch helper script 等流程
+4. 本輪 migration 的 decision source of truth 為 [docs/tachimint-chrome-sidepanel-migration.md](tachimint-chrome-sidepanel-migration.md)
 
-因此，這份文件的用途是「盤點與拆題」，不是把 Chrome Extension 寫成既定現況。
+因此，這份文件的用途是說明術語與現況的落差，協助後續 migration 拆題；它不是完整 migration spec。
 
 ---
 
@@ -24,8 +25,8 @@
 
 | 類別 | 代表什麼 | 目前狀態 |
 |---|---|---|
-| 產品形式 | 使用者最終安裝與使用的前端形態 | 尚未有已定案、可實作的 Chrome Extension migration spec |
-| 現行 runtime | 現在程式真正依賴的執行環境 | Twitch-hosted extension |
+| 產品形式 | 使用者最終安裝與使用的前端形態 | 已定案為 Chrome sidepanel extension |
+| 現行 runtime | 現在程式真正依賴的執行環境 | Twitch-hosted extension，將分階段遷移 |
 | 模組 / API 命名 | `/extension/*`、`ExtensionService`、`extension_jwt` 等名稱 | 已存在於前後端契約與程式結構中 |
 
 以下文件已在本輪 docs 收斂中處理：
@@ -71,8 +72,12 @@
 
 ### C. 文件中容易造成誤解的地方
 
-目前 repo 內多數架構與設計文件仍以 Twitch Extension 為現況描述，這與程式 reality 一致。
-若未來要引入 Chrome Extension 的產品方向，應明確標示為「未來規劃」或「待定 migration」，不能直接覆寫現況描述。
+目前 repo 內多數架構與設計文件仍以 Twitch Extension 為現況描述，這反映既有程式 reality。
+但 migration 方向現在已定案，因此後續文件應逐步收斂為：
+
+- 既有 runtime 現況：仍有 Twitch-hosted 遺留
+- 產品方向：`tachimint` 遷移為 Chrome sidepanel
+- 本階段邊界：仍沿用 Twitch identity 與既有 backend contract
 
 ---
 
@@ -81,21 +86,21 @@
 ### 第一類：文件 truth 校正
 
 目標：
-- 明確標示目前是 Twitch-hosted implementation
-- 避免把尚未定案的 Chrome Extension migration 寫成既定事實
+- 明確標示既有實作仍含 Twitch-hosted 遺留
+- 明確標示 Chrome sidepanel migration 已是既定方向
 
 適合放進同一張 docs PR 的內容：
 - README 說明補強
-- 名詞盤點文件
-- 未來 migration 需要回答的問題列表
+- 名詞盤點文件更新
+- migration decision doc
 
-### 第二類：Chrome Extension migration spec
+### 第二類：Chrome Extension migration implementation
 
-這必須是獨立 issue / spec：
-- 身份來源是否仍依賴 Twitch
-- `extension_jwt` 的替代方案是什麼
-- Bits / viewer context / broadcaster context 如何取得
-- `window.Twitch.ext` mock 與 hosted 測試流程如何替換
+這必須是獨立 frontend PR：
+- sidepanel runtime 骨架
+- 新 app shell / UI 導入
+- Twitch auth / heartbeat / claim 邏輯接線
+- 舊殼與 `extensions/` cleanup
 
 ### 第三類：程式碼命名清理
 
@@ -107,13 +112,17 @@
 
 ---
 
-## 5. 後續需要明確回答的問題
+## 5. 已回答與待後續處理的問題
 
-在開始任何 Chrome Extension migration 前，至少要先定義：
+本輪已回答：
 
-1. `tachimint` 現在是否仍以 Twitch-hosted extension 為唯一可運作實作？
-2. Chrome Extension 是已定案產品方向，還是僅為探索中的可能形態？
-3. 若要遷移，誰提供 viewer identity、channel context、Bits 相關能力？
-4. 哪些文件是新的 source of truth？
+1. `tachimint/` 保留，作為唯一正式前端 surface
+2. Chrome sidepanel 是已定案產品方向
+3. 本階段仍沿用 Twitch identity 與既有 backend contract
+4. 新的 migration decision source of truth 為 [docs/tachimint-chrome-sidepanel-migration.md](tachimint-chrome-sidepanel-migration.md)
 
-在這些問題被正式回答前，建議 repo 文件保持「現況真實」優先。
+仍待後續 implementation PR 處理：
+
+1. sidepanel runtime 內如何承接既有 Twitch auth/context 流程
+2. demo state 如何逐步替換為正式 product state
+3. 哪些 Twitch-hosted 遺留檔案可以在最後 cleanup PR 刪除

--- a/docs/tachimint-chrome-sidepanel-migration.md
+++ b/docs/tachimint-chrome-sidepanel-migration.md
@@ -1,0 +1,65 @@
+# Tachimint Chrome Sidepanel Migration Decision
+
+> 用途：記錄 `tachimint` 前端 migration 的已定案方向，作為後續 PR 的共同 source of truth。
+> 狀態：已定案的 migration decision，不是完整實作 spec。
+> 最後更新：2026-04-16
+
+---
+
+## 1. 本次已定案事項
+
+`tachimint` 前端接下來採用以下方向：
+
+1. 保留 `tachimint/` 目錄名稱，不另開長期並行的第二前端 product surface
+2. 前端 runtime 由舊的 Twitch-hosted panel，遷移為 Chrome sidepanel extension
+3. 身份來源在本階段仍沿用 Twitch 相關流程
+4. backend contract 在本階段沿用既有 API，不於本輪重設
+5. `extensions/tachigo-demo-sidepanel/` 視為 migration source，不是長期保留的正式產品入口
+
+---
+
+## 2. 本輪明確不做
+
+這次 migration decision 只定義前端方向，不包含以下內容：
+
+- 不重做 backend API contract
+- 不重新設計 viewer identity / channel context 來源
+- 不同步擴張到 `backend/` 或 `dashboard/`
+- 不在同一輪順便做 terminology 全面重命名
+- 不把 demo state 直接當成正式 domain model 定案
+
+---
+
+## 3. 為什麼要這樣切
+
+目前 `tachimint` 內仍有既有產品邏輯與後端契約，例如 Twitch auth、heartbeat、claim 與相關 API wiring；另一方面，`extensions/tachigo-demo-sidepanel/` 已經提供較接近目標方向的 Chrome sidepanel shell 與新 UI。
+
+因此這次 migration 採用的策略是：
+
+- 保留 `tachimint/` 作為唯一正式前端 surface
+- 以 `extensions/` 的 runtime 與 UI 作為 migration source
+- 逐步把既有 `tachimint` 的產品邏輯接回新的 sidepanel shell
+
+---
+
+## 4. 後續 PR 期望拆法
+
+後續實作以小顆粒 frontend PR 進行，原則如下：
+
+1. 先建立 `tachimint` 的 sidepanel runtime 骨架
+2. 再導入新 app shell 與視覺
+3. 再把 Twitch auth、heartbeat、claim 等既有邏輯接回
+4. 最後再移除 `extensions/tachigo-demo-sidepanel/` 與過時舊殼
+
+---
+
+## 5. 與現有命名的關係
+
+本 decision 只處理產品 runtime 與 migration 邊界，不直接表示下列命名在本輪就要同步變更：
+
+- `extension_jwt`
+- `/extension/*` routes
+- `ExtensionService`
+- 其他既有 contract / schema / Swagger 用語
+
+這些內容若要調整，應另開獨立的 contract / refactor scope 處理。

--- a/tachimint/README.md
+++ b/tachimint/README.md
@@ -1,45 +1,27 @@
 # tachimint
 
-`tachimint` 是 `tachigo` repo 內唯一正式維護的前端 surface。
+Twitch Extension frontend for tachigo.
+Built with React + TypeScript + Vite.
 
-目前已定案的方向是：
+目前實作仍依賴 Twitch-hosted runtime / helper 與 `extension_jwt` 流程。
+若未來要改成 Chrome Extension，需要另行定義 migration spec，而不是直接把現況文件整批改名。
 
-- 前端 runtime 逐步遷移為 Chrome sidepanel extension
-- 本階段仍沿用 Twitch identity / extension auth 相關流程
-- backend contract 仍沿用既有 API
+## Dev
 
-完整決策請見 [../docs/tachimint-chrome-sidepanel-migration.md](../docs/tachimint-chrome-sidepanel-migration.md)。
+Run from the repo root:
 
-## 目前定位
+```bash
+make dev          # starts Vite dev server at http://localhost:5173
+```
 
-這個目錄是後續 migration 的收斂目標，不會與 `extensions/tachigo-demo-sidepanel/` 長期並存成兩個正式產品入口。
+`window.Twitch.ext` is automatically mocked in dev mode.
+No Twitch Developer Rig needed for UI development.
 
-`extensions/tachigo-demo-sidepanel/` 在這個階段的角色是 migration source：
+## Build
 
-- 提供 sidepanel runtime 方向
-- 提供新 app shell / UI 參考
-- 不作為長期保留的正式前端 surface
+```bash
+docker compose run --no-deps --rm frontend npm run build
+# output -> dist/
+```
 
-## 本輪 migration 邊界
-
-這個 migration decision 目前只固定以下原則：
-
-- 保留 `tachimint/` 目錄名稱
-- runtime 遷移到 Chrome sidepanel
-- 暫時保留 Twitch identity 與既有 extension auth 相關流程
-- 暫時沿用既有 backend contract
-
-這個階段明確不做：
-
-- 不重做 backend API contract
-- 不另建新的 viewer identity 系統
-- 不同步擴張到 `backend/` 或 `dashboard/`
-
-## 後續實作方向
-
-後續 frontend PR 預期按這個順序收斂：
-
-1. 建立 sidepanel runtime 骨架
-2. 導入新的 app shell 與 UI
-3. 把 Twitch auth、heartbeat、claim 等既有邏輯接回
-4. 最後清掉過時舊殼與 `extensions/` 遺留
+Upload `dist/` to the Twitch Developer Console to test as a hosted extension.

--- a/tachimint/README.md
+++ b/tachimint/README.md
@@ -1,27 +1,45 @@
 # tachimint
 
-Twitch Extension frontend for tachigo.
-Built with React + TypeScript + Vite.
+`tachimint` 是 `tachigo` repo 內唯一正式維護的前端 surface。
 
-目前實作仍依賴 Twitch-hosted runtime / helper 與 `extension_jwt` 流程。
-若未來要改成 Chrome Extension，需要另行定義 migration spec，而不是直接把現況文件整批改名。
+目前已定案的方向是：
 
-## Dev
+- 前端 runtime 逐步遷移為 Chrome sidepanel extension
+- 本階段仍沿用 Twitch identity / extension auth 相關流程
+- backend contract 仍沿用既有 API
 
-Run from the repo root:
+完整決策請見 [../docs/tachimint-chrome-sidepanel-migration.md](../docs/tachimint-chrome-sidepanel-migration.md)。
 
-```bash
-make dev          # starts Vite dev server at http://localhost:5173
-```
+## 目前定位
 
-`window.Twitch.ext` is automatically mocked in dev mode.
-No Twitch Developer Rig needed for UI development.
+這個目錄是後續 migration 的收斂目標，不會與 `extensions/tachigo-demo-sidepanel/` 長期並存成兩個正式產品入口。
 
-## Build
+`extensions/tachigo-demo-sidepanel/` 在這個階段的角色是 migration source：
 
-```bash
-docker compose run --no-deps --rm frontend npm run build
-# output -> dist/
-```
+- 提供 sidepanel runtime 方向
+- 提供新 app shell / UI 參考
+- 不作為長期保留的正式前端 surface
 
-Upload `dist/` to the Twitch Developer Console to test as a hosted extension.
+## 本輪 migration 邊界
+
+這個 migration decision 目前只固定以下原則：
+
+- 保留 `tachimint/` 目錄名稱
+- runtime 遷移到 Chrome sidepanel
+- 暫時保留 Twitch identity 與既有 extension auth 相關流程
+- 暫時沿用既有 backend contract
+
+這個階段明確不做：
+
+- 不重做 backend API contract
+- 不另建新的 viewer identity 系統
+- 不同步擴張到 `backend/` 或 `dashboard/`
+
+## 後續實作方向
+
+後續 frontend PR 預期按這個順序收斂：
+
+1. 建立 sidepanel runtime 骨架
+2. 導入新的 app shell 與 UI
+3. 把 Twitch auth、heartbeat、claim 等既有邏輯接回
+4. 最後清掉過時舊殼與 `extensions/` 遺留


### PR DESCRIPTION
## 什麼改動
- 新增 `docs/tachimint-chrome-sidepanel-migration.md`，記錄已定案的 frontend migration decision
- 同步更新 `docs/architecture.md`、`docs/chrome-extension-terminology-audit.md` 與 repo root `README.md`
- 將 `tachimint` 的方向收斂為 Chrome sidepanel runtime，並註明本階段仍沿用 Twitch identity 與既有 backend contract

## 為什麼
- 先建立 repo 內可引用的 source of truth，讓後續 frontend migration PR 可以小顆粒拆開進行
- 避免 `tachimint` 新方向只停留在 issue 討論串，導致後續 review 與文件描述不一致

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#246、`docs/tachimint-chrome-sidepanel-migration.md`
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 `tachimint/` runtime code
  - 不刪除 `extensions/tachigo-demo-sidepanel/`
  - 不修改 `backend/` / `dashboard/` scope
  - 不重做 backend contract 或 viewer identity 系統

## 超出範圍內容
- 無

## 測試方式
- [x] 文件與 repo 描述人工檢查
- [ ] 本地自動化測試

## 備註
- refs #246