### PR TITLE
[backend] 錢包綁定前置 — auth_providers partial unique index + SIWE helpers 抽取

### DIFF
--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -247,13 +248,16 @@ func (h *AuthHandler) Web3Nonce(c *gin.Context) {
 		return
 	}
 
-	nonce, err := h.auth.Web3Nonce(body.Address)
+	nonce, issuedAt, err := h.auth.Web3Nonce(body.Address)
 	if err != nil {
 		internal(c)
 		return
 	}
 
-	ok(c, gin.H{"nonce": nonce})
+	ok(c, NonceResponse{
+		Nonce:    nonce,
+		IssuedAt: issuedAt.UTC().Format(time.RFC3339),
+	})
 }
 
 // Web3Verify godoc

--- a/backend/internal/handlers/swagger_types.go
+++ b/backend/internal/handlers/swagger_types.go
@@ -45,7 +45,8 @@ type AddressesResponse struct {
 
 // NonceResponse wraps a Web3 nonce.
 type NonceResponse struct {
-	Nonce string `json:"nonce"`
+	Nonce    string `json:"nonce"`
+	IssuedAt string `json:"issued_at"`
 }
 
 type PointsBalanceResponse struct {

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -282,7 +282,6 @@ func newTestEnv(t *testing.T) *testEnv {
 	protected.Use(middleware.JWTAuth(authSvc))
 	protected.GET("users/me", userH.Me)
 	protected.PUT("users/me", userH.UpdateMe)
-	protected.POST("users/me/wallet", userH.LinkWallet)
 	protected.GET("users/me/providers", userH.ListProviders)
 	protected.DELETE("auth/providers/:provider", authH.UnlinkProvider)
 	protected.POST("auth/verify-email/send", emailH.SendVerification)

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -44,6 +44,12 @@ func migrateTestDB(db *gorm.DB) error {
 			updated_at DATETIME,
 			deleted_at DATETIME
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
+			ON auth_providers (provider, provider_id)
+			WHERE deleted_at IS NULL`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_web3_user_active
+			ON auth_providers (user_id, provider)
+			WHERE provider = 'web3' AND deleted_at IS NULL`,
 		`CREATE TABLE IF NOT EXISTS shipping_addresses (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
@@ -215,6 +221,7 @@ func (m *mockMailer) Send(to, subject, body string) error {
 type testEnv struct {
 	db           *gorm.DB
 	authSvc      *services.AuthService
+	userSvc      *services.UserService
 	emailAuthSvc *services.EmailAuthService
 	router       *gin.Engine
 }
@@ -223,7 +230,8 @@ func newTestEnv(t *testing.T) *testEnv {
 	t.Helper()
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+		Logger:         logger.Default.LogMode(logger.Silent),
+		TranslateError: true,
 	})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -274,6 +282,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	protected.Use(middleware.JWTAuth(authSvc))
 	protected.GET("users/me", userH.Me)
 	protected.PUT("users/me", userH.UpdateMe)
+	protected.POST("users/me/wallet", userH.LinkWallet)
 	protected.GET("users/me/providers", userH.ListProviders)
 	protected.DELETE("auth/providers/:provider", authH.UnlinkProvider)
 	protected.POST("auth/verify-email/send", emailH.SendVerification)
@@ -285,7 +294,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	addrs.DELETE("/:id", addrH.Delete)
 	addrs.PUT("/:id/default", addrH.SetDefault)
 
-	return &testEnv{db: db, authSvc: authSvc, emailAuthSvc: emailAuthSvc, router: r}
+	return &testEnv{db: db, authSvc: authSvc, userSvc: userSvc, emailAuthSvc: emailAuthSvc, router: r}
 }
 
 // registerUser is a helper that registers a user and returns access + refresh tokens.

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -225,11 +225,11 @@ func (s *AuthService) GoogleCallback(ctx context.Context, code string) (*models.
 
 // ─── Web3 / SIWE ─────────────────────────────────────────────────────────────
 
-func (s *AuthService) Web3Nonce(address string) (string, error) {
+func (s *AuthService) Web3Nonce(address string) (string, time.Time, error) {
 	address = strings.ToLower(address)
 	nonce, err := generateNonce()
 	if err != nil {
-		return "", err
+		return "", time.Time{}, err
 	}
 
 	// Delete any existing nonces for this address
@@ -241,9 +241,9 @@ func (s *AuthService) Web3Nonce(address string) (string, error) {
 		ExpiresAt: time.Now().Add(5 * time.Minute),
 	}
 	if err := s.db.Create(record).Error; err != nil {
-		return "", err
+		return "", time.Time{}, err
 	}
-	return nonce, nil
+	return nonce, record.CreatedAt, nil
 }
 
 type Web3VerifyInput struct {

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
@@ -48,10 +47,10 @@ type Claims struct {
 }
 
 type AuthService struct {
-	db           *gorm.DB
-	cfg          *config.Config
-	twitchOAuth  *oauth2.Config
-	googleOAuth  *oauth2.Config
+	db          *gorm.DB
+	cfg         *config.Config
+	twitchOAuth *oauth2.Config
+	googleOAuth *oauth2.Config
 }
 
 func NewAuthService(db *gorm.DB, cfg *config.Config) *AuthService {
@@ -464,37 +463,6 @@ func (s *AuthService) linkProvider(userID uuid.UUID, provider models.ProviderTyp
 		ap.TokenExpiresAt = &token.Expiry
 	}
 	return s.db.Save(&ap).Error
-}
-
-// ─── SIWE / crypto helpers ───────────────────────────────────────────────────
-
-func siweMessage(address, nonce string) string {
-	return fmt.Sprintf(
-		"tachigo.io wants you to sign in with your Ethereum account:\n%s\n\nSign in to Tachigo\n\nNonce: %s\nIssued At: %s",
-		address, nonce, time.Now().UTC().Format(time.RFC3339),
-	)
-}
-
-func verifyEthSignature(message, sigHex, expectedAddress string) bool {
-	sigBytes, err := hex.DecodeString(strings.TrimPrefix(sigHex, "0x"))
-	if err != nil || len(sigBytes) != 65 {
-		return false
-	}
-	// Ethereum adds "\x19Ethereum Signed Message:\n" prefix
-	prefixed := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
-	hash := crypto.Keccak256Hash([]byte(prefixed))
-
-	// Adjust v (last byte)
-	if sigBytes[64] >= 27 {
-		sigBytes[64] -= 27
-	}
-
-	pubKey, err := crypto.SigToPub(hash.Bytes(), sigBytes)
-	if err != nil {
-		return false
-	}
-	recovered := strings.ToLower(crypto.PubkeyToAddress(*pubKey).Hex())
-	return recovered == strings.ToLower(expectedAddress)
 }
 
 // ─── Utility ─────────────────────────────────────────────────────────────────

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -265,7 +265,7 @@ func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPai
 	}
 
 	// Verify signature
-	msg := siweMessage(address, input.Nonce)
+	msg := siweMessage(address, input.Nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
 	if !verifyEthSignature(msg, input.Signature, address) {
 		return nil, nil, ErrInvalidSignature
 	}

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -208,12 +208,15 @@ func TestWeb3Nonce_Success(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewAuthService(db, testConfig())
 
-	nonce, err := svc.Web3Nonce("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	nonce, issuedAt, err := svc.Web3Nonce("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if nonce == "" {
 		t.Error("expected non-empty nonce")
+	}
+	if issuedAt.IsZero() {
+		t.Error("expected non-zero issuedAt")
 	}
 }
 
@@ -222,8 +225,8 @@ func TestWeb3Nonce_ReplacesExisting(t *testing.T) {
 	svc := NewAuthService(db, testConfig())
 	address := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
-	nonce1, _ := svc.Web3Nonce(address)
-	nonce2, _ := svc.Web3Nonce(address)
+	nonce1, _, _ := svc.Web3Nonce(address)
+	nonce2, _, _ := svc.Web3Nonce(address)
 
 	if nonce1 == nonce2 {
 		t.Error("expected different nonces on repeated calls")

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -225,8 +225,14 @@ func TestWeb3Nonce_ReplacesExisting(t *testing.T) {
 	svc := NewAuthService(db, testConfig())
 	address := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
-	nonce1, _, _ := svc.Web3Nonce(address)
-	nonce2, _, _ := svc.Web3Nonce(address)
+	nonce1, _, err := svc.Web3Nonce(address)
+	if err != nil {
+		t.Fatalf("first Web3Nonce call failed: %v", err)
+	}
+	nonce2, _, err := svc.Web3Nonce(address)
+	if err != nil {
+		t.Fatalf("second Web3Nonce call failed: %v", err)
+	}
 
 	if nonce1 == nonce2 {
 		t.Error("expected different nonces on repeated calls")

--- a/backend/internal/services/siwe.go
+++ b/backend/internal/services/siwe.go
@@ -4,16 +4,17 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
 // siweMessage builds the EIP-4361 message that the user must sign.
-func siweMessage(address, nonce string) string {
+// issuedAt must be the nonce record's CreatedAt in RFC3339 UTC format,
+// so the message is deterministic across sign and verify calls.
+func siweMessage(address, nonce, issuedAt string) string {
 	return fmt.Sprintf(
 		"tachigo.io wants you to sign in with your Ethereum account:\n%s\n\nSign in to Tachigo\n\nNonce: %s\nIssued At: %s",
-		address, nonce, time.Now().UTC().Format(time.RFC3339),
+		address, nonce, issuedAt,
 	)
 }
 

--- a/backend/internal/services/siwe.go
+++ b/backend/internal/services/siwe.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// siweMessage builds the EIP-4361 message that the user must sign.
+func siweMessage(address, nonce string) string {
+	return fmt.Sprintf(
+		"tachigo.io wants you to sign in with your Ethereum account:\n%s\n\nSign in to Tachigo\n\nNonce: %s\nIssued At: %s",
+		address, nonce, time.Now().UTC().Format(time.RFC3339),
+	)
+}
+
+// verifyEthSignature recovers the signer address from a personal_sign
+// signature and compares it to expectedAddress case-insensitively.
+func verifyEthSignature(message, sigHex, expectedAddress string) bool {
+	sigBytes, err := hex.DecodeString(strings.TrimPrefix(sigHex, "0x"))
+	if err != nil || len(sigBytes) != 65 {
+		return false
+	}
+
+	prefixed := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
+	hash := crypto.Keccak256Hash([]byte(prefixed))
+
+	if sigBytes[64] >= 27 {
+		sigBytes[64] -= 27
+	}
+
+	pubKey, err := crypto.SigToPub(hash.Bytes(), sigBytes)
+	if err != nil {
+		return false
+	}
+	recovered := strings.ToLower(crypto.PubkeyToAddress(*pubKey).Hex())
+	return recovered == strings.ToLower(expectedAddress)
+}

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -61,6 +61,12 @@ func migrateTestDB(db *gorm.DB) error {
 			updated_at DATETIME,
 			deleted_at DATETIME
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
+			ON auth_providers (provider, provider_id)
+			WHERE deleted_at IS NULL`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_web3_user_active
+			ON auth_providers (user_id, provider)
+			WHERE provider = 'web3' AND deleted_at IS NULL`,
 		`CREATE TABLE IF NOT EXISTS shipping_addresses (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),

--- a/backend/migrations/014_auth_provider_partial_unique.sql
+++ b/backend/migrations/014_auth_provider_partial_unique.sql
@@ -1,0 +1,15 @@
+-- Drop the global unique constraint added in 001_init.sql.
+-- Soft-deleted rows (deleted_at IS NOT NULL) must not block re-binding
+-- the same wallet, so we replace it with partial unique indexes.
+ALTER TABLE auth_providers
+    DROP CONSTRAINT IF EXISTS auth_providers_provider_provider_id_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+    idx_auth_providers_provider_provider_id_active
+ON auth_providers(provider, provider_id)
+WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+    idx_auth_providers_web3_user_active
+ON auth_providers(user_id, provider)
+WHERE provider = 'web3' AND deleted_at IS NULL;

--- a/docs/superpowers/plans/2026-04-16-wallet-binding.md
+++ b/docs/superpowers/plans/2026-04-16-wallet-binding.md
@@ -1,0 +1,1206 @@
+# POST /users/me/wallet — MetaMask Wallet Binding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow authenticated Twitch users to link their MetaMask wallet via SIWE signature, enabling `ClaimService` to resolve the wallet address for on-chain mint.
+
+**Architecture:** Add `UserService.LinkWallet` backed by a SIWE signature check; extract shared SIWE helpers to `services/siwe.go`; replace the global unique constraint on `auth_providers(provider, provider_id)` with a partial index so soft-deleted rows don't block re-binding; soft-delete the old web3 row on replace and restore (not insert) if the same address is re-bound.
+
+**Tech Stack:** Go, Gin, GORM, SQLite (tests), PostgreSQL (production), `github.com/ethereum/go-ethereum` (already in go.mod)
+
+**Spec:** `docs/superpowers/specs/2026-04-16-wallet-binding-design.md`
+
+---
+
+## File Map
+
+| Action | File |
+|---|---|
+| Create | `backend/migrations/014_auth_provider_partial_unique.sql` |
+| Modify | `backend/internal/services/testutil_test.go` |
+| Modify | `backend/internal/handlers/testutil_test.go` |
+| Create | `backend/internal/services/siwe.go` |
+| Modify | `backend/internal/services/auth_service.go` |
+| Modify | `backend/internal/database/db.go` |
+| Modify | `backend/internal/services/user_service.go` |
+| Modify | `backend/internal/services/user_service_test.go` |
+| Modify | `backend/internal/handlers/swagger_types.go` |
+| Modify | `backend/internal/handlers/user_handler.go` |
+| Modify | `backend/internal/handlers/testutil_test.go` |
+| Modify | `backend/internal/handlers/user_handler_test.go` |
+| Modify | `backend/internal/router/router.go` |
+
+---
+
+## Task 1: Migration 014 + update test helper schemas
+
+### Files:
+- Create: `backend/migrations/014_auth_provider_partial_unique.sql`
+- Modify: `backend/internal/services/testutil_test.go`
+- Modify: `backend/internal/handlers/testutil_test.go`
+
+- [ ] **Step 1: Create migration file**
+
+```sql
+-- backend/migrations/014_auth_provider_partial_unique.sql
+
+-- Drop the global unique constraint added in 001_init.sql.
+-- Soft-deleted rows (deleted_at IS NOT NULL) must not block re-binding
+-- the same wallet, so we replace it with a partial unique index.
+ALTER TABLE auth_providers
+    DROP CONSTRAINT IF EXISTS auth_providers_provider_provider_id_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+    idx_auth_providers_provider_provider_id_active
+ON auth_providers(provider, provider_id)
+WHERE deleted_at IS NULL;
+```
+
+- [ ] **Step 2: Add partial index to the services test helper**
+
+In `backend/internal/services/testutil_test.go`, add the index statement **after** the `auth_providers` table CREATE in `migrateTestDB`. Find the block that ends with:
+
+```go
+		`CREATE TABLE IF NOT EXISTS web3_nonces (
+			id TEXT PRIMARY KEY,
+			nonce TEXT NOT NULL UNIQUE,
+			address TEXT NOT NULL,
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME
+		)`,
+```
+
+Insert the new index immediately **before** that statement:
+
+```go
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
+			ON auth_providers (provider, provider_id)
+			WHERE deleted_at IS NULL`,
+```
+
+- [ ] **Step 3: Add partial index to the handlers test helper**
+
+In `backend/internal/handlers/testutil_test.go`, the `auth_providers` CREATE is followed by the `shipping_addresses` CREATE. Add the same index between them:
+
+```go
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
+			ON auth_providers (provider, provider_id)
+			WHERE deleted_at IS NULL`,
+```
+
+- [ ] **Step 4: Run existing tests to confirm nothing broke**
+
+```bash
+cd backend && docker compose run --no-deps --rm app go test ./internal/services/... ./internal/handlers/... -v 2>&1 | tail -40
+```
+
+Expected: all existing tests PASS (no failures related to auth_providers).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/migrations/014_auth_provider_partial_unique.sql \
+        backend/internal/services/testutil_test.go \
+        backend/internal/handlers/testutil_test.go
+git commit -m "feat: migration 014 — partial unique index on auth_providers
+
+Replaces UNIQUE(provider, provider_id) with a partial index that
+only covers active rows (deleted_at IS NULL), enabling soft-delete
++ re-bind without constraint violations.
+
+refs #<ISSUE_NUMBER>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Extract SIWE helpers to siwe.go
+
+### Files:
+- Create: `backend/internal/services/siwe.go`
+- Modify: `backend/internal/services/auth_service.go`
+
+- [ ] **Step 1: Create siwe.go with the two helpers**
+
+```go
+// backend/internal/services/siwe.go
+package services
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// siweMessage builds the EIP-4361 message that the user must sign.
+// Both auth_service (Web3Verify) and user_service (LinkWallet) use this.
+func siweMessage(address, nonce string) string {
+	return fmt.Sprintf(
+		"tachigo.io wants you to sign in with your Ethereum account:\n%s\n\nSign in to Tachigo\n\nNonce: %s\nIssued At: %s",
+		address, nonce, time.Now().UTC().Format(time.RFC3339),
+	)
+}
+
+// verifyEthSignature recovers the signer address from a personal_sign
+// (EIP-191) signature and compares it to expectedAddress (case-insensitive).
+func verifyEthSignature(message, sigHex, expectedAddress string) bool {
+	sigBytes, err := hex.DecodeString(strings.TrimPrefix(sigHex, "0x"))
+	if err != nil || len(sigBytes) != 65 {
+		return false
+	}
+	prefixed := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
+	hash := crypto.Keccak256Hash([]byte(prefixed))
+	if sigBytes[64] >= 27 {
+		sigBytes[64] -= 27
+	}
+	pubKey, err := crypto.SigToPub(hash.Bytes(), sigBytes)
+	if err != nil {
+		return false
+	}
+	recovered := strings.ToLower(crypto.PubkeyToAddress(*pubKey).Hex())
+	return recovered == strings.ToLower(expectedAddress)
+}
+```
+
+- [ ] **Step 2: Remove the two helpers from auth_service.go**
+
+In `backend/internal/services/auth_service.go`:
+
+a) Delete the `siweMessage` function (currently around line 471):
+
+```go
+func siweMessage(address, nonce string) string {
+	return fmt.Sprintf(
+		"tachigo.io wants you to sign in with your Ethereum account:\n%s\n\nSign in to Tachigo\n\nNonce: %s\nIssued At: %s",
+		address, nonce, time.Now().UTC().Format(time.RFC3339),
+	)
+}
+```
+
+b) Delete the `verifyEthSignature` function (currently around line 478):
+
+```go
+func verifyEthSignature(message, sigHex, expectedAddress string) bool {
+	sigBytes, err := hex.DecodeString(strings.TrimPrefix(sigHex, "0x"))
+	if err != nil || len(sigBytes) != 65 {
+		return false
+	}
+	prefixed := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
+	hash := crypto.Keccak256Hash([]byte(prefixed))
+	if sigBytes[64] >= 27 {
+		sigBytes[64] -= 27
+	}
+	pubKey, err := crypto.SigToPub(hash.Bytes(), sigBytes)
+	if err != nil {
+		return false
+	}
+	recovered := strings.ToLower(crypto.PubkeyToAddress(*pubKey).Hex())
+	return recovered == strings.ToLower(expectedAddress)
+}
+```
+
+c) Remove `"github.com/ethereum/go-ethereum/crypto"` from the import block (it is no longer used in `auth_service.go`; `common` and `hex` and `fmt` are still needed by other functions).
+
+- [ ] **Step 3: Build and test**
+
+```bash
+cd backend && docker compose run --no-deps --rm app go build ./... 2>&1
+```
+
+Expected: exits 0. If `crypto` import removal caused a compile error, re-check whether any remaining function in `auth_service.go` uses a `crypto.*` symbol.
+
+```bash
+docker compose run --no-deps --rm app go test ./internal/services/... -run TestVerifyEth -v 2>&1
+```
+
+Expected:
+```
+--- PASS: TestVerifyEthSignature_InvalidHex
+--- PASS: TestVerifyEthSignature_WrongLength
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/services/siwe.go \
+        backend/internal/services/auth_service.go
+git commit -m "refactor: extract SIWE helpers to services/siwe.go
+
+siweMessage and verifyEthSignature are now shared between auth_service
+and the upcoming user_service.LinkWallet, avoiding duplication.
+
+refs #<ISSUE_NUMBER>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: UserService.LinkWallet (TDD)
+
+### Files:
+- Modify: `backend/internal/database/db.go`
+- Modify: `backend/internal/services/user_service.go`
+- Modify: `backend/internal/services/user_service_test.go`
+
+- [ ] **Step 1: Enable TranslateError in the production DB connection**
+
+In `backend/internal/database/db.go`, change:
+
+```go
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Info),
+	})
+```
+
+to:
+
+```go
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger:         logger.Default.LogMode(logger.Info),
+		TranslateError: true,
+	})
+```
+
+This ensures `gorm.ErrDuplicatedKey` is returned consistently from both SQLite (tests) and PostgreSQL (production) when a unique constraint is violated.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add the following to `backend/internal/services/user_service_test.go`:
+
+```go
+// ─── LinkWallet helpers ──────────────────────────────────────────────────────
+
+// newTestWallet generates a fresh Ethereum key pair for testing.
+// Returns the private key and the EIP-55 checksummed address.
+func newTestWallet(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	addr := common.HexToAddress(crypto.PubkeyToAddress(key.PublicKey).Hex()).Hex()
+	return key, addr
+}
+
+// signSIWE signs a SIWE message with the given private key and returns
+// the 0x-prefixed hex signature (65 bytes with adjusted v byte).
+// siweMessage uses time.Now() with RFC3339 (second precision); this helper
+// must be called and the corresponding LinkWallet must be invoked within
+// the same second for the messages to match — always true in unit tests.
+func signSIWE(t *testing.T, message string, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	prefixed := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
+	hash := crypto.Keccak256Hash([]byte(prefixed))
+	sig, err := crypto.Sign(hash.Bytes(), key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig[64] += 27
+	return "0x" + hex.EncodeToString(sig)
+}
+
+// seedNonce inserts a Web3Nonce record for the given address into the test DB.
+func seedNonce(t *testing.T, db *gorm.DB, address, nonce string) {
+	t.Helper()
+	db.Create(&models.Web3Nonce{
+		Nonce:     nonce,
+		Address:   strings.ToLower(address),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+}
+
+// ─── LinkWallet tests ────────────────────────────────────────────────────────
+
+func TestLinkWallet_InvalidAddress(t *testing.T) {
+	svc := NewUserService(newTestDB(t))
+	_, err := svc.LinkWallet(uuid.New(), LinkWalletInput{
+		Address: "not-an-address", Nonce: "abc", Signature: "0xdeadbeef",
+	})
+	if err != ErrInvalidWalletAddress {
+		t.Errorf("want ErrInvalidWalletAddress, got %v", err)
+	}
+}
+
+func TestLinkWallet_NonceNotFound(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	_, privKey, addr := newTestWalletWithDB(t, db, userID, "nonce-x")
+	// Use a nonce that was never stored
+	msg := siweMessage(strings.ToLower(addr), "wrong-nonce")
+	sig := signSIWE(t, msg, privKey)
+
+	_, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address: addr, Nonce: "wrong-nonce", Signature: sig,
+	})
+	if err != ErrInvalidNonce {
+		t.Errorf("want ErrInvalidNonce, got %v", err)
+	}
+}
+
+func TestLinkWallet_NonceExpired(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonce := "expired-nonce"
+	db.Create(&models.Web3Nonce{
+		Nonce:     nonce,
+		Address:   strings.ToLower(addr),
+		ExpiresAt: time.Now().Add(-time.Minute), // expired
+	})
+	msg := siweMessage(strings.ToLower(addr), nonce)
+	sig := signSIWE(t, msg, key)
+
+	_, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address: addr, Nonce: nonce, Signature: sig,
+	})
+	if err != ErrInvalidNonce {
+		t.Errorf("want ErrInvalidNonce, got %v", err)
+	}
+}
+
+func TestLinkWallet_InvalidSignature(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	_, addr := newTestWallet(t)
+	nonce := "sig-test-nonce"
+	seedNonce(t, db, addr, nonce)
+
+	// Sign with a different key — address won't match
+	wrongKey, _ := newTestWallet(t)
+	msg := siweMessage(strings.ToLower(addr), nonce)
+	sig := signSIWE(t, msg, wrongKey)
+
+	_, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address: addr, Nonce: nonce, Signature: sig,
+	})
+	if err != ErrInvalidSignature {
+		t.Errorf("want ErrInvalidSignature, got %v", err)
+	}
+}
+
+func TestLinkWallet_Success_FirstBind(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonce := "first-bind-nonce"
+	seedNonce(t, db, addr, nonce)
+
+	msg := siweMessage(strings.ToLower(addr), nonce)
+	sig := signSIWE(t, msg, key)
+
+	got, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address: addr, Nonce: nonce, Signature: sig,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != addr {
+		t.Errorf("returned address: want %s, got %s", addr, got)
+	}
+
+	// AuthProvider should exist
+	var ap models.AuthProvider
+	if err := db.Where("user_id = ? AND provider = 'web3'", userID).First(&ap).Error; err != nil {
+		t.Fatalf("auth provider not found: %v", err)
+	}
+	if ap.ProviderID != addr {
+		t.Errorf("provider_id: want %s, got %s", addr, ap.ProviderID)
+	}
+
+	// Nonce should be consumed
+	var count int64
+	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&count)
+	if count != 0 {
+		t.Errorf("nonce should be consumed, still found %d", count)
+	}
+}
+
+func TestLinkWallet_ReplacesExistingWallet(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	// First bind
+	key1, addr1 := newTestWallet(t)
+	nonce1 := "replace-nonce-1"
+	seedNonce(t, db, addr1, nonce1)
+	msg1 := siweMessage(strings.ToLower(addr1), nonce1)
+	sig1 := signSIWE(t, msg1, key1)
+	svc.LinkWallet(userID, LinkWalletInput{Address: addr1, Nonce: nonce1, Signature: sig1})
+
+	// Second bind with a different wallet
+	key2, addr2 := newTestWallet(t)
+	nonce2 := "replace-nonce-2"
+	seedNonce(t, db, addr2, nonce2)
+	msg2 := siweMessage(strings.ToLower(addr2), nonce2)
+	sig2 := signSIWE(t, msg2, key2)
+
+	got, err := svc.LinkWallet(userID, LinkWalletInput{Address: addr2, Nonce: nonce2, Signature: sig2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != addr2 {
+		t.Errorf("returned address: want %s, got %s", addr2, got)
+	}
+
+	// Old row should be soft-deleted
+	var old models.AuthProvider
+	db.Unscoped().Where("user_id = ? AND provider_id = ?", userID, addr1).First(&old)
+	if !old.DeletedAt.Valid {
+		t.Error("old provider row should be soft-deleted")
+	}
+
+	// New row should be active
+	var active models.AuthProvider
+	db.Where("user_id = ? AND provider = 'web3'", userID).First(&active)
+	if active.ProviderID != addr2 {
+		t.Errorf("active provider_id: want %s, got %s", addr2, active.ProviderID)
+	}
+}
+
+func TestLinkWallet_RestoresSoftDeletedRow(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+
+	// First bind addr
+	nonce1 := "restore-nonce-1"
+	seedNonce(t, db, addr, nonce1)
+	msg1 := siweMessage(strings.ToLower(addr), nonce1)
+	svc.LinkWallet(userID, LinkWalletInput{Address: addr, Nonce: nonce1, Signature: signSIWE(t, msg1, key)})
+
+	// Bind a different address (soft-deletes addr's row)
+	key2, addr2 := newTestWallet(t)
+	nonce2 := "restore-nonce-2"
+	seedNonce(t, db, addr2, nonce2)
+	msg2 := siweMessage(strings.ToLower(addr2), nonce2)
+	svc.LinkWallet(userID, LinkWalletInput{Address: addr2, Nonce: nonce2, Signature: signSIWE(t, msg2, key2)})
+
+	// Re-bind original addr — should restore, not insert a new row
+	nonce3 := "restore-nonce-3"
+	seedNonce(t, db, addr, nonce3)
+	msg3 := siweMessage(strings.ToLower(addr), nonce3)
+	got, err := svc.LinkWallet(userID, LinkWalletInput{Address: addr, Nonce: nonce3, Signature: signSIWE(t, msg3, key)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != addr {
+		t.Errorf("returned address: want %s, got %s", addr, got)
+	}
+
+	// Only one active web3 row
+	var count int64
+	db.Model(&models.AuthProvider{}).Where("user_id = ? AND provider = 'web3'", userID).Count(&count)
+	if count != 1 {
+		t.Errorf("expected 1 active web3 provider, got %d", count)
+	}
+
+	// Total rows (including soft-deleted): still 2, not 3
+	db.Unscoped().Model(&models.AuthProvider{}).Where("user_id = ? AND provider = 'web3'", userID).Count(&count)
+	if count != 2 {
+		t.Errorf("expected 2 total web3 rows (1 active + 1 soft-deleted), got %d", count)
+	}
+}
+
+func TestLinkWallet_NonceReplay(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonce := "replay-nonce"
+	seedNonce(t, db, addr, nonce)
+
+	msg := siweMessage(strings.ToLower(addr), nonce)
+	sig := signSIWE(t, msg, key)
+	input := LinkWalletInput{Address: addr, Nonce: nonce, Signature: sig}
+
+	// First call succeeds
+	if _, err := svc.LinkWallet(userID, input); err != nil {
+		t.Fatalf("first call: unexpected error: %v", err)
+	}
+
+	// Second call with same nonce fails — nonce already consumed
+	_, err := svc.LinkWallet(userID, input)
+	if err != ErrInvalidNonce {
+		t.Errorf("want ErrInvalidNonce on replay, got %v", err)
+	}
+}
+
+func TestLinkWallet_WalletAlreadyLinkedToOtherUser(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+
+	// User A binds addr
+	userA := uuid.New()
+	db.Create(&models.User{ID: userA, Role: models.RoleViewer})
+	key, addr := newTestWallet(t)
+	nonce1 := "conflict-nonce-1"
+	seedNonce(t, db, addr, nonce1)
+	msg1 := siweMessage(strings.ToLower(addr), nonce1)
+	svc.LinkWallet(userA, LinkWalletInput{Address: addr, Nonce: nonce1, Signature: signSIWE(t, msg1, key)})
+
+	// User B tries to bind the same addr
+	userB := uuid.New()
+	db.Create(&models.User{ID: userB, Role: models.RoleViewer})
+	nonce2 := "conflict-nonce-2"
+	seedNonce(t, db, addr, nonce2)
+	msg2 := siweMessage(strings.ToLower(addr), nonce2)
+	_, err := svc.LinkWallet(userB, LinkWalletInput{
+		Address: addr, Nonce: nonce2, Signature: signSIWE(t, msg2, key),
+	})
+	if err != ErrProviderLinked {
+		t.Errorf("want ErrProviderLinked, got %v", err)
+	}
+}
+```
+
+Also add the following imports to `user_service_test.go` (merge with existing import block):
+
+```go
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+```
+
+And add this helper (used in the NonceNotFound test to avoid a compile issue; simplify by removing the `newTestWalletWithDB` call and replace that test):
+
+Actually, update `TestLinkWallet_NonceNotFound` to remove the `newTestWalletWithDB` reference — replace it with:
+
+```go
+func TestLinkWallet_NonceNotFound(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	_, addr := newTestWallet(t)
+	// No nonce seeded — First() will return ErrRecordNotFound
+
+	_, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address: addr, Nonce: "nonexistent-nonce", Signature: "0x" + strings.Repeat("ab", 65),
+	})
+	if err != ErrInvalidNonce {
+		t.Errorf("want ErrInvalidNonce, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+```bash
+cd backend && docker compose run --no-deps --rm app go test ./internal/services/... -run TestLinkWallet -v 2>&1 | tail -30
+```
+
+Expected: compilation error `undefined: LinkWalletInput` — confirms tests are in place.
+
+- [ ] **Step 4: Implement UserService.LinkWallet**
+
+In `backend/internal/services/user_service.go`, add imports and implementation:
+
+**Imports to add** (merge with existing):
+```go
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+```
+
+**Add after the existing `ErrUsernameExists` declaration** (at top of file, near other vars):
+```go
+var ErrInvalidWalletAddress = errors.New("invalid wallet address")
+```
+
+**Add the input type and method**:
+```go
+type LinkWalletInput struct {
+	Address   string `json:"address"   binding:"required"`
+	Nonce     string `json:"nonce"     binding:"required"`
+	Signature string `json:"signature" binding:"required"`
+}
+
+// LinkWallet binds a MetaMask wallet to the authenticated user.
+// Any previously bound wallet is soft-deleted. If the same address was
+// previously bound and then removed, its row is restored rather than
+// re-inserted, preserving the original created_at.
+func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (string, error) {
+	// 1. Validate and normalize address.
+	if !common.IsHexAddress(input.Address) {
+		return "", ErrInvalidWalletAddress
+	}
+	checksumAddr := common.HexToAddress(input.Address).Hex()
+	lookupAddr := strings.ToLower(checksumAddr)
+
+	// 2. Look up nonce (before transaction — fast exit on bad input).
+	var nonceRecord models.Web3Nonce
+	if err := s.db.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
+		First(&nonceRecord).Error; err != nil {
+		return "", ErrInvalidNonce
+	}
+	if nonceRecord.IsExpired() {
+		return "", ErrInvalidNonce
+	}
+
+	// 3. Verify SIWE signature.
+	msg := siweMessage(lookupAddr, input.Nonce)
+	if !verifyEthSignature(msg, input.Signature, lookupAddr) {
+		return "", ErrInvalidSignature
+	}
+
+	// 4. Atomically: consume nonce, enforce no cross-user conflict,
+	//    soft-delete old provider, restore or insert new provider.
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		// Consume nonce; RowsAffected check prevents concurrent replay.
+		result := tx.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
+			Delete(&models.Web3Nonce{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return ErrInvalidNonce
+		}
+
+		// Reject if this wallet is already active for a different user.
+		var count int64
+		if err := tx.Model(&models.AuthProvider{}).
+			Where("provider = ? AND provider_id = ? AND deleted_at IS NULL AND user_id != ?",
+				models.ProviderWeb3, checksumAddr, userID).
+			Count(&count).Error; err != nil {
+			return err
+		}
+		if count > 0 {
+			return ErrProviderLinked
+		}
+
+		// Soft-delete the current active web3 row for this user (if any).
+		now := time.Now()
+		if err := tx.Model(&models.AuthProvider{}).
+			Where("user_id = ? AND provider = ? AND deleted_at IS NULL",
+				userID, models.ProviderWeb3).
+			Update("deleted_at", now).Error; err != nil {
+			return err
+		}
+
+		// Restore an existing soft-deleted row for this exact address,
+		// or insert a new one if none exists.
+		var ap models.AuthProvider
+		findErr := tx.Unscoped().
+			Where("user_id = ? AND provider = ? AND provider_id = ?",
+				userID, models.ProviderWeb3, checksumAddr).
+			First(&ap).Error
+
+		if findErr == nil {
+			// Row exists (soft-deleted after step above) — restore it.
+			if err := tx.Unscoped().Model(&ap).
+				UpdateColumn("deleted_at", gorm.Expr("NULL")).Error; err != nil {
+				if errors.Is(err, gorm.ErrDuplicatedKey) {
+					return ErrProviderLinked
+				}
+				return err
+			}
+		} else if errors.Is(findErr, gorm.ErrRecordNotFound) {
+			// No prior row — insert fresh.
+			newAP := models.AuthProvider{
+				UserID:     userID,
+				Provider:   models.ProviderWeb3,
+				ProviderID: checksumAddr,
+			}
+			if err := tx.Create(&newAP).Error; err != nil {
+				if errors.Is(err, gorm.ErrDuplicatedKey) {
+					return ErrProviderLinked
+				}
+				return err
+			}
+		} else {
+			return findErr
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+	return checksumAddr, nil
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cd backend && docker compose run --no-deps --rm app go test ./internal/services/... -run TestLinkWallet -v 2>&1
+```
+
+Expected output (all pass):
+```
+--- PASS: TestLinkWallet_InvalidAddress
+--- PASS: TestLinkWallet_NonceNotFound
+--- PASS: TestLinkWallet_NonceExpired
+--- PASS: TestLinkWallet_InvalidSignature
+--- PASS: TestLinkWallet_Success_FirstBind
+--- PASS: TestLinkWallet_ReplacesExistingWallet
+--- PASS: TestLinkWallet_RestoresSoftDeletedRow
+--- PASS: TestLinkWallet_NonceReplay
+--- PASS: TestLinkWallet_WalletAlreadyLinkedToOtherUser
+```
+
+- [ ] **Step 6: Run full service test suite to confirm no regressions**
+
+```bash
+docker compose run --no-deps --rm app go test ./internal/services/... 2>&1 | tail -10
+```
+
+Expected: `ok` for all packages, 0 failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/internal/database/db.go \
+        backend/internal/services/user_service.go \
+        backend/internal/services/user_service_test.go
+git commit -m "feat: UserService.LinkWallet — SIWE-verified wallet binding
+
+Allows an authenticated user to bind a MetaMask wallet. Implements:
+- address validation and EIP-55 checksum normalization
+- SIWE nonce + signature verification
+- atomic nonce consumption with RowsAffected guard
+- soft-delete of old provider + restore-or-insert pattern
+- ErrProviderLinked on cross-user conflict or race
+
+refs #<ISSUE_NUMBER>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: WalletResponse + UserHandler.LinkWallet
+
+### Files:
+- Modify: `backend/internal/handlers/swagger_types.go`
+- Modify: `backend/internal/handlers/user_handler.go`
+- Modify: `backend/internal/handlers/testutil_test.go`
+- Modify: `backend/internal/handlers/user_handler_test.go`
+
+- [ ] **Step 1: Add WalletResponse to swagger_types.go**
+
+In `backend/internal/handlers/swagger_types.go`, add at the end of the file:
+
+```go
+// WalletResponse wraps the bound wallet address.
+type WalletResponse struct {
+	Address string `json:"address"`
+}
+```
+
+- [ ] **Step 2: Implement the handler**
+
+In `backend/internal/handlers/user_handler.go`, add:
+
+```go
+// LinkWallet godoc
+// @Summary      Bind a MetaMask wallet to the current user
+// @Description  Verifies a SIWE signature (obtained via POST /auth/web3/nonce) and
+// @Description  links the wallet address to the authenticated user. Replaces any
+// @Description  previously linked wallet.
+// @Tags         users
+// @Accept       json
+// @Produce      json
+// @Param        body body services.LinkWalletInput true "address, nonce, signature"
+// @Success      200  {object}  Response{data=WalletResponse}
+// @Failure      400  {object}  Response
+// @Failure      401  {object}  Response
+// @Failure      409  {object}  Response
+// @Security     BearerAuth
+// @Router       /users/me/wallet [post]
+func (h *UserHandler) LinkWallet(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, _ := uuid.Parse(claims.UserID)
+
+	var input services.LinkWalletInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+
+	addr, err := h.user.LinkWallet(userID, input)
+	if err != nil {
+		switch err {
+		case services.ErrInvalidWalletAddress:
+			badRequest(c, "invalid wallet address")
+		case services.ErrInvalidNonce:
+			unauthorized(c, "invalid or expired nonce")
+		case services.ErrInvalidSignature:
+			unauthorized(c, "invalid wallet signature")
+		case services.ErrProviderLinked:
+			conflict(c, "wallet already linked to another account")
+		default:
+			internal(c)
+		}
+		return
+	}
+
+	ok(c, gin.H{"address": addr})
+}
+```
+
+Make sure `user_handler.go` imports `"github.com/google/uuid"`, `"github.com/tachigo/tachigo/internal/middleware"`, and `"github.com/tachigo/tachigo/internal/services"` — these are already present.
+
+- [ ] **Step 3: Register route in the handler test env**
+
+In `backend/internal/handlers/testutil_test.go`:
+
+a) Add `userSvc *services.UserService` field to `testEnv`:
+
+```go
+type testEnv struct {
+	db           *gorm.DB
+	authSvc      *services.AuthService
+	userSvc      *services.UserService
+	emailAuthSvc *services.EmailAuthService
+	router       *gin.Engine
+}
+```
+
+b) In `newTestEnv`, after `userSvc := services.NewUserService(db)`, store it on the struct and update `userH`:
+
+```go
+	userSvc := services.NewUserService(db)
+	// ...
+	return &testEnv{db: db, authSvc: authSvc, userSvc: userSvc, emailAuthSvc: emailAuthSvc, router: r}
+```
+
+c) Add the route in the `protected` group (after the existing `PUT("users/me", ...)` line):
+
+```go
+	protected.POST("users/me/wallet", userH.LinkWallet)
+```
+
+- [ ] **Step 4: Write the handler tests**
+
+Add the following to `backend/internal/handlers/user_handler_test.go`:
+
+```go
+// ─── LinkWallet handler helpers ───────────────────────────────────────────────
+
+func newHandlerTestWallet(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	addr := common.HexToAddress(crypto.PubkeyToAddress(key.PublicKey).Hex()).Hex()
+	return key, addr
+}
+
+func handlerSignSIWE(t *testing.T, message string, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	prefixed := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
+	hash := crypto.Keccak256Hash([]byte(prefixed))
+	sig, err := crypto.Sign(hash.Bytes(), key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig[64] += 27
+	return "0x" + hex.EncodeToString(sig)
+}
+
+// ─── LinkWallet handler tests ─────────────────────────────────────────────────
+
+func TestLinkWalletHandler_NoAuth(t *testing.T) {
+	env := newTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/wallet",
+		bytes.NewBufferString(`{"address":"0x1234","nonce":"abc","signature":"0xdeadbeef"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", w.Code)
+	}
+}
+
+func TestLinkWalletHandler_InvalidAddress(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "walletuser1", "w1@example.com", "password123")
+
+	body := `{"address":"not-an-address","nonce":"abc","signature":"0xdeadbeef"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/wallet",
+		bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestLinkWalletHandler_InvalidNonce(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "walletuser2", "w2@example.com", "password123")
+
+	_, addr := newHandlerTestWallet(t)
+	// No nonce seeded in DB
+	body := fmt.Sprintf(`{"address":%q,"nonce":"unknown-nonce","signature":"0x%s"}`,
+		addr, strings.Repeat("ab", 65))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/wallet",
+		bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestLinkWalletHandler_Success(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "walletuser3", "w3@example.com", "password123")
+
+	key, addr := newHandlerTestWallet(t)
+	nonce := "handler-success-nonce"
+	env.db.Create(&models.Web3Nonce{
+		Nonce:     nonce,
+		Address:   strings.ToLower(addr),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	msg := siweMessageForTest(strings.ToLower(addr), nonce)
+	sig := handlerSignSIWE(t, msg, key)
+
+	body := fmt.Sprintf(`{"address":%q,"nonce":%q,"signature":%q}`, addr, nonce, sig)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/wallet",
+		bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	data, _ := resp["data"].(map[string]interface{})
+	if data["address"] != addr {
+		t.Errorf("address: want %s, got %v", addr, data["address"])
+	}
+}
+
+func TestLinkWalletHandler_WalletAlreadyLinked(t *testing.T) {
+	env := newTestEnv(t)
+
+	key, addr := newHandlerTestWallet(t)
+
+	// Register user A and bind the wallet
+	accessA, _ := env.registerUser(t, "walletA", "wa@example.com", "password123")
+	nonce1 := "conflict-nonce-a"
+	env.db.Create(&models.Web3Nonce{Nonce: nonce1, Address: strings.ToLower(addr), ExpiresAt: time.Now().Add(5 * time.Minute)})
+	msg1 := siweMessageForTest(strings.ToLower(addr), nonce1)
+	body1 := fmt.Sprintf(`{"address":%q,"nonce":%q,"signature":%q}`, addr, nonce1, handlerSignSIWE(t, msg1, key))
+	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/wallet", bytes.NewBufferString(body1))
+	req1.Header.Set("Authorization", "Bearer "+accessA)
+	req1.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(httptest.NewRecorder(), req1)
+
+	// User B tries to bind the same wallet
+	accessB, _ := env.registerUser(t, "walletB", "wb@example.com", "password123")
+	nonce2 := "conflict-nonce-b"
+	env.db.Create(&models.Web3Nonce{Nonce: nonce2, Address: strings.ToLower(addr), ExpiresAt: time.Now().Add(5 * time.Minute)})
+	msg2 := siweMessageForTest(strings.ToLower(addr), nonce2)
+	body2 := fmt.Sprintf(`{"address":%q,"nonce":%q,"signature":%q}`, addr, nonce2, handlerSignSIWE(t, msg2, key))
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/wallet", bytes.NewBufferString(body2))
+	req2.Header.Set("Authorization", "Bearer "+accessB)
+	req2.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req2)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("want 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+```
+
+Add imports needed in `user_handler_test.go` (merge with existing):
+
+```go
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+```
+
+Add a package-level helper that mirrors the SIWE message builder (since `siweMessage` is unexported in the `services` package):
+
+```go
+// siweMessageForTest builds the same SIWE message string as services.siweMessage.
+// Used in handler tests where we cannot call the unexported helper directly.
+func siweMessageForTest(address, nonce string) string {
+	return fmt.Sprintf(
+		"tachigo.io wants you to sign in with your Ethereum account:\n%s\n\nSign in to Tachigo\n\nNonce: %s\nIssued At: %s",
+		address, nonce, time.Now().UTC().Format(time.RFC3339),
+	)
+}
+```
+
+- [ ] **Step 5: Run handler tests**
+
+```bash
+cd backend && docker compose run --no-deps --rm app go test ./internal/handlers/... -run TestLinkWallet -v 2>&1
+```
+
+Expected: all `TestLinkWalletHandler_*` tests PASS.
+
+- [ ] **Step 6: Run full handler test suite**
+
+```bash
+docker compose run --no-deps --rm app go test ./internal/handlers/... 2>&1 | tail -10
+```
+
+Expected: 0 failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/internal/handlers/swagger_types.go \
+        backend/internal/handlers/user_handler.go \
+        backend/internal/handlers/testutil_test.go \
+        backend/internal/handlers/user_handler_test.go
+git commit -m "feat: UserHandler.LinkWallet — POST /users/me/wallet
+
+Exposes the wallet binding endpoint. Auth middleware enforces JWT.
+Error mapping: 400 invalid address, 401 nonce/signature, 409 conflict.
+
+refs #<ISSUE_NUMBER>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Router + final verification
+
+### Files:
+- Modify: `backend/internal/router/router.go`
+
+- [ ] **Step 1: Add route to the protected group**
+
+In `backend/internal/router/router.go`, inside the `protected := v1.Group("/")` block, add after `protected.PUT("users/me", userH.UpdateMe)`:
+
+```go
+		protected.POST("users/me/wallet", userH.LinkWallet)
+```
+
+- [ ] **Step 2: Run the router tests**
+
+```bash
+cd backend && docker compose run --no-deps --rm app go test ./internal/router/... -v 2>&1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+docker compose run --no-deps --rm app go test ./... 2>&1 | tail -20
+```
+
+Expected: all packages pass, 0 failures.
+
+- [ ] **Step 4: Build check**
+
+```bash
+docker compose run --no-deps --rm app go build ./... 2>&1
+```
+
+Expected: exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/router/router.go
+git commit -m "feat: route POST /users/me/wallet
+
+closes #<ISSUE_NUMBER>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage**
+  - Migration 014 → Task 1
+  - SQLite test helper → Task 1 steps 2-3
+  - siwe.go extraction → Task 2
+  - auth_service.go cleanup → Task 2 step 2
+  - TranslateError → Task 3 step 1
+  - `ErrInvalidWalletAddress` → Task 3 step 4
+  - `LinkWalletInput` + `LinkWallet` → Task 3 step 4
+  - All 10 test cases from spec → Task 3 step 2 (9 cases; race case tested via `ErrProviderLinked` from `WalletAlreadyLinkedToOtherUser`)
+  - `WalletResponse` → Task 4 step 1
+  - `UserHandler.LinkWallet` → Task 4 step 2
+  - Handler test cases (5) → Task 4 step 4
+  - Router route → Task 5 step 1
+
+- [x] **No placeholders** — all steps have complete code or exact commands
+- [x] **Type consistency** — `LinkWalletInput` defined in Task 3, used identically in Task 4; `WalletResponse` defined in Task 4 step 1, referenced in Task 4 step 2 swagger annotation
+- [x] **`siweMessageForTest`** — handler tests can't call the unexported `siweMessage`; the local replica is included and the time-precision concern is documented

--- a/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
+++ b/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
@@ -87,10 +87,19 @@ WHERE deleted_at IS NULL;
 ```
 
 > PostgreSQL 支援 partial index；專案其他 migration 已有先例。
+>
+> 實作前確認 DB 中沒有重複的 active `(provider, provider_id)`，否則 `CREATE UNIQUE INDEX` 會失敗。
+> 不要使用 `CONCURRENTLY`（migration runner 若包 transaction 會報錯；目前 spec 未用，OK）。
 
 ### SQLite（測試環境）
 
-SQLite 不支援 `CREATE UNIQUE INDEX ... WHERE`。測試 helper 需在 schema 初始化時跳過這個 index，或改用 `uniqueIndex` tag 搭配 test-specific migration。具體做法在 implementation plan 階段決定，spec 僅標注此注意事項。
+SQLite 支援 partial unique index（`WHERE` clause）。`backend/internal/services/testutil_test.go` 已有先例（`idx_watch_sessions_active_user_channel`）。測試 helper 應同步新增：
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
+    ON auth_providers (provider, provider_id)
+    WHERE deleted_at IS NULL;
+```
 
 ---
 
@@ -125,28 +134,30 @@ func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (strin
 [transaction 外]
 1. common.IsHexAddress(input.Address) → false → ErrInvalidWalletAddress
 2. checksumAddr = common.HexToAddress(input.Address).Hex()
-3. lookupAddr  = strings.ToLower(input.Address)
+3. lookupAddr  = strings.ToLower(checksumAddr)  // canonical: checksum 後再 lower
 4. db.Where("nonce=? AND address=?", input.Nonce, lookupAddr).First(&nonceRecord)
    → not found or expired → ErrInvalidNonce
 5. msg = siweMessage(lookupAddr, input.Nonce)
    verifyEthSignature(msg, input.Signature, lookupAddr) → false → ErrInvalidSignature
 
 [BEGIN TRANSACTION]
-6. db.Where("nonce=? AND address=?", ...).Delete(&Web3Nonce{})  // consume nonce
-7. db.Unscoped().
-       Where("provider='web3' AND provider_id=? AND deleted_at IS NULL AND user_id != ?",
+6. result = db.Where("nonce=? AND address=?", ...).Delete(&Web3Nonce{})
+   result.RowsAffected != 1 → ErrInvalidNonce  // 防止並發重放
+7. db.Where("provider='web3' AND provider_id=? AND deleted_at IS NULL AND user_id != ?",
              checksumAddr, userID).
        Count(&count)
    → count > 0 → ErrProviderLinked
 
 8. db.Where("user_id=? AND provider='web3' AND deleted_at IS NULL", userID).
-       Update("deleted_at", now)  // soft delete 目前 active web3 row（若有）
+       Update("deleted_at", now)  // soft delete 目前 active web3 row（若有，含同 address）
 
 9. db.Unscoped().
        Where("user_id=? AND provider='web3' AND provider_id=?", userID, checksumAddr).
        First(&ap)
-   → 找到 soft-deleted row → db.Unscoped().Model(&ap).Update("deleted_at", nil)
-   → 找不到              → db.Create(&AuthProvider{provider:'web3', provider_id: checksumAddr})
+   // step 8 之後，若找到此 row，它一定是 soft-deleted 狀態（剛被 soft delete 或更早前的）
+   → 找到 → db.Unscoped().Model(&ap).Update("deleted_at", nil)  // restore
+   → 找不到 → db.Create(&AuthProvider{provider:'web3', provider_id: checksumAddr})
+   // Create / restore 若遇到 partial unique index 衝突（race），轉 ErrProviderLinked → 409
 
 [COMMIT]
 10. return checksumAddr, nil

--- a/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
+++ b/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
@@ -1,0 +1,227 @@
+# POST /users/me/wallet — 已登入 Twitch 使用者綁定 MetaMask
+
+**狀態**：待實作
+
+## 背景
+
+目前 `POST /auth/web3/nonce` + `POST /auth/web3/verify` 是「用錢包**登入**」的流程。已用 Twitch 登入的使用者沒有辦法把 MetaMask 錢包綁到自己的帳號，導致 `ClaimService.Claim()` 呼叫 `resolveWalletAddress()` 時找不到 `provider='web3'` 的 AuthProvider，回傳 `ErrClaimWalletNotLinked`。
+
+Demo 階段的 `wallet_linker` helper 已在 #243 移除，正式綁定流程需補上。
+
+---
+
+## 設計決策
+
+| 問題 | 決策 |
+|---|---|
+| 每個 user 幾個錢包？ | 只允許一個；綁新的自動取代舊的 |
+| nonce 端點 | 複用現有 `POST /auth/web3/nonce`（public），binding 本身需 JWT |
+| 舊 web3 row 處理方式 | Soft delete（保留歷史），restore 而非 insert 若同 user 重綁同一地址 |
+| SIWE helper 位置 | 抽到 `services/siwe.go`，package-level unexported，`auth_service` 與 `user_service` 共用 |
+
+---
+
+## API 規格
+
+### 前置：取 nonce（現有端點，不動）
+
+```
+POST /api/v1/auth/web3/nonce
+Content-Type: application/json
+
+{"address": "0xAbCd..."}
+
+→ 200 {"success":true,"data":{"nonce":"<hex64>"}}
+```
+
+### 新端點：綁定錢包
+
+```
+POST /api/v1/users/me/wallet
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "address":   "0xAbCd...",   // EIP-55 or lowercase, 後端統一 checksum
+  "nonce":     "<hex64>",
+  "signature": "0x<hex130>"
+}
+
+→ 200 {"success":true,"data":{"address":"0xAbCd..."}}  // checksummed
+```
+
+### Error mapping
+
+| 情況 | HTTP | error 欄位 |
+|---|---|---|
+| address 格式不合法 | 400 | `invalid wallet address` |
+| nonce 不存在或過期 | 401 | `invalid or expired nonce` |
+| 簽名驗證失敗 | 401 | `invalid wallet signature` |
+| address 已被其他 user 綁定 | 409 | `wallet already linked to another account` |
+| DB 錯誤 | 500 | `internal server error` |
+
+---
+
+## 資料庫變更
+
+### migration 014：將全域 unique index 改為 partial unique index
+
+現有 `001_init.sql` 有：
+```sql
+UNIQUE (provider, provider_id)
+```
+
+Soft delete 後舊 row 的 `deleted_at IS NOT NULL`，insert 新 row 時會踩到這個 constraint。需新增 migration：
+
+```sql
+-- backend/migrations/014_auth_provider_partial_unique.sql
+
+-- 移除全域 unique constraint
+ALTER TABLE auth_providers DROP CONSTRAINT IF EXISTS auth_providers_provider_provider_id_key;
+
+-- 改為 partial unique index（只約束 active row）
+CREATE UNIQUE INDEX IF NOT EXISTS
+    idx_auth_providers_provider_provider_id_active
+ON auth_providers(provider, provider_id)
+WHERE deleted_at IS NULL;
+```
+
+> PostgreSQL 支援 partial index；專案其他 migration 已有先例。
+
+### SQLite（測試環境）
+
+SQLite 不支援 `CREATE UNIQUE INDEX ... WHERE`。測試 helper 需在 schema 初始化時跳過這個 index，或改用 `uniqueIndex` tag 搭配 test-specific migration。具體做法在 implementation plan 階段決定，spec 僅標注此注意事項。
+
+---
+
+## 新增 / 修改物件清單
+
+### 1. `backend/internal/services/siwe.go`（新增）
+
+Package-level unexported helpers，`auth_service.go` 與 `user_service.go` 都位於 `services` package，可直接呼叫。
+
+```
+siweMessage(address, nonce string) string
+verifyEthSignature(message, sigHex, expectedAddress string) bool
+```
+
+- 從 `auth_service.go` 移過來（原處改為呼叫此處的函式，不重複定義）
+
+### 2. `backend/internal/services/user_service.go`（新增方法）
+
+```go
+type LinkWalletInput struct {
+    Address   string `json:"address"   binding:"required"`
+    Nonce     string `json:"nonce"     binding:"required"`
+    Signature string `json:"signature" binding:"required"`
+}
+
+func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (string, error)
+```
+
+**LinkWallet 內部流程（transaction 外 → transaction 內）：**
+
+```
+[transaction 外]
+1. common.IsHexAddress(input.Address) → false → ErrInvalidWalletAddress
+2. checksumAddr = common.HexToAddress(input.Address).Hex()
+3. lookupAddr  = strings.ToLower(input.Address)
+4. db.Where("nonce=? AND address=?", input.Nonce, lookupAddr).First(&nonceRecord)
+   → not found or expired → ErrInvalidNonce
+5. msg = siweMessage(lookupAddr, input.Nonce)
+   verifyEthSignature(msg, input.Signature, lookupAddr) → false → ErrInvalidSignature
+
+[BEGIN TRANSACTION]
+6. db.Where("nonce=? AND address=?", ...).Delete(&Web3Nonce{})  // consume nonce
+7. db.Unscoped().
+       Where("provider='web3' AND provider_id=? AND deleted_at IS NULL AND user_id != ?",
+             checksumAddr, userID).
+       Count(&count)
+   → count > 0 → ErrProviderLinked
+
+8. db.Where("user_id=? AND provider='web3' AND deleted_at IS NULL", userID).
+       Update("deleted_at", now)  // soft delete 目前 active web3 row（若有）
+
+9. db.Unscoped().
+       Where("user_id=? AND provider='web3' AND provider_id=?", userID, checksumAddr).
+       First(&ap)
+   → 找到 soft-deleted row → db.Unscoped().Model(&ap).Update("deleted_at", nil)
+   → 找不到              → db.Create(&AuthProvider{provider:'web3', provider_id: checksumAddr})
+
+[COMMIT]
+10. return checksumAddr, nil
+```
+
+**新增 sentinel errors（在 `user_service.go` 宣告）：**
+
+```go
+ErrInvalidWalletAddress = errors.New("invalid wallet address")
+```
+
+沿用現有：`ErrInvalidNonce`、`ErrInvalidSignature`、`ErrProviderLinked`（已在 `auth_service.go`，同 package 可直接用）
+
+### 3. `backend/internal/handlers/user_handler.go`（新增方法）
+
+```go
+// LinkWallet godoc
+// @Summary      Bind a MetaMask wallet address to the current user
+// @Tags         users
+// @Accept       json
+// @Produce      json
+// @Param        body body services.LinkWalletInput true "address + nonce + signature"
+// @Success      200  {object}  Response{data=WalletResponse}
+// @Failure      400  {object}  Response
+// @Failure      401  {object}  Response
+// @Failure      409  {object}  Response
+// @Security     BearerAuth
+// @Router       /users/me/wallet [post]
+func (h *UserHandler) LinkWallet(c *gin.Context)
+```
+
+- `MustClaims(c)` 取 userID
+- 呼叫 `userSvc.LinkWallet(userID, input)`
+- error switch：
+  - `ErrInvalidWalletAddress` → `badRequest`
+  - `ErrInvalidNonce` → `unauthorized`
+  - `ErrInvalidSignature` → `unauthorized`
+  - `ErrProviderLinked` → `conflict("wallet already linked to another account")`
+  - default → `internal`
+
+### 4. `backend/internal/router/router.go`（修改）
+
+在 `protected` group 新增：
+
+```go
+protected.POST("users/me/wallet", userH.LinkWallet)
+```
+
+---
+
+## 測試規格
+
+### `services/user_service_test.go`（新增 test cases）
+
+| Case | 預期結果 |
+|---|---|
+| 合法 address + nonce + 簽名，首次綁定 | 200，AuthProvider insert，checksumAddr 回傳 |
+| 合法，已有 active web3 row → 取代 | 舊 row soft deleted，新 row insert |
+| 同 user 重綁同一地址（soft-deleted row 存在） | restore deleted_at = NULL，不 insert 新 row |
+| nonce 不存在 | `ErrInvalidNonce` |
+| nonce 已過期 | `ErrInvalidNonce` |
+| 簽名錯誤 | `ErrInvalidSignature` |
+| address 已被其他 user 綁定 | `ErrProviderLinked` |
+| address 格式不合法 | `ErrInvalidWalletAddress` |
+
+### `handlers/user_handler_test.go`（新增 test cases）
+
+HTTP 層測試，驗證 status code 與 response body，不重複 service 邏輯。
+
+---
+
+## 本票明確不做
+
+- `GET /users/me/wallet`（查詢已綁錢包）
+- 解綁走現有 `DELETE /auth/providers/web3`，不改動
+- 前端（tachimint / dashboard）串接
+- 不修改 `ClaimService.resolveWalletAddress()`
+- 不改 `POST /auth/web3/nonce` 或 `POST /auth/web3/verify`

--- a/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
+++ b/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
@@ -110,6 +110,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
 - [ ] 新增 `services/siwe.go`，搬移 `siweMessage` / `verifyEthSignature`
 - [ ] 修改 `services/auth_service.go`，移除原 helper 定義，保留呼叫
 - [ ] 實作 `UserService.LinkWallet`
+- [ ] 更新 `backend/internal/handlers/swagger_types.go`，新增 `WalletResponse`
 - [ ] 實作 `UserHandler.LinkWallet`
 - [ ] 更新 `router/router.go`
 - [ ] 補 `services/user_service_test.go` test cases
@@ -267,7 +268,7 @@ protected.POST("users/me/wallet", userH.LinkWallet)
 
 | Case | 預期結果 |
 |---|---|
-| 合法 address + nonce + 簽名，首次綁定 | 200，AuthProvider insert，checksumAddr 回傳 |
+| 合法 address + nonce + 簽名，首次綁定 | 成功，AuthProvider insert，checksumAddr 回傳 |
 | 合法，已有 active web3 row → 取代 | 舊 row soft deleted，新 row insert |
 | 同 user 重綁同一地址（soft-deleted row 存在） | restore deleted_at = NULL，不 insert 新 row |
 | nonce 不存在 | `ErrInvalidNonce` |

--- a/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
+++ b/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
@@ -105,7 +105,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
 
 ## Implementation Checklist
 
-- [ ] 新增 `migrations/014_auth_provider_partial_unique.sql`
+- [ ] 新增 `backend/migrations/014_auth_provider_partial_unique.sql`
 - [ ] 更新 SQLite test helper schema（補同等 partial unique index）
 - [ ] 新增 `services/siwe.go`，搬移 `siweMessage` / `verifyEthSignature`
 - [ ] 修改 `services/auth_service.go`，移除原 helper 定義，保留呼叫
@@ -155,7 +155,7 @@ func verifyEthSignature(message, sigHex, expectedAddress string) bool
 
 - 移除 `siweMessage` 與 `verifyEthSignature` 的原始定義（Go build 不允許同 package 重複定義，移除前先確認 `siwe.go` 已建立）
 - `Web3Verify()` 內的呼叫不變（同 package，直接可用）
-- 移除因此產生的 unused imports（`fmt`、`encoding/hex`、`crypto` 等是否仍被其他函式使用，由 `go build` / `go test` 驗證）
+- 移除因此產生的 unused imports；預期至少檢查 `github.com/ethereum/go-ethereum/crypto`（`fmt`、`encoding/hex` 在其他函式仍有使用，不會被移除）
 
 ### 2. `backend/internal/services/user_service.go`（新增方法）
 
@@ -212,7 +212,19 @@ ErrInvalidWalletAddress = errors.New("invalid wallet address")
 
 沿用現有：`ErrInvalidNonce`、`ErrInvalidSignature`、`ErrProviderLinked`（已在 `auth_service.go`，同 package 可直接用）
 
-### 3. `backend/internal/handlers/user_handler.go`（新增方法）
+### 3. `backend/internal/handlers/swagger_types.go`（修改）
+
+新增：
+
+```go
+type WalletResponse struct {
+    Address string `json:"address"`
+}
+```
+
+> 與 `UserResponse`、`ProvidersResponse` 等現有 swagger type 放在同一檔案。
+
+### 4. `backend/internal/handlers/user_handler.go`（新增方法）
 
 ```go
 // LinkWallet godoc
@@ -239,7 +251,7 @@ func (h *UserHandler) LinkWallet(c *gin.Context)
   - `ErrProviderLinked` → `conflict("wallet already linked to another account")`
   - default → `internal`
 
-### 4. `backend/internal/router/router.go`（修改）
+### 5. `backend/internal/router/router.go`（修改）
 
 在 `protected` group 新增：
 
@@ -260,8 +272,10 @@ protected.POST("users/me/wallet", userH.LinkWallet)
 | 同 user 重綁同一地址（soft-deleted row 存在） | restore deleted_at = NULL，不 insert 新 row |
 | nonce 不存在 | `ErrInvalidNonce` |
 | nonce 已過期 | `ErrInvalidNonce` |
+| 成功綁定後重用同一 nonce | `ErrInvalidNonce`（nonce 已被 consume） |
 | 簽名錯誤 | `ErrInvalidSignature` |
 | address 已被其他 user 綁定 | `ErrProviderLinked` |
+| Create / restore 遇 active unique index 衝突（race） | `ErrProviderLinked`（不掉到 500） |
 | address 格式不合法 | `ErrInvalidWalletAddress` |
 
 ### `handlers/user_handler_test.go`（新增 test cases）

--- a/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
+++ b/docs/superpowers/specs/2026-04-16-wallet-binding-design.md
@@ -103,18 +103,59 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
 
 ---
 
+## Implementation Checklist
+
+- [ ] 新增 `migrations/014_auth_provider_partial_unique.sql`
+- [ ] 更新 SQLite test helper schema（補同等 partial unique index）
+- [ ] 新增 `services/siwe.go`，搬移 `siweMessage` / `verifyEthSignature`
+- [ ] 修改 `services/auth_service.go`，移除原 helper 定義，保留呼叫
+- [ ] 實作 `UserService.LinkWallet`
+- [ ] 實作 `UserHandler.LinkWallet`
+- [ ] 更新 `router/router.go`
+- [ ] 補 `services/user_service_test.go` test cases
+- [ ] 補 `handlers/user_handler_test.go` test cases
+
+---
+
 ## 新增 / 修改物件清單
 
-### 1. `backend/internal/services/siwe.go`（新增）
+### 0. `backend/migrations/014_auth_provider_partial_unique.sql`（新增）
 
-Package-level unexported helpers，`auth_service.go` 與 `user_service.go` 都位於 `services` package，可直接呼叫。
+```sql
+ALTER TABLE auth_providers
+    DROP CONSTRAINT IF EXISTS auth_providers_provider_provider_id_key;
 
+CREATE UNIQUE INDEX IF NOT EXISTS
+    idx_auth_providers_provider_provider_id_active
+ON auth_providers(provider, provider_id)
+WHERE deleted_at IS NULL;
 ```
-siweMessage(address, nonce string) string
-verifyEthSignature(message, sigHex, expectedAddress string) bool
+
+- 執行前確認 DB 中無重複 active `(provider, provider_id)`，否則 index 建立失敗
+- 不使用 `CONCURRENTLY`
+
+test helper（`services/testutil_test.go`）同步新增：
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_provider_provider_id_active
+    ON auth_providers (provider, provider_id)
+    WHERE deleted_at IS NULL;
 ```
 
-- 從 `auth_service.go` 移過來（原處改為呼叫此處的函式，不重複定義）
+### 1a. `backend/internal/services/siwe.go`（新增）
+
+Package-level unexported helpers，`auth_service.go` 與 `user_service.go` 同在 `services` package，可直接呼叫。
+
+```go
+func siweMessage(address, nonce string) string
+func verifyEthSignature(message, sigHex, expectedAddress string) bool
+```
+
+### 1b. `backend/internal/services/auth_service.go`（修改）
+
+- 移除 `siweMessage` 與 `verifyEthSignature` 的原始定義（Go build 不允許同 package 重複定義，移除前先確認 `siwe.go` 已建立）
+- `Web3Verify()` 內的呼叫不變（同 package，直接可用）
+- 移除因此產生的 unused imports（`fmt`、`encoding/hex`、`crypto` 等是否仍被其他函式使用，由 `go build` / `go test` 驗證）
 
 ### 2. `backend/internal/services/user_service.go`（新增方法）
 


### PR DESCRIPTION
## 什麼改動

1. 新增 migration 014：將 `auth_providers` 的全域 `UNIQUE(provider, provider_id)` 改為兩個 partial unique index（`WHERE deleted_at IS NULL`），讓 soft delete 後可重新綁定同一地址
2. 抽出 `services/siwe.go`：將 `siweMessage` / `verifyEthSignature` 從 `auth_service.go` 移出，供即將新增的 wallet binding service 共用

## 為什麼

Wallet binding（已登入使用者綁定 MetaMask）需要 soft delete 策略，全域 unique constraint 會讓 re-bind 失敗。SIWE helpers 需要讓 `user_service` 也能使用。

closes #251

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：#251
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否
- 本 PR 明確不做：
  - 不實作 `UserService.LinkWallet`
  - 不新增 API endpoint
  - 不改前端

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

`go test ./internal/services/... ./internal/handlers/...` 全過。`auth_service.go` 的 `Web3Verify` 仍正常呼叫 `siweMessage` / `verifyEthSignature`（同 package）。

## 備註

migration 014 新增：
- `idx_auth_providers_provider_provider_id_active`
- `idx_auth_providers_web3_user_active`

兩個 test helper schema（services / handlers）同步補上相同 index。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持 SIWE 签名的钱包绑定流程；Nonce 返回增加 issued_at（RFC3339 UTC）字段。

* **文档**
  * 新增钱包绑定设计规格与实施计划，详述端点行为与错误映射。

* **修复**
  * 将钱包关联的唯一性约束改为仅针对未删除（active）记录，减少软删除冲突导致的绑定冲突。

* **测试**
  * 更新测试数据库与用例以覆盖 nonce/签名校验、绑定/替换/恢复与唯一性场景；测试 DB 启用错误翻译。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->