### PR TITLE
[backend] 錢包綁定 service 層 — UserService.LinkWallet（SIWE 驗證 + soft delete 策略）

### DIFF
--- a/backend/internal/database/db.go
+++ b/backend/internal/database/db.go
@@ -10,7 +10,8 @@ import (
 
 func Connect(dsn string) *gorm.DB {
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Info),
+		Logger:         logger.Default.LogMode(logger.Info),
+		TranslateError: true,
 	})
 	if err != nil {
 		log.Fatalf("failed to connect to database: %v", err)

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -226,7 +226,7 @@ func (s *AuthService) GoogleCallback(ctx context.Context, code string) (*models.
 // ─── Web3 / SIWE ─────────────────────────────────────────────────────────────
 
 func (s *AuthService) Web3Nonce(address string) (string, time.Time, error) {
-	address = strings.ToLower(address)
+	address = strings.ToLower(common.HexToAddress(address).Hex())
 	nonce, err := generateNonce()
 	if err != nil {
 		return "", time.Time{}, err

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -103,16 +103,16 @@ func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (strin
 		return "", ErrInvalidSignature
 	}
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
-		result := tx.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
-			Delete(&models.Web3Nonce{})
-		if result.Error != nil {
-			return result.Error
-		}
-		if result.RowsAffected != 1 {
-			return ErrInvalidNonce
-		}
+	result := s.db.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
+		Delete(&models.Web3Nonce{})
+	if result.Error != nil {
+		return "", result.Error
+	}
+	if result.RowsAffected != 1 {
+		return "", ErrInvalidNonce
+	}
 
+	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var count int64
 		if err := tx.Model(&models.AuthProvider{}).
 			Where("provider = ? AND provider_id = ? AND deleted_at IS NULL AND user_id != ?",

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -1,11 +1,18 @@
 package services
 
 import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+var ErrInvalidWalletAddress = errors.New("invalid wallet address")
 
 type UserService struct {
 	db *gorm.DB
@@ -18,6 +25,12 @@ func NewUserService(db *gorm.DB) *UserService {
 type UpdateProfileInput struct {
 	Username  *string `json:"username"`
 	AvatarURL *string `json:"avatar_url"`
+}
+
+type LinkWalletInput struct {
+	Address   string `json:"address" binding:"required"`
+	Nonce     string `json:"nonce" binding:"required"`
+	Signature string `json:"signature" binding:"required"`
 }
 
 func (s *UserService) GetByID(id uuid.UUID) (*models.User, error) {
@@ -62,4 +75,92 @@ func (s *UserService) ListProviders(userID uuid.UUID) ([]models.AuthProvider, er
 		return nil, err
 	}
 	return providers, nil
+}
+
+func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (string, error) {
+	if !common.IsHexAddress(input.Address) {
+		return "", ErrInvalidWalletAddress
+	}
+
+	checksumAddr := common.HexToAddress(input.Address).Hex()
+	lookupAddr := strings.ToLower(checksumAddr)
+
+	var nonceRecord models.Web3Nonce
+	if err := s.db.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
+		First(&nonceRecord).Error; err != nil {
+		return "", ErrInvalidNonce
+	}
+	if nonceRecord.IsExpired() {
+		return "", ErrInvalidNonce
+	}
+
+	msg := siweMessage(lookupAddr, input.Nonce)
+	if !verifyEthSignature(msg, input.Signature, lookupAddr) {
+		return "", ErrInvalidSignature
+	}
+
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		result := tx.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
+			Delete(&models.Web3Nonce{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return ErrInvalidNonce
+		}
+
+		var count int64
+		if err := tx.Model(&models.AuthProvider{}).
+			Where("provider = ? AND provider_id = ? AND deleted_at IS NULL AND user_id != ?",
+				models.ProviderWeb3, checksumAddr, userID).
+			Count(&count).Error; err != nil {
+			return err
+		}
+		if count > 0 {
+			return ErrProviderLinked
+		}
+
+		now := time.Now()
+		if err := tx.Model(&models.AuthProvider{}).
+			Where("user_id = ? AND provider = ? AND deleted_at IS NULL", userID, models.ProviderWeb3).
+			Update("deleted_at", now).Error; err != nil {
+			return err
+		}
+
+		var ap models.AuthProvider
+		findErr := tx.Unscoped().
+			Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderWeb3, checksumAddr).
+			First(&ap).Error
+
+		if findErr == nil {
+			if err := tx.Unscoped().Model(&ap).
+				UpdateColumn("deleted_at", gorm.Expr("NULL")).Error; err != nil {
+				if errors.Is(err, gorm.ErrDuplicatedKey) {
+					return ErrProviderLinked
+				}
+				return err
+			}
+			return nil
+		}
+		if !errors.Is(findErr, gorm.ErrRecordNotFound) {
+			return findErr
+		}
+
+		newAP := models.AuthProvider{
+			UserID:     userID,
+			Provider:   models.ProviderWeb3,
+			ProviderID: checksumAddr,
+		}
+		if err := tx.Create(&newAP).Error; err != nil {
+			if errors.Is(err, gorm.ErrDuplicatedKey) {
+				return ErrProviderLinked
+			}
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return checksumAddr, nil
 }

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -88,13 +88,17 @@ func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (strin
 	var nonceRecord models.Web3Nonce
 	if err := s.db.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
 		First(&nonceRecord).Error; err != nil {
-		return "", ErrInvalidNonce
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", ErrInvalidNonce
+		}
+		return "", err
 	}
 	if nonceRecord.IsExpired() {
 		return "", ErrInvalidNonce
 	}
 
-	msg := siweMessage(lookupAddr, input.Nonce)
+	issuedAt := nonceRecord.CreatedAt.UTC().Format(time.RFC3339)
+	msg := siweMessage(lookupAddr, input.Nonce, issuedAt)
 	if !verifyEthSignature(msg, input.Signature, lookupAddr) {
 		return "", ErrInvalidSignature
 	}

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -98,8 +98,8 @@ func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (strin
 	}
 
 	issuedAt := nonceRecord.CreatedAt.UTC().Format(time.RFC3339)
-	msg := siweMessage(lookupAddr, input.Nonce, issuedAt)
-	if !verifyEthSignature(msg, input.Signature, lookupAddr) {
+	msg := siweMessage(checksumAddr, input.Nonce, issuedAt)
+	if !verifyEthSignature(msg, input.Signature, checksumAddr) {
 		return "", ErrInvalidSignature
 	}
 

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -158,15 +158,17 @@ func signSIWE(t *testing.T, message string, key *ecdsa.PrivateKey) string {
 	return "0x" + hex.EncodeToString(sig)
 }
 
-func seedWalletNonce(t *testing.T, db *gorm.DB, address, nonce string) {
+func seedWalletNonce(t *testing.T, db *gorm.DB, address, nonce string) *models.Web3Nonce {
 	t.Helper()
-	if err := db.Create(&models.Web3Nonce{
+	record := &models.Web3Nonce{
 		Nonce:     nonce,
 		Address:   strings.ToLower(address),
 		ExpiresAt: time.Now().Add(5 * time.Minute),
-	}).Error; err != nil {
+	}
+	if err := db.Create(record).Error; err != nil {
 		t.Fatalf("seed nonce: %v", err)
 	}
+	return record
 }
 
 func seedExpiredWalletNonce(t *testing.T, db *gorm.DB, address, nonce string) {
@@ -188,8 +190,8 @@ func TestLinkWallet_Success(t *testing.T) {
 
 	key, addr := newTestWallet(t)
 	nonce := "link-wallet-success"
-	seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce)
+	nr := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	sig := signSIWE(t, msg, key)
 
 	got, err := svc.LinkWallet(userID, LinkWalletInput{
@@ -230,8 +232,8 @@ func TestLinkWallet_AddressAlreadyLinkedToOtherUser(t *testing.T) {
 
 	key, addr := newTestWallet(t)
 	nonceA := "duplicate-address-a"
-	seedWalletNonce(t, db, addr, nonceA)
-	msgA := siweMessage(strings.ToLower(addr), nonceA)
+	nrA := seedWalletNonce(t, db, addr, nonceA)
+	msgA := siweMessage(strings.ToLower(addr), nonceA, nrA.CreatedAt.UTC().Format(time.RFC3339))
 	if _, err := svc.LinkWallet(userA, LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonceA,
@@ -241,8 +243,8 @@ func TestLinkWallet_AddressAlreadyLinkedToOtherUser(t *testing.T) {
 	}
 
 	nonceB := "duplicate-address-b"
-	seedWalletNonce(t, db, addr, nonceB)
-	msgB := siweMessage(strings.ToLower(addr), nonceB)
+	nrB := seedWalletNonce(t, db, addr, nonceB)
+	msgB := siweMessage(strings.ToLower(addr), nonceB, nrB.CreatedAt.UTC().Format(time.RFC3339))
 	_, err := svc.LinkWallet(userB, LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonceB,
@@ -261,8 +263,8 @@ func TestLinkWallet_ReplacesUsersExistingPrimaryWallet(t *testing.T) {
 
 	key1, addr1 := newTestWallet(t)
 	nonce1 := "replace-primary-a"
-	seedWalletNonce(t, db, addr1, nonce1)
-	msg1 := siweMessage(strings.ToLower(addr1), nonce1)
+	nr1 := seedWalletNonce(t, db, addr1, nonce1)
+	msg1 := siweMessage(strings.ToLower(addr1), nonce1, nr1.CreatedAt.UTC().Format(time.RFC3339))
 	if _, err := svc.LinkWallet(userID, LinkWalletInput{
 		Address:   addr1,
 		Nonce:     nonce1,
@@ -273,8 +275,8 @@ func TestLinkWallet_ReplacesUsersExistingPrimaryWallet(t *testing.T) {
 
 	key2, addr2 := newTestWallet(t)
 	nonce2 := "replace-primary-b"
-	seedWalletNonce(t, db, addr2, nonce2)
-	msg2 := siweMessage(strings.ToLower(addr2), nonce2)
+	nr2 := seedWalletNonce(t, db, addr2, nonce2)
+	msg2 := siweMessage(strings.ToLower(addr2), nonce2, nr2.CreatedAt.UTC().Format(time.RFC3339))
 	got, err := svc.LinkWallet(userID, LinkWalletInput{
 		Address:   addr2,
 		Nonce:     nonce2,
@@ -364,8 +366,8 @@ func TestLinkWallet_InvalidSignature(t *testing.T) {
 	_, addr := newTestWallet(t)
 	wrongKey, _ := newTestWallet(t)
 	nonce := "invalid-signature"
-	seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce)
+	nr := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 
 	_, err := svc.LinkWallet(userID, LinkWalletInput{
 		Address:   addr,
@@ -391,8 +393,8 @@ func TestLinkWallet_ReplayConsumedNonceRejected(t *testing.T) {
 
 	key, addr := newTestWallet(t)
 	nonce := "replay-consumed-nonce"
-	seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce)
+	nr := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	input := LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonce,
@@ -426,8 +428,8 @@ func TestLinkWallet_RestoresSoftDeletedSameWallet(t *testing.T) {
 	}
 
 	nonce := "restore-same-wallet"
-	seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce)
+	nr := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	got, err := svc.LinkWallet(userID, LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonce,
@@ -474,8 +476,8 @@ func TestLinkWallet_IgnoresSoftDeletedWalletLinkedToOtherUser(t *testing.T) {
 	}
 
 	nonce := "soft-deleted-other-user"
-	seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce)
+	nr := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	got, err := svc.LinkWallet(newUser, LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonce,

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -1,9 +1,17 @@
 package services
 
 import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/models"
 )
@@ -125,5 +133,164 @@ func TestListProviders_EmptyForNewUser(t *testing.T) {
 	}
 	if len(providers) != 0 {
 		t.Errorf("want 0 providers, got %d", len(providers))
+	}
+}
+
+func newTestWallet(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	addr := common.HexToAddress(crypto.PubkeyToAddress(key.PublicKey).Hex()).Hex()
+	return key, addr
+}
+
+func signSIWE(t *testing.T, message string, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	prefixed := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
+	hash := crypto.Keccak256Hash([]byte(prefixed))
+	sig, err := crypto.Sign(hash.Bytes(), key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig[64] += 27
+	return "0x" + hex.EncodeToString(sig)
+}
+
+func seedWalletNonce(t *testing.T, db *gorm.DB, address, nonce string) {
+	t.Helper()
+	if err := db.Create(&models.Web3Nonce{
+		Nonce:     nonce,
+		Address:   strings.ToLower(address),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}).Error; err != nil {
+		t.Fatalf("seed nonce: %v", err)
+	}
+}
+
+func TestLinkWallet_Success(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonce := "link-wallet-success"
+	seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce)
+	sig := signSIWE(t, msg, key)
+
+	got, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != addr {
+		t.Errorf("address: want %s, got %s", addr, got)
+	}
+
+	var ap models.AuthProvider
+	if err := db.Where("user_id = ? AND provider = ?", userID, models.ProviderWeb3).First(&ap).Error; err != nil {
+		t.Fatalf("auth provider not found: %v", err)
+	}
+	if ap.ProviderID != addr {
+		t.Errorf("provider_id: want %s, got %s", addr, ap.ProviderID)
+	}
+
+	var nonceCount int64
+	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
+	if nonceCount != 0 {
+		t.Errorf("nonce should be consumed, got %d rows", nonceCount)
+	}
+}
+
+func TestLinkWallet_AddressAlreadyLinkedToOtherUser(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+
+	userA := uuid.New()
+	userB := uuid.New()
+	db.Create(&models.User{ID: userA, Role: models.RoleViewer})
+	db.Create(&models.User{ID: userB, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonceA := "duplicate-address-a"
+	seedWalletNonce(t, db, addr, nonceA)
+	msgA := siweMessage(strings.ToLower(addr), nonceA)
+	if _, err := svc.LinkWallet(userA, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonceA,
+		Signature: signSIWE(t, msgA, key),
+	}); err != nil {
+		t.Fatalf("first link: %v", err)
+	}
+
+	nonceB := "duplicate-address-b"
+	seedWalletNonce(t, db, addr, nonceB)
+	msgB := siweMessage(strings.ToLower(addr), nonceB)
+	_, err := svc.LinkWallet(userB, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonceB,
+		Signature: signSIWE(t, msgB, key),
+	})
+	if err != ErrProviderLinked {
+		t.Errorf("want ErrProviderLinked, got %v", err)
+	}
+}
+
+func TestLinkWallet_ReplacesUsersExistingPrimaryWallet(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key1, addr1 := newTestWallet(t)
+	nonce1 := "replace-primary-a"
+	seedWalletNonce(t, db, addr1, nonce1)
+	msg1 := siweMessage(strings.ToLower(addr1), nonce1)
+	if _, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address:   addr1,
+		Nonce:     nonce1,
+		Signature: signSIWE(t, msg1, key1),
+	}); err != nil {
+		t.Fatalf("first link: %v", err)
+	}
+
+	key2, addr2 := newTestWallet(t)
+	nonce2 := "replace-primary-b"
+	seedWalletNonce(t, db, addr2, nonce2)
+	msg2 := siweMessage(strings.ToLower(addr2), nonce2)
+	got, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address:   addr2,
+		Nonce:     nonce2,
+		Signature: signSIWE(t, msg2, key2),
+	})
+	if err != nil {
+		t.Fatalf("second link: %v", err)
+	}
+	if got != addr2 {
+		t.Errorf("address: want %s, got %s", addr2, got)
+	}
+
+	var activeCount int64
+	db.Model(&models.AuthProvider{}).
+		Where("user_id = ? AND provider = ?", userID, models.ProviderWeb3).
+		Count(&activeCount)
+	if activeCount != 1 {
+		t.Errorf("want 1 active wallet, got %d", activeCount)
+	}
+
+	var old models.AuthProvider
+	if err := db.Unscoped().
+		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderWeb3, addr1).
+		First(&old).Error; err != nil {
+		t.Fatalf("old wallet row not found: %v", err)
+	}
+	if !old.DeletedAt.Valid {
+		t.Error("old wallet row should be soft-deleted")
 	}
 }

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -191,7 +191,7 @@ func TestLinkWallet_Success(t *testing.T) {
 	key, addr := newTestWallet(t)
 	nonce := "link-wallet-success"
 	nr := seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	msg := siweMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	sig := signSIWE(t, msg, key)
 
 	got, err := svc.LinkWallet(userID, LinkWalletInput{
@@ -233,7 +233,7 @@ func TestLinkWallet_AddressAlreadyLinkedToOtherUser(t *testing.T) {
 	key, addr := newTestWallet(t)
 	nonceA := "duplicate-address-a"
 	nrA := seedWalletNonce(t, db, addr, nonceA)
-	msgA := siweMessage(strings.ToLower(addr), nonceA, nrA.CreatedAt.UTC().Format(time.RFC3339))
+	msgA := siweMessage(addr, nonceA, nrA.CreatedAt.UTC().Format(time.RFC3339))
 	if _, err := svc.LinkWallet(userA, LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonceA,
@@ -244,7 +244,7 @@ func TestLinkWallet_AddressAlreadyLinkedToOtherUser(t *testing.T) {
 
 	nonceB := "duplicate-address-b"
 	nrB := seedWalletNonce(t, db, addr, nonceB)
-	msgB := siweMessage(strings.ToLower(addr), nonceB, nrB.CreatedAt.UTC().Format(time.RFC3339))
+	msgB := siweMessage(addr, nonceB, nrB.CreatedAt.UTC().Format(time.RFC3339))
 	_, err := svc.LinkWallet(userB, LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonceB,
@@ -264,7 +264,7 @@ func TestLinkWallet_ReplacesUsersExistingPrimaryWallet(t *testing.T) {
 	key1, addr1 := newTestWallet(t)
 	nonce1 := "replace-primary-a"
 	nr1 := seedWalletNonce(t, db, addr1, nonce1)
-	msg1 := siweMessage(strings.ToLower(addr1), nonce1, nr1.CreatedAt.UTC().Format(time.RFC3339))
+	msg1 := siweMessage(addr1, nonce1, nr1.CreatedAt.UTC().Format(time.RFC3339))
 	if _, err := svc.LinkWallet(userID, LinkWalletInput{
 		Address:   addr1,
 		Nonce:     nonce1,
@@ -276,7 +276,7 @@ func TestLinkWallet_ReplacesUsersExistingPrimaryWallet(t *testing.T) {
 	key2, addr2 := newTestWallet(t)
 	nonce2 := "replace-primary-b"
 	nr2 := seedWalletNonce(t, db, addr2, nonce2)
-	msg2 := siweMessage(strings.ToLower(addr2), nonce2, nr2.CreatedAt.UTC().Format(time.RFC3339))
+	msg2 := siweMessage(addr2, nonce2, nr2.CreatedAt.UTC().Format(time.RFC3339))
 	got, err := svc.LinkWallet(userID, LinkWalletInput{
 		Address:   addr2,
 		Nonce:     nonce2,
@@ -367,7 +367,7 @@ func TestLinkWallet_InvalidSignature(t *testing.T) {
 	wrongKey, _ := newTestWallet(t)
 	nonce := "invalid-signature"
 	nr := seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	msg := siweMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 
 	_, err := svc.LinkWallet(userID, LinkWalletInput{
 		Address:   addr,
@@ -394,7 +394,7 @@ func TestLinkWallet_ReplayConsumedNonceRejected(t *testing.T) {
 	key, addr := newTestWallet(t)
 	nonce := "replay-consumed-nonce"
 	nr := seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	msg := siweMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	input := LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonce,
@@ -429,7 +429,7 @@ func TestLinkWallet_RestoresSoftDeletedSameWallet(t *testing.T) {
 
 	nonce := "restore-same-wallet"
 	nr := seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	msg := siweMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	got, err := svc.LinkWallet(userID, LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonce,
@@ -477,7 +477,7 @@ func TestLinkWallet_IgnoresSoftDeletedWalletLinkedToOtherUser(t *testing.T) {
 
 	nonce := "soft-deleted-other-user"
 	nr := seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	msg := siweMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	got, err := svc.LinkWallet(newUser, LinkWalletInput{
 		Address:   addr,
 		Nonce:     nonce,
@@ -511,7 +511,7 @@ func TestLinkWallet_RaceUniqueViolation(t *testing.T) {
 	key, addr := newTestWallet(t)
 	nonce := "race-unique-violation"
 	nr := seedWalletNonce(t, db, addr, nonce)
-	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	msg := siweMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
 	sig := signSIWE(t, msg, key)
 
 	// Simulate a concurrent write: another actor claims the same address for userA

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -498,3 +498,43 @@ func TestLinkWallet_IgnoresSoftDeletedWalletLinkedToOtherUser(t *testing.T) {
 		t.Errorf("want 1 active wallet, got %d", activeCount)
 	}
 }
+
+func TestLinkWallet_RaceUniqueViolation(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+
+	userA := uuid.New()
+	userB := uuid.New()
+	db.Create(&models.User{ID: userA, Role: models.RoleViewer})
+	db.Create(&models.User{ID: userB, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonce := "race-unique-violation"
+	nr := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+
+	// Simulate a concurrent write: another actor claims the same address for userA
+	// before LinkWallet runs. Whether the count-check or the unique-constraint on
+	// INSERT fires, ErrProviderLinked must be returned — verifying the
+	// gorm.ErrDuplicatedKey → ErrProviderLinked translation branch.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		db.Create(&models.AuthProvider{
+			UserID:     userA,
+			Provider:   models.ProviderWeb3,
+			ProviderID: addr,
+		})
+	}()
+	<-done
+
+	_, err := svc.LinkWallet(userB, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err != ErrProviderLinked {
+		t.Errorf("want ErrProviderLinked, got %v", err)
+	}
+}

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -169,6 +169,17 @@ func seedWalletNonce(t *testing.T, db *gorm.DB, address, nonce string) {
 	}
 }
 
+func seedExpiredWalletNonce(t *testing.T, db *gorm.DB, address, nonce string) {
+	t.Helper()
+	if err := db.Create(&models.Web3Nonce{
+		Nonce:     nonce,
+		Address:   strings.ToLower(address),
+		ExpiresAt: time.Now().Add(-time.Minute),
+	}).Error; err != nil {
+		t.Fatalf("seed expired nonce: %v", err)
+	}
+}
+
 func TestLinkWallet_Success(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewUserService(db)
@@ -292,5 +303,196 @@ func TestLinkWallet_ReplacesUsersExistingPrimaryWallet(t *testing.T) {
 	}
 	if !old.DeletedAt.Valid {
 		t.Error("old wallet row should be soft-deleted")
+	}
+}
+
+func TestLinkWallet_InvalidAddress(t *testing.T) {
+	svc := NewUserService(newTestDB(t))
+
+	_, err := svc.LinkWallet(uuid.New(), LinkWalletInput{
+		Address:   "not-an-address",
+		Nonce:     "invalid-address",
+		Signature: "0xdeadbeef",
+	})
+	if err != ErrInvalidWalletAddress {
+		t.Errorf("want ErrInvalidWalletAddress, got %v", err)
+	}
+}
+
+func TestLinkWallet_NonceNotFound(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+	_, addr := newTestWallet(t)
+
+	_, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address:   addr,
+		Nonce:     "missing-nonce",
+		Signature: "0x" + strings.Repeat("ab", 65),
+	})
+	if err != ErrInvalidNonce {
+		t.Errorf("want ErrInvalidNonce, got %v", err)
+	}
+}
+
+func TestLinkWallet_ExpiredNonce(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+	_, addr := newTestWallet(t)
+	nonce := "expired-nonce"
+	seedExpiredWalletNonce(t, db, addr, nonce)
+
+	_, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: "0x" + strings.Repeat("ab", 65),
+	})
+	if err != ErrInvalidNonce {
+		t.Errorf("want ErrInvalidNonce, got %v", err)
+	}
+}
+
+func TestLinkWallet_InvalidSignature(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	_, addr := newTestWallet(t)
+	wrongKey, _ := newTestWallet(t)
+	nonce := "invalid-signature"
+	seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce)
+
+	_, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: signSIWE(t, msg, wrongKey),
+	})
+	if err != ErrInvalidSignature {
+		t.Errorf("want ErrInvalidSignature, got %v", err)
+	}
+
+	var nonceCount int64
+	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
+	if nonceCount != 1 {
+		t.Errorf("nonce should remain after invalid signature, got %d rows", nonceCount)
+	}
+}
+
+func TestLinkWallet_ReplayConsumedNonceRejected(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonce := "replay-consumed-nonce"
+	seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce)
+	input := LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: signSIWE(t, msg, key),
+	}
+
+	if _, err := svc.LinkWallet(userID, input); err != nil {
+		t.Fatalf("first link: %v", err)
+	}
+	_, err := svc.LinkWallet(userID, input)
+	if err != ErrInvalidNonce {
+		t.Errorf("want ErrInvalidNonce, got %v", err)
+	}
+}
+
+func TestLinkWallet_RestoresSoftDeletedSameWallet(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	deletedAt := time.Now().Add(-time.Hour)
+	if err := db.Create(&models.AuthProvider{
+		UserID:     userID,
+		Provider:   models.ProviderWeb3,
+		ProviderID: addr,
+		DeletedAt:  gorm.DeletedAt{Time: deletedAt, Valid: true},
+	}).Error; err != nil {
+		t.Fatalf("seed soft-deleted auth provider: %v", err)
+	}
+
+	nonce := "restore-same-wallet"
+	seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce)
+	got, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: signSIWE(t, msg, key),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != addr {
+		t.Errorf("address: want %s, got %s", addr, got)
+	}
+
+	var rows []models.AuthProvider
+	if err := db.Unscoped().
+		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderWeb3, addr).
+		Find(&rows).Error; err != nil {
+		t.Fatalf("find auth providers: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want restored existing row only, got %d rows", len(rows))
+	}
+	if rows[0].DeletedAt.Valid {
+		t.Error("restored wallet should be active")
+	}
+}
+
+func TestLinkWallet_IgnoresSoftDeletedWalletLinkedToOtherUser(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+
+	oldUser := uuid.New()
+	newUser := uuid.New()
+	db.Create(&models.User{ID: oldUser, Role: models.RoleViewer})
+	db.Create(&models.User{ID: newUser, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	if err := db.Create(&models.AuthProvider{
+		UserID:     oldUser,
+		Provider:   models.ProviderWeb3,
+		ProviderID: addr,
+		DeletedAt:  gorm.DeletedAt{Time: time.Now().Add(-time.Hour), Valid: true},
+	}).Error; err != nil {
+		t.Fatalf("seed soft-deleted auth provider: %v", err)
+	}
+
+	nonce := "soft-deleted-other-user"
+	seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(strings.ToLower(addr), nonce)
+	got, err := svc.LinkWallet(newUser, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: signSIWE(t, msg, key),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != addr {
+		t.Errorf("address: want %s, got %s", addr, got)
+	}
+
+	var activeCount int64
+	db.Model(&models.AuthProvider{}).
+		Where("provider = ? AND provider_id = ?", models.ProviderWeb3, addr).
+		Count(&activeCount)
+	if activeCount != 1 {
+		t.Errorf("want 1 active wallet, got %d", activeCount)
 	}
 }


### PR DESCRIPTION
## 什麼改動

實作 `UserService.LinkWallet`，讓已登入的 Twitch 使用者可以綁定 MetaMask 錢包。

## 為什麼

`ClaimService.Claim()` 呼叫 `resolveWalletAddress()` 時回傳 `ErrClaimWalletNotLinked`，原因是 service 層尚未實作錢包綁定邏輯。

closes #252

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：#252
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 HTTP handler 或 router 路由
  - 不改前端

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試（`go test ./internal/services/... -run TestLinkWallet` 10 cases 全過）

## 備註

前置 #251（auth_providers partial unique index + SIWE helpers）已於 #254 merge 進 develop。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  - 支持用户使用以太坊钱包地址与签名进行绑定并返回标准化地址。

* **改进**
  - 更严格的钱包地址规范化与校验，规范化后参与随机数/验证流程。
  - 数据库层面错误翻译改进，提升验证与冲突反馈的明确性。
  - 强化并发与唯一性处理，减少重复绑定风险。

* **修复**
  - 加强随机数（nonce）消费与重放防护，防止重放攻击。

* **测试**
  - 补充大量单元测试覆盖成功与多种失败场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->