### PR TITLE
[frontend] feat(tachimint): add Chrome sidepanel runtime skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Lint
         run: docker compose run --no-deps --rm frontend pnpm lint
 
+      - name: Test
+        run: docker compose run --no-deps --rm frontend pnpm test
+
       - name: Build
         run: docker compose run --no-deps --rm frontend pnpm build
 

--- a/tachimint/package.json
+++ b/tachimint/package.json
@@ -13,6 +13,7 @@
     "build": "tsc -b && vite build",
     "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",
     "lint": "eslint .",
+    "test": "node --experimental-strip-types --test src/extension/*.test.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/tachimint/package.json
+++ b/tachimint/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/chrome": "^0.1.40",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/tachimint/pnpm-lock.yaml
+++ b/tachimint/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.0)
+      '@types/chrome':
+        specifier: ^0.1.40
+        version: 0.1.40
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -330,11 +333,23 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chrome@0.1.40':
+    resolution: {integrity: sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1323,9 +1338,22 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chrome@0.1.40':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/tachimint/public/manifest.json
+++ b/tachimint/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tachimint",
   "description": "Tachimint Chrome sidepanel extension.",
   "version": "0.0.1",
-  "permissions": ["sidePanel", "storage", "tabs"],
+  "permissions": ["sidePanel", "storage", "activeTab"],
   "background": {
     "service_worker": "assets/background.js",
     "type": "module"

--- a/tachimint/public/manifest.json
+++ b/tachimint/public/manifest.json
@@ -1,0 +1,24 @@
+{
+  "manifest_version": 3,
+  "name": "Tachimint",
+  "description": "Tachimint Chrome sidepanel extension.",
+  "version": "0.0.1",
+  "permissions": ["sidePanel", "storage", "tabs"],
+  "background": {
+    "service_worker": "assets/background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://localhost:3000/*"],
+      "js": ["assets/content.js"]
+    }
+  ],
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
+  "action": {
+    "default_title": "Open Tachimint"
+  },
+  "host_permissions": ["http://localhost:8001/*"]
+}

--- a/tachimint/public/manifest.json
+++ b/tachimint/public/manifest.json
@@ -20,5 +20,5 @@
   "action": {
     "default_title": "Open Tachimint"
   },
-  "host_permissions": ["http://localhost:8001/*"]
+  "host_permissions": ["http://localhost:8080/*"]
 }

--- a/tachimint/sidepanel.html
+++ b/tachimint/sidepanel.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tachimint</title>
+    <style>
+      html, body { height: 100%; margin: 0; }
+      #root { height: 100%; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/tachimint/src/extension/background.test.ts
+++ b/tachimint/src/extension/background.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test, { afterEach } from 'node:test'
+
+type ChromeMock = typeof globalThis & {
+  chrome?: {
+    runtime: {
+      onInstalled: { addListener: (callback: () => void) => void }
+      onStartup: { addListener: (callback: () => void) => void }
+      onMessage: { addListener: (callback: () => undefined) => void }
+    }
+    sidePanel: {
+      setPanelBehavior: (options: { openPanelOnActionClick: boolean }) => Promise<void>
+    }
+    action: {
+      onClicked: { addListener: (callback: (tab: { windowId?: number }) => void) => void }
+    }
+  }
+}
+
+const globalForTest = globalThis as ChromeMock
+const originalChrome = globalForTest.chrome
+
+afterEach(() => {
+  globalForTest.chrome = originalChrome
+})
+
+async function importBackgroundModule() {
+  return import(`./background.ts?test=${Date.now()}-${Math.random()}`)
+}
+
+test('background enables openPanelOnActionClick without registering manual action click handling', async () => {
+  const installedListeners: Array<() => void> = []
+  const startupListeners: Array<() => void> = []
+  const messageListeners: Array<() => undefined> = []
+  const panelBehaviorCalls: Array<{ openPanelOnActionClick: boolean }> = []
+  let actionClickListeners = 0
+
+  globalForTest.chrome = {
+    runtime: {
+      onInstalled: { addListener: (callback) => installedListeners.push(callback) },
+      onStartup: { addListener: (callback) => startupListeners.push(callback) },
+      onMessage: { addListener: (callback) => messageListeners.push(callback) },
+    },
+    sidePanel: {
+      setPanelBehavior: async (options) => {
+        panelBehaviorCalls.push(options)
+      },
+    },
+    action: {
+      onClicked: {
+        addListener: () => {
+          actionClickListeners += 1
+        },
+      },
+    },
+  }
+
+  await importBackgroundModule()
+
+  assert.equal(installedListeners.length, 1)
+  assert.equal(startupListeners.length, 1)
+  assert.equal(messageListeners.length, 1)
+  assert.equal(actionClickListeners, 0)
+
+  installedListeners[0]()
+  startupListeners[0]()
+  await Promise.resolve()
+
+  assert.deepEqual(panelBehaviorCalls, [
+    { openPanelOnActionClick: true },
+    { openPanelOnActionClick: true },
+  ])
+})

--- a/tachimint/src/extension/background.ts
+++ b/tachimint/src/extension/background.ts
@@ -1,0 +1,34 @@
+async function enableSidePanelAction() {
+  if (!chrome.sidePanel?.setPanelBehavior) {
+    return
+  }
+
+  try {
+    await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
+  } catch (error) {
+    console.warn('Failed to enable side panel action behavior', error)
+  }
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  void enableSidePanelAction()
+})
+
+chrome.runtime.onStartup.addListener(() => {
+  void enableSidePanelAction()
+})
+
+chrome.action.onClicked.addListener((tab) => {
+  if (!chrome.sidePanel?.open || typeof tab.windowId !== 'number') {
+    return
+  }
+
+  void chrome.sidePanel.open({ windowId: tab.windowId }).catch((error) => {
+    console.warn('Failed to open side panel from action click', error)
+  })
+})
+
+// Message listener stub — wired in PR 3
+chrome.runtime.onMessage.addListener((_message, _sender, _sendResponse) => {
+  // no-op placeholder
+})

--- a/tachimint/src/extension/background.ts
+++ b/tachimint/src/extension/background.ts
@@ -29,6 +29,4 @@ chrome.action.onClicked.addListener((tab) => {
 })
 
 // Message listener stub — wired in PR 3
-chrome.runtime.onMessage.addListener((_message, _sender, _sendResponse) => {
-  // no-op placeholder
-})
+chrome.runtime.onMessage.addListener(() => undefined)

--- a/tachimint/src/extension/background.ts
+++ b/tachimint/src/extension/background.ts
@@ -18,15 +18,5 @@ chrome.runtime.onStartup.addListener(() => {
   void enableSidePanelAction()
 })
 
-chrome.action.onClicked.addListener((tab) => {
-  if (!chrome.sidePanel?.open || typeof tab.windowId !== 'number') {
-    return
-  }
-
-  void chrome.sidePanel.open({ windowId: tab.windowId }).catch((error) => {
-    console.warn('Failed to open side panel from action click', error)
-  })
-})
-
 // Message listener stub — wired in PR 3
 chrome.runtime.onMessage.addListener(() => undefined)

--- a/tachimint/src/extension/content.ts
+++ b/tachimint/src/extension/content.ts
@@ -1,0 +1,2 @@
+// Content script placeholder — messaging bridge to be wired in PR 3
+export {}

--- a/tachimint/src/extension/runtime-config.test.ts
+++ b/tachimint/src/extension/runtime-config.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFile } from 'node:fs/promises'
+
+async function readManifest() {
+  const raw = await readFile(new URL('../../public/manifest.json', import.meta.url), 'utf8')
+  return JSON.parse(raw) as {
+    host_permissions?: string[]
+  }
+}
+
+async function readEnvExample() {
+  return readFile(new URL('../../.env.example', import.meta.url), 'utf8')
+}
+
+test('manifest allows requests to the default local API base url', async () => {
+  const manifest = await readManifest()
+  const envExample = await readEnvExample()
+  const apiUrl = envExample.match(/^VITE_TACHIGO_API_URL=(.+)$/m)?.[1]
+
+  assert.equal(apiUrl, 'http://localhost:8080')
+  assert.ok(manifest.host_permissions?.includes('http://localhost:8080/*'))
+})

--- a/tachimint/src/extension/storage.test.ts
+++ b/tachimint/src/extension/storage.test.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+type StorageLike = {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+}
+
+type ChromeStorageArea = {
+  get: (key: string, callback: (result: Record<string, unknown>) => void) => void
+  set: (items: Record<string, unknown>, callback: () => void) => void
+}
+
+type TestGlobal = typeof globalThis & {
+  chrome?: {
+    runtime?: { lastError?: { message?: string } }
+    storage?: { local?: ChromeStorageArea }
+  }
+  window?: { localStorage: StorageLike }
+}
+
+const globalForTest = globalThis as TestGlobal
+
+function setWindowLocalStorage(localStorage: StorageLike) {
+  globalForTest.window = { localStorage }
+}
+
+function setChromeStorage(local: ChromeStorageArea | undefined) {
+  globalForTest.chrome = local
+    ? {
+        runtime: {},
+        storage: { local },
+      }
+    : undefined
+}
+
+async function importStorageModule() {
+  return import(`./storage.ts?test=${Date.now()}-${Math.random()}`)
+}
+
+test('loadDemoState falls back to localStorage when chrome storage key is missing', async () => {
+  const localState = {
+    screen: 'coupon',
+    language: 'zh-TW',
+    hud: {
+      points: 7,
+      totalPoints: 99,
+      countdown: 12,
+      isWatching: false,
+      clickCount: 3,
+    },
+    tcgBalance: 8,
+    redeemedCouponIds: ['coupon-1'],
+  }
+
+  setWindowLocalStorage({
+    getItem: () => JSON.stringify(localState),
+    setItem: () => {},
+  })
+  setChromeStorage({
+    get: (_key, callback) => callback({}),
+    set: (_items, callback) => callback(),
+  })
+
+  const storage = await importStorageModule()
+
+  assert.deepEqual(await storage.loadDemoState(), localState)
+})
+
+test('loadDemoState falls back to localStorage when chrome storage read errors', async () => {
+  const localState = {
+    screen: 'hud',
+    language: 'en',
+    hud: {
+      points: 4,
+      totalPoints: 20,
+      countdown: 10,
+      isWatching: true,
+      clickCount: 2,
+    },
+    tcgBalance: 5,
+    redeemedCouponIds: [],
+  }
+
+  setWindowLocalStorage({
+    getItem: () => JSON.stringify(localState),
+    setItem: () => {},
+  })
+  setChromeStorage({
+    get: (_key, callback) => {
+      if (globalForTest.chrome?.runtime) {
+        globalForTest.chrome.runtime.lastError = { message: 'storage failed' }
+      }
+      callback({})
+      if (globalForTest.chrome?.runtime) {
+        delete globalForTest.chrome.runtime.lastError
+      }
+    },
+    set: (_items, callback) => callback(),
+  })
+
+  const storage = await importStorageModule()
+
+  assert.deepEqual(await storage.loadDemoState(), localState)
+})
+
+test('loadDemoState returns default state when localStorage read throws', async () => {
+  setChromeStorage(undefined)
+  setWindowLocalStorage({
+    getItem: () => {
+      throw new Error('denied')
+    },
+    setItem: () => {},
+  })
+
+  const storage = await importStorageModule()
+
+  await assert.doesNotReject(() => storage.loadDemoState())
+  assert.deepEqual(await storage.loadDemoState(), {
+    screen: 'login',
+    language: 'en',
+    hud: {
+      points: 0,
+      totalPoints: 12847,
+      countdown: 60,
+      isWatching: true,
+      clickCount: 0,
+    },
+    tcgBalance: 0,
+    redeemedCouponIds: [],
+  })
+})
+
+test('saveDemoState sanitizes values and ignores localStorage write errors', async () => {
+  let written: { key: string; value: string } | null = null
+
+  setChromeStorage(undefined)
+  setWindowLocalStorage({
+    getItem: () => null,
+    setItem: (key, value) => {
+      written = { key, value }
+      throw new Error('quota exceeded')
+    },
+  })
+
+  const storage = await importStorageModule()
+
+  await assert.doesNotReject(() =>
+    storage.saveDemoState({
+      screen: 'hud',
+      language: 'zh-TW',
+      hud: {
+        points: Number.NaN,
+        totalPoints: Number.POSITIVE_INFINITY,
+        countdown: Number.NaN,
+        isWatching: false,
+        clickCount: Number.NEGATIVE_INFINITY,
+      },
+      tcgBalance: -10,
+      redeemedCouponIds: ['coupon-1', 2 as never],
+    }),
+  )
+
+  assert.ok(written)
+  assert.equal(written.key, 'tachigo.sidepanel.demo-state.v2')
+  assert.deepEqual(JSON.parse(written.value), {
+    screen: 'hud',
+    language: 'zh-TW',
+    hud: {
+      points: 0,
+      totalPoints: 12847,
+      countdown: 60,
+      isWatching: false,
+      clickCount: 0,
+    },
+    tcgBalance: 0,
+    redeemedCouponIds: ['coupon-1'],
+  })
+})

--- a/tachimint/src/extension/storage.test.ts
+++ b/tachimint/src/extension/storage.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import test from 'node:test'
+import test, { afterEach } from 'node:test'
 
 const STORAGE_KEY = 'tachigo.sidepanel.demo-state.v2'
 
@@ -22,6 +22,13 @@ type TestGlobal = typeof globalThis & {
 }
 
 const globalForTest = globalThis as TestGlobal
+const originalWindow = globalForTest.window
+const originalChrome = globalForTest.chrome
+
+afterEach(() => {
+  globalForTest.window = originalWindow
+  globalForTest.chrome = originalChrome
+})
 
 function setWindowLocalStorage(localStorage: StorageLike) {
   globalForTest.window = { localStorage }

--- a/tachimint/src/extension/storage.test.ts
+++ b/tachimint/src/extension/storage.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+const STORAGE_KEY = 'tachigo.sidepanel.demo-state.v2'
+
 type StorageLike = {
   getItem: (key: string) => string | null
   setItem: (key: string, value: string) => void
@@ -54,7 +56,10 @@ test('loadDemoState falls back to localStorage when chrome storage key is missin
   }
 
   setWindowLocalStorage({
-    getItem: () => JSON.stringify(localState),
+    getItem: (key) => {
+      assert.equal(key, STORAGE_KEY)
+      return JSON.stringify(localState)
+    },
     setItem: () => {},
   })
   setChromeStorage({
@@ -83,7 +88,10 @@ test('loadDemoState falls back to localStorage when chrome storage read errors',
   }
 
   setWindowLocalStorage({
-    getItem: () => JSON.stringify(localState),
+    getItem: (key) => {
+      assert.equal(key, STORAGE_KEY)
+      return JSON.stringify(localState)
+    },
     setItem: () => {},
   })
   setChromeStorage({
@@ -107,7 +115,8 @@ test('loadDemoState falls back to localStorage when chrome storage read errors',
 test('loadDemoState returns default state when localStorage read throws', async () => {
   setChromeStorage(undefined)
   setWindowLocalStorage({
-    getItem: () => {
+    getItem: (key) => {
+      assert.equal(key, STORAGE_KEY)
       throw new Error('denied')
     },
     setItem: () => {},
@@ -136,8 +145,12 @@ test('saveDemoState sanitizes values and ignores localStorage write errors', asy
 
   setChromeStorage(undefined)
   setWindowLocalStorage({
-    getItem: () => null,
+    getItem: (key) => {
+      assert.equal(key, STORAGE_KEY)
+      return null
+    },
     setItem: (key, value) => {
+      assert.equal(key, STORAGE_KEY)
       written = { key, value }
       throw new Error('quota exceeded')
     },

--- a/tachimint/src/extension/storage.test.ts
+++ b/tachimint/src/extension/storage.test.ts
@@ -190,3 +190,63 @@ test('saveDemoState sanitizes values and ignores localStorage write errors', asy
     redeemedCouponIds: ['coupon-1'],
   })
 })
+
+test('saveDemoState falls back to localStorage when chrome storage write fails', async () => {
+  let written: { key: string; value: string } | null = null
+
+  setChromeStorage({
+    get: (_key, callback) => callback({}),
+    set: (_items, callback) => {
+      if (globalForTest.chrome?.runtime) {
+        globalForTest.chrome.runtime.lastError = { message: 'write failed' }
+      }
+      callback()
+      if (globalForTest.chrome?.runtime) {
+        delete globalForTest.chrome.runtime.lastError
+      }
+    },
+  })
+  setWindowLocalStorage({
+    getItem: (key) => {
+      assert.equal(key, STORAGE_KEY)
+      return null
+    },
+    setItem: (key, value) => {
+      assert.equal(key, STORAGE_KEY)
+      written = { key, value }
+    },
+  })
+
+  const storage = await importStorageModule()
+
+  await assert.doesNotReject(() =>
+    storage.saveDemoState({
+      screen: 'claim',
+      language: 'zh-CN',
+      hud: {
+        points: Number.NaN,
+        totalPoints: 33,
+        countdown: Number.POSITIVE_INFINITY,
+        isWatching: true,
+        clickCount: 2,
+      },
+      tcgBalance: -5,
+      redeemedCouponIds: ['coupon-2'],
+    }),
+  )
+
+  assert.ok(written)
+  assert.deepEqual(JSON.parse(written.value), {
+    screen: 'claim',
+    language: 'zh-CN',
+    hud: {
+      points: 0,
+      totalPoints: 33,
+      countdown: 60,
+      isWatching: true,
+      clickCount: 2,
+    },
+    tcgBalance: 0,
+    redeemedCouponIds: ['coupon-2'],
+  })
+})

--- a/tachimint/src/extension/storage.ts
+++ b/tachimint/src/extension/storage.ts
@@ -1,4 +1,4 @@
-import { defaultDemoState, sanitizeDemoState, type DemoState } from './types'
+import { createDefaultDemoState, sanitizeDemoState, type DemoState } from './types.ts'
 
 const STORAGE_KEY = 'tachigo.sidepanel.demo-state.v2'
 
@@ -22,7 +22,12 @@ async function getChromeStoredState(): Promise<DemoState | null> {
         return
       }
 
-      resolve(sanitizeDemoState(result?.[STORAGE_KEY]))
+      if (!result || !Object.prototype.hasOwnProperty.call(result, STORAGE_KEY)) {
+        resolve(null)
+        return
+      }
+
+      resolve(sanitizeDemoState(result[STORAGE_KEY]))
     })
   })
 }
@@ -50,19 +55,25 @@ async function setChromeStoredState(state: DemoState): Promise<void> {
 
 function getLocalStorageState(): DemoState {
   if (typeof window === 'undefined') {
-    return defaultDemoState
+    return createDefaultDemoState()
   }
 
-  const raw = window.localStorage.getItem(STORAGE_KEY)
+  let raw: string | null = null
+
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return createDefaultDemoState()
+  }
 
   if (!raw) {
-    return defaultDemoState
+    return createDefaultDemoState()
   }
 
   try {
     return sanitizeDemoState(JSON.parse(raw))
   } catch {
-    return defaultDemoState
+    return createDefaultDemoState()
   }
 }
 
@@ -71,7 +82,11 @@ function setLocalStorageState(state: DemoState) {
     return
   }
 
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // Ignore localStorage write failures in restricted environments.
+  }
 }
 
 export async function loadDemoState(): Promise<DemoState> {

--- a/tachimint/src/extension/storage.ts
+++ b/tachimint/src/extension/storage.ts
@@ -104,8 +104,13 @@ export async function saveDemoState(state: DemoState): Promise<void> {
 
   const chromeStorage = getChromeStorageArea()
   if (chromeStorage) {
-    await setChromeStoredState(sanitizedState)
-    return
+    try {
+      await setChromeStoredState(sanitizedState)
+      return
+    } catch {
+      setLocalStorageState(sanitizedState)
+      return
+    }
   }
 
   setLocalStorageState(sanitizedState)

--- a/tachimint/src/extension/storage.ts
+++ b/tachimint/src/extension/storage.ts
@@ -1,0 +1,97 @@
+import { defaultDemoState, sanitizeDemoState, type DemoState } from './types'
+
+const STORAGE_KEY = 'tachigo.sidepanel.demo-state.v2'
+
+function getChromeStorageArea() {
+  return globalThis.chrome?.storage?.local
+}
+
+async function getChromeStoredState(): Promise<DemoState | null> {
+  const storage = getChromeStorageArea()
+
+  if (!storage) {
+    return null
+  }
+
+  return new Promise((resolve, reject) => {
+    storage.get(STORAGE_KEY, (result) => {
+      const runtimeError = globalThis.chrome?.runtime?.lastError
+
+      if (runtimeError) {
+        reject(new Error(runtimeError.message))
+        return
+      }
+
+      resolve(sanitizeDemoState(result?.[STORAGE_KEY]))
+    })
+  })
+}
+
+async function setChromeStoredState(state: DemoState): Promise<void> {
+  const storage = getChromeStorageArea()
+
+  if (!storage) {
+    return
+  }
+
+  return new Promise((resolve, reject) => {
+    storage.set({ [STORAGE_KEY]: state }, () => {
+      const runtimeError = globalThis.chrome?.runtime?.lastError
+
+      if (runtimeError) {
+        reject(new Error(runtimeError.message))
+        return
+      }
+
+      resolve()
+    })
+  })
+}
+
+function getLocalStorageState(): DemoState {
+  if (typeof window === 'undefined') {
+    return defaultDemoState
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+
+  if (!raw) {
+    return defaultDemoState
+  }
+
+  try {
+    return sanitizeDemoState(JSON.parse(raw))
+  } catch {
+    return defaultDemoState
+  }
+}
+
+function setLocalStorageState(state: DemoState) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+}
+
+export async function loadDemoState(): Promise<DemoState> {
+  const chromeState = await getChromeStoredState().catch(() => null)
+
+  if (chromeState) {
+    return chromeState
+  }
+
+  return getLocalStorageState()
+}
+
+export async function saveDemoState(state: DemoState): Promise<void> {
+  const sanitizedState = sanitizeDemoState(state)
+
+  const chromeStorage = getChromeStorageArea()
+  if (chromeStorage) {
+    await setChromeStoredState(sanitizedState)
+    return
+  }
+
+  setLocalStorageState(sanitizedState)
+}

--- a/tachimint/src/extension/storage.ts
+++ b/tachimint/src/extension/storage.ts
@@ -58,7 +58,7 @@ function getLocalStorageState(): DemoState {
     return createDefaultDemoState()
   }
 
-  let raw: string | null = null
+  let raw: string | null
 
   try {
     raw = window.localStorage.getItem(STORAGE_KEY)

--- a/tachimint/src/extension/types.test.ts
+++ b/tachimint/src/extension/types.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+async function importTypesModule() {
+  return import(`./types.ts?test=${Date.now()}-${Math.random()}`)
+}
+
+test('sanitizeDemoState returns fresh default objects instead of shared references', async () => {
+  const types = await importTypesModule()
+
+  const first = types.sanitizeDemoState(null)
+  first.hud.points = 99
+  first.redeemedCouponIds.push('coupon-1')
+
+  const second = types.sanitizeDemoState(null)
+
+  assert.notEqual(first, second)
+  assert.notEqual(first.hud, second.hud)
+  assert.deepEqual(second, {
+    screen: 'login',
+    language: 'en',
+    hud: {
+      points: 0,
+      totalPoints: 12847,
+      countdown: 60,
+      isWatching: true,
+      clickCount: 0,
+    },
+    tcgBalance: 0,
+    redeemedCouponIds: [],
+  })
+})
+
+test('sanitizeHudDemoState rejects non-finite numeric values', async () => {
+  const types = await importTypesModule()
+
+  assert.deepEqual(
+    types.sanitizeHudDemoState({
+      points: Number.NaN,
+      totalPoints: Number.POSITIVE_INFINITY,
+      countdown: Number.NEGATIVE_INFINITY,
+      isWatching: false,
+      clickCount: Number.NaN,
+    }),
+    {
+      points: 0,
+      totalPoints: 12847,
+      countdown: 60,
+      isWatching: false,
+      clickCount: 0,
+    },
+  )
+})

--- a/tachimint/src/extension/types.ts
+++ b/tachimint/src/extension/types.ts
@@ -1,0 +1,90 @@
+import type { AppLanguage } from '../i18n'
+
+export type DemoScreen = 'login' | 'loading' | 'hud' | 'claim' | 'coupon'
+
+export interface HudDemoState {
+  points: number
+  totalPoints: number
+  countdown: number
+  isWatching: boolean
+  clickCount: number
+}
+
+export type CouponRedeemResult = 'success' | 'insufficient' | 'already_redeemed'
+
+export interface DemoState {
+  screen: DemoScreen
+  language: AppLanguage
+  hud: HudDemoState
+  tcgBalance: number
+  redeemedCouponIds: string[]
+}
+
+export const defaultHudDemoState: HudDemoState = {
+  points: 0,
+  totalPoints: 12847,
+  countdown: 60,
+  isWatching: true,
+  clickCount: 0,
+}
+
+export const defaultDemoState: DemoState = {
+  screen: 'login',
+  language: 'en',
+  hud: defaultHudDemoState,
+  tcgBalance: 0,
+  redeemedCouponIds: [],
+}
+
+export function normalizeAppLanguage(language: string | null | undefined): AppLanguage {
+  if (language === 'en' || language === 'zh-TW' || language === 'zh-CN') {
+    return language
+  }
+
+  return defaultDemoState.language
+}
+
+export function sanitizeHudDemoState(value: unknown): HudDemoState {
+  if (!value || typeof value !== 'object') {
+    return defaultHudDemoState
+  }
+
+  const candidate = value as Partial<HudDemoState>
+
+  return {
+    points: typeof candidate.points === 'number' ? candidate.points : defaultHudDemoState.points,
+    totalPoints: typeof candidate.totalPoints === 'number' ? candidate.totalPoints : defaultHudDemoState.totalPoints,
+    countdown: typeof candidate.countdown === 'number' ? candidate.countdown : defaultHudDemoState.countdown,
+    isWatching: typeof candidate.isWatching === 'boolean' ? candidate.isWatching : defaultHudDemoState.isWatching,
+    clickCount: typeof candidate.clickCount === 'number' ? candidate.clickCount : defaultHudDemoState.clickCount,
+  }
+}
+
+export function sanitizeDemoState(value: unknown): DemoState {
+  if (!value || typeof value !== 'object') {
+    return defaultDemoState
+  }
+
+  const candidate = value as Partial<DemoState>
+  const screen = candidate.screen === 'login' || candidate.screen === 'loading' || candidate.screen === 'hud' || candidate.screen === 'claim' || candidate.screen === 'coupon'
+    ? candidate.screen
+    : defaultDemoState.screen
+
+  const tcgBalance =
+    typeof candidate.tcgBalance === 'number' && Number.isFinite(candidate.tcgBalance)
+      ? Math.max(0, candidate.tcgBalance)
+      : defaultDemoState.tcgBalance
+
+  const redeemedRaw = candidate.redeemedCouponIds
+  const redeemedCouponIds = Array.isArray(redeemedRaw)
+    ? redeemedRaw.filter((id): id is string => typeof id === 'string')
+    : defaultDemoState.redeemedCouponIds
+
+  return {
+    screen,
+    language: normalizeAppLanguage(candidate.language),
+    hud: sanitizeHudDemoState(candidate.hud),
+    tcgBalance,
+    redeemedCouponIds,
+  }
+}

--- a/tachimint/src/extension/types.ts
+++ b/tachimint/src/extension/types.ts
@@ -36,6 +36,22 @@ export const defaultDemoState: DemoState = {
   redeemedCouponIds: [],
 }
 
+export function createDefaultHudDemoState(): HudDemoState {
+  return { ...defaultHudDemoState }
+}
+
+export function createDefaultDemoState(): DemoState {
+  return {
+    ...defaultDemoState,
+    hud: createDefaultHudDemoState(),
+    redeemedCouponIds: [...defaultDemoState.redeemedCouponIds],
+  }
+}
+
+function toFiniteNumber(value: unknown, fallback: number) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
 export function normalizeAppLanguage(language: string | null | undefined): AppLanguage {
   if (language === 'en' || language === 'zh-TW' || language === 'zh-CN') {
     return language
@@ -46,23 +62,23 @@ export function normalizeAppLanguage(language: string | null | undefined): AppLa
 
 export function sanitizeHudDemoState(value: unknown): HudDemoState {
   if (!value || typeof value !== 'object') {
-    return defaultHudDemoState
+    return createDefaultHudDemoState()
   }
 
   const candidate = value as Partial<HudDemoState>
 
   return {
-    points: typeof candidate.points === 'number' ? candidate.points : defaultHudDemoState.points,
-    totalPoints: typeof candidate.totalPoints === 'number' ? candidate.totalPoints : defaultHudDemoState.totalPoints,
-    countdown: typeof candidate.countdown === 'number' ? candidate.countdown : defaultHudDemoState.countdown,
+    points: toFiniteNumber(candidate.points, defaultHudDemoState.points),
+    totalPoints: toFiniteNumber(candidate.totalPoints, defaultHudDemoState.totalPoints),
+    countdown: toFiniteNumber(candidate.countdown, defaultHudDemoState.countdown),
     isWatching: typeof candidate.isWatching === 'boolean' ? candidate.isWatching : defaultHudDemoState.isWatching,
-    clickCount: typeof candidate.clickCount === 'number' ? candidate.clickCount : defaultHudDemoState.clickCount,
+    clickCount: toFiniteNumber(candidate.clickCount, defaultHudDemoState.clickCount),
   }
 }
 
 export function sanitizeDemoState(value: unknown): DemoState {
   if (!value || typeof value !== 'object') {
-    return defaultDemoState
+    return createDefaultDemoState()
   }
 
   const candidate = value as Partial<DemoState>
@@ -78,13 +94,13 @@ export function sanitizeDemoState(value: unknown): DemoState {
   const redeemedRaw = candidate.redeemedCouponIds
   const redeemedCouponIds = Array.isArray(redeemedRaw)
     ? redeemedRaw.filter((id): id is string => typeof id === 'string')
-    : defaultDemoState.redeemedCouponIds
+    : createDefaultDemoState().redeemedCouponIds
 
   return {
     screen,
     language: normalizeAppLanguage(candidate.language),
     hud: sanitizeHudDemoState(candidate.hud),
     tcgBalance,
-    redeemedCouponIds,
+    redeemedCouponIds: [...redeemedCouponIds],
   }
 }

--- a/tachimint/tsconfig.app.json
+++ b/tachimint/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["chrome", "vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/tachimint/vite.config.ts
+++ b/tachimint/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite'
+import path from 'path'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
@@ -6,6 +7,21 @@ export default defineConfig({
   plugins: [react()],
   build: {
     chunkSizeWarningLimit: 350,
+    rollupOptions: {
+      input: {
+        sidepanel: path.resolve(__dirname, 'sidepanel.html'),
+        popup: path.resolve(__dirname, 'index.html'),
+        background: path.resolve(__dirname, 'src/extension/background.ts'),
+        content: path.resolve(__dirname, 'src/extension/content.ts'),
+      },
+      output: {
+        entryFileNames: (chunkInfo) => (
+          chunkInfo.name === 'background' || chunkInfo.name === 'content'
+            ? 'assets/[name].js'
+            : 'assets/[name]-[hash].js'
+        ),
+      },
+    },
   },
   server: {
     host: true,


### PR DESCRIPTION
## Scope 對齊

Source of truth: [docs/tachimint-chrome-sidepanel-migration.md](docs/tachimint-chrome-sidepanel-migration.md) — Step 1 of 4（migration decision: #246）

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 這張 PR 做了什麼

依照 migration decision doc Section 4 拆題順序，建立 `tachimint/` 的 Chrome Extension (Manifest v3) runtime 骨架，讓它能以 Chrome sidepanel extension 身份 load 起來。

**不動任何既有產品邏輯**（hooks、App.tsx、api.ts、services 全未修改）。目前 sidepanel 開啟後仍顯示既有 Twitch-hosted UI，屬預期行為，待 PR 2 導入新 app shell。

### 新增檔案

| 檔案 | 說明 |
|---|---|
| `tachimint/public/manifest.json` | Manifest v3，sidePanel + storage + tabs permissions |
| `tachimint/sidepanel.html` | Chrome sidepanel entry HTML (320×600) |
| `tachimint/src/extension/background.ts` | Minimal service worker — `openPanelOnActionClick` only；音效合成 deferred |
| `tachimint/src/extension/content.ts` | Content script placeholder |
| `tachimint/src/extension/types.ts` | DemoState 型別，ported from migration source |
| `tachimint/src/extension/storage.ts` | `chrome.storage.local` + `localStorage` fallback |

### 修改檔案

| 檔案 | 說明 |
|---|---|
| `tachimint/vite.config.ts` | Multi-entry build；background.js / content.js 輸出無 hash（Chrome service worker 需固定檔名） |
| `tachimint/tsconfig.app.json` | `types` 加入 `"chrome"` |
| `tachimint/package.json` | 新增 `@types/chrome ^0.1.40` devDependency |

## 本 PR 明確不做

- 不修改 `src/App.tsx`、`src/hooks/`、`src/services/api.ts`（Twitch 邏輯在 Step 3 才接線）
- 不導入新 app shell 或視覺（Step 2）
- 不刪除 `index.html`（Twitch panel entry，Step 4 cleanup 才移除）
- 不加音效合成（defer to Step 3）
- 不修改 `backend/`、`dashboard/` 或 `extensions/tachigo-demo-sidepanel/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加 Chrome 扩展支持：侧边面板、工具栏操作与内容脚本集成，提供侧边面板入口页与默认界面布局。
  * 引入持久化与状态管理：保存/恢复演示状态并对输入进行校验与容错回退。

* **测试**
  * 新增单元测试，覆盖存储读写回退、数据清理与背景脚本行为验证。

* **杂项**
  * 更新构建与类型配置并调整开发依赖以支持扩展运行环境。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->