### PR TITLE
[frontend] add LoginScreen, LoadingScreen, LanguageSwitcher, useSound and theme to tachimint (2b/5)

### DIFF
--- a/tachimint/scripts/review-feedback-regression.test.ts
+++ b/tachimint/scripts/review-feedback-regression.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFile } from 'node:fs/promises'
+
+async function readLoginScreen() {
+  return readFile(new URL('../src/app/components/LoginScreen.tsx', import.meta.url), 'utf8')
+}
+
+async function readUseSound() {
+  return readFile(new URL('../src/app/hooks/useSound.ts', import.meta.url), 'utf8')
+}
+
+test('login fields expose stable accessible names', async () => {
+  const source = await readLoginScreen()
+
+  assert.match(source, /aria-label=\{t\('login\.usernamePlaceholder'\)\}/)
+  assert.match(source, /aria-label=\{t\('login\.passwordPlaceholder'\)\}/)
+})
+
+test('sound bridge falls back when content delivery reports false', async () => {
+  const source = await readUseSound()
+
+  assert.match(source, /const delivered = await sendToContentScript\(type, variant\)/)
+  assert.match(source, /if \(!delivered\) \{\s*setBridgeStatus\('unsupported'\);\s*return false;\s*\}/)
+})
+
+test('background music tracks bridge and local playback reentry state', async () => {
+  const source = await readUseSound()
+
+  assert.match(source, /const bgPlayingRef = useRef\(false\)/)
+  assert.match(source, /if \(bgPlayingRef\.current\) return/)
+  assert.match(source, /bgPlayingRef\.current = true/)
+  assert.match(source, /bgPlayingRef\.current = false/)
+})

--- a/tachimint/src/app/components/LanguageSwitcher.tsx
+++ b/tachimint/src/app/components/LanguageSwitcher.tsx
@@ -1,0 +1,48 @@
+import type { AppLanguage } from '../../i18n/index'
+
+const LANGS: { code: AppLanguage; label: string }[] = [
+  { code: 'en', label: 'EN' },
+  { code: 'zh-TW', label: '繁中' },
+  { code: 'zh-CN', label: '简中' },
+]
+
+interface LanguageSwitcherProps {
+  currentLanguage: AppLanguage
+  onChangeLanguage: (language: AppLanguage) => void
+}
+
+export function LanguageSwitcher({ currentLanguage, onChangeLanguage }: LanguageSwitcherProps) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6, position: 'relative', zIndex: 2 }}>
+      {LANGS.map((lang, idx) => (
+        <div key={lang.code} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          {idx > 0 ? (
+            <span style={{ fontSize: 10, color: 'rgba(100,100,140,0.3)', fontFamily: 'var(--pixel-font-family)' }}>·</span>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => onChangeLanguage(lang.code)}
+            aria-pressed={currentLanguage === lang.code}
+            style={{
+              padding: '5px 10px',
+              borderRadius: 4,
+              border: '1px solid rgba(255,255,255,0.1)',
+              background: currentLanguage === lang.code ? 'rgba(145,70,255,0.15)' : 'transparent',
+              color: currentLanguage === lang.code ? 'rgba(145,70,255,0.9)' : 'rgba(100,100,140,0.4)',
+              fontSize: 9,
+              fontFamily: 'var(--pixel-font-family)',
+              cursor: 'pointer',
+              letterSpacing: '0.08em',
+              pointerEvents: 'auto',
+              touchAction: 'manipulation',
+              position: 'relative',
+              zIndex: 3,
+            }}
+          >
+            {lang.label}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/tachimint/src/app/components/LoadingScreen.tsx
+++ b/tachimint/src/app/components/LoadingScreen.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next'
+import logoImage from '../../assets/242a2b8162b4542ca6839e84ad45ad4a36c0257c.png';
+
+// ─── Loading Screen (Mario Design Philosophy) ─────────────
+export function LoadingScreen({ onComplete }: { onComplete?: () => void }) {
+  const { t } = useTranslation()
+  const [progress, setProgress] = useState(0);
+  const onCompleteRef = useRef(onComplete)
+  const intervalRef = useRef<number | null>(null)
+  const completeTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+  }, [onComplete])
+
+  useEffect(() => {
+    intervalRef.current = window.setInterval(() => {
+      setProgress((prev) => Math.min(prev + 2, 100))
+    }, 50)
+
+    return () => {
+      if (intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current)
+      }
+      if (completeTimeoutRef.current !== null) {
+        window.clearTimeout(completeTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (progress < 100) {
+      return
+    }
+
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+
+    if (completeTimeoutRef.current !== null) {
+      window.clearTimeout(completeTimeoutRef.current)
+    }
+
+    completeTimeoutRef.current = window.setTimeout(() => {
+      onCompleteRef.current?.()
+    }, 300)
+  }, [progress])
+
+  return (
+    <div
+      style={{
+        width: 320,
+        height: 600,
+        background: '#0d0d1a',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'relative',
+        overflow: 'hidden',
+        fontFamily: 'var(--pixel-font-family)',
+        userSelect: 'none',
+      }}
+    >
+      {/* ════════════════════════════════
+          CENTERED GROUP (Logo + Loading + Progress)
+      ════════════════════════════════ */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0,
+        }}
+      >
+        {/* 1. LOGO IMAGE */}
+        <img
+          src={logoImage}
+          alt="Tachigo Logo"
+          style={{
+            width: '35%',
+            height: 'auto',
+            display: 'block',
+            marginBottom: 16,
+          }}
+        />
+
+        {/* 2. LOADING TEXT */}
+        <div
+          style={{
+            fontFamily: 'var(--pixel-font-family)',
+            fontSize: 8,
+            color: '#9146FF',
+            letterSpacing: '0.1em',
+            marginBottom: 8,
+          }}
+        >
+          {t('loading.text')}
+        </div>
+
+        {/* 3. PROGRESS BAR */}
+        <div
+          style={{
+            width: 192,
+            height: 20,
+            background: '#2a2a3e',
+            border: '2px solid #9146FF',
+            borderRadius: 2,
+            overflow: 'hidden',
+            position: 'relative',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: `${progress}%`,
+              background: '#9146FF',
+              transition: 'width 0.05s linear',
+              boxShadow: '0 0 10px rgba(145,70,255,0.8)',
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tachimint/src/app/components/LoginScreen.tsx
+++ b/tachimint/src/app/components/LoginScreen.tsx
@@ -1,0 +1,348 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next'
+
+function CuteCapybaraLogin() {
+  return (
+    <svg
+      viewBox="0 0 320 230"
+      width="320"
+      height="230"
+      style={{ display: 'block' }}
+    >
+      <ellipse cx="160" cy="225" rx="138" ry="42" fill="#7A5228" />
+      <ellipse cx="160" cy="215" rx="100" ry="28" fill="#8B6038" fillOpacity="0.6" />
+      <rect x="118" y="185" width="84" height="50" rx="24" fill="#905A30" />
+      <rect x="52" y="82" width="216" height="138" rx="54" fill="#C07A3C" />
+      <ellipse cx="160" cy="168" rx="94" ry="54" fill="#D4904E" fillOpacity="0.48" />
+      <ellipse cx="62" cy="100" rx="30" ry="26" fill="#A86030" />
+      <ellipse cx="63" cy="104" rx="17" ry="14" fill="#E09A5A" />
+      <ellipse cx="258" cy="100" rx="30" ry="26" fill="#A86030" />
+      <ellipse cx="257" cy="104" rx="17" ry="14" fill="#E09A5A" />
+      <defs>
+        <clipPath id="hatClipLogin">
+          <rect x="0" y="0" width="320" height="100" />
+        </clipPath>
+      </defs>
+      <ellipse
+        cx="160" cy="100" rx="108" ry="86"
+        fill="#F5C842"
+        clipPath="url(#hatClipLogin)"
+      />
+      <ellipse
+        cx="146" cy="52" rx="52" ry="26"
+        fill="#FFE95A"
+        fillOpacity="0.52"
+        clipPath="url(#hatClipLogin)"
+      />
+      <rect x="47" y="97" width="226" height="15" rx="7.5" fill="#C8A010" />
+      <rect x="49" y="97" width="224" height="5" rx="2.5" fill="#F0C820" fillOpacity="0.38" />
+      <ellipse cx="216" cy="76" rx="20" ry="14" fill="#FFF8CC" />
+      <ellipse cx="216" cy="76" rx="13" ry="9" fill="#FFE820" />
+      <circle cx="216" cy="76" r="5.5" fill="white" fillOpacity="0.95" />
+      <line x1="232" y1="69" x2="252" y2="56" stroke="#FFF5AA" strokeWidth="2.5"
+            strokeOpacity="0.42" strokeLinecap="round" />
+      <line x1="234" y1="76" x2="256" y2="71" stroke="#FFF5AA" strokeWidth="2"
+            strokeOpacity="0.28" strokeLinecap="round" />
+      <line x1="232" y1="83" x2="250" y2="88" stroke="#FFF5AA" strokeWidth="1.5"
+            strokeOpacity="0.18" strokeLinecap="round" />
+      <g className="capy-eye-blink" style={{ transformOrigin: '110px 136px' }}>
+        <ellipse cx="110" cy="136" rx="33" ry="35" fill="white" />
+        <ellipse cx="110" cy="148" rx="30" ry="22" fill="rgba(192,120,60,0.09)" />
+        <ellipse cx="112" cy="139" rx="23" ry="25" fill="#1C0A00" />
+        <ellipse cx="112" cy="139" rx="16" ry="18" fill="#5E3010" />
+        <ellipse cx="114" cy="141" rx="10" ry="11" fill="#050100" />
+        <ellipse cx="122" cy="128" rx="9.5" ry="8.5" fill="white" />
+        <ellipse cx="113" cy="124" rx="4" ry="3.5" fill="white" fillOpacity="0.68" />
+      </g>
+      <g className="capy-eye-blink" style={{ transformOrigin: '210px 136px' }}>
+        <ellipse cx="210" cy="136" rx="33" ry="35" fill="white" />
+        <ellipse cx="210" cy="148" rx="30" ry="22" fill="rgba(192,120,60,0.09)" />
+        <ellipse cx="208" cy="139" rx="23" ry="25" fill="#1C0A00" />
+        <ellipse cx="208" cy="139" rx="16" ry="18" fill="#5E3010" />
+        <ellipse cx="206" cy="141" rx="10" ry="11" fill="#050100" />
+        <ellipse cx="198" cy="128" rx="9.5" ry="8.5" fill="white" />
+        <ellipse cx="207" cy="124" rx="4" ry="3.5" fill="white" fillOpacity="0.68" />
+      </g>
+      <path d="M82,112 Q110,102 136,107" stroke="#8B4A20"
+            strokeWidth="4" fill="none" strokeLinecap="round" strokeOpacity="0.62" />
+      <path d="M184,107 Q210,102 238,112" stroke="#8B4A20"
+            strokeWidth="4" fill="none" strokeLinecap="round" strokeOpacity="0.62" />
+      <ellipse cx="78" cy="172" rx="32" ry="21" fill="#FF8888" fillOpacity="0.24" />
+      <ellipse cx="242" cy="172" rx="32" ry="21" fill="#FF8888" fillOpacity="0.24" />
+      <rect x="106" y="166" width="108" height="46" rx="23" fill="#9A5A28" />
+      <rect x="116" y="173" width="88" height="30" rx="15" fill="#AA6A38" />
+      <ellipse cx="160" cy="177" rx="28" ry="7" fill="rgba(255,200,150,0.18)" />
+      <ellipse cx="141" cy="184" rx="11" ry="7.5" fill="#6A3618" fillOpacity="0.78" />
+      <ellipse cx="179" cy="184" rx="11" ry="7.5" fill="#6A3618" fillOpacity="0.78" />
+      <path d="M137,207 Q160,220 183,207" stroke="#7A3E18"
+            strokeWidth="3.5" fill="none" strokeLinecap="round" />
+      <rect x="150" y="209" width="8" height="7" rx="2" fill="white" fillOpacity="0.82" />
+      <rect x="162" y="209" width="8" height="7" rx="2" fill="white" fillOpacity="0.82" />
+      <ellipse cx="160" cy="228" rx="120" ry="10" fill="rgba(0,0,0,0.25)" />
+    </svg>
+  );
+}
+export function LoginScreen({ onLogin }: { onLogin?: () => void }) {
+  const { t } = useTranslation()
+  const [username, setUsername]   = useState('');
+  const [pass, setPass]           = useState('');
+  const [error, setError]         = useState(false);
+  const [loading, setLoading]     = useState(false);
+  const [focusedUser, setFocusedUser] = useState(false);
+  const [focusedPass, setFocusedPass] = useState(false);
+  const unlockTimerRef = useRef<number | null>(null)
+
+  const hasInput = username.length > 0 && pass.length > 0;
+
+  useEffect(() => {
+    return () => {
+      if (unlockTimerRef.current !== null) {
+        window.clearTimeout(unlockTimerRef.current)
+      }
+    }
+  }, [])
+
+  const handleUnlock = () => {
+    if (loading) {
+      return;
+    }
+
+    if (!hasInput) {
+      setError(true);
+      return;
+    }
+
+    if (unlockTimerRef.current !== null) {
+      window.clearTimeout(unlockTimerRef.current)
+    }
+
+    setLoading(true);
+    setError(false);
+    unlockTimerRef.current = window.setTimeout(() => {
+      setLoading(false);
+      unlockTimerRef.current = null
+      onLogin?.();
+    }, 1300);
+  };
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleUnlock();
+    }
+  };
+
+  return (
+    <div
+      style={{
+        width: 320,
+        height: 600,
+        background: '#0b0b13',
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+        overflow: 'hidden',
+        fontFamily: 'var(--pixel-font-family)',
+        userSelect: 'none',
+      }}
+    >
+      {/* ════════════════════════════════
+          TOP SPACER
+      ════════════════════════════════ */}
+      <div style={{ height: 44, flexShrink: 0 }} />
+
+      {/* ════════════════════════════════
+          1. LOGO / BRAND  (元素 1)
+      ════════════════════════════════ */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          flexShrink: 0,
+        }}
+      >
+        {/* Wordmark */}
+        <div
+          style={{
+            fontFamily: 'var(--pixel-font-family)',
+            fontSize: 28,
+            color: '#9146FF',
+            letterSpacing: '0.02em',
+            lineHeight: 1,
+          }}
+        >
+          TACHIGO
+        </div>
+
+        {/* Tagline */}
+        <div
+          style={{
+            fontFamily: 'var(--pixel-font-family)',
+            fontSize: 6.5,
+            color: '#FFB000',
+            letterSpacing: '0.18em',
+            marginTop: 16,
+          }}
+        >
+          MINE · WATCH · EARN
+        </div>
+      </div>
+
+      {/* ════════════════════════════════
+          FORM SPACER
+      ════════════════════════════════ */}
+      <div style={{ height: 56, flexShrink: 0 }} />
+
+      {/* ════════════════════════════════
+          2. INPUT  (元素 2)
+          3. CTA    (元素 3)
+          4. LINK   (元素 4)
+      ════════════════════════════════ */}
+      <div style={{ padding: '0 26px', flexShrink: 0 }}>
+
+        {/* ── Username input ── */}
+        <div style={{ marginBottom: 14 }}>
+          <input
+            type="text"
+            value={username}
+            onChange={e => { setUsername(e.target.value); setError(false); }}
+            onKeyDown={handleKey}
+            onFocus={() => setFocusedUser(true)}
+            onBlur={() => setFocusedUser(false)}
+            placeholder={t('login.usernamePlaceholder')}
+            autoComplete="username"
+            style={{
+              width: '100%',
+              padding: '15px 17px',
+              background: 'rgba(255,255,255,0.05)',
+              border: error
+                ? '1.5px solid rgba(239,68,68,0.7)'
+                : focusedUser
+                ? '1.5px solid rgba(145,70,255,0.55)'
+                : '1.5px solid rgba(255,255,255,0.1)',
+              borderRadius: 11,
+              color: 'white',
+              fontSize: 9,
+              outline: 'none',
+              fontFamily: 'var(--pixel-font-family)',
+              boxSizing: 'border-box',
+              transition: 'border-color 0.18s',
+            }}
+          />
+        </div>
+
+        {/* ── Password input ── */}
+        <div>
+          <input
+            type="password"
+            value={pass}
+            onChange={e => { setPass(e.target.value); setError(false); }}
+            onKeyDown={handleKey}
+            onFocus={() => setFocusedPass(true)}
+            onBlur={() => setFocusedPass(false)}
+            placeholder={t('login.passwordPlaceholder')}
+            autoComplete="current-password"
+            style={{
+              width: '100%',
+              padding: '15px 17px',
+              background: 'rgba(255,255,255,0.05)',
+              border: error
+                ? '1.5px solid rgba(239,68,68,0.7)'
+                : focusedPass
+                ? '1.5px solid rgba(145,70,255,0.55)'
+                : '1.5px solid rgba(255,255,255,0.1)',
+              borderRadius: 11,
+              color: 'white',
+              fontSize: 9,
+              outline: 'none',
+              fontFamily: 'var(--pixel-font-family)',
+              boxSizing: 'border-box',
+              transition: 'border-color 0.18s',
+            }}
+          />
+        </div>
+
+        {/* Error message */}
+        {error && (
+          <div
+            style={{
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 7,
+              color: '#ef4444',
+              marginTop: 6,
+              paddingLeft: 4,
+              letterSpacing: '0.08em',
+            }}
+          >
+            {t('login.required')}
+          </div>
+        )}
+
+        {/* ── CTA Button ── */}
+        <button
+          onClick={handleUnlock}
+          disabled={loading}
+          style={{
+            width: '100%',
+            marginTop: error ? 10 : 12,
+            padding: '16px 0',
+            borderRadius: 11,
+            border: 'none',
+            background: hasInput
+              ? '#9146FF'
+              : 'rgba(255,255,255,0.07)',
+            color: hasInput ? '#ffffff' : 'rgba(107,114,128,0.5)',
+            fontFamily: 'var(--pixel-font-family)',
+            fontSize: 10,
+            letterSpacing: '0.1em',
+            cursor: loading ? 'wait' : 'pointer',
+            boxShadow: hasInput
+              ? '0 0 22px rgba(145,70,255,0.4), 0 2px 8px rgba(0,0,0,0.4)'
+              : 'none',
+            transition: 'all 0.2s ease',
+            lineHeight: 1,
+          }}
+          onMouseDown={e => {
+            if (hasInput) e.currentTarget.style.transform = 'scale(0.98)';
+          }}
+          onMouseUp={e => (e.currentTarget.style.transform = '')}
+          onMouseLeave={e => (e.currentTarget.style.transform = '')}
+        >
+          {loading ? t('login.buttonLoading') : t('login.button')}
+        </button>
+
+        {/* ── Forgot / Help link ── */}
+        <div style={{ textAlign: 'center', marginTop: 22 }}>
+          <a
+            href="#"
+            onClick={e => e.preventDefault()}
+            style={{
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 7,
+              color: '#9146FF',
+              textDecoration: 'none',
+              letterSpacing: '0.08em',
+              transition: 'opacity 0.15s',
+              opacity: 0.7,
+            }}
+            onMouseEnter={e => (e.currentTarget.style.opacity = '1')}
+            onMouseLeave={e => (e.currentTarget.style.opacity = '0.7')}
+          >
+            {t('login.forgotPassword')}
+          </a>
+        </div>
+      </div>
+
+      {/* ════════════════════════════════
+          FLEX SPACER — pushes capybara to bottom
+      ════════════════════════════════ */}
+      <div style={{ flex: 1 }} />
+
+      {/* ════════════════════════════════
+          CUTE CAPYBARA — peeking from bottom
+          (follows MetaMask fox philosophy)
+      ════════════════════════════════ */}
+      <CuteCapybaraLogin />
+    </div>
+  );
+}

--- a/tachimint/src/app/components/LoginScreen.tsx
+++ b/tachimint/src/app/components/LoginScreen.tsx
@@ -209,6 +209,7 @@ export function LoginScreen({ onLogin }: { onLogin?: () => void }) {
             onKeyDown={handleKey}
             onFocus={() => setFocusedUser(true)}
             onBlur={() => setFocusedUser(false)}
+            aria-label={t('login.usernamePlaceholder')}
             placeholder={t('login.usernamePlaceholder')}
             autoComplete="username"
             style={{
@@ -240,6 +241,7 @@ export function LoginScreen({ onLogin }: { onLogin?: () => void }) {
             onKeyDown={handleKey}
             onFocus={() => setFocusedPass(true)}
             onBlur={() => setFocusedPass(false)}
+            aria-label={t('login.passwordPlaceholder')}
             placeholder={t('login.passwordPlaceholder')}
             autoComplete="current-password"
             style={{

--- a/tachimint/src/app/hooks/useSound.ts
+++ b/tachimint/src/app/hooks/useSound.ts
@@ -179,11 +179,16 @@ export function useSound() {
   const bgTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const bgStepRef  = useRef(0);
   const bgSessionRef = useRef(0);
+  const bgPlayingRef = useRef(false);
   const [bridgeStatus, setBridgeStatus] = useState<'ready' | 'unsupported'>('ready');
 
   const sendBridgeSound = useCallback(async (type: SoundType, variant?: HitVariant) => {
     try {
-      await sendToContentScript(type, variant);
+      const delivered = await sendToContentScript(type, variant);
+      if (!delivered) {
+        setBridgeStatus('unsupported');
+        return false;
+      }
       setBridgeStatus('ready');
       return true;
     } catch (error) {
@@ -264,44 +269,57 @@ export function useSound() {
 
   // ── 背景音樂（原創 8-bit 冒險主題）──────────────────────
   const startBgMusic = useCallback(() => {
-    if (bgTimerRef.current !== null) return;
+    if (bgPlayingRef.current) return;
+    bgPlayingRef.current = true;
     const sessionId = bgSessionRef.current + 1;
     bgSessionRef.current = sessionId;
     void (async () => {
-      if (await sendBridgeSound('start-bg-music')) return;
-      const ctx = await getReadyCtx(ctxRef);
-      if (bgSessionRef.current !== sessionId || bgTimerRef.current !== null) {
-        return;
-      }
-
-      const playStep = () => {
+      try {
+        if (await sendBridgeSound('start-bg-music')) return;
+        const ctx = await getReadyCtx(ctxRef);
         if (bgSessionRef.current !== sessionId) {
+          bgPlayingRef.current = false;
+          return;
+        }
+        if (bgTimerRef.current !== null) {
           return;
         }
 
-        const [freq, durMs] = BG_NOTES[bgStepRef.current % BG_NOTES.length];
-        bgStepRef.current++;
+        const playStep = () => {
+          if (bgSessionRef.current !== sessionId) {
+            return;
+          }
 
-        if (freq > 0) {
-          const osc  = ctx.createOscillator();
-          const gain = ctx.createGain();
-          osc.type = 'square';
-          osc.frequency.setValueAtTime(freq, ctx.currentTime);
-          gain.gain.setValueAtTime(0.036, ctx.currentTime);
-          gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + (durMs / 1000) * 0.85);
-          osc.connect(gain); gain.connect(ctx.destination);
-          osc.start(ctx.currentTime); osc.stop(ctx.currentTime + durMs / 1000);
+          const [freq, durMs] = BG_NOTES[bgStepRef.current % BG_NOTES.length];
+          bgStepRef.current++;
+
+          if (freq > 0) {
+            const osc  = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'square';
+            osc.frequency.setValueAtTime(freq, ctx.currentTime);
+            gain.gain.setValueAtTime(0.036, ctx.currentTime);
+            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + (durMs / 1000) * 0.85);
+            osc.connect(gain); gain.connect(ctx.destination);
+            osc.start(ctx.currentTime); osc.stop(ctx.currentTime + durMs / 1000);
+          }
+
+          bgTimerRef.current = setTimeout(playStep, durMs);
+        };
+
+        playStep();
+      } catch (error) {
+        if (bgSessionRef.current === sessionId) {
+          bgPlayingRef.current = false;
         }
-
-        bgTimerRef.current = setTimeout(playStep, durMs);
-      };
-
-      playStep();
+        console.warn('Failed to start background music.', error);
+      }
     })();
   }, [sendBridgeSound]);
 
   const stopBgMusic = useCallback(() => {
     bgSessionRef.current += 1;
+    bgPlayingRef.current = false;
     if (bgTimerRef.current !== null) {
       clearTimeout(bgTimerRef.current);
       bgTimerRef.current = null;

--- a/tachimint/src/app/hooks/useSound.ts
+++ b/tachimint/src/app/hooks/useSound.ts
@@ -1,0 +1,323 @@
+import { useRef, useCallback, useEffect, useState } from 'react';
+
+type SoundType = 'mining-click' | 'reward-complete' | 'max-clicks' | 'toggle-watch'
+               | 'start-bg-music' | 'stop-bg-music';
+type HitVariant = 'light' | 'normal' | 'critical';
+
+function pickVariant(): HitVariant {
+  const r = Math.random();
+  if (r < 0.20) return 'light';
+  if (r < 0.85) return 'normal';
+  return 'critical';
+}
+
+// 原創 8-bit 冒險主題（G大調，非任何現有曲子）
+const BG_NOTES: [number, number][] = [
+  // Phrase 1 — 上行，明亮感
+  [392,125],[494,125],[587,125],[784,250],
+  [587,125],[494,125],[392,250],[0,125],
+  // Phrase 2 — 回應句，略高
+  [440,125],[523,125],[659,125],[880,250],
+  [659,125],[523,125],[440,375],[0,125],
+  // Bridge — 活力衝刺
+  [494,100],[587,100],[740,100],[988,200],
+  [880,100],[784,100],[740,100],[659,100],
+  [784,200],[0,100],[784,200],[0,100],
+  // Resolution — 收尾回主調
+  [392,125],[494,125],[587,125],[784,125],
+  [659,125],[587,125],[494,125],[440,125],
+  [392,375],[0,250],
+];
+
+async function sendToContentScript(type: SoundType, variant?: HitVariant) {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  const tabId = tabs[0]?.id;
+  if (tabId == null) {
+    return false;
+  }
+
+  await chrome.tabs.sendMessage(tabId, { type: 'PLAY_SOUND', sound: type, variant });
+  return true;
+}
+
+function buildCtx(ctxRef: { current: AudioContext | null }): AudioContext {
+  if (!ctxRef.current) ctxRef.current = new AudioContext();
+  return ctxRef.current;
+}
+
+async function getReadyCtx(ctxRef: { current: AudioContext | null }): Promise<AudioContext> {
+  const ctx = buildCtx(ctxRef);
+  if (ctx.state === 'suspended') {
+    await ctx.resume();
+  }
+  return ctx;
+}
+// ── 3 Variant 礦石敲擊合成 ───────────────────────────────────
+const VARIANT_PARAMS = {
+  light:    { pitchMult: 1.15, gainMult: 0.55, duration: 0.06, thumpGain: 0.15, sparkleGain: 0.00, noiseDecay: 0.05 },
+  normal:   { pitchMult: 1.00, gainMult: 1.00, duration: 0.08, thumpGain: 0.40, sparkleGain: 0.05, noiseDecay: 0.07 },
+  critical: { pitchMult: 1.05, gainMult: 1.30, duration: 0.12, thumpGain: 0.60, sparkleGain: 0.12, noiseDecay: 0.10 },
+} as const;
+
+function synthesizeMiningHit(ctx: AudioContext, variant: HitVariant = 'normal') {
+  const now   = ctx.currentTime;
+  const p     = VARIANT_PARAMS[variant];
+  const pitch = (1 + (Math.random() - 0.5) * 0.1) * p.pitchMult;
+  const vol   = (0.9 + Math.random() * 0.2) * p.gainMult;
+
+  // Layer 1: Impact transient（三角波）
+  const osc1 = ctx.createOscillator(); const gain1 = ctx.createGain();
+  osc1.type = 'triangle';
+  osc1.frequency.setValueAtTime(900 * pitch, now);
+  osc1.frequency.exponentialRampToValueAtTime(400 * pitch, now + 0.04);
+  gain1.gain.setValueAtTime(0, now);
+  gain1.gain.linearRampToValueAtTime(0.6 * vol, now + 0.002);
+  gain1.gain.exponentialRampToValueAtTime(0.001, now + p.duration);
+  osc1.connect(gain1); gain1.connect(ctx.destination);
+  osc1.start(now); osc1.stop(now + p.duration);
+
+  // Layer 2: Metallic overtone（sawtooth 1800Hz）
+  const osc2 = ctx.createOscillator(); const gain2 = ctx.createGain();
+  osc2.type = 'sawtooth';
+  osc2.frequency.setValueAtTime(1800 * pitch, now);
+  gain2.gain.setValueAtTime(0.15 * vol, now + 0.001);
+  gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.045);
+  osc2.connect(gain2); gain2.connect(ctx.destination);
+  osc2.start(now); osc2.stop(now + 0.05);
+
+  // Layer 3: Bandpass noise（debris/friction）
+  const bufLen = Math.floor(ctx.sampleRate * 0.12);
+  const buf = ctx.createBuffer(1, bufLen, ctx.sampleRate);
+  const data = buf.getChannelData(0);
+  for (let i = 0; i < bufLen; i++) data[i] = Math.random() * 2 - 1;
+  const noise = ctx.createBufferSource(); noise.buffer = buf;
+  const bpf = ctx.createBiquadFilter();
+  bpf.type = 'bandpass'; bpf.frequency.setValueAtTime(2000, now); bpf.Q.setValueAtTime(1.5, now);
+  const gain3 = ctx.createGain();
+  gain3.gain.setValueAtTime(0.3 * vol, now);
+  gain3.gain.exponentialRampToValueAtTime(0.001, now + p.noiseDecay);
+  noise.connect(bpf); bpf.connect(gain3); gain3.connect(ctx.destination);
+  noise.start(now); noise.stop(now + p.noiseDecay);
+
+  // Layer 4: Low thump（sine 100Hz）
+  const osc4 = ctx.createOscillator(); const gain4 = ctx.createGain();
+  osc4.type = 'sine';
+  osc4.frequency.setValueAtTime(100 * pitch, now);
+  gain4.gain.setValueAtTime(0, now);
+  gain4.gain.linearRampToValueAtTime(p.thumpGain * vol, now + 0.001);
+  gain4.gain.exponentialRampToValueAtTime(0.001, now + 0.05);
+  osc4.connect(gain4); gain4.connect(ctx.destination);
+  osc4.start(now); osc4.stop(now + 0.05);
+
+  // Layer 5: Sparkle（light 無，critical 雙 sparkle）
+  if (p.sparkleGain > 0) {
+    const d1 = 0.025;
+    const dur1 = variant === 'critical' ? 0.07 : 0.04;
+    const osc5 = ctx.createOscillator(); const gain5 = ctx.createGain();
+    osc5.type = 'sine';
+    osc5.frequency.setValueAtTime(2800 * pitch, now + d1);
+    gain5.gain.setValueAtTime(0, now + d1);
+    gain5.gain.linearRampToValueAtTime(p.sparkleGain * vol, now + d1 + 0.003);
+    gain5.gain.exponentialRampToValueAtTime(0.001, now + d1 + dur1);
+    osc5.connect(gain5); gain5.connect(ctx.destination);
+    osc5.start(now + d1); osc5.stop(now + d1 + dur1);
+
+    if (variant === 'critical') {
+      const d2 = 0.06;
+      const osc6 = ctx.createOscillator(); const gain6 = ctx.createGain();
+      osc6.type = 'sine';
+      osc6.frequency.setValueAtTime(3500 * pitch, now + d2);
+      gain6.gain.setValueAtTime(0, now + d2);
+      gain6.gain.linearRampToValueAtTime(0.08 * vol, now + d2 + 0.003);
+      gain6.gain.exponentialRampToValueAtTime(0.001, now + d2 + 0.05);
+      osc6.connect(gain6); gain6.connect(ctx.destination);
+      osc6.start(now + d2); osc6.stop(now + d2 + 0.05);
+    }
+  }
+}
+
+// ── 提領獎勵音效（金屬幣擊 + 上行確認 + shimmer 收尾）────────
+function synthesizeClaimReward(ctx: AudioContext) {
+  const now = ctx.currentTime;
+
+  // Layer 1: Metallic coin hit（triangle，快速衰減）
+  const osc1 = ctx.createOscillator(); const g1 = ctx.createGain();
+  osc1.type = 'triangle';
+  osc1.frequency.setValueAtTime(1400, now);
+  osc1.frequency.exponentialRampToValueAtTime(1100, now + 0.05);
+  g1.gain.setValueAtTime(0, now);
+  g1.gain.linearRampToValueAtTime(0.35, now + 0.003);
+  g1.gain.exponentialRampToValueAtTime(0.001, now + 0.09);
+  osc1.connect(g1); g1.connect(ctx.destination);
+  osc1.start(now); osc1.stop(now + 0.09);
+
+  // Layer 2: Upward confirmation tone（sine 滑音，上揚感）
+  const osc2 = ctx.createOscillator(); const g2 = ctx.createGain();
+  osc2.type = 'sine';
+  osc2.frequency.setValueAtTime(800, now + 0.02);
+  osc2.frequency.exponentialRampToValueAtTime(1400, now + 0.12);
+  g2.gain.setValueAtTime(0, now + 0.02);
+  g2.gain.linearRampToValueAtTime(0.22, now + 0.025);
+  g2.gain.exponentialRampToValueAtTime(0.001, now + 0.18);
+  osc2.connect(g2); g2.connect(ctx.destination);
+  osc2.start(now + 0.02); osc2.stop(now + 0.18);
+
+  // Layer 3: High shimmer tail（cyber retro 收尾）
+  const osc3 = ctx.createOscillator(); const g3 = ctx.createGain();
+  osc3.type = 'sine';
+  osc3.frequency.setValueAtTime(3200, now + 0.05);
+  osc3.frequency.linearRampToValueAtTime(3600, now + 0.18);
+  g3.gain.setValueAtTime(0, now + 0.05);
+  g3.gain.linearRampToValueAtTime(0.09, now + 0.055);
+  g3.gain.exponentialRampToValueAtTime(0.001, now + 0.22);
+  osc3.connect(g3); g3.connect(ctx.destination);
+  osc3.start(now + 0.05); osc3.stop(now + 0.22);
+}
+
+export function useSound() {
+  const ctxRef     = useRef<AudioContext | null>(null);
+  const bgTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const bgStepRef  = useRef(0);
+  const bgSessionRef = useRef(0);
+  const [bridgeStatus, setBridgeStatus] = useState<'ready' | 'unsupported'>('ready');
+
+  const sendBridgeSound = useCallback(async (type: SoundType, variant?: HitVariant) => {
+    try {
+      await sendToContentScript(type, variant);
+      setBridgeStatus('ready');
+      return true;
+    } catch (error) {
+      console.warn('Tab audio bridge unavailable for the current tab.', error);
+      setBridgeStatus('unsupported');
+      return false;
+    }
+  }, []);
+
+  // ── 礦石敲擊（3 variant 隨機）────────────────────────────
+  const playMiningClick = useCallback(() => {
+    const variant = pickVariant();
+    void (async () => {
+      if (await sendBridgeSound('mining-click', variant)) return;
+      synthesizeMiningHit(await getReadyCtx(ctxRef), variant);
+    })();
+  }, [sendBridgeSound]);
+
+  // ── FF 勝利號角 ────────────────────────────────────────────
+  const playRewardComplete = useCallback(() => {
+    void (async () => {
+      if (await sendBridgeSound('reward-complete')) return;
+      const ctx = await getReadyCtx(ctxRef);
+      const notes: [number, number, number][] = [
+        [440, 0.00, 0.10],[440, 0.13, 0.10],[440, 0.26, 0.10],
+        [349, 0.39, 0.18],[523, 0.59, 0.06],[440, 0.67, 0.28],
+        [349, 0.97, 0.18],[523, 1.17, 0.06],[440, 1.25, 0.55],
+      ];
+      notes.forEach(([freq, offset, dur]) => {
+        const osc  = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'square';
+        osc.frequency.setValueAtTime(freq, ctx.currentTime + offset);
+        gain.gain.setValueAtTime(0.18, ctx.currentTime + offset);
+        gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + offset + dur);
+        osc.connect(gain); gain.connect(ctx.destination);
+        osc.start(ctx.currentTime + offset);
+        osc.stop(ctx.currentTime + offset + dur + 0.01);
+      });
+    })();
+  }, [sendBridgeSound]);
+
+  // ── 雙聲答錯蜂鳴器 ────────────────────────────────────────
+  const playMaxClicks = useCallback(() => {
+    void (async () => {
+      if (await sendBridgeSound('max-clicks')) return;
+      const ctx = await getReadyCtx(ctxRef);
+      [[0, 0.18, 180], [0.23, 0.37, 160]].forEach(([start, end, freq]) => {
+        const osc  = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(freq, ctx.currentTime + start);
+        gain.gain.setValueAtTime(0.2, ctx.currentTime + start);
+        gain.gain.setValueAtTime(0.2, ctx.currentTime + end - 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + end);
+        osc.connect(gain); gain.connect(ctx.destination);
+        osc.start(ctx.currentTime + start);
+        osc.stop(ctx.currentTime + end);
+      });
+    })();
+  }, [sendBridgeSound]);
+
+  // ── SW 切換音效 ────────────────────────────────────────────
+  const playToggleWatch = useCallback(() => {
+    void (async () => {
+      if (await sendBridgeSound('toggle-watch')) return;
+      const ctx  = await getReadyCtx(ctxRef);
+      const osc  = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(550, ctx.currentTime);
+      gain.gain.setValueAtTime(0.1, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.06);
+      osc.connect(gain); gain.connect(ctx.destination);
+      osc.start(ctx.currentTime); osc.stop(ctx.currentTime + 0.06);
+    })();
+  }, [sendBridgeSound]);
+
+  // ── 背景音樂（原創 8-bit 冒險主題）──────────────────────
+  const startBgMusic = useCallback(() => {
+    if (bgTimerRef.current !== null) return;
+    const sessionId = bgSessionRef.current + 1;
+    bgSessionRef.current = sessionId;
+    void (async () => {
+      if (await sendBridgeSound('start-bg-music')) return;
+      const ctx = await getReadyCtx(ctxRef);
+      if (bgSessionRef.current !== sessionId || bgTimerRef.current !== null) {
+        return;
+      }
+
+      const playStep = () => {
+        if (bgSessionRef.current !== sessionId) {
+          return;
+        }
+
+        const [freq, durMs] = BG_NOTES[bgStepRef.current % BG_NOTES.length];
+        bgStepRef.current++;
+
+        if (freq > 0) {
+          const osc  = ctx.createOscillator();
+          const gain = ctx.createGain();
+          osc.type = 'square';
+          osc.frequency.setValueAtTime(freq, ctx.currentTime);
+          gain.gain.setValueAtTime(0.036, ctx.currentTime);
+          gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + (durMs / 1000) * 0.85);
+          osc.connect(gain); gain.connect(ctx.destination);
+          osc.start(ctx.currentTime); osc.stop(ctx.currentTime + durMs / 1000);
+        }
+
+        bgTimerRef.current = setTimeout(playStep, durMs);
+      };
+
+      playStep();
+    })();
+  }, [sendBridgeSound]);
+
+  const stopBgMusic = useCallback(() => {
+    bgSessionRef.current += 1;
+    if (bgTimerRef.current !== null) {
+      clearTimeout(bgTimerRef.current);
+      bgTimerRef.current = null;
+    }
+    void sendBridgeSound('stop-bg-music');
+  }, [sendBridgeSound]);
+
+  // ── 提領音效（不走 bridge，直接本地合成）────────────────────
+  const playClaimSound = useCallback(() => {
+    void (async () => {
+      const ctx = await getReadyCtx(ctxRef);
+      synthesizeClaimReward(ctx);
+    })();
+  }, []);
+
+  useEffect(() => () => stopBgMusic(), [stopBgMusic]);
+
+  return { playMiningClick, playRewardComplete, playMaxClicks, playToggleWatch, startBgMusic, stopBgMusic, bridgeStatus, playClaimSound };
+}

--- a/tachimint/src/app/theme/backgrounds.ts
+++ b/tachimint/src/app/theme/backgrounds.ts
@@ -1,0 +1,42 @@
+export const CAVE_SVG_BG = (() => {
+  const svg = [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="600">',
+    '<path d="M0 0L65 0L42 62L70 128L30 194L60 258L24 322L56 385L16 445L48 500L0 560Z" fill="rgba(20,10,50,0.90)"/>',
+    '<path d="M320 0L255 0L278 68L252 136L284 198L256 262L290 324L262 388L298 448L266 502L320 562Z" fill="rgba(20,10,50,0.90)"/>',
+    '<path d="M0 0L320 0L320 68L292 44L250 78L205 48L162 70L120 44L82 72L40 42L0 68Z" fill="rgba(6,2,18,0.97)"/>',
+    '<path d="M0 600L320 600L320 574L292 582L258 562L224 580L188 562L154 578L118 562L84 580L48 562L12 578Z" fill="rgba(4,1,12,0.95)"/>',
+    '<polygon points="2,478 20,456 36,467 42,492 31,512 6,516 0,499" fill="rgba(195,138,20,0.46)"/>',
+    '<polygon points="0,516 18,501 29,518 21,540 4,544 0,534" fill="rgba(170,118,14,0.38)"/>',
+    '<polygon points="28,454 44,434 58,444 62,464 48,478 30,482" fill="rgba(215,158,30,0.40)"/>',
+    '<polygon points="12,482 26,469 36,475 39,494 30,508 14,510" fill="rgba(242,188,48,0.20)"/>',
+    '<polygon points="299,474 316,455 320,467 320,491 307,499 292,492" fill="rgba(195,138,20,0.42)"/>',
+    '<polygon points="280,495 298,481 316,490 320,514 300,520 278,512" fill="rgba(170,118,14,0.35)"/>',
+    '<polygon points="304,452 320,434 320,456 320,468 315,474 304,474" fill="rgba(215,158,30,0.34)"/>',
+    '<polygon points="288,498 304,488 316,497 318,514 302,520 284,512" fill="rgba(242,188,48,0.18)"/>',
+    '<polygon points="0,204 24,181 40,200 33,228 14,236 0,227" fill="rgba(102,58,210,0.30)"/>',
+    '<polygon points="0,248 20,232 32,250 25,271 0,276" fill="rgba(84,46,185,0.24)"/>',
+    '<polygon points="6,210 20,196 30,210 26,222 8,226" fill="rgba(155,100,252,0.18)"/>',
+    '<polygon points="320,154 302,135 292,156 299,180 320,184" fill="rgba(102,58,210,0.28)"/>',
+    '<polygon points="320,196 306,182 299,200 307,220 320,224" fill="rgba(84,46,185,0.22)"/>',
+    '<path d="M0 90L58 67L76 90L64 126L40 138L0 126Z" fill="rgba(15,7,40,0.90)"/>',
+    '<line x1="25" y1="95" x2="58" y2="112" stroke="rgba(35,16,72,0.70)" stroke-width="1.5"/>',
+    '<line x1="38" y1="70" x2="60" y2="84" stroke="rgba(35,16,72,0.55)" stroke-width="1"/>',
+    '<path d="M320 100L270 78L256 100L268 128L288 140L320 128Z" fill="rgba(15,7,40,0.90)"/>',
+    '<line x1="295" y1="105" x2="268" y2="120" stroke="rgba(35,16,72,0.65)" stroke-width="1.5"/>',
+    '</svg>',
+  ].join('')
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`
+})()
+
+export const hudPanelBackground = [
+  'radial-gradient(ellipse 54% 44% at 50% 42%, #0d0d1a 28%, transparent 100%)',
+  `${CAVE_SVG_BG} center/100% 100% no-repeat`,
+  'radial-gradient(ellipse 48% 65% at -8% 62%, rgba(82,34,152,0.42) 0%, transparent 55%)',
+  'radial-gradient(ellipse 44% 60% at 108% 38%, rgba(65,27,135,0.36) 0%, transparent 55%)',
+  'radial-gradient(ellipse 95% 32% at 50% -8%, rgba(4,2,12,0.95) 0%, transparent 78%)',
+  'radial-gradient(ellipse 100% 28% at 50% 108%, rgba(10,4,25,0.82) 0%, transparent 70%)',
+  'radial-gradient(ellipse 24% 15% at 4% 84%, rgba(198,148,20,0.30) 0%, transparent 62%)',
+  'radial-gradient(ellipse 20% 12% at 96% 80%, rgba(178,128,16,0.24) 0%, transparent 62%)',
+  'radial-gradient(ellipse 130% 85% at 50% 30%, rgba(28,12,68,0.30) 0%, transparent 70%)',
+  'linear-gradient(170deg, #0e0d22 0%, #060510 45%, #0a0818 100%)',
+].join(', ')


### PR DESCRIPTION
## 什麼改動

- `LoginScreen`：pixel-art 登入表單，含帳密欄位、i18n、error 狀態
- `LoadingScreen`：進度條動畫 + logo，完成後觸發 `onComplete` callback
- `LanguageSwitcher`：EN / 繁 / 简 旗幟按鈕切換元件
- `useSound`：Web Audio API hook（coin collect / claim / redeem / BGM loop）
- `theme/backgrounds.ts`：共用漸層 / panel 背景常數

## 為什麼

依照 `docs/tachimint-chrome-sidepanel-migration.md` 的 Step 2 拆題順序，這些 leaf-level 組件先獨立落地，後續 2c / 2d 可以專注在核心互動組件與 App 整合。migration decision 仍來自 #246，但本 PR 的直接 implementation source of truth 是 migration doc。

## Release Context

- Release type：n/a

## Scope 對齊

Source of truth：`docs/tachimint-chrome-sidepanel-migration.md` — Step 2 of 4（leaf app-shell components；migration decision: #246）
Depends on PR：#265
Backend contract already in develop:
  - [x] yes
  - [ ] no
本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
本 PR 明確不做：
  - 不含複雜組件（ClaimPanel / CouponShopPanel / MarioHUD）
  - 不含 App 進入點邏輯

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [ ] 有寫 / 更新測試

## 備註

Step 2 of 5 (2b/4)：堆疊 #264 → #265 → 2b → 2c → 2d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加语言切换器，支持英文、繁体中文和简体中文
  * 新增加载屏幕，包含进度条与完成回调
  * 新增登录界面，带输入校验与加载状态
  * 引入游戏/界面音效系统，含多种交互音效与背景音乐控制
  * 优化视觉主题，新增洞穴背景与面板样式

* **测试**
  * 增加回归测试，覆盖登录可访问性与音效/背景音乐行为验证
<!-- end of auto-generated comment: release notes by coderabbit.ai -->