### PR TITLE
[infra] Skip backend integration for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_ci: ${{ steps.evaluate.outputs.run_ci }}
+      run_backend_integration: ${{ steps.evaluate.outputs.run_backend_integration }}
     steps:
       - name: Evaluate PR scope for CI
         id: evaluate
@@ -25,6 +26,7 @@ jobs:
             if (!pr) {
               core.notice('Non-PR event detected; running CI without scope gate restrictions.')
               core.setOutput('run_ci', 'true')
+              core.setOutput('run_backend_integration', 'true')
               return
             }
 
@@ -59,7 +61,7 @@ jobs:
             const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
             const body = pr.body || ''
             const title = pr.title || ''
-            const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]']
+            const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]', '[infra]', '[chore]']
             const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
             const touches = {
               backend: filenames.some((name) => name.startsWith('backend/')),
@@ -111,9 +113,23 @@ jobs:
               (isReleasePromotionPr || !(titlePrefix === '[contract]' && (touches.backend || touches.dashboard || touches.tachimint))) &&
               !dependencyBlocked
 
+            const backendIntegrationPaths = [
+              /^backend\//,
+              /^contracts\//,
+              /^docker-compose(?:\..+)?\.ya?ml$/,
+              /^\.github\/workflows\/ci\.yml$/,
+            ]
+            const runBackendIntegration = filenames.some((name) =>
+              backendIntegrationPaths.some((pattern) => pattern.test(name)),
+            )
+
             core.setOutput('run_ci', runCi ? 'true' : 'false')
+            core.setOutput('run_backend_integration', runBackendIntegration ? 'true' : 'false')
             if (!runCi) {
               core.notice('Skipping heavy CI because this PR does not currently pass scope rules.')
+            }
+            if (runCi && !runBackendIntegration) {
+              core.notice('Skipping backend integration tests because this PR does not touch backend, contracts, docker compose, or CI workflow files.')
             }
 
   backend:
@@ -133,7 +149,8 @@ jobs:
   backend-integration:
     name: Backend integration tests
     runs-on: ubuntu-latest
-    needs: backend
+    needs: [scope-gate, backend]
+    if: github.event_name == 'push' || (needs.scope-gate.outputs.run_ci == 'true' && needs.scope-gate.outputs.run_backend_integration == 'true')
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
             if (labels.some((label) => bypassLabels.has(label))) {
               core.notice('Scope gate bypassed by scope-exception label.')
               core.setOutput('run_ci', 'true')
+              core.setOutput('run_backend_integration', 'true')
               return
             }
 


### PR DESCRIPTION
Source of truth: #273

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## Summary

- Add a scope-gate output that decides whether backend integration tests are relevant for a PR.
- Run backend integration tests on pushes and on PRs touching backend, contracts, docker compose, or this CI workflow.
- Skip backend integration tests for docs-only / agent-rules-only PRs.
- Align CI scope-gate title prefixes with PR Scope Police by allowing [infra] and [chore].

## 本 PR 明確不做

- Does not skip backend unit tests.
- Does not change frontend, dashboard, or contract build policy.
- Does not add label-based CI bypasses.

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 变更说明

* **持续集成改进**
  * 优化了 CI 工作流管理，根据代码变更内容智能决定是否执行后端集成测试。
  * 扩展了提交标题前缀支持，现已包含 `[infra]` 和 `[chore]` 标签。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->