### PR TITLE
[chore] Swagger 契約正規化與產生器版本對齊（移除 invalid "": []）

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.25-alpine AS dev
 
 RUN apk add --no-cache git build-base && \
     go install github.com/air-verse/air@latest && \
-    go install github.com/swaggo/swag/cmd/swag@v1.8.12
+    go install github.com/swaggo/swag/cmd/swag@v1.16.6
 
 WORKDIR /app
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -32,7 +32,6 @@ import (
 
 const defaultSepoliaRPCURL = "https://ethereum-sepolia-rpc.publicnode.com"
 
-// @security BearerAuth
 func main() {
 	// Load .env (ignore error in production where env is set externally)
 	_ = godotenv.Load()

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -17,7 +17,6 @@ const docTemplate = `{
     "paths": {
         "/auth/forgot-password": {
             "post": {
-                "security": [],
                 "description": "Always returns 200 to prevent user enumeration",
                 "consumes": [
                     "application/json"
@@ -75,7 +74,6 @@ const docTemplate = `{
         },
         "/auth/google": {
             "get": {
-                "security": [],
                 "produces": [
                     "application/json"
                 ],
@@ -92,7 +90,6 @@ const docTemplate = `{
         },
         "/auth/google/callback": {
             "get": {
-                "security": [],
                 "produces": [
                     "application/json"
                 ],
@@ -152,7 +149,6 @@ const docTemplate = `{
         },
         "/auth/login": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -210,7 +206,6 @@ const docTemplate = `{
         },
         "/auth/logout": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -226,7 +221,6 @@ const docTemplate = `{
                         "description": "Refresh token fallback when cookie is unavailable",
                         "name": "body",
                         "in": "body",
-                        "required": false,
                         "schema": {
                             "type": "object",
                             "properties": {
@@ -330,7 +324,6 @@ const docTemplate = `{
         },
         "/auth/refresh": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -346,7 +339,6 @@ const docTemplate = `{
                         "description": "Refresh token fallback when cookie is unavailable",
                         "name": "body",
                         "in": "body",
-                        "required": false,
                         "schema": {
                             "type": "object",
                             "properties": {
@@ -393,7 +385,6 @@ const docTemplate = `{
         },
         "/auth/register": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -451,7 +442,6 @@ const docTemplate = `{
         },
         "/auth/reset-password": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -511,7 +501,6 @@ const docTemplate = `{
         },
         "/auth/twitch": {
             "get": {
-                "security": [],
                 "produces": [
                     "application/json"
                 ],
@@ -528,7 +517,6 @@ const docTemplate = `{
         },
         "/auth/twitch/callback": {
             "get": {
-                "security": [],
                 "produces": [
                     "application/json"
                 ],
@@ -588,7 +576,6 @@ const docTemplate = `{
         },
         "/auth/verify-email/confirm": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -693,7 +680,6 @@ const docTemplate = `{
         },
         "/auth/web3/nonce": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -756,7 +742,6 @@ const docTemplate = `{
         },
         "/auth/web3/verify": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -814,7 +799,6 @@ const docTemplate = `{
         },
         "/extension/auth/login": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -877,7 +861,6 @@ const docTemplate = `{
         },
         "/extension/bits/complete": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -937,6 +920,74 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/spend/redeem": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "spend"
+                ],
+                "summary": "Burn $TACHI to redeem a discount coupon",
+                "parameters": [
+                    {
+                        "description": "Amount to burn (must be \u003e 0)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.redeemRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.redeemResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
@@ -1374,6 +1425,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/me/points/claim": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tachi"
+                ],
+                "summary": "Claim T-Points as $TACHI",
+                "parameters": [
+                    {
+                        "description": "Amount to claim (0 = all)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.claimRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.tachiBalanceResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/users/me/points/history": {
             "get": {
                 "security": [
@@ -1466,6 +1584,48 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/users/me/tachi/balance": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tachi"
+                ],
+                "summary": "Get my $TACHI balance",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.tachiBalanceResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1510,6 +1670,9 @@ const docTemplate = `{
         "handlers.NonceResponse": {
             "type": "object",
             "properties": {
+                "issued_at": {
+                    "type": "string"
+                },
                 "nonce": {
                     "type": "string"
                 }
@@ -1598,6 +1761,43 @@ const docTemplate = `{
             "properties": {
                 "user": {
                     "$ref": "#/definitions/models.User"
+                }
+            }
+        },
+        "handlers.claimRequest": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "0 = claim all",
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.redeemRequest": {
+            "type": "object",
+            "required": [
+                "amount"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "handlers.redeemResponse": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.tachiBalanceResponse": {
+            "type": "object",
+            "properties": {
+                "tachi_balance": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -50,13 +50,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -66,7 +66,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -119,13 +119,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -135,13 +135,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -166,7 +166,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.LoginInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.LoginInput"
                         }
                     }
                 ],
@@ -176,13 +176,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -192,13 +192,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -237,13 +237,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -253,7 +253,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -294,13 +294,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -310,13 +310,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -355,13 +355,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.TokensResponse"
+                                            "$ref": "#/definitions/internal_handlers.TokensResponse"
                                         }
                                     }
                                 }
@@ -371,13 +371,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -402,7 +402,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.RegisterInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.RegisterInput"
                         }
                     }
                 ],
@@ -412,13 +412,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -428,13 +428,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -477,13 +477,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -493,7 +493,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -546,13 +546,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -562,13 +562,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -608,13 +608,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -624,7 +624,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -650,13 +650,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -666,13 +666,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -712,13 +712,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.NonceResponse"
+                                            "$ref": "#/definitions/internal_handlers.NonceResponse"
                                         }
                                     }
                                 }
@@ -728,13 +728,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -759,7 +759,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.Web3VerifyInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.Web3VerifyInput"
                         }
                     }
                 ],
@@ -769,13 +769,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -785,13 +785,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -831,13 +831,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -847,13 +847,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -899,13 +899,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -915,13 +915,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -951,7 +951,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.redeemRequest"
+                            "$ref": "#/definitions/internal_handlers.redeemRequest"
                         }
                     }
                 ],
@@ -961,13 +961,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.redeemResponse"
+                                            "$ref": "#/definitions/internal_handlers.redeemResponse"
                                         }
                                     }
                                 }
@@ -977,19 +977,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1015,13 +1015,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.UserResponse"
+                                            "$ref": "#/definitions/internal_handlers.UserResponse"
                                         }
                                     }
                                 }
@@ -1031,7 +1031,7 @@ const docTemplate = `{
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1059,7 +1059,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.UpdateProfileInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.UpdateProfileInput"
                         }
                     }
                 ],
@@ -1069,13 +1069,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.UserResponse"
+                                            "$ref": "#/definitions/internal_handlers.UserResponse"
                                         }
                                     }
                                 }
@@ -1085,13 +1085,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1117,13 +1117,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AddressesResponse"
+                                            "$ref": "#/definitions/internal_handlers.AddressesResponse"
                                         }
                                     }
                                 }
@@ -1155,7 +1155,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.AddressInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.AddressInput"
                         }
                     }
                 ],
@@ -1165,13 +1165,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AddressResponse"
+                                            "$ref": "#/definitions/internal_handlers.AddressResponse"
                                         }
                                     }
                                 }
@@ -1181,7 +1181,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1218,7 +1218,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.AddressInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.AddressInput"
                         }
                     }
                 ],
@@ -1228,13 +1228,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AddressResponse"
+                                            "$ref": "#/definitions/internal_handlers.AddressResponse"
                                         }
                                     }
                                 }
@@ -1244,13 +1244,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1283,13 +1283,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -1299,13 +1299,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1340,13 +1340,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AddressResponse"
+                                            "$ref": "#/definitions/internal_handlers.AddressResponse"
                                         }
                                     }
                                 }
@@ -1356,13 +1356,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1397,13 +1397,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PointsBalanceResponse"
+                                            "$ref": "#/definitions/internal_handlers.PointsBalanceResponse"
                                         }
                                     }
                                 }
@@ -1413,13 +1413,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1448,7 +1448,7 @@ const docTemplate = `{
                         "name": "body",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/handlers.claimRequest"
+                            "$ref": "#/definitions/internal_handlers.claimRequest"
                         }
                     }
                 ],
@@ -1458,13 +1458,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.tachiBalanceResponse"
+                                            "$ref": "#/definitions/internal_handlers.tachiBalanceResponse"
                                         }
                                     }
                                 }
@@ -1474,19 +1474,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1521,13 +1521,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PointsHistoryResponse"
+                                            "$ref": "#/definitions/internal_handlers.PointsHistoryResponse"
                                         }
                                     }
                                 }
@@ -1537,13 +1537,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1569,13 +1569,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ProvidersResponse"
+                                            "$ref": "#/definitions/internal_handlers.ProvidersResponse"
                                         }
                                     }
                                 }
@@ -1605,13 +1605,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.tachiBalanceResponse"
+                                            "$ref": "#/definitions/internal_handlers.tachiBalanceResponse"
                                         }
                                     }
                                 }
@@ -1621,7 +1621,7 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1629,179 +1629,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "handlers.AddressResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "$ref": "#/definitions/models.ShippingAddress"
-                }
-            }
-        },
-        "handlers.AddressesResponse": {
-            "type": "object",
-            "properties": {
-                "addresses": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.ShippingAddress"
-                    }
-                }
-            }
-        },
-        "handlers.AuthResponse": {
-            "type": "object",
-            "properties": {
-                "tokens": {
-                    "$ref": "#/definitions/services.TokenPair"
-                },
-                "user": {
-                    "$ref": "#/definitions/models.User"
-                }
-            }
-        },
-        "handlers.MessageResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "handlers.NonceResponse": {
-            "type": "object",
-            "properties": {
-                "issued_at": {
-                    "type": "string"
-                },
-                "nonce": {
-                    "type": "string"
-                }
-            }
-        },
-        "handlers.PointsBalanceResponse": {
-            "type": "object",
-            "properties": {
-                "cumulative_total": {
-                    "type": "integer"
-                },
-                "spendable_balance": {
-                    "type": "integer"
-                }
-            }
-        },
-        "handlers.PointsHistoryItem": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "note": {
-                    "type": "string"
-                },
-                "sku": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "earn",
-                        "spend"
-                    ]
-                }
-            }
-        },
-        "handlers.PointsHistoryResponse": {
-            "type": "object",
-            "properties": {
-                "transactions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/handlers.PointsHistoryItem"
-                    }
-                }
-            }
-        },
-        "handlers.ProvidersResponse": {
-            "type": "object",
-            "properties": {
-                "providers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.AuthProvider"
-                    }
-                }
-            }
-        },
-        "handlers.Response": {
-            "type": "object",
-            "properties": {
-                "data": {},
-                "error": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "handlers.TokensResponse": {
-            "type": "object",
-            "properties": {
-                "tokens": {
-                    "$ref": "#/definitions/services.TokenPair"
-                }
-            }
-        },
-        "handlers.UserResponse": {
-            "type": "object",
-            "properties": {
-                "user": {
-                    "$ref": "#/definitions/models.User"
-                }
-            }
-        },
-        "handlers.claimRequest": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "description": "0 = claim all",
-                    "type": "integer"
-                }
-            }
-        },
-        "handlers.redeemRequest": {
-            "type": "object",
-            "required": [
-                "amount"
-            ],
-            "properties": {
-                "amount": {
-                    "type": "integer",
-                    "minimum": 1
-                }
-            }
-        },
-        "handlers.redeemResponse": {
-            "type": "object",
-            "properties": {
-                "balance": {
-                    "type": "integer"
-                }
-            }
-        },
-        "handlers.tachiBalanceResponse": {
-            "type": "object",
-            "properties": {
-                "tachi_balance": {
-                    "type": "integer"
-                }
-            }
-        },
-        "models.AuthProvider": {
+        "github_com_tachigo_tachigo_internal_models.AuthProvider": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -1814,7 +1642,7 @@ const docTemplate = `{
                     "type": "object"
                 },
                 "provider": {
-                    "$ref": "#/definitions/models.ProviderType"
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.ProviderType"
                 },
                 "provider_id": {
                     "type": "string"
@@ -1827,7 +1655,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.ProviderType": {
+        "github_com_tachigo_tachigo_internal_models.ProviderType": {
             "type": "string",
             "enum": [
                 "twitch",
@@ -1842,7 +1670,7 @@ const docTemplate = `{
                 "ProviderEmail"
             ]
         },
-        "models.ShippingAddress": {
+        "github_com_tachigo_tachigo_internal_models.ShippingAddress": {
             "type": "object",
             "properties": {
                 "address_line1": {
@@ -1886,19 +1714,19 @@ const docTemplate = `{
                 }
             }
         },
-        "models.User": {
+        "github_com_tachigo_tachigo_internal_models.User": {
             "type": "object",
             "properties": {
                 "addresses": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.ShippingAddress"
+                        "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress"
                     }
                 },
                 "auth_providers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.AuthProvider"
+                        "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.AuthProvider"
                     }
                 },
                 "avatar_url": {
@@ -1920,7 +1748,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "role": {
-                    "$ref": "#/definitions/models.UserRole"
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.UserRole"
                 },
                 "updated_at": {
                     "type": "string"
@@ -1930,7 +1758,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.UserRole": {
+        "github_com_tachigo_tachigo_internal_models.UserRole": {
             "type": "string",
             "enum": [
                 "viewer",
@@ -1945,7 +1773,7 @@ const docTemplate = `{
                 "RoleAdmin"
             ]
         },
-        "services.AddressInput": {
+        "github_com_tachigo_tachigo_internal_services.AddressInput": {
             "type": "object",
             "required": [
                 "address_line1",
@@ -1982,7 +1810,7 @@ const docTemplate = `{
                 }
             }
         },
-        "services.LoginInput": {
+        "github_com_tachigo_tachigo_internal_services.LoginInput": {
             "type": "object",
             "required": [
                 "email",
@@ -1997,7 +1825,7 @@ const docTemplate = `{
                 }
             }
         },
-        "services.RegisterInput": {
+        "github_com_tachigo_tachigo_internal_services.RegisterInput": {
             "type": "object",
             "required": [
                 "email",
@@ -2019,7 +1847,7 @@ const docTemplate = `{
                 }
             }
         },
-        "services.TokenPair": {
+        "github_com_tachigo_tachigo_internal_services.TokenPair": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -2034,7 +1862,7 @@ const docTemplate = `{
                 }
             }
         },
-        "services.UpdateProfileInput": {
+        "github_com_tachigo_tachigo_internal_services.UpdateProfileInput": {
             "type": "object",
             "properties": {
                 "avatar_url": {
@@ -2045,7 +1873,7 @@ const docTemplate = `{
                 }
             }
         },
-        "services.Web3VerifyInput": {
+        "github_com_tachigo_tachigo_internal_services.Web3VerifyInput": {
             "type": "object",
             "required": [
                 "address",
@@ -2063,6 +1891,178 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "internal_handlers.AddressResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress"
+                }
+            }
+        },
+        "internal_handlers.AddressesResponse": {
+            "type": "object",
+            "properties": {
+                "addresses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress"
+                    }
+                }
+            }
+        },
+        "internal_handlers.AuthResponse": {
+            "type": "object",
+            "properties": {
+                "tokens": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.TokenPair"
+                },
+                "user": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.User"
+                }
+            }
+        },
+        "internal_handlers.MessageResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handlers.NonceResponse": {
+            "type": "object",
+            "properties": {
+                "issued_at": {
+                    "type": "string"
+                },
+                "nonce": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handlers.PointsBalanceResponse": {
+            "type": "object",
+            "properties": {
+                "cumulative_total": {
+                    "type": "integer"
+                },
+                "spendable_balance": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handlers.PointsHistoryItem": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "note": {
+                    "type": "string"
+                },
+                "sku": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "earn",
+                        "spend"
+                    ]
+                }
+            }
+        },
+        "internal_handlers.PointsHistoryResponse": {
+            "type": "object",
+            "properties": {
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_handlers.PointsHistoryItem"
+                    }
+                }
+            }
+        },
+        "internal_handlers.ProvidersResponse": {
+            "type": "object",
+            "properties": {
+                "providers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.AuthProvider"
+                    }
+                }
+            }
+        },
+        "internal_handlers.Response": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "error": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_handlers.TokensResponse": {
+            "type": "object",
+            "properties": {
+                "tokens": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.TokenPair"
+                }
+            }
+        },
+        "internal_handlers.UserResponse": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.User"
+                }
+            }
+        },
+        "internal_handlers.claimRequest": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "0 = claim all",
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handlers.redeemRequest": {
+            "type": "object",
+            "required": [
+                "amount"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "internal_handlers.redeemResponse": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handlers.tachiBalanceResponse": {
+            "type": "object",
+            "properties": {
+                "tachi_balance": {
+                    "type": "integer"
+                }
+            }
         }
     },
     "securityDefinitions": {
@@ -2072,12 +2072,7 @@ const docTemplate = `{
             "name": "Authorization",
             "in": "header"
         }
-    },
-    "security": [
-        {
-            "BearerAuth": []
-        }
-    ]
+    }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it

--- a/backend/docs/docs_test.go
+++ b/backend/docs/docs_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestSwaggerDoc_UsesGlobalBearerAuthAndPublicOverrides(t *testing.T) {
+func TestSwaggerDoc_NoGlobalSecurity_ProtectedOpsRequireBearerAuth(t *testing.T) {
 	raw := SwaggerInfo.ReadDoc()
 
 	var doc map[string]any
@@ -14,18 +14,16 @@ func TestSwaggerDoc_UsesGlobalBearerAuthAndPublicOverrides(t *testing.T) {
 		t.Fatalf("unmarshal doc: %v", err)
 	}
 
-	security, ok := doc["security"].([]any)
-	if !ok || len(security) != 1 {
-		t.Fatalf("root security: want one BearerAuth requirement, got %#v", doc["security"])
+	if _, hasRootSecurity := doc["security"]; hasRootSecurity {
+		t.Fatalf("root security must be absent; protected endpoints should declare BearerAuth explicitly, got %#v", doc["security"])
 	}
 
-	firstReq, ok := security[0].(map[string]any)
+	securityDefs, ok := doc["securityDefinitions"].(map[string]any)
 	if !ok {
-		t.Fatalf("root security requirement shape: got %#v", security[0])
+		t.Fatalf("securityDefinitions: got %#v", doc["securityDefinitions"])
 	}
-	bearerScopes, ok := firstReq["BearerAuth"].([]any)
-	if !ok || len(bearerScopes) != 0 {
-		t.Fatalf("root security: want BearerAuth: [], got %#v", firstReq["BearerAuth"])
+	if _, ok := securityDefs["BearerAuth"]; !ok {
+		t.Fatalf("securityDefinitions: missing BearerAuth, got %#v", securityDefs)
 	}
 
 	paths, ok := doc["paths"].(map[string]any)
@@ -64,19 +62,22 @@ func TestSwaggerDoc_UsesGlobalBearerAuthAndPublicOverrides(t *testing.T) {
 				t.Fatalf("%s %s: operation missing, got %#v", tc.method, tc.path, pathItem[tc.method])
 			}
 
-			// Public endpoints may omit `security` entirely or set it to an empty array.
-			rawSecurity, exists := op["security"]
-			if !exists {
-				return
+			operationSecurity, hasOperationSecurity := op["security"].([]any)
+			if hasOperationSecurity {
+				for _, req := range operationSecurity {
+					reqMap, ok := req.(map[string]any)
+					if !ok {
+						t.Fatalf("%s %s: security requirement shape invalid, got %#v", tc.method, tc.path, req)
+					}
+					if _, ok := reqMap[""]; ok {
+						t.Fatalf("%s %s: found invalid empty security scheme key: %#v", tc.method, tc.path, reqMap)
+					}
+					if _, ok := reqMap["BearerAuth"]; ok {
+						t.Fatalf("%s %s: public endpoint must not require BearerAuth, got %#v", tc.method, tc.path, reqMap)
+					}
+				}
 			}
 
-			override, ok := rawSecurity.([]any)
-			if !ok {
-				t.Fatalf("%s %s: security override shape invalid, got %#v", tc.method, tc.path, rawSecurity)
-			}
-			if len(override) != 0 {
-				t.Fatalf("%s %s: want empty security override when present, got %#v", tc.method, tc.path, override)
-			}
 		})
 	}
 
@@ -84,8 +85,20 @@ func TestSwaggerDoc_UsesGlobalBearerAuthAndPublicOverrides(t *testing.T) {
 		path   string
 		method string
 	}{
+		{path: "/auth/providers/{provider}", method: "delete"},
+		{path: "/auth/verify-email/send", method: "post"},
+		{path: "/spend/redeem", method: "post"},
+		{path: "/users/me", method: "get"},
+		{path: "/users/me/addresses", method: "get"},
+		{path: "/users/me/addresses", method: "post"},
+		{path: "/users/me/addresses/{id}", method: "put"},
+		{path: "/users/me/addresses/{id}", method: "delete"},
+		{path: "/users/me/addresses/{id}/default", method: "put"},
 		{path: "/users/me/points", method: "get"},
+		{path: "/users/me/points/claim", method: "post"},
 		{path: "/users/me/points/history", method: "get"},
+		{path: "/users/me/providers", method: "get"},
+		{path: "/users/me/tachi/balance", method: "get"},
 	} {
 		tc := tc
 		t.Run(fmt.Sprintf("protected %s %s", tc.method, tc.path), func(t *testing.T) {
@@ -108,6 +121,9 @@ func TestSwaggerDoc_UsesGlobalBearerAuthAndPublicOverrides(t *testing.T) {
 			bearerScopes, ok := firstReq["BearerAuth"].([]any)
 			if !ok || len(bearerScopes) != 0 {
 				t.Fatalf("%s %s: want BearerAuth: [], got %#v", tc.method, tc.path, firstReq["BearerAuth"])
+			}
+			if _, ok := firstReq[""]; ok {
+				t.Fatalf("%s %s: protected endpoint must not use invalid empty security scheme key: %#v", tc.method, tc.path, firstReq)
 			}
 		})
 	}

--- a/backend/docs/docs_test.go
+++ b/backend/docs/docs_test.go
@@ -63,12 +63,19 @@ func TestSwaggerDoc_UsesGlobalBearerAuthAndPublicOverrides(t *testing.T) {
 			if !ok {
 				t.Fatalf("%s %s: operation missing, got %#v", tc.method, tc.path, pathItem[tc.method])
 			}
-			override, ok := op["security"].([]any)
+
+			// Public endpoints may omit `security` entirely or set it to an empty array.
+			rawSecurity, exists := op["security"]
+			if !exists {
+				return
+			}
+
+			override, ok := rawSecurity.([]any)
 			if !ok {
-				t.Fatalf("%s %s: security override missing, got %#v", tc.method, tc.path, op["security"])
+				t.Fatalf("%s %s: security override shape invalid, got %#v", tc.method, tc.path, rawSecurity)
 			}
 			if len(override) != 0 {
-				t.Fatalf("%s %s: want empty security override, got %#v", tc.method, tc.path, override)
+				t.Fatalf("%s %s: want empty security override when present, got %#v", tc.method, tc.path, override)
 			}
 		})
 	}

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -11,7 +11,6 @@
     "paths": {
         "/auth/forgot-password": {
             "post": {
-                "security": [],
                 "description": "Always returns 200 to prevent user enumeration",
                 "consumes": [
                     "application/json"
@@ -69,7 +68,6 @@
         },
         "/auth/google": {
             "get": {
-                "security": [],
                 "produces": [
                     "application/json"
                 ],
@@ -86,7 +84,6 @@
         },
         "/auth/google/callback": {
             "get": {
-                "security": [],
                 "produces": [
                     "application/json"
                 ],
@@ -146,7 +143,6 @@
         },
         "/auth/login": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -204,7 +200,6 @@
         },
         "/auth/logout": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -220,7 +215,6 @@
                         "description": "Refresh token fallback when cookie is unavailable",
                         "name": "body",
                         "in": "body",
-                        "required": false,
                         "schema": {
                             "type": "object",
                             "properties": {
@@ -324,7 +318,6 @@
         },
         "/auth/refresh": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -340,7 +333,6 @@
                         "description": "Refresh token fallback when cookie is unavailable",
                         "name": "body",
                         "in": "body",
-                        "required": false,
                         "schema": {
                             "type": "object",
                             "properties": {
@@ -387,7 +379,6 @@
         },
         "/auth/register": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -445,7 +436,6 @@
         },
         "/auth/reset-password": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -505,7 +495,6 @@
         },
         "/auth/twitch": {
             "get": {
-                "security": [],
                 "produces": [
                     "application/json"
                 ],
@@ -522,7 +511,6 @@
         },
         "/auth/twitch/callback": {
             "get": {
-                "security": [],
                 "produces": [
                     "application/json"
                 ],
@@ -582,7 +570,6 @@
         },
         "/auth/verify-email/confirm": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -687,7 +674,6 @@
         },
         "/auth/web3/nonce": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -750,7 +736,6 @@
         },
         "/auth/web3/verify": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -808,7 +793,6 @@
         },
         "/extension/auth/login": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -871,7 +855,6 @@
         },
         "/extension/bits/complete": {
             "post": {
-                "security": [],
                 "consumes": [
                     "application/json"
                 ],
@@ -931,6 +914,74 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/spend/redeem": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "spend"
+                ],
+                "summary": "Burn $TACHI to redeem a discount coupon",
+                "parameters": [
+                    {
+                        "description": "Amount to burn (must be \u003e 0)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.redeemRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.redeemResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
@@ -1368,6 +1419,73 @@
                 }
             }
         },
+        "/users/me/points/claim": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tachi"
+                ],
+                "summary": "Claim T-Points as $TACHI",
+                "parameters": [
+                    {
+                        "description": "Amount to claim (0 = all)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.claimRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.tachiBalanceResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/users/me/points/history": {
             "get": {
                 "security": [
@@ -1460,6 +1578,48 @@
                     }
                 }
             }
+        },
+        "/users/me/tachi/balance": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tachi"
+                ],
+                "summary": "Get my $TACHI balance",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.tachiBalanceResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1504,6 +1664,9 @@
         "handlers.NonceResponse": {
             "type": "object",
             "properties": {
+                "issued_at": {
+                    "type": "string"
+                },
                 "nonce": {
                     "type": "string"
                 }
@@ -1592,6 +1755,43 @@
             "properties": {
                 "user": {
                     "$ref": "#/definitions/models.User"
+                }
+            }
+        },
+        "handlers.claimRequest": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "0 = claim all",
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.redeemRequest": {
+            "type": "object",
+            "required": [
+                "amount"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "handlers.redeemResponse": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.tachiBalanceResponse": {
+            "type": "object",
+            "properties": {
+                "tachi_balance": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -44,13 +44,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -60,7 +60,7 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -113,13 +113,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -129,13 +129,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -160,7 +160,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.LoginInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.LoginInput"
                         }
                     }
                 ],
@@ -170,13 +170,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -186,13 +186,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -231,13 +231,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -247,7 +247,7 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -288,13 +288,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -304,13 +304,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -349,13 +349,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.TokensResponse"
+                                            "$ref": "#/definitions/internal_handlers.TokensResponse"
                                         }
                                     }
                                 }
@@ -365,13 +365,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -396,7 +396,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.RegisterInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.RegisterInput"
                         }
                     }
                 ],
@@ -406,13 +406,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -422,13 +422,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -471,13 +471,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -487,7 +487,7 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -540,13 +540,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -556,13 +556,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -602,13 +602,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -618,7 +618,7 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -644,13 +644,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -660,13 +660,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -706,13 +706,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.NonceResponse"
+                                            "$ref": "#/definitions/internal_handlers.NonceResponse"
                                         }
                                     }
                                 }
@@ -722,13 +722,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -753,7 +753,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.Web3VerifyInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.Web3VerifyInput"
                         }
                     }
                 ],
@@ -763,13 +763,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -779,13 +779,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -825,13 +825,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -841,13 +841,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -893,13 +893,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                            "$ref": "#/definitions/internal_handlers.AuthResponse"
                                         }
                                     }
                                 }
@@ -909,13 +909,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -945,7 +945,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.redeemRequest"
+                            "$ref": "#/definitions/internal_handlers.redeemRequest"
                         }
                     }
                 ],
@@ -955,13 +955,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.redeemResponse"
+                                            "$ref": "#/definitions/internal_handlers.redeemResponse"
                                         }
                                     }
                                 }
@@ -971,19 +971,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1009,13 +1009,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.UserResponse"
+                                            "$ref": "#/definitions/internal_handlers.UserResponse"
                                         }
                                     }
                                 }
@@ -1025,7 +1025,7 @@
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1053,7 +1053,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.UpdateProfileInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.UpdateProfileInput"
                         }
                     }
                 ],
@@ -1063,13 +1063,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.UserResponse"
+                                            "$ref": "#/definitions/internal_handlers.UserResponse"
                                         }
                                     }
                                 }
@@ -1079,13 +1079,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1111,13 +1111,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AddressesResponse"
+                                            "$ref": "#/definitions/internal_handlers.AddressesResponse"
                                         }
                                     }
                                 }
@@ -1149,7 +1149,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.AddressInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.AddressInput"
                         }
                     }
                 ],
@@ -1159,13 +1159,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AddressResponse"
+                                            "$ref": "#/definitions/internal_handlers.AddressResponse"
                                         }
                                     }
                                 }
@@ -1175,7 +1175,7 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1212,7 +1212,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/services.AddressInput"
+                            "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.AddressInput"
                         }
                     }
                 ],
@@ -1222,13 +1222,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AddressResponse"
+                                            "$ref": "#/definitions/internal_handlers.AddressResponse"
                                         }
                                     }
                                 }
@@ -1238,13 +1238,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1277,13 +1277,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.MessageResponse"
+                                            "$ref": "#/definitions/internal_handlers.MessageResponse"
                                         }
                                     }
                                 }
@@ -1293,13 +1293,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1334,13 +1334,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AddressResponse"
+                                            "$ref": "#/definitions/internal_handlers.AddressResponse"
                                         }
                                     }
                                 }
@@ -1350,13 +1350,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1391,13 +1391,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PointsBalanceResponse"
+                                            "$ref": "#/definitions/internal_handlers.PointsBalanceResponse"
                                         }
                                     }
                                 }
@@ -1407,13 +1407,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1442,7 +1442,7 @@
                         "name": "body",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/handlers.claimRequest"
+                            "$ref": "#/definitions/internal_handlers.claimRequest"
                         }
                     }
                 ],
@@ -1452,13 +1452,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.tachiBalanceResponse"
+                                            "$ref": "#/definitions/internal_handlers.tachiBalanceResponse"
                                         }
                                     }
                                 }
@@ -1468,19 +1468,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1515,13 +1515,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PointsHistoryResponse"
+                                            "$ref": "#/definitions/internal_handlers.PointsHistoryResponse"
                                         }
                                     }
                                 }
@@ -1531,13 +1531,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1563,13 +1563,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ProvidersResponse"
+                                            "$ref": "#/definitions/internal_handlers.ProvidersResponse"
                                         }
                                     }
                                 }
@@ -1599,13 +1599,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/handlers.Response"
+                                    "$ref": "#/definitions/internal_handlers.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.tachiBalanceResponse"
+                                            "$ref": "#/definitions/internal_handlers.tachiBalanceResponse"
                                         }
                                     }
                                 }
@@ -1615,7 +1615,7 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Response"
+                            "$ref": "#/definitions/internal_handlers.Response"
                         }
                     }
                 }
@@ -1623,179 +1623,7 @@
         }
     },
     "definitions": {
-        "handlers.AddressResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "$ref": "#/definitions/models.ShippingAddress"
-                }
-            }
-        },
-        "handlers.AddressesResponse": {
-            "type": "object",
-            "properties": {
-                "addresses": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.ShippingAddress"
-                    }
-                }
-            }
-        },
-        "handlers.AuthResponse": {
-            "type": "object",
-            "properties": {
-                "tokens": {
-                    "$ref": "#/definitions/services.TokenPair"
-                },
-                "user": {
-                    "$ref": "#/definitions/models.User"
-                }
-            }
-        },
-        "handlers.MessageResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "handlers.NonceResponse": {
-            "type": "object",
-            "properties": {
-                "issued_at": {
-                    "type": "string"
-                },
-                "nonce": {
-                    "type": "string"
-                }
-            }
-        },
-        "handlers.PointsBalanceResponse": {
-            "type": "object",
-            "properties": {
-                "cumulative_total": {
-                    "type": "integer"
-                },
-                "spendable_balance": {
-                    "type": "integer"
-                }
-            }
-        },
-        "handlers.PointsHistoryItem": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "note": {
-                    "type": "string"
-                },
-                "sku": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "earn",
-                        "spend"
-                    ]
-                }
-            }
-        },
-        "handlers.PointsHistoryResponse": {
-            "type": "object",
-            "properties": {
-                "transactions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/handlers.PointsHistoryItem"
-                    }
-                }
-            }
-        },
-        "handlers.ProvidersResponse": {
-            "type": "object",
-            "properties": {
-                "providers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.AuthProvider"
-                    }
-                }
-            }
-        },
-        "handlers.Response": {
-            "type": "object",
-            "properties": {
-                "data": {},
-                "error": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "handlers.TokensResponse": {
-            "type": "object",
-            "properties": {
-                "tokens": {
-                    "$ref": "#/definitions/services.TokenPair"
-                }
-            }
-        },
-        "handlers.UserResponse": {
-            "type": "object",
-            "properties": {
-                "user": {
-                    "$ref": "#/definitions/models.User"
-                }
-            }
-        },
-        "handlers.claimRequest": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "description": "0 = claim all",
-                    "type": "integer"
-                }
-            }
-        },
-        "handlers.redeemRequest": {
-            "type": "object",
-            "required": [
-                "amount"
-            ],
-            "properties": {
-                "amount": {
-                    "type": "integer",
-                    "minimum": 1
-                }
-            }
-        },
-        "handlers.redeemResponse": {
-            "type": "object",
-            "properties": {
-                "balance": {
-                    "type": "integer"
-                }
-            }
-        },
-        "handlers.tachiBalanceResponse": {
-            "type": "object",
-            "properties": {
-                "tachi_balance": {
-                    "type": "integer"
-                }
-            }
-        },
-        "models.AuthProvider": {
+        "github_com_tachigo_tachigo_internal_models.AuthProvider": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -1808,7 +1636,7 @@
                     "type": "object"
                 },
                 "provider": {
-                    "$ref": "#/definitions/models.ProviderType"
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.ProviderType"
                 },
                 "provider_id": {
                     "type": "string"
@@ -1821,7 +1649,7 @@
                 }
             }
         },
-        "models.ProviderType": {
+        "github_com_tachigo_tachigo_internal_models.ProviderType": {
             "type": "string",
             "enum": [
                 "twitch",
@@ -1836,7 +1664,7 @@
                 "ProviderEmail"
             ]
         },
-        "models.ShippingAddress": {
+        "github_com_tachigo_tachigo_internal_models.ShippingAddress": {
             "type": "object",
             "properties": {
                 "address_line1": {
@@ -1880,19 +1708,19 @@
                 }
             }
         },
-        "models.User": {
+        "github_com_tachigo_tachigo_internal_models.User": {
             "type": "object",
             "properties": {
                 "addresses": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.ShippingAddress"
+                        "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress"
                     }
                 },
                 "auth_providers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.AuthProvider"
+                        "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.AuthProvider"
                     }
                 },
                 "avatar_url": {
@@ -1914,7 +1742,7 @@
                     "type": "boolean"
                 },
                 "role": {
-                    "$ref": "#/definitions/models.UserRole"
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.UserRole"
                 },
                 "updated_at": {
                     "type": "string"
@@ -1924,7 +1752,7 @@
                 }
             }
         },
-        "models.UserRole": {
+        "github_com_tachigo_tachigo_internal_models.UserRole": {
             "type": "string",
             "enum": [
                 "viewer",
@@ -1939,7 +1767,7 @@
                 "RoleAdmin"
             ]
         },
-        "services.AddressInput": {
+        "github_com_tachigo_tachigo_internal_services.AddressInput": {
             "type": "object",
             "required": [
                 "address_line1",
@@ -1976,7 +1804,7 @@
                 }
             }
         },
-        "services.LoginInput": {
+        "github_com_tachigo_tachigo_internal_services.LoginInput": {
             "type": "object",
             "required": [
                 "email",
@@ -1991,7 +1819,7 @@
                 }
             }
         },
-        "services.RegisterInput": {
+        "github_com_tachigo_tachigo_internal_services.RegisterInput": {
             "type": "object",
             "required": [
                 "email",
@@ -2013,7 +1841,7 @@
                 }
             }
         },
-        "services.TokenPair": {
+        "github_com_tachigo_tachigo_internal_services.TokenPair": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -2028,7 +1856,7 @@
                 }
             }
         },
-        "services.UpdateProfileInput": {
+        "github_com_tachigo_tachigo_internal_services.UpdateProfileInput": {
             "type": "object",
             "properties": {
                 "avatar_url": {
@@ -2039,7 +1867,7 @@
                 }
             }
         },
-        "services.Web3VerifyInput": {
+        "github_com_tachigo_tachigo_internal_services.Web3VerifyInput": {
             "type": "object",
             "required": [
                 "address",
@@ -2057,6 +1885,178 @@
                     "type": "string"
                 }
             }
+        },
+        "internal_handlers.AddressResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress"
+                }
+            }
+        },
+        "internal_handlers.AddressesResponse": {
+            "type": "object",
+            "properties": {
+                "addresses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress"
+                    }
+                }
+            }
+        },
+        "internal_handlers.AuthResponse": {
+            "type": "object",
+            "properties": {
+                "tokens": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.TokenPair"
+                },
+                "user": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.User"
+                }
+            }
+        },
+        "internal_handlers.MessageResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handlers.NonceResponse": {
+            "type": "object",
+            "properties": {
+                "issued_at": {
+                    "type": "string"
+                },
+                "nonce": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handlers.PointsBalanceResponse": {
+            "type": "object",
+            "properties": {
+                "cumulative_total": {
+                    "type": "integer"
+                },
+                "spendable_balance": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handlers.PointsHistoryItem": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "note": {
+                    "type": "string"
+                },
+                "sku": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "earn",
+                        "spend"
+                    ]
+                }
+            }
+        },
+        "internal_handlers.PointsHistoryResponse": {
+            "type": "object",
+            "properties": {
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_handlers.PointsHistoryItem"
+                    }
+                }
+            }
+        },
+        "internal_handlers.ProvidersResponse": {
+            "type": "object",
+            "properties": {
+                "providers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.AuthProvider"
+                    }
+                }
+            }
+        },
+        "internal_handlers.Response": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "error": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_handlers.TokensResponse": {
+            "type": "object",
+            "properties": {
+                "tokens": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_services.TokenPair"
+                }
+            }
+        },
+        "internal_handlers.UserResponse": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "$ref": "#/definitions/github_com_tachigo_tachigo_internal_models.User"
+                }
+            }
+        },
+        "internal_handlers.claimRequest": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "0 = claim all",
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handlers.redeemRequest": {
+            "type": "object",
+            "required": [
+                "amount"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "internal_handlers.redeemResponse": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handlers.tachiBalanceResponse": {
+            "type": "object",
+            "properties": {
+                "tachi_balance": {
+                    "type": "integer"
+                }
+            }
         }
     },
     "securityDefinitions": {
@@ -2066,10 +2066,5 @@
             "name": "Authorization",
             "in": "header"
         }
-    },
-    "security": [
-        {
-            "BearerAuth": []
-        }
-    ]
+    }
 }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -26,6 +26,8 @@ definitions:
     type: object
   handlers.NonceResponse:
     properties:
+      issued_at:
+        type: string
       nonce:
         type: string
     type: object
@@ -84,6 +86,30 @@ definitions:
     properties:
       user:
         $ref: '#/definitions/models.User'
+    type: object
+  handlers.claimRequest:
+    properties:
+      amount:
+        description: 0 = claim all
+        type: integer
+    type: object
+  handlers.redeemRequest:
+    properties:
+      amount:
+        minimum: 1
+        type: integer
+    required:
+    - amount
+    type: object
+  handlers.redeemResponse:
+    properties:
+      balance:
+        type: integer
+    type: object
+  handlers.tachiBalanceResponse:
+    properties:
+      tachi_balance:
+        type: integer
     type: object
   models.AuthProvider:
     properties:
@@ -303,7 +329,6 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Request a password reset email
       tags:
       - auth
@@ -314,7 +339,6 @@ paths:
       responses:
         "302":
           description: Found
-      security: []
       summary: Redirect to Google OAuth
       tags:
       - auth
@@ -351,7 +375,6 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Google OAuth callback
       tags:
       - auth
@@ -386,7 +409,6 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Login with email and password
       tags:
       - auth
@@ -398,7 +420,6 @@ paths:
       - description: Refresh token fallback when cookie is unavailable
         in: body
         name: body
-        required: false
         schema:
           properties:
             refresh_token:
@@ -420,7 +441,6 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Logout and invalidate refresh token
       tags:
       - auth
@@ -470,7 +490,6 @@ paths:
       - description: Refresh token fallback when cookie is unavailable
         in: body
         name: body
-        required: false
         schema:
           properties:
             refresh_token:
@@ -496,7 +515,6 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Refresh access token
       tags:
       - auth
@@ -531,7 +549,6 @@ paths:
           description: Conflict
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Register a new user
       tags:
       - auth
@@ -567,7 +584,6 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Reset password using token
       tags:
       - auth
@@ -578,7 +594,6 @@ paths:
       responses:
         "302":
           description: Found
-      security: []
       summary: Redirect to Twitch OAuth
       tags:
       - auth
@@ -615,7 +630,6 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Twitch OAuth callback
       tags:
       - auth
@@ -649,7 +663,6 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Confirm email verification token
       tags:
       - auth
@@ -714,7 +727,6 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Get a sign-in nonce for a wallet address
       tags:
       - auth
@@ -749,7 +761,6 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Verify wallet signature and authenticate
       tags:
       - auth
@@ -787,7 +798,6 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Authenticate via Twitch Extension JWT
       tags:
       - extension
@@ -829,10 +839,49 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
-      security: []
       summary: Complete a Bits transaction
       tags:
       - extension
+  /spend/redeem:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Amount to burn (must be > 0)
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.redeemRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/handlers.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.redeemResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Burn $TACHI to redeem a discount coupon
+      tags:
+      - spend
   /users/me:
     get:
       produces:
@@ -1080,6 +1129,45 @@ paths:
       summary: Get my points balance
       tags:
       - points
+  /users/me/points/claim:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Amount to claim (0 = all)
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/handlers.claimRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/handlers.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.tachiBalanceResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Claim T-Points as $TACHI
+      tags:
+      - tachi
   /users/me/points/history:
     get:
       parameters:
@@ -1132,6 +1220,29 @@ paths:
       summary: List linked OAuth providers
       tags:
       - users
+  /users/me/tachi/balance:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/handlers.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.tachiBalanceResponse'
+              type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Get my $TACHI balance
+      tags:
+      - tachi
 security:
 - BearerAuth: []
 securityDefinitions:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,117 +1,6 @@
 basePath: /api/v1
 definitions:
-  handlers.AddressResponse:
-    properties:
-      address:
-        $ref: '#/definitions/models.ShippingAddress'
-    type: object
-  handlers.AddressesResponse:
-    properties:
-      addresses:
-        items:
-          $ref: '#/definitions/models.ShippingAddress'
-        type: array
-    type: object
-  handlers.AuthResponse:
-    properties:
-      tokens:
-        $ref: '#/definitions/services.TokenPair'
-      user:
-        $ref: '#/definitions/models.User'
-    type: object
-  handlers.MessageResponse:
-    properties:
-      message:
-        type: string
-    type: object
-  handlers.NonceResponse:
-    properties:
-      issued_at:
-        type: string
-      nonce:
-        type: string
-    type: object
-  handlers.PointsBalanceResponse:
-    properties:
-      cumulative_total:
-        type: integer
-      spendable_balance:
-        type: integer
-    type: object
-  handlers.PointsHistoryItem:
-    properties:
-      amount:
-        type: integer
-      created_at:
-        format: date-time
-        type: string
-      note:
-        type: string
-      sku:
-        type: string
-      type:
-        enum:
-        - earn
-        - spend
-        type: string
-    type: object
-  handlers.PointsHistoryResponse:
-    properties:
-      transactions:
-        items:
-          $ref: '#/definitions/handlers.PointsHistoryItem'
-        type: array
-    type: object
-  handlers.ProvidersResponse:
-    properties:
-      providers:
-        items:
-          $ref: '#/definitions/models.AuthProvider'
-        type: array
-    type: object
-  handlers.Response:
-    properties:
-      data: {}
-      error:
-        type: string
-      success:
-        type: boolean
-    type: object
-  handlers.TokensResponse:
-    properties:
-      tokens:
-        $ref: '#/definitions/services.TokenPair'
-    type: object
-  handlers.UserResponse:
-    properties:
-      user:
-        $ref: '#/definitions/models.User'
-    type: object
-  handlers.claimRequest:
-    properties:
-      amount:
-        description: 0 = claim all
-        type: integer
-    type: object
-  handlers.redeemRequest:
-    properties:
-      amount:
-        minimum: 1
-        type: integer
-    required:
-    - amount
-    type: object
-  handlers.redeemResponse:
-    properties:
-      balance:
-        type: integer
-    type: object
-  handlers.tachiBalanceResponse:
-    properties:
-      tachi_balance:
-        type: integer
-    type: object
-  models.AuthProvider:
+  github_com_tachigo_tachigo_internal_models.AuthProvider:
     properties:
       created_at:
         type: string
@@ -120,7 +9,7 @@ definitions:
       metadata:
         type: object
       provider:
-        $ref: '#/definitions/models.ProviderType'
+        $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.ProviderType'
       provider_id:
         type: string
       updated_at:
@@ -128,7 +17,7 @@ definitions:
       user_id:
         type: string
     type: object
-  models.ProviderType:
+  github_com_tachigo_tachigo_internal_models.ProviderType:
     enum:
     - twitch
     - google
@@ -140,7 +29,7 @@ definitions:
     - ProviderGoogle
     - ProviderWeb3
     - ProviderEmail
-  models.ShippingAddress:
+  github_com_tachigo_tachigo_internal_models.ShippingAddress:
     properties:
       address_line1:
         type: string
@@ -169,15 +58,15 @@ definitions:
       user_id:
         type: string
     type: object
-  models.User:
+  github_com_tachigo_tachigo_internal_models.User:
     properties:
       addresses:
         items:
-          $ref: '#/definitions/models.ShippingAddress'
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress'
         type: array
       auth_providers:
         items:
-          $ref: '#/definitions/models.AuthProvider'
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.AuthProvider'
         type: array
       avatar_url:
         type: string
@@ -192,13 +81,13 @@ definitions:
       is_active:
         type: boolean
       role:
-        $ref: '#/definitions/models.UserRole'
+        $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.UserRole'
       updated_at:
         type: string
       username:
         type: string
     type: object
-  models.UserRole:
+  github_com_tachigo_tachigo_internal_models.UserRole:
     enum:
     - viewer
     - streamer
@@ -210,7 +99,7 @@ definitions:
     - RoleStreamer
     - RoleAgency
     - RoleAdmin
-  services.AddressInput:
+  github_com_tachigo_tachigo_internal_services.AddressInput:
     properties:
       address_line1:
         type: string
@@ -235,7 +124,7 @@ definitions:
     - city
     - recipient_name
     type: object
-  services.LoginInput:
+  github_com_tachigo_tachigo_internal_services.LoginInput:
     properties:
       email:
         type: string
@@ -245,7 +134,7 @@ definitions:
     - email
     - password
     type: object
-  services.RegisterInput:
+  github_com_tachigo_tachigo_internal_services.RegisterInput:
     properties:
       email:
         type: string
@@ -261,7 +150,7 @@ definitions:
     - password
     - username
     type: object
-  services.TokenPair:
+  github_com_tachigo_tachigo_internal_services.TokenPair:
     properties:
       access_token:
         type: string
@@ -271,14 +160,14 @@ definitions:
       refresh_token:
         type: string
     type: object
-  services.UpdateProfileInput:
+  github_com_tachigo_tachigo_internal_services.UpdateProfileInput:
     properties:
       avatar_url:
         type: string
       username:
         type: string
     type: object
-  services.Web3VerifyInput:
+  github_com_tachigo_tachigo_internal_services.Web3VerifyInput:
     properties:
       address:
         type: string
@@ -290,6 +179,117 @@ definitions:
     - address
     - nonce
     - signature
+    type: object
+  internal_handlers.AddressResponse:
+    properties:
+      address:
+        $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress'
+    type: object
+  internal_handlers.AddressesResponse:
+    properties:
+      addresses:
+        items:
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.ShippingAddress'
+        type: array
+    type: object
+  internal_handlers.AuthResponse:
+    properties:
+      tokens:
+        $ref: '#/definitions/github_com_tachigo_tachigo_internal_services.TokenPair'
+      user:
+        $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.User'
+    type: object
+  internal_handlers.MessageResponse:
+    properties:
+      message:
+        type: string
+    type: object
+  internal_handlers.NonceResponse:
+    properties:
+      issued_at:
+        type: string
+      nonce:
+        type: string
+    type: object
+  internal_handlers.PointsBalanceResponse:
+    properties:
+      cumulative_total:
+        type: integer
+      spendable_balance:
+        type: integer
+    type: object
+  internal_handlers.PointsHistoryItem:
+    properties:
+      amount:
+        type: integer
+      created_at:
+        format: date-time
+        type: string
+      note:
+        type: string
+      sku:
+        type: string
+      type:
+        enum:
+        - earn
+        - spend
+        type: string
+    type: object
+  internal_handlers.PointsHistoryResponse:
+    properties:
+      transactions:
+        items:
+          $ref: '#/definitions/internal_handlers.PointsHistoryItem'
+        type: array
+    type: object
+  internal_handlers.ProvidersResponse:
+    properties:
+      providers:
+        items:
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.AuthProvider'
+        type: array
+    type: object
+  internal_handlers.Response:
+    properties:
+      data: {}
+      error:
+        type: string
+      success:
+        type: boolean
+    type: object
+  internal_handlers.TokensResponse:
+    properties:
+      tokens:
+        $ref: '#/definitions/github_com_tachigo_tachigo_internal_services.TokenPair'
+    type: object
+  internal_handlers.UserResponse:
+    properties:
+      user:
+        $ref: '#/definitions/github_com_tachigo_tachigo_internal_models.User'
+    type: object
+  internal_handlers.claimRequest:
+    properties:
+      amount:
+        description: 0 = claim all
+        type: integer
+    type: object
+  internal_handlers.redeemRequest:
+    properties:
+      amount:
+        minimum: 1
+        type: integer
+    required:
+    - amount
+    type: object
+  internal_handlers.redeemResponse:
+    properties:
+      balance:
+        type: integer
+    type: object
+  internal_handlers.tachiBalanceResponse:
+    properties:
+      tachi_balance:
+        type: integer
     type: object
 host: localhost:8080
 info:
@@ -320,15 +320,15 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.MessageResponse'
+                  $ref: '#/definitions/internal_handlers.MessageResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Request a password reset email
       tags:
       - auth
@@ -362,19 +362,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AuthResponse'
+                  $ref: '#/definitions/internal_handlers.AuthResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Google OAuth callback
       tags:
       - auth
@@ -388,7 +388,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/services.LoginInput'
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_services.LoginInput'
       produces:
       - application/json
       responses:
@@ -396,19 +396,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AuthResponse'
+                  $ref: '#/definitions/internal_handlers.AuthResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Login with email and password
       tags:
       - auth
@@ -432,15 +432,15 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.MessageResponse'
+                  $ref: '#/definitions/internal_handlers.MessageResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Logout and invalidate refresh token
       tags:
       - auth
@@ -464,19 +464,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.MessageResponse'
+                  $ref: '#/definitions/internal_handlers.MessageResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Unlink an OAuth provider from the current user
@@ -502,19 +502,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.TokensResponse'
+                  $ref: '#/definitions/internal_handlers.TokensResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Refresh access token
       tags:
       - auth
@@ -528,7 +528,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/services.RegisterInput'
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_services.RegisterInput'
       produces:
       - application/json
       responses:
@@ -536,19 +536,19 @@ paths:
           description: Created
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AuthResponse'
+                  $ref: '#/definitions/internal_handlers.AuthResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Register a new user
       tags:
       - auth
@@ -575,15 +575,15 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.MessageResponse'
+                  $ref: '#/definitions/internal_handlers.MessageResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Reset password using token
       tags:
       - auth
@@ -617,19 +617,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AuthResponse'
+                  $ref: '#/definitions/internal_handlers.AuthResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Twitch OAuth callback
       tags:
       - auth
@@ -654,15 +654,15 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.MessageResponse'
+                  $ref: '#/definitions/internal_handlers.MessageResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Confirm email verification token
       tags:
       - auth
@@ -675,19 +675,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.MessageResponse'
+                  $ref: '#/definitions/internal_handlers.MessageResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Send or resend email verification
@@ -714,19 +714,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.NonceResponse'
+                  $ref: '#/definitions/internal_handlers.NonceResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Get a sign-in nonce for a wallet address
       tags:
       - auth
@@ -740,7 +740,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/services.Web3VerifyInput'
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_services.Web3VerifyInput'
       produces:
       - application/json
       responses:
@@ -748,19 +748,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AuthResponse'
+                  $ref: '#/definitions/internal_handlers.AuthResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Verify wallet signature and authenticate
       tags:
       - auth
@@ -785,19 +785,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AuthResponse'
+                  $ref: '#/definitions/internal_handlers.AuthResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Authenticate via Twitch Extension JWT
       tags:
       - extension
@@ -826,19 +826,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AuthResponse'
+                  $ref: '#/definitions/internal_handlers.AuthResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       summary: Complete a Bits transaction
       tags:
       - extension
@@ -852,7 +852,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/handlers.redeemRequest'
+          $ref: '#/definitions/internal_handlers.redeemRequest'
       produces:
       - application/json
       responses:
@@ -860,23 +860,23 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.redeemResponse'
+                  $ref: '#/definitions/internal_handlers.redeemResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Burn $TACHI to redeem a discount coupon
@@ -891,15 +891,15 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.UserResponse'
+                  $ref: '#/definitions/internal_handlers.UserResponse'
               type: object
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Get current user profile
@@ -914,7 +914,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/services.UpdateProfileInput'
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_services.UpdateProfileInput'
       produces:
       - application/json
       responses:
@@ -922,19 +922,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.UserResponse'
+                  $ref: '#/definitions/internal_handlers.UserResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Update current user profile
@@ -949,10 +949,10 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AddressesResponse'
+                  $ref: '#/definitions/internal_handlers.AddressesResponse'
               type: object
       security:
       - BearerAuth: []
@@ -968,7 +968,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/services.AddressInput'
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_services.AddressInput'
       produces:
       - application/json
       responses:
@@ -976,15 +976,15 @@ paths:
           description: Created
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AddressResponse'
+                  $ref: '#/definitions/internal_handlers.AddressResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Create a shipping address
@@ -1005,19 +1005,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.MessageResponse'
+                  $ref: '#/definitions/internal_handlers.MessageResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Delete a shipping address
@@ -1037,7 +1037,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/services.AddressInput'
+          $ref: '#/definitions/github_com_tachigo_tachigo_internal_services.AddressInput'
       produces:
       - application/json
       responses:
@@ -1045,19 +1045,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AddressResponse'
+                  $ref: '#/definitions/internal_handlers.AddressResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Update a shipping address
@@ -1078,19 +1078,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AddressResponse'
+                  $ref: '#/definitions/internal_handlers.AddressResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Set an address as default
@@ -1111,19 +1111,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.PointsBalanceResponse'
+                  $ref: '#/definitions/internal_handlers.PointsBalanceResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Get my points balance
@@ -1138,7 +1138,7 @@ paths:
         in: body
         name: body
         schema:
-          $ref: '#/definitions/handlers.claimRequest'
+          $ref: '#/definitions/internal_handlers.claimRequest'
       produces:
       - application/json
       responses:
@@ -1146,23 +1146,23 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.tachiBalanceResponse'
+                  $ref: '#/definitions/internal_handlers.tachiBalanceResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Claim T-Points as $TACHI
@@ -1183,19 +1183,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.PointsHistoryResponse'
+                  $ref: '#/definitions/internal_handlers.PointsHistoryResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: List my recent points transactions
@@ -1210,10 +1210,10 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.ProvidersResponse'
+                  $ref: '#/definitions/internal_handlers.ProvidersResponse'
               type: object
       security:
       - BearerAuth: []
@@ -1229,22 +1229,20 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/handlers.Response'
+            - $ref: '#/definitions/internal_handlers.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.tachiBalanceResponse'
+                  $ref: '#/definitions/internal_handlers.tachiBalanceResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.Response'
+            $ref: '#/definitions/internal_handlers.Response'
       security:
       - BearerAuth: []
       summary: Get my $TACHI balance
       tags:
       - tachi
-security:
-- BearerAuth: []
 securityDefinitions:
   BearerAuth:
     description: 'Enter: Bearer {access_token}'

--- a/backend/docs/swagger_contract_regression_test.go
+++ b/backend/docs/swagger_contract_regression_test.go
@@ -1,0 +1,22 @@
+package docs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSwaggerArtifacts_NoInvalidEmptySecurityScheme(t *testing.T) {
+	t.Helper()
+
+	path := filepath.Join("swagger.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	if strings.Contains(string(raw), `"": []`) {
+		t.Fatalf("%s contains invalid Swagger 2.0 security requirement \"\": []", path)
+	}
+}

--- a/backend/docs/swagger_contract_regression_test.go
+++ b/backend/docs/swagger_contract_regression_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestSwaggerArtifacts_NoInvalidEmptySecurityScheme(t *testing.T) {
-	t.Helper()
-
 	path := filepath.Join("swagger.json")
 	raw, err := os.ReadFile(path)
 	if err != nil {

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -50,7 +50,6 @@ func (h *AuthHandler) WithEmailAuth(svc *services.EmailAuthService) *AuthHandler
 // @Success      201  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      409  {object}  Response
-// @Security
 // @Router       /auth/register [post]
 func (h *AuthHandler) Register(c *gin.Context) {
 	var input services.RegisterInput
@@ -90,7 +89,6 @@ func (h *AuthHandler) Register(c *gin.Context) {
 // @Success      200  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
-// @Security
 // @Router       /auth/login [post]
 func (h *AuthHandler) Login(c *gin.Context) {
 	var input services.LoginInput
@@ -118,7 +116,6 @@ func (h *AuthHandler) Login(c *gin.Context) {
 // @Success      200  {object}  Response{data=TokensResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
-// @Security
 // @Router       /auth/refresh [post]
 func (h *AuthHandler) Refresh(c *gin.Context) {
 	refreshToken, err := h.refreshTokenFromRequest(c)
@@ -145,7 +142,6 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 // @Param        body body object{refresh_token=string} false "Refresh token fallback when cookie is unavailable"
 // @Success      200  {object}  Response{data=MessageResponse}
 // @Failure      400  {object}  Response
-// @Security
 // @Router       /auth/logout [post]
 func (h *AuthHandler) Logout(c *gin.Context) {
 	refreshToken, err := h.refreshTokenFromRequest(c)
@@ -164,7 +160,6 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 // @Tags         auth
 // @Produce      json
 // @Success      302
-// @Security
 // @Router       /auth/twitch [get]
 func (h *AuthHandler) TwitchLogin(c *gin.Context) {
 	state := oauthState()
@@ -181,7 +176,6 @@ func (h *AuthHandler) TwitchLogin(c *gin.Context) {
 // @Success      200  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
-// @Security
 // @Router       /auth/twitch/callback [get]
 func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 	if err := validateOAuthState(c); err != nil {
@@ -205,7 +199,6 @@ func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 // @Tags         auth
 // @Produce      json
 // @Success      302
-// @Security
 // @Router       /auth/google [get]
 func (h *AuthHandler) GoogleLogin(c *gin.Context) {
 	state := oauthState()
@@ -222,7 +215,6 @@ func (h *AuthHandler) GoogleLogin(c *gin.Context) {
 // @Success      200  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
-// @Security
 // @Router       /auth/google/callback [get]
 func (h *AuthHandler) GoogleCallback(c *gin.Context) {
 	if err := validateOAuthState(c); err != nil {
@@ -250,7 +242,6 @@ func (h *AuthHandler) GoogleCallback(c *gin.Context) {
 // @Success      200  {object}  Response{data=NonceResponse}
 // @Failure      400  {object}  Response
 // @Failure      500  {object}  Response
-// @Security
 // @Router       /auth/web3/nonce [post]
 func (h *AuthHandler) Web3Nonce(c *gin.Context) {
 	var body struct {
@@ -282,7 +273,6 @@ func (h *AuthHandler) Web3Nonce(c *gin.Context) {
 // @Success      200  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
-// @Security
 // @Router       /auth/web3/verify [post]
 func (h *AuthHandler) Web3Verify(c *gin.Context) {
 	var input services.Web3VerifyInput

--- a/backend/internal/handlers/email_auth_handler.go
+++ b/backend/internal/handlers/email_auth_handler.go
@@ -54,7 +54,6 @@ func (h *EmailAuthHandler) SendVerification(c *gin.Context) {
 // @Param        body body object{token=string} true "Verification token"
 // @Success      200  {object}  Response{data=MessageResponse}
 // @Failure      400  {object}  Response
-// @Security
 // @Router       /auth/verify-email/confirm [post]
 func (h *EmailAuthHandler) ConfirmVerification(c *gin.Context) {
 	var body struct {
@@ -87,7 +86,6 @@ func (h *EmailAuthHandler) ConfirmVerification(c *gin.Context) {
 // @Param        body body object{email=string} true "Email address"
 // @Success      200  {object}  Response{data=MessageResponse}
 // @Failure      400  {object}  Response
-// @Security
 // @Router       /auth/forgot-password [post]
 func (h *EmailAuthHandler) ForgotPassword(c *gin.Context) {
 	var body struct {
@@ -115,7 +113,6 @@ func (h *EmailAuthHandler) ForgotPassword(c *gin.Context) {
 // @Param        body body object{token=string,new_password=string} true "Token and new password (min 8 chars)"
 // @Success      200  {object}  Response{data=MessageResponse}
 // @Failure      400  {object}  Response
-// @Security
 // @Router       /auth/reset-password [post]
 func (h *EmailAuthHandler) ResetPassword(c *gin.Context) {
 	var body struct {

--- a/backend/internal/handlers/extension_handler.go
+++ b/backend/internal/handlers/extension_handler.go
@@ -23,7 +23,6 @@ func NewExtensionHandler(ext *services.ExtensionService) *ExtensionHandler {
 // @Success      200  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
-// @Security
 // @Router       /extension/auth/login [post]
 func (h *ExtensionHandler) Login(c *gin.Context) {
 	var body struct {
@@ -61,7 +60,6 @@ func (h *ExtensionHandler) Login(c *gin.Context) {
 // @Success      200  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
-// @Security
 // @Router       /extension/bits/complete [post]
 func (h *ExtensionHandler) BitsComplete(c *gin.Context) {
 	var body struct {

--- a/backend/internal/handlers/swagger_annotations_test.go
+++ b/backend/internal/handlers/swagger_annotations_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestSwaggerAnnotations_NoEmptySecurityDirective(t *testing.T) {
-	t.Helper()
-
 	emptySecurity := regexp.MustCompile(`(?m)^//\s*@Security\s*$`)
 
 	for _, rel := range []string{

--- a/backend/internal/handlers/swagger_annotations_test.go
+++ b/backend/internal/handlers/swagger_annotations_test.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestSwaggerAnnotations_NoEmptySecurityDirective(t *testing.T) {
+	t.Helper()
+
+	emptySecurity := regexp.MustCompile(`(?m)^//\s*@Security\s*$`)
+
+	for _, rel := range []string{
+		"auth_handler.go",
+		"email_auth_handler.go",
+		"extension_handler.go",
+	} {
+		path := filepath.Join(rel)
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+
+		if emptySecurity.Match(b) {
+			t.Fatalf("%s contains empty @Security directive; remove it from public endpoints", rel)
+		}
+	}
+}


### PR DESCRIPTION
## 什麼改動
- 對齊 `swag` 版本：`backend/go.mod` 與 `backend/Dockerfile` 同步為 `v1.16.6`
- 移除 public endpoints 的空白 `@Security` 註解（auth / email auth / extension）
- 重新產生並提交 Swagger 產物：
  - `backend/docs/docs.go`
  - `backend/docs/swagger.json`
  - `backend/docs/swagger.yaml`
- 新增回歸測試：
  - `backend/internal/handlers/swagger_annotations_test.go`（禁止空白 `@Security`）
  - `backend/docs/swagger_contract_regression_test.go`（禁止 `"": []`）
- 調整 `backend/docs/docs_test.go`：public endpoint 的 `security` 允許「省略或空陣列」兩種合法表示

## 為什麼
- 修正 Swagger 2.0 invalid security requirement（`"": []`）
- 消除生成器版本漂移造成的契約輸出不一致風險
- 建立防回歸護欄，避免同類問題再次出現

closes #270

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#270
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增/調整任何業務 API 行為
  - 不修改 #254 / #256 的 service 或 migration
  - 不處理 #269 內 `@Router` 註解 typo（留在 #269 修）

## 超出範圍內容
- 無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

- `cd backend && GOCACHE=/tmp/go-build-cache go test ./...`

## 備註
- public endpoints 的 security 表示採「省略或空陣列均合法」策略，與 #270 完成條件一致。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增三个受保护的API端点：支出兑换、T-Points 认领和 $TACHI 余额查询。

* **文档**
  * 重构 Swagger 参考与定义命名空间，添加相关请求/响应模型（含 nonce.issued_at）。
  * 移除全局文档级别的 security 声明，并删除多处请求上的显式空安全覆盖；部分路由改为显式要求 BearerAuth。
  * 调整登出/刷新接口请求体在规范中的必填性声明。

* **测试**
  * 新增文档回归与源码注释校验测试，防止无效或空的安全指令出现在规范/注释中。

* **维护**
  * 更新开发阶段 Go 工具链依赖版本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->