### PR TITLE
[infra] CI — parallelize backend unit and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,8 @@ jobs:
       - name: Verify CI workflow assertions
         run: node --test .github/workflows/ci.test.mjs
 
-  backend:
-    name: Backend tests
+  backend-build:
+    name: Build backend image
     needs: [scope-gate]
     if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
     runs-on: ubuntu-latest
@@ -178,28 +178,50 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Export image artifact
+        run: docker save tachigo-app:latest | gzip > tachigo-app.tar.gz
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-image
+          path: tachigo-app.tar.gz
+          retention-days: 1
+
+  backend:
+    name: Backend tests
+    needs: [scope-gate, backend-build]
+    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-image
+
+      - name: Load backend image
+        run: docker load < tachigo-app.tar.gz
+
       - name: Run tests
         run: docker compose run --pull never --no-deps --rm app go test ./...
 
   backend-integration:
     name: Backend integration tests
-    needs: [scope-gate, backend]
+    needs: [scope-gate, backend-build]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (needs.scope-gate.outputs.run_ci == 'true' && needs.scope-gate.outputs.run_backend_integration == 'true')
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build backend image
-        uses: docker/build-push-action@v6
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
         with:
-          context: ./backend
-          target: dev
-          load: true
-          tags: tachigo-app:latest
-          cache-from: type=gha
+          name: backend-image
+
+      - name: Load backend image
+        run: docker load < tachigo-app.tar.gz
 
       - name: Start PostgreSQL
         run: docker compose up -d --wait postgres
@@ -279,7 +301,7 @@ jobs:
 
   notify-discord:
     name: Notify Discord on failure
-    needs: [workflow-regression, check-cache-wiring, backend, backend-integration, frontend, dashboard, contracts]
+    needs: [workflow-regression, check-cache-wiring, backend-build, backend, backend-integration, frontend, dashboard, contracts]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Export image artifact
-        run: docker save tachigo-app:latest | gzip > tachigo-app.tar.gz
+        run: |
+          set -euo pipefail
+          docker save tachigo-app:latest | gzip -c > tachigo-app.tar.gz
+          test -s tachigo-app.tar.gz
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,9 +302,31 @@ jobs:
         working-directory: contracts
         run: forge test
 
+  backend-ci:
+    name: Backend CI (gate)
+    needs: [backend-build, backend, backend-integration]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check backend CI status
+        run: |
+          if [ "${{ needs.backend-build.result }}" != "success" ]; then
+            echo "❌ Backend build failed"
+            exit 1
+          fi
+          if [ "${{ needs.backend.result }}" = "failure" ]; then
+            echo "❌ Backend tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.backend-integration.result }}" = "failure" ]; then
+            echo "❌ Backend integration tests failed"
+            exit 1
+          fi
+          echo "✓ Backend CI passed"
+
   notify-discord:
     name: Notify Discord on failure
-    needs: [workflow-regression, check-cache-wiring, backend-build, backend, backend-integration, frontend, dashboard, contracts]
+    needs: [workflow-regression, check-cache-wiring, backend-ci, frontend, dashboard, contracts]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
     steps:
       - name: Check backend CI status
         run: |
-          if [ "${{ needs.backend-build.result }}" != "success" ]; then
+          if [ "${{ needs.backend-build.result }}" = "failure" ]; then
             echo "❌ Backend build failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,18 +310,13 @@ jobs:
     steps:
       - name: Check backend CI status
         run: |
-          if [ "${{ needs.backend-build.result }}" = "failure" ]; then
-            echo "❌ Backend build failed"
-            exit 1
-          fi
-          if [ "${{ needs.backend.result }}" = "failure" ]; then
-            echo "❌ Backend tests failed"
-            exit 1
-          fi
-          if [ "${{ needs.backend-integration.result }}" = "failure" ]; then
-            echo "❌ Backend integration tests failed"
-            exit 1
-          fi
+          for job in backend-build backend backend-integration; do
+            result=$(eval echo "\${{ needs.$job.result }}")
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "❌ $job: $result"
+              exit 1
+            fi
+          done
           echo "✓ Backend CI passed"
 
   notify-discord:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,9 +309,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check backend CI status
+        env:
+          BACKEND_BUILD_RESULT: ${{ needs.backend-build.result }}
+          BACKEND_RESULT: ${{ needs.backend.result }}
+          BACKEND_INTEGRATION_RESULT: ${{ needs.backend-integration.result }}
         run: |
-          for job in backend-build backend backend-integration; do
-            result=$(eval echo "\${{ needs.$job.result }}")
+          for item in \
+            "backend-build:$BACKEND_BUILD_RESULT" \
+            "backend:$BACKEND_RESULT" \
+            "backend-integration:$BACKEND_INTEGRATION_RESULT"
+          do
+            job="${item%%:*}"
+            result="${item#*:}"
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "❌ $job: $result"
               exit 1

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -183,7 +183,7 @@ repo 的 CI 目前改成：
 至少設成 required：
 
 - `PR Scope Police / Scope police`
-- `CI / Backend tests`
+- `CI / Backend CI (gate)`
 - `CI / Frontend build`
 - `CI / Dashboard build`
 


### PR DESCRIPTION
## Summary

Extract independent backend-build job that builds Docker image once, then 
backend and backend-integration jobs download the artifact and run tests in parallel.

## 改動

- 新增 backend-build job：Set up Buildx → Build image → docker save → upload artifact
- 修改 backend job：download artifact → docker load → run unit tests
- 修改 backend-integration job：download artifact → docker load → run integration tests
- 兩個 test job 並行依賴 backend-build
- notify-discord 更新 needs 加入 backend-build

## 為什麼

目前 backend-integration depends on backend，導致串行運行。改為獨立 build job 後：
- CI 總時間從 `build × 2 + unit + integration` 縮短為 `build + max(unit, integration)`
- GHA artifact 傳輸速度遠快於 build（通常 < 10 秒 vs > 3 分鐘）

## Scope 對齊

Source of truth：.github/workflows/ci.yml 的 backend CI 結構優化

Depends on PR：none

Backend contract already in develop:
- [ ] yes
- [x] no（infra 改動，無 backend contract）

本 PR 是否完全在 source of truth 範圍內？
- [x] 是
- [ ] 否，已另開 issue / PR 處理超出部分

## 本 PR 明確不做

- 不改變 build 邏輯或配置
- 不改變 test 邏輯
- 不改變 cache 策略

refs #285