### PR TITLE
[chore]: tune Dependabot update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,60 +4,89 @@ updates:
     directory: /backend
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Taipei
     target-branch: develop
+    open-pull-requests-limit: 2
     labels:
       - chore
+    groups:
+      backend-go-deps:
+        patterns:
+          - "*"
 
+  # Dependabot uses the "npm" ecosystem name for npm, yarn, and pnpm projects.
   - package-ecosystem: npm
     directory: /dashboard
     schedule:
       interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Taipei
     target-branch: develop
+    open-pull-requests-limit: 2
     labels:
       - chore
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 21
+      semver-patch-days: 21
+      include:
+        - "@eslint/*"
+        - "@types/*"
+        - "@vitejs/*"
+        - "autoprefixer"
+        - "eslint*"
+        - "globals"
+        - "jsdom"
+        - "postcss"
+        - "tailwindcss"
+        - "typescript"
+        - "typescript-eslint"
+        - "vite"
+        - "vitest"
     groups:
-      typescript-tooling:
+      dashboard-prod-deps:
+        dependency-type: production
         patterns:
-          - "typescript"
-          - "@typescript-eslint/*"
-          - "eslint*"
-          - "@eslint/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react*"
-      vite:
-        patterns:
-          - "vite"
-          - "@vitejs/*"
-      deps:
+          - "*"
+      dashboard-dev-tooling:
+        dependency-type: development
         patterns:
           - "*"
 
+  # Dependabot uses the "npm" ecosystem name for npm, yarn, and pnpm projects.
   - package-ecosystem: npm
     directory: /tachimint
     schedule:
       interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Asia/Taipei
     target-branch: develop
+    open-pull-requests-limit: 2
     labels:
       - chore
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 21
+      semver-patch-days: 21
+      include:
+        - "@eslint/*"
+        - "@types/*"
+        - "@vitejs/*"
+        - "eslint*"
+        - "globals"
+        - "typescript"
+        - "typescript-eslint"
+        - "vite"
     groups:
-      typescript-tooling:
+      tachimint-prod-deps:
+        dependency-type: production
         patterns:
-          - "typescript"
-          - "@typescript-eslint/*"
-          - "eslint*"
-          - "@eslint/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react*"
-      vite:
-        patterns:
-          - "vite"
-          - "@vitejs/*"
-      deps:
+          - "*"
+      tachimint-dev-tooling:
+        dependency-type: development
         patterns:
           - "*"

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -100,6 +100,7 @@ jobs:
 
             const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]', '[infra]', '[chore]']
             const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
+            const isInfraOrChore = titlePrefix === '[infra]' || titlePrefix === '[chore]'
             const hasSourceOfTruth = /(?:^|\n)\s*-?\s*Source of truth\s*[：:]/i.test(body)
             const hasExplicitNonGoals = body.includes('本 PR 明確不做')
             const dependsOnMatch = body.match(/(?:^|\n)\s*-?\s*Depends on PR\s*[：:]\s*(.+)/i)
@@ -126,27 +127,25 @@ jobs:
                 policyFailures.push('`[release]` PR is reserved for formal `develop -> main` promotion PRs only.')
               }
 
-              if (!isReleasePromotionPr && !/#\d+/.test(body)) {
+              if (!isReleasePromotionPr && !isInfraOrChore && !/#\d+/.test(body)) {
                 policyFailures.push('PR body must reference at least one issue or PR number such as `#123`.')
               }
 
-              if (!hasSourceOfTruth) {
+              if (!isInfraOrChore && !hasSourceOfTruth) {
                 policyFailures.push('PR body must include a `Source of truth` line in the Scope 對齊 section.')
               }
 
-              if (!hasExplicitNonGoals) {
+              if (!isInfraOrChore && !hasExplicitNonGoals) {
                 policyFailures.push('PR body must include a `本 PR 明確不做` section.')
               }
 
-              if (!dependsOnRaw) {
+              if (!isInfraOrChore && !dependsOnRaw) {
                 policyFailures.push('PR body must include a `Depends on PR` line with `none` or `#123`.')
               }
 
-              if (dependsOnRaw && !dependsOnNone && !dependsOnPrMatch) {
+              if (!isInfraOrChore && dependsOnRaw && !dependsOnNone && !dependsOnPrMatch) {
                 policyFailures.push('`Depends on PR` must be `none` or a single PR number such as `#123`.')
               }
-
-              const isInfraOrChore = titlePrefix === '[infra]' || titlePrefix === '[chore]'
 
               if (!isInfraOrChore && !isDocsTemplateOrMetadataOnly) {
                 if (!backendContractYes && !backendContractNo) {

--- a/docs/dependabot-update-policy.md
+++ b/docs/dependabot-update-policy.md
@@ -1,0 +1,66 @@
+# Dependabot Update Policy
+
+This repo uses Dependabot to keep Go and pnpm dependencies current without
+turning routine tooling churn into review noise.
+
+## Package Ecosystems
+
+Dependabot uses `package-ecosystem: npm` for npm, yarn, and pnpm projects.
+The dashboard and Twitch extension are pnpm projects because each directory has
+its own `pnpm-lock.yaml`:
+
+- `dashboard/pnpm-lock.yaml`
+- `tachimint/pnpm-lock.yaml`
+
+Do not change these entries to a non-existent `pnpm` ecosystem name.
+
+## Scheduling
+
+Version updates target `develop` and run on Monday morning in `Asia/Taipei`:
+
+- `/backend`: 09:00
+- `/dashboard`: 09:30
+- `/tachimint`: 10:00
+
+Each ecosystem has `open-pull-requests-limit: 2` so Dependabot cannot flood the
+queue when many packages release close together.
+
+## Grouping
+
+Dependency updates are grouped by review shape:
+
+- Go modules in `/backend` are grouped into `backend-go-deps`.
+- Dashboard pnpm updates are split into production and development groups.
+- Tachimint pnpm updates are split into production and development groups.
+
+The production/development split keeps runtime dependency updates visible while
+still batching development tooling changes such as TypeScript, ESLint, Vite, and
+test tooling.
+
+## Cooldown
+
+High-frequency frontend tooling updates use Dependabot cooldown:
+
+- patch updates: 21 days
+- minor updates: 21 days
+- major updates: 30 days
+
+This applies to common development tooling packages such as `typescript`,
+`eslint*`, `@types/*`, `@vitejs/*`, `vite`, and related dashboard test/build
+tooling.
+
+The goal is to let small toolchain releases settle before opening PRs, while
+still allowing security alerts and runtime dependency updates to remain visible.
+
+## Auto-Merge Boundary
+
+The `dependabot-automerge.yml` workflow remains conservative:
+
+- security updates may auto-merge when checks pass
+- updates explicitly labeled `safe-to-automerge` may auto-merge when checks pass
+- selected direct development patch/minor updates may auto-merge
+- production dependency updates, major updates, and excluded tooling packages do
+  not auto-merge by default
+
+If a Dependabot PR touches runtime behavior or a production dependency, review it
+as a normal PR instead of relying on automation.


### PR DESCRIPTION
## Summary

- group backend Go and frontend pnpm Dependabot updates by review shape
- add cooldown for noisy frontend development tooling updates
- limit concurrent Dependabot PRs per ecosystem
- document the dependency update policy in docs/dependabot-update-policy.md

## Validation

- Parsed .github/dependabot.yml with Ruby YAML loader
- Reviewed staged diff before commit

Closes #301