### PR TITLE
[backend] feat: Twitch API 訂閱名單同步 (#228)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -144,6 +144,9 @@ func main() {
 	}
 	claimSvc := services.NewClaimService(db, cfg.Contract, ethClient)
 	spendSvc := services.NewSpendService(db, cfg.Contract, ethClient)
+	if cfg.Server.Env == "production" && cfg.OAuth.Twitch.ClientID == "" {
+		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
+	}
 	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID)
 	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -144,7 +144,7 @@ func main() {
 	}
 	claimSvc := services.NewClaimService(db, cfg.Contract, ethClient)
 	spendSvc := services.NewSpendService(db, cfg.Contract, ethClient)
-	raffleSvc := services.NewRaffleService(db)
+	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID)
 	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	// CORS origins from env, default to localhost for dev

--- a/backend/internal/handlers/raffle_handler.go
+++ b/backend/internal/handlers/raffle_handler.go
@@ -428,6 +428,8 @@ func (h *RaffleHandler) Snapshot(c *gin.Context) {
 			badRequest(c, "no twitch access token: streamer must log in via twitch")
 		case errors.Is(err, services.ErrTwitchInsufficientScope):
 			badRequest(c, "insufficient twitch scope: requires channel:read:subscriptions")
+		case errors.Is(err, services.ErrUnsupportedRaffleSource):
+			badRequest(c, "raffle source must be twitch_api to use snapshot sync")
 		default:
 			log.Printf("raffle snapshot: %v", err)
 			internal(c)

--- a/backend/internal/handlers/raffle_handler.go
+++ b/backend/internal/handlers/raffle_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
 
@@ -377,6 +378,63 @@ type publicDrawView struct {
 		TwitchLogin string `json:"twitch_login"`
 		DisplayName string `json:"display_name"`
 	} `json:"entry"`
+}
+
+// Snapshot godoc
+// @Summary      Sync raffle entries from Twitch subscriber list
+// @Tags         raffles
+// @Security     BearerAuth
+// @Accept       json
+// @Produce      json
+// @Param        id   path string true "Raffle ID"
+// @Param        body body object{source=string} true "source must be twitch_api"
+// @Success      200  {object}  Response
+// @Failure      400  {object}  Response
+// @Router       /dashboard/raffles/{id}/snapshot [post]
+func (h *RaffleHandler) Snapshot(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+
+	raffleID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid raffle id")
+		return
+	}
+
+	var body struct {
+		Source string `json:"source" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+	if body.Source != string(models.RaffleSourceTwitchAPI) {
+		badRequest(c, "unsupported source: must be twitch_api")
+		return
+	}
+
+	result, err := h.raffleSvc.SyncFromTwitchAPI(c.Request.Context(), raffleID, userID)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrRaffleNotFound):
+			notFound(c, "raffle not found")
+		case errors.Is(err, services.ErrRaffleForbidden):
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		case errors.Is(err, services.ErrTwitchTokenMissing):
+			badRequest(c, "no twitch access token: streamer must log in via twitch")
+		case errors.Is(err, services.ErrTwitchInsufficientScope):
+			badRequest(c, "insufficient twitch scope: requires channel:read:subscriptions")
+		default:
+			log.Printf("raffle snapshot: %v", err)
+			internal(c)
+		}
+		return
+	}
+	ok(c, gin.H{"result": result})
 }
 
 // GetResult godoc

--- a/backend/internal/handlers/raffle_handler_test.go
+++ b/backend/internal/handlers/raffle_handler_test.go
@@ -613,41 +613,31 @@ func TestRaffle_Snapshot_TwitchScopeError(t *testing.T) {
 	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
 	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
 
-	createBody, _ := json.Marshal(map[string]string{"title": "test raffle"})
-	wc := httptest.NewRecorder()
-	rc, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(createBody))
-	rc.Header.Set("Content-Type", "application/json")
-	rc.Header.Set("Authorization", bearer(token))
-	env.router.ServeHTTP(wc, rc)
-	if wc.Code != http.StatusCreated {
-		t.Fatalf("create raffle: %d", wc.Code)
-	}
-	raffleID := parseBody(t, wc.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
-
-	// give streamer a Twitch provider with access token
-	streamerUser, _, _ := env.authSvc.Register(services.RegisterInput{Username: "tw_s1", Email: "tw@test.com", Password: "pass1234"})
-	at := "fake-token"
-	provID, _ := uuid.NewV7()
-	_ = env.db.Exec(
-		`INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, created_at, updated_at) VALUES (?, ?, 'twitch', 'twitch_broadcaster_1', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-		provID.String(), streamerUser.ID.String(), at,
-	)
-	// attach the twitch provider to the streamer (reuse streamer's user_id)
-	streamerUserID := parseBody(t, wc.Body.Bytes()) // just get the raffle owner
-	_ = streamerUserID
-	// simpler: insert auth_provider for the streamer who owns the raffle
-	// look up the owner from raffle table
+	// Look up the streamer's user ID and insert a twitch_api raffle directly.
 	var ownerID string
-	_ = env.db.Raw("SELECT user_id FROM raffles WHERE id = ?", raffleID).Scan(&ownerID)
-	provID2, _ := uuid.NewV7()
-	_ = env.db.Exec(
-		`INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, created_at, updated_at) VALUES (?, ?, 'twitch', 'twitch_broadcaster_owner', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-		provID2.String(), ownerID, at,
-	)
+	if err := env.db.Raw("SELECT id FROM users WHERE email = ?", "s1@test.com").Scan(&ownerID).Error; err != nil || ownerID == "" {
+		t.Fatalf("get owner id: %v", err)
+	}
+	raffleID, _ := uuid.NewV7()
+	if err := env.db.Exec(
+		`INSERT INTO raffles (id, user_id, title, status, source, created_at, updated_at) VALUES (?, ?, 'test raffle', 'draft', 'twitch_api', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		raffleID.String(), ownerID,
+	).Error; err != nil {
+		t.Fatalf("insert raffle: %v", err)
+	}
+
+	// Give the streamer a Twitch auth_provider with an access token.
+	provID, _ := uuid.NewV7()
+	if err := env.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, created_at, updated_at) VALUES (?, ?, 'twitch', 'twitch_broadcaster_owner', 'fake-token', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		provID.String(), ownerID,
+	).Error; err != nil {
+		t.Fatalf("insert auth_provider: %v", err)
+	}
 
 	body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/snapshot", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID.String()+"/snapshot", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", bearer(token))
 	env.router.ServeHTTP(w, req)

--- a/backend/internal/handlers/raffle_handler_test.go
+++ b/backend/internal/handlers/raffle_handler_test.go
@@ -649,3 +649,199 @@ func TestRaffle_Snapshot_TwitchScopeError(t *testing.T) {
 		t.Errorf("expected scope error message, got: %v", msg)
 	}
 }
+
+// setupTwitchRaffle inserts a twitch_api raffle and a Twitch auth_provider for
+// the streamer identified by email, returning the raffle UUID string.
+func (e *raffleTestEnv) setupTwitchRaffle(t *testing.T, email, accessToken string) string {
+	t.Helper()
+	var ownerID string
+	if err := e.db.Raw("SELECT id FROM users WHERE email = ?", email).Scan(&ownerID).Error; err != nil || ownerID == "" {
+		t.Fatalf("setupTwitchRaffle: get owner: %v", err)
+	}
+	raffleID, _ := uuid.NewV7()
+	if err := e.db.Exec(
+		`INSERT INTO raffles (id, user_id, title, status, source, created_at, updated_at) VALUES (?, ?, 'twitch raffle', 'draft', 'twitch_api', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		raffleID.String(), ownerID,
+	).Error; err != nil {
+		t.Fatalf("setupTwitchRaffle: insert raffle: %v", err)
+	}
+	provID, _ := uuid.NewV7()
+	if err := e.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, created_at, updated_at) VALUES (?, ?, 'twitch', 'broadcaster_id_1', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		provID.String(), ownerID, accessToken,
+	).Error; err != nil {
+		t.Fatalf("setupTwitchRaffle: insert auth_provider: %v", err)
+	}
+	return raffleID.String()
+}
+
+// twitchSubsJSON returns a Twitch helix/subscriptions JSON response.
+func twitchSubsJSON(subs []map[string]string, cursor string) string {
+	items := ""
+	for i, s := range subs {
+		if i > 0 {
+			items += ","
+		}
+		items += fmt.Sprintf(`{"user_id":%q,"user_login":%q,"user_name":%q}`, s["user_id"], s["user_login"], s["user_name"])
+	}
+	pag := `"pagination":{}`
+	if cursor != "" {
+		pag = fmt.Sprintf(`"pagination":{"cursor":%q}`, cursor)
+	}
+	return fmt.Sprintf(`{"data":[%s],%s}`, items, pag)
+}
+
+func TestRaffle_Snapshot_Success(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
+
+	// Create a tachigo user linked to the Twitch subscriber.
+	env.createTwitchLinkedUser(t, "viewer1")
+	// Override provider_id to match what the mock returns.
+	_ = env.db.Exec(`UPDATE auth_providers SET provider_id = 'viewer_twitch_id_1' WHERE provider_id = 'twitch_id_viewer1'`)
+
+	sub := map[string]string{"user_id": "viewer_twitch_id_1", "user_login": "viewer1", "user_name": "Viewer1"}
+	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, twitchSubsJSON([]map[string]string{sub}, ""))
+	}))
+	defer mockTwitch.Close()
+	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
+
+	raffleID := env.setupTwitchRaffle(t, "s1@test.com", "fake-token")
+
+	body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/snapshot", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})
+	result := data["result"].(map[string]interface{})
+	if result["imported"].(float64) != 1 {
+		t.Errorf("want imported=1, got %v", result["imported"])
+	}
+	if result["skipped"].(float64) != 0 {
+		t.Errorf("want skipped=0, got %v", result["skipped"])
+	}
+}
+
+func TestRaffle_Snapshot_Pagination(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
+
+	env.createTwitchLinkedUser(t, "viewer1")
+	env.createTwitchLinkedUser(t, "viewer2")
+	_ = env.db.Exec(`UPDATE auth_providers SET provider_id = 'vid1' WHERE provider_id = 'twitch_id_viewer1'`)
+	_ = env.db.Exec(`UPDATE auth_providers SET provider_id = 'vid2' WHERE provider_id = 'twitch_id_viewer2'`)
+
+	page1 := []map[string]string{{"user_id": "vid1", "user_login": "viewer1", "user_name": "Viewer1"}}
+	page2 := []map[string]string{{"user_id": "vid2", "user_login": "viewer2", "user_name": "Viewer2"}}
+	calls := 0
+	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		calls++
+		if r.URL.Query().Get("after") == "" {
+			fmt.Fprint(w, twitchSubsJSON(page1, "cursor-page2"))
+		} else {
+			fmt.Fprint(w, twitchSubsJSON(page2, ""))
+		}
+	}))
+	defer mockTwitch.Close()
+	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
+
+	raffleID := env.setupTwitchRaffle(t, "s1@test.com", "fake-token")
+
+	body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/snapshot", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if calls != 2 {
+		t.Errorf("want 2 Twitch API calls (pagination), got %d", calls)
+	}
+	result := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["result"].(map[string]interface{})
+	if result["imported"].(float64) != 2 {
+		t.Errorf("want imported=2, got %v", result["imported"])
+	}
+}
+
+func TestRaffle_Snapshot_DuplicateSkip(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
+
+	env.createTwitchLinkedUser(t, "viewer1")
+	_ = env.db.Exec(`UPDATE auth_providers SET provider_id = 'vid1' WHERE provider_id = 'twitch_id_viewer1'`)
+
+	sub := map[string]string{"user_id": "vid1", "user_login": "viewer1", "user_name": "Viewer1"}
+	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, twitchSubsJSON([]map[string]string{sub}, ""))
+	}))
+	defer mockTwitch.Close()
+	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
+
+	raffleID := env.setupTwitchRaffle(t, "s1@test.com", "fake-token")
+
+	doSnapshot := func() map[string]interface{} {
+		body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/snapshot", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", bearer(token))
+		env.router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+		}
+		return parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["result"].(map[string]interface{})
+	}
+
+	first := doSnapshot()
+	if first["imported"].(float64) != 1 {
+		t.Errorf("first sync: want imported=1, got %v", first["imported"])
+	}
+	second := doSnapshot()
+	if second["imported"].(float64) != 0 || second["skipped"].(float64) != 1 {
+		t.Errorf("second sync: want imported=0 skipped=1, got %v", second)
+	}
+}
+
+func TestRaffle_Snapshot_UnlinkedSkip(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
+
+	// Subscriber has no tachigo account.
+	sub := map[string]string{"user_id": "unknown_id", "user_login": "stranger", "user_name": "Stranger"}
+	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, twitchSubsJSON([]map[string]string{sub}, ""))
+	}))
+	defer mockTwitch.Close()
+	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
+
+	raffleID := env.setupTwitchRaffle(t, "s1@test.com", "fake-token")
+
+	body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/snapshot", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	result := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["result"].(map[string]interface{})
+	if result["skipped"].(float64) != 1 || result["imported"].(float64) != 0 {
+		t.Errorf("want skipped=1 imported=0, got %v", result)
+	}
+}

--- a/backend/internal/handlers/raffle_handler_test.go
+++ b/backend/internal/handlers/raffle_handler_test.go
@@ -60,7 +60,7 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 
 	cfg := testConfig()
 	authSvc := services.NewAuthService(db, cfg)
-	raffleSvc := services.NewRaffleService(db)
+	raffleSvc := services.NewRaffleService(db, "")
 	raffleH := handlers.NewRaffleHandler(raffleSvc)
 
 	r := gin.New()
@@ -87,6 +87,7 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 	dash.POST("/raffles/:id/draws", raffleH.DrawNext)
 	dash.GET("/raffles/:id/draws", raffleH.ListDraws)
 	dash.POST("/raffles/:id/complete", raffleH.Complete)
+	dash.POST("/raffles/:id/snapshot", raffleH.Snapshot)
 
 	return &raffleTestEnv{db: db, authSvc: authSvc, raffleSvc: raffleSvc, router: r}
 }
@@ -544,5 +545,117 @@ func testConfig() *config.Config {
 			AccessTTL:     15 * time.Minute,
 			RefreshTTL:    30 * 24 * time.Hour,
 		},
+	}
+}
+
+// ── Snapshot tests ────────────────────────────────────────────────────────────
+
+func TestRaffle_Snapshot_Unauthorized(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	w := httptest.NewRecorder()
+	body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+uuid.New().String()+"/snapshot", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_Snapshot_RaffleNotFound(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+uuid.New().String()+"/snapshot", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_Snapshot_NoTwitchToken(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
+
+	createBody, _ := json.Marshal(map[string]string{"title": "test raffle"})
+	wc := httptest.NewRecorder()
+	rc, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(createBody))
+	rc.Header.Set("Content-Type", "application/json")
+	rc.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(wc, rc)
+	if wc.Code != http.StatusCreated {
+		t.Fatalf("create raffle: %d", wc.Code)
+	}
+	raffleID := parseBody(t, wc.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/snapshot", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 (no twitch token), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_Snapshot_TwitchScopeError(t *testing.T) {
+	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer mockTwitch.Close()
+
+	env := newRaffleTestEnv(t)
+	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
+	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
+
+	createBody, _ := json.Marshal(map[string]string{"title": "test raffle"})
+	wc := httptest.NewRecorder()
+	rc, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(createBody))
+	rc.Header.Set("Content-Type", "application/json")
+	rc.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(wc, rc)
+	if wc.Code != http.StatusCreated {
+		t.Fatalf("create raffle: %d", wc.Code)
+	}
+	raffleID := parseBody(t, wc.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	// give streamer a Twitch provider with access token
+	streamerUser, _, _ := env.authSvc.Register(services.RegisterInput{Username: "tw_s1", Email: "tw@test.com", Password: "pass1234"})
+	at := "fake-token"
+	provID, _ := uuid.NewV7()
+	_ = env.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, created_at, updated_at) VALUES (?, ?, 'twitch', 'twitch_broadcaster_1', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		provID.String(), streamerUser.ID.String(), at,
+	)
+	// attach the twitch provider to the streamer (reuse streamer's user_id)
+	streamerUserID := parseBody(t, wc.Body.Bytes()) // just get the raffle owner
+	_ = streamerUserID
+	// simpler: insert auth_provider for the streamer who owns the raffle
+	// look up the owner from raffle table
+	var ownerID string
+	_ = env.db.Raw("SELECT user_id FROM raffles WHERE id = ?", raffleID).Scan(&ownerID)
+	provID2, _ := uuid.NewV7()
+	_ = env.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, created_at, updated_at) VALUES (?, ?, 'twitch', 'twitch_broadcaster_owner', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		provID2.String(), ownerID, at,
+	)
+
+	body, _ := json.Marshal(map[string]string{"source": "twitch_api"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/snapshot", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 (scope error), got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "scope") {
+		t.Errorf("expected scope error message, got: %v", msg)
 	}
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -206,6 +206,9 @@ func New(
 		dashboard.POST("/raffles/:id/complete",
 			middleware.RequireRole(models.RoleStreamer),
 			raffleH.Complete)
+		dashboard.POST("/raffles/:id/snapshot",
+			middleware.RequireRole(models.RoleStreamer),
+			raffleH.Snapshot)
 	}
 
 	dashboardAirdrop := v1.Group("/dashboard/channels/:channel_id")

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -86,7 +86,7 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
 	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
-	raffleSvc := services.NewRaffleService(db)
+	raffleSvc := services.NewRaffleService(db, "")
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(
@@ -442,7 +442,7 @@ func TestInternalRouter_SkipsRouteWhenSharedSecretMissing(t *testing.T) {
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
 	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
-	raffleSvc := services.NewRaffleService(db)
+	raffleSvc := services.NewRaffleService(db, "")
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(
@@ -523,7 +523,7 @@ func TestInternalRouter_WithSecretSet_MiddlewareRejectsAndRouteRegistered(t *tes
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
 	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
-	raffleSvc := services.NewRaffleService(db)
+	raffleSvc := services.NewRaffleService(db, "")
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/tachigo/tachigo/internal/models"
 )
@@ -25,8 +27,9 @@ var (
 	ErrClaimTokenExpired       = errors.New("claim token has expired")
 	ErrClaimNotFound           = errors.New("claim token not found")
 	ErrClaimAlreadyDone        = errors.New("claim already submitted")
-	ErrTwitchTokenMissing      = errors.New("no twitch access token: streamer must log in via twitch")
-	ErrTwitchInsufficientScope = errors.New("twitch token lacks channel:read:subscriptions scope")
+	ErrTwitchTokenMissing       = errors.New("no twitch access token: streamer must log in via twitch")
+	ErrTwitchInsufficientScope  = errors.New("twitch token lacks channel:read:subscriptions scope")
+	ErrUnsupportedRaffleSource  = errors.New("raffle source does not support twitch sync")
 )
 
 const claimTokenTTL = 7 * 24 * time.Hour
@@ -35,13 +38,19 @@ type RaffleService struct {
 	db             *gorm.DB
 	twitchClientID string
 	twitchBaseURL  string
+	httpClient     *http.Client
 }
 
 func NewRaffleService(db *gorm.DB, twitchClientID string) *RaffleService {
-	return &RaffleService{db: db, twitchClientID: twitchClientID, twitchBaseURL: "https://api.twitch.tv"}
+	return &RaffleService{
+		db:             db,
+		twitchClientID: twitchClientID,
+		twitchBaseURL:  "https://api.twitch.tv",
+		httpClient:     &http.Client{Timeout: 10 * time.Second},
+	}
 }
 
-func (s *RaffleService) SetTwitchBaseURL(url string) { s.twitchBaseURL = url }
+func (s *RaffleService) SetTwitchBaseURL(u string) { s.twitchBaseURL = u }
 
 // Create creates a new raffle owned by the given user.
 func (s *RaffleService) Create(userID uuid.UUID, title string) (*models.Raffle, error) {
@@ -355,18 +364,26 @@ type twitchSubsPage struct {
 }
 
 func (s *RaffleService) fetchTwitchSubsPage(ctx context.Context, accessToken, broadcasterID, cursor string) ([]twitchSubscription, string, error) {
-	url := fmt.Sprintf("%s/helix/subscriptions?broadcaster_id=%s&first=100", s.twitchBaseURL, broadcasterID)
-	if cursor != "" {
-		url += "&after=" + cursor
+	endpoint, err := url.Parse(strings.TrimRight(s.twitchBaseURL, "/") + "/helix/subscriptions")
+	if err != nil {
+		return nil, "", err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	q := endpoint.Query()
+	q.Set("broadcaster_id", broadcasterID)
+	q.Set("first", "100")
+	if cursor != "" {
+		q.Set("after", cursor)
+	}
+	endpoint.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return nil, "", err
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Client-Id", s.twitchClientID)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, "", err
 	}
@@ -390,8 +407,12 @@ func (s *RaffleService) fetchTwitchSubsPage(ctx context.Context, accessToken, br
 // and inserts them as RaffleEntry rows (idempotent; duplicates are skipped).
 // Only subscribers who already have a tachigo account are imported.
 func (s *RaffleService) SyncFromTwitchAPI(ctx context.Context, raffleID, userID uuid.UUID) (*SyncFromTwitchResult, error) {
-	if _, err := s.GetByID(raffleID, userID); err != nil {
+	raffle, err := s.GetByID(raffleID, userID)
+	if err != nil {
 		return nil, err
+	}
+	if raffle.Source != models.RaffleSourceTwitchAPI {
+		return nil, ErrUnsupportedRaffleSource
 	}
 
 	var ap models.AuthProvider
@@ -414,17 +435,6 @@ func (s *RaffleService) SyncFromTwitchAPI(ctx context.Context, raffleID, userID 
 		}
 
 		for _, sub := range subs {
-			var count int64
-			if err := s.db.Model(&models.RaffleEntry{}).
-				Where("raffle_id = ? AND twitch_login = ?", raffleID, sub.UserLogin).
-				Count(&count).Error; err != nil {
-				return nil, err
-			}
-			if count > 0 {
-				result.Skipped++
-				continue
-			}
-
 			var provider models.AuthProvider
 			if err := s.db.
 				Joins("JOIN users ON users.id = auth_providers.user_id AND users.deleted_at IS NULL").
@@ -444,8 +454,16 @@ func (s *RaffleService) SyncFromTwitchAPI(ctx context.Context, raffleID, userID 
 				TwitchLogin: sub.UserLogin,
 				DisplayName: sub.UserName,
 			}
-			if err := s.db.Create(entry).Error; err != nil {
-				return nil, err
+			res := s.db.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "raffle_id"}, {Name: "twitch_login"}},
+				DoNothing: true,
+			}).Create(entry)
+			if res.Error != nil {
+				return nil, res.Error
+			}
+			if res.RowsAffected == 0 {
+				result.Skipped++
+				continue
 			}
 			result.Imported++
 		}

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -1,9 +1,13 @@
 package services
 
 import (
+	"context"
 	"encoding/csv"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -14,24 +18,30 @@ import (
 )
 
 var (
-	ErrRaffleNotFound    = errors.New("raffle not found")
-	ErrRaffleForbidden   = errors.New("raffle does not belong to this user")
-	ErrRaffleExhausted   = errors.New("all entries have been drawn")
-	ErrRaffleCompleted   = errors.New("raffle is already completed")
-	ErrClaimTokenExpired = errors.New("claim token has expired")
-	ErrClaimNotFound     = errors.New("claim token not found")
-	ErrClaimAlreadyDone  = errors.New("claim already submitted")
+	ErrRaffleNotFound          = errors.New("raffle not found")
+	ErrRaffleForbidden         = errors.New("raffle does not belong to this user")
+	ErrRaffleExhausted         = errors.New("all entries have been drawn")
+	ErrRaffleCompleted         = errors.New("raffle is already completed")
+	ErrClaimTokenExpired       = errors.New("claim token has expired")
+	ErrClaimNotFound           = errors.New("claim token not found")
+	ErrClaimAlreadyDone        = errors.New("claim already submitted")
+	ErrTwitchTokenMissing      = errors.New("no twitch access token: streamer must log in via twitch")
+	ErrTwitchInsufficientScope = errors.New("twitch token lacks channel:read:subscriptions scope")
 )
 
 const claimTokenTTL = 7 * 24 * time.Hour
 
 type RaffleService struct {
-	db *gorm.DB
+	db             *gorm.DB
+	twitchClientID string
+	twitchBaseURL  string
 }
 
-func NewRaffleService(db *gorm.DB) *RaffleService {
-	return &RaffleService{db: db}
+func NewRaffleService(db *gorm.DB, twitchClientID string) *RaffleService {
+	return &RaffleService{db: db, twitchClientID: twitchClientID, twitchBaseURL: "https://api.twitch.tv"}
 }
+
+func (s *RaffleService) SetTwitchBaseURL(url string) { s.twitchBaseURL = url }
 
 // Create creates a new raffle owned by the given user.
 func (s *RaffleService) Create(userID uuid.UUID, title string) (*models.Raffle, error) {
@@ -322,4 +332,129 @@ func (s *RaffleService) GetDrawsByRafflePublic(raffleID uuid.UUID) ([]models.Raf
 		return []models.RaffleDraw{}, nil
 	}
 	return draws, nil
+}
+
+// ── Twitch API sync ───────────────────────────────────────────────────────────
+
+type SyncFromTwitchResult struct {
+	Imported int `json:"imported"`
+	Skipped  int `json:"skipped"`
+}
+
+type twitchSubscription struct {
+	UserID    string `json:"user_id"`
+	UserLogin string `json:"user_login"`
+	UserName  string `json:"user_name"`
+}
+
+type twitchSubsPage struct {
+	Data       []twitchSubscription `json:"data"`
+	Pagination struct {
+		Cursor string `json:"cursor"`
+	} `json:"pagination"`
+}
+
+func (s *RaffleService) fetchTwitchSubsPage(ctx context.Context, accessToken, broadcasterID, cursor string) ([]twitchSubscription, string, error) {
+	url := fmt.Sprintf("%s/helix/subscriptions?broadcaster_id=%s&first=100", s.twitchBaseURL, broadcasterID)
+	if cursor != "" {
+		url += "&after=" + cursor
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Client-Id", s.twitchClientID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, "", ErrTwitchInsufficientScope
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("twitch api: unexpected status %d", resp.StatusCode)
+	}
+
+	var page twitchSubsPage
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return nil, "", err
+	}
+	return page.Data, page.Pagination.Cursor, nil
+}
+
+// SyncFromTwitchAPI pulls the broadcaster's subscriber list from Twitch Helix
+// and inserts them as RaffleEntry rows (idempotent; duplicates are skipped).
+// Only subscribers who already have a tachigo account are imported.
+func (s *RaffleService) SyncFromTwitchAPI(ctx context.Context, raffleID, userID uuid.UUID) (*SyncFromTwitchResult, error) {
+	if _, err := s.GetByID(raffleID, userID); err != nil {
+		return nil, err
+	}
+
+	var ap models.AuthProvider
+	if err := s.db.Where("user_id = ? AND provider = ?", userID, models.ProviderTwitch).First(&ap).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrTwitchTokenMissing
+		}
+		return nil, err
+	}
+	if ap.AccessToken == nil {
+		return nil, ErrTwitchTokenMissing
+	}
+
+	result := &SyncFromTwitchResult{}
+	cursor := ""
+	for {
+		subs, nextCursor, err := s.fetchTwitchSubsPage(ctx, *ap.AccessToken, ap.ProviderID, cursor)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, sub := range subs {
+			var count int64
+			if err := s.db.Model(&models.RaffleEntry{}).
+				Where("raffle_id = ? AND twitch_login = ?", raffleID, sub.UserLogin).
+				Count(&count).Error; err != nil {
+				return nil, err
+			}
+			if count > 0 {
+				result.Skipped++
+				continue
+			}
+
+			var provider models.AuthProvider
+			if err := s.db.
+				Joins("JOIN users ON users.id = auth_providers.user_id AND users.deleted_at IS NULL").
+				Where("auth_providers.provider = ? AND auth_providers.provider_id = ?", models.ProviderTwitch, sub.UserID).
+				First(&provider).Error; err != nil {
+				if !errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, err
+				}
+				result.Skipped++
+				continue
+			}
+
+			uid := provider.UserID
+			entry := &models.RaffleEntry{
+				RaffleID:    raffleID,
+				UserID:      &uid,
+				TwitchLogin: sub.UserLogin,
+				DisplayName: sub.UserName,
+			}
+			if err := s.db.Create(entry).Error; err != nil {
+				return nil, err
+			}
+			result.Imported++
+		}
+
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
## 什麼改動

實作 Twitch Helix API 訂閱名單同步：`RaffleService.SyncFromTwitchAPI` + `POST /dashboard/raffles/:id/snapshot` endpoint。

## 為什麼

抽獎系統支援兩種名單來源，CSV 匯入已在 #227 完成，本票實作 Twitch API 自動同步，主播不需手動下載訂閱者清單。closes #228

## Release Context
- Release type：n/a

## Scope 對齊

- Source of truth：#228
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作排程自動觸發
  - 不修改 CSV 匯入流程
  - 不修改領獎驗證邏輯（已另開 #303）
  - 不修改 tachimint / dashboard UI

## 超出範圍內容

無。領獎驗證改善（需要登入才能領）已獨立開 #303。

## 測試方式
- [x] build 通過（`go build ./...`）
- [x] 有寫測試：4 個 snapshot handler 單元測試（unauthorized、not found、no twitch token、scope error + mock Twitch server）
- [ ] Docker 整合測試（`go test -tags integration ./...`）需在 CI 驗證

## 備註

- `NewRaffleService` 新增 `twitchClientID` 參數（router_test / handler_test 傳 `""`）
- `SetTwitchBaseURL` 方法供測試注入 mock server
- Twitch token 只在 server 端使用，不回傳 client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了从 Twitch API 同步抽奖条目的功能，主播现在可以直接将 Twitch 订阅者同步到其抽奖中
  * 为已认证的主播用户提供新的仪表板端点以触发同步操作

* **错误处理改进**
  * 改进了 Twitch 令牌缺失或权限不足时的错误响应

<!-- end of auto-generated comment: release notes by coderabbit.ai -->