### PR TITLE
[backend] Issue #258 PR1: claims schema & model foundation

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -69,6 +69,9 @@ func main() {
 		&models.BroadcastTimeLog{},
 		// Tachi token balance — refs #103
 		&models.TachiBalance{},
+		// Claim lifecycle
+		&models.Claim{},
+		&models.ClaimItem{},
 		// Agency management — refs #99
 		&models.AgencyStreamer{},
 	); err != nil {

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -160,6 +160,40 @@ func migrateTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE TABLE IF NOT EXISTS claims (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			wallet_addr TEXT NOT NULL,
+			amount INTEGER NOT NULL CHECK (amount > 0),
+			status TEXT NOT NULL CHECK (status IN ('pending', 'broadcast', 'confirmed', 'failed')),
+			tx_hash TEXT,
+			error_message TEXT,
+			broadcast_at DATETIME,
+			confirmed_at DATETIME,
+			failed_at DATETIME,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
+			ON claims (user_id, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
+			ON claims (status, created_at DESC)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_tx_hash_not_null
+			ON claims (tx_hash)
+			WHERE tx_hash IS NOT NULL`,
+		`CREATE TABLE IF NOT EXISTS claim_items (
+			id TEXT PRIMARY KEY,
+			claim_id TEXT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
+			points_transaction_id TEXT NOT NULL REFERENCES points_transactions(id),
+			amount INTEGER NOT NULL CHECK (amount > 0),
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE (points_transaction_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id
+			ON claim_items (claim_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_claim_items_ledger_id
+			ON claim_items (ledger_id)`,
 		`CREATE TABLE IF NOT EXISTS watch_time_stats (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),

--- a/backend/internal/models/claim.go
+++ b/backend/internal/models/claim.go
@@ -7,6 +7,8 @@ import (
 	"gorm.io/gorm"
 )
 
+var uuidV7Func = uuid.NewV7
+
 type ClaimStatus string
 
 const (
@@ -37,7 +39,10 @@ type Claim struct {
 
 func (c *Claim) BeforeCreate(tx *gorm.DB) error {
 	if c.ID == uuid.Nil {
-		id, _ := uuid.NewV7()
+		id, err := uuidV7Func()
+		if err != nil {
+			id = uuid.New()
+		}
 		c.ID = id
 	}
 	return nil
@@ -59,7 +64,10 @@ type ClaimItem struct {
 
 func (c *ClaimItem) BeforeCreate(tx *gorm.DB) error {
 	if c.ID == uuid.Nil {
-		id, _ := uuid.NewV7()
+		id, err := uuidV7Func()
+		if err != nil {
+			id = uuid.New()
+		}
 		c.ID = id
 	}
 	return nil

--- a/backend/internal/models/claim.go
+++ b/backend/internal/models/claim.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type ClaimStatus string
+
+const (
+	ClaimStatusPending   ClaimStatus = "pending"
+	ClaimStatusBroadcast ClaimStatus = "broadcast"
+	ClaimStatusConfirmed ClaimStatus = "confirmed"
+	ClaimStatusFailed    ClaimStatus = "failed"
+)
+
+// Claim tracks a single on-chain mint request lifecycle.
+type Claim struct {
+	ID           uuid.UUID   `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"                                                          json:"id"`
+	UserID       uuid.UUID   `gorm:"type:uuid;not null;index:idx_claims_user_created_at,priority:1"                                         json:"user_id"`
+	WalletAddr   string      `gorm:"type:varchar(42);not null"                                                                               json:"wallet_addr"`
+	Amount       int64       `gorm:"not null;check:chk_claim_amount_gt_0,amount > 0"                                                        json:"amount"`
+	Status       ClaimStatus `gorm:"type:varchar(20);not null;index:idx_claims_status_created_at,priority:1;check:chk_claim_status,status IN ('pending','broadcast','confirmed','failed')" json:"status"`
+	TxHash       *string     `gorm:"type:varchar(66)"                                                                                         json:"tx_hash"`
+	ErrorMessage *string     `gorm:"type:text"                                                                                                json:"error_message"`
+	BroadcastAt  *time.Time  `                                                                                                                json:"broadcast_at"`
+	ConfirmedAt  *time.Time  `                                                                                                                json:"confirmed_at"`
+	FailedAt     *time.Time  `                                                                                                                json:"failed_at"`
+	CreatedAt    time.Time   `gorm:"index:idx_claims_user_created_at,priority:2;index:idx_claims_status_created_at,priority:2"             json:"created_at"`
+	UpdatedAt    time.Time   `                                                                                                                json:"updated_at"`
+
+	User  User        `gorm:"foreignKey:UserID" json:"-"`
+	Items []ClaimItem `gorm:"foreignKey:ClaimID" json:"items,omitempty"`
+}
+
+func (c *Claim) BeforeCreate(tx *gorm.DB) error {
+	if c.ID == uuid.Nil {
+		id, _ := uuid.NewV7()
+		c.ID = id
+	}
+	return nil
+}
+
+// ClaimItem stores per-ledger deduction rows that belong to a claim request.
+type ClaimItem struct {
+	ID                  uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"                 json:"id"`
+	ClaimID             uuid.UUID `gorm:"type:uuid;not null;index"                                        json:"claim_id"`
+	LedgerID            uuid.UUID `gorm:"type:uuid;not null;index"                                        json:"ledger_id"`
+	PointsTransactionID uuid.UUID `gorm:"type:uuid;not null;uniqueIndex"                                  json:"points_transaction_id"`
+	Amount              int64     `gorm:"not null;check:chk_claim_item_amount_gt_0,amount > 0"           json:"amount"`
+	CreatedAt           time.Time `                                                                        json:"created_at"`
+
+	Claim             Claim             `gorm:"foreignKey:ClaimID"             json:"-"`
+	Ledger            PointsLedger      `gorm:"foreignKey:LedgerID"            json:"-"`
+	PointsTransaction PointsTransaction `gorm:"foreignKey:PointsTransactionID" json:"-"`
+}
+
+func (c *ClaimItem) BeforeCreate(tx *gorm.DB) error {
+	if c.ID == uuid.Nil {
+		id, _ := uuid.NewV7()
+		c.ID = id
+	}
+	return nil
+}

--- a/backend/internal/models/claim_test.go
+++ b/backend/internal/models/claim_test.go
@@ -1,6 +1,11 @@
 package models
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
 
 func TestClaimStatusValues(t *testing.T) {
 	tests := []struct {
@@ -18,5 +23,37 @@ func TestClaimStatusValues(t *testing.T) {
 		if string(tc.got) != tc.want {
 			t.Fatalf("%s: want %q, got %q", tc.name, tc.want, tc.got)
 		}
+	}
+}
+
+func TestClaimBeforeCreate_UsesFallbackUUIDWhenV7Fails(t *testing.T) {
+	orig := uuidV7Func
+	uuidV7Func = func() (uuid.UUID, error) {
+		return uuid.Nil, errors.New("boom")
+	}
+	t.Cleanup(func() { uuidV7Func = orig })
+
+	c := &Claim{}
+	if err := c.BeforeCreate(nil); err != nil {
+		t.Fatalf("before create: %v", err)
+	}
+	if c.ID.String() == "00000000-0000-0000-0000-000000000000" {
+		t.Fatalf("expected non-nil UUID fallback")
+	}
+}
+
+func TestClaimItemBeforeCreate_UsesFallbackUUIDWhenV7Fails(t *testing.T) {
+	orig := uuidV7Func
+	uuidV7Func = func() (uuid.UUID, error) {
+		return uuid.Nil, errors.New("boom")
+	}
+	t.Cleanup(func() { uuidV7Func = orig })
+
+	c := &ClaimItem{}
+	if err := c.BeforeCreate(nil); err != nil {
+		t.Fatalf("before create: %v", err)
+	}
+	if c.ID.String() == "00000000-0000-0000-0000-000000000000" {
+		t.Fatalf("expected non-nil UUID fallback")
 	}
 }

--- a/backend/internal/models/claim_test.go
+++ b/backend/internal/models/claim_test.go
@@ -1,0 +1,22 @@
+package models
+
+import "testing"
+
+func TestClaimStatusValues(t *testing.T) {
+	tests := []struct {
+		name string
+		got  ClaimStatus
+		want string
+	}{
+		{name: "pending", got: ClaimStatusPending, want: "pending"},
+		{name: "broadcast", got: ClaimStatusBroadcast, want: "broadcast"},
+		{name: "confirmed", got: ClaimStatusConfirmed, want: "confirmed"},
+		{name: "failed", got: ClaimStatusFailed, want: "failed"},
+	}
+
+	for _, tc := range tests {
+		if string(tc.got) != tc.want {
+			t.Fatalf("%s: want %q, got %q", tc.name, tc.want, tc.got)
+		}
+	}
+}

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -251,6 +251,40 @@ func migrateTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE TABLE IF NOT EXISTS claims (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			wallet_addr TEXT NOT NULL,
+			amount INTEGER NOT NULL CHECK (amount > 0),
+			status TEXT NOT NULL CHECK (status IN ('pending', 'broadcast', 'confirmed', 'failed')),
+			tx_hash TEXT,
+			error_message TEXT,
+			broadcast_at DATETIME,
+			confirmed_at DATETIME,
+			failed_at DATETIME,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
+			ON claims (user_id, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
+			ON claims (status, created_at DESC)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_tx_hash_not_null
+			ON claims (tx_hash)
+			WHERE tx_hash IS NOT NULL`,
+		`CREATE TABLE IF NOT EXISTS claim_items (
+			id TEXT PRIMARY KEY,
+			claim_id TEXT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
+			points_transaction_id TEXT NOT NULL REFERENCES points_transactions(id),
+			amount INTEGER NOT NULL CHECK (amount > 0),
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE (points_transaction_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id
+			ON claim_items (claim_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_claim_items_ledger_id
+			ON claim_items (ledger_id)`,
 		`CREATE TABLE IF NOT EXISTS watch_time_stats (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),

--- a/backend/internal/services/claim_schema_test.go
+++ b/backend/internal/services/claim_schema_test.go
@@ -1,6 +1,11 @@
 package services
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"gorm.io/gorm"
+)
 
 func TestMigrateTestDB_CreatesClaimTables(t *testing.T) {
 	db := newTestDB(t)
@@ -19,5 +24,41 @@ func TestMigrateTestDB_CreatesClaimTables(t *testing.T) {
 	}
 	if claimItemsCount != 1 {
 		t.Fatalf("expected claim_items table to exist, got count=%d", claimItemsCount)
+	}
+
+	var claimsDDL string
+	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'claims'").Scan(&claimsDDL).Error; err != nil {
+		t.Fatalf("query claims ddl: %v", err)
+	}
+	assertContains(t, claimsDDL, "CHECK (amount > 0)")
+	assertContains(t, claimsDDL, "CHECK (status IN ('pending', 'broadcast', 'confirmed', 'failed'))")
+	assertContains(t, claimsDDL, "created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP")
+	assertContains(t, claimsDDL, "updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP")
+
+	var claimItemsDDL string
+	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'claim_items'").Scan(&claimItemsDDL).Error; err != nil {
+		t.Fatalf("query claim_items ddl: %v", err)
+	}
+	assertContains(t, claimItemsDDL, "UNIQUE (points_transaction_id)")
+
+	assertIndexExists(t, db, "idx_claims_tx_hash_not_null")
+}
+
+func assertIndexExists(t *testing.T, db *gorm.DB, name string) {
+	t.Helper()
+
+	var n int64
+	if err := db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", name).Scan(&n).Error; err != nil {
+		t.Fatalf("query index %s: %v", name, err)
+	}
+	if n != 1 {
+		t.Fatalf("expected index %s to exist, got count=%d", name, n)
+	}
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected DDL to contain %q\nDDL=%s", want, got)
 	}
 }

--- a/backend/internal/services/claim_schema_test.go
+++ b/backend/internal/services/claim_schema_test.go
@@ -1,0 +1,23 @@
+package services
+
+import "testing"
+
+func TestMigrateTestDB_CreatesClaimTables(t *testing.T) {
+	db := newTestDB(t)
+
+	var claimsCount int64
+	if err := db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'claims'").Scan(&claimsCount).Error; err != nil {
+		t.Fatalf("query claims table: %v", err)
+	}
+	if claimsCount != 1 {
+		t.Fatalf("expected claims table to exist, got count=%d", claimsCount)
+	}
+
+	var claimItemsCount int64
+	if err := db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'claim_items'").Scan(&claimItemsCount).Error; err != nil {
+		t.Fatalf("query claim_items table: %v", err)
+	}
+	if claimItemsCount != 1 {
+		t.Fatalf("expected claim_items table to exist, got count=%d", claimItemsCount)
+	}
+}

--- a/backend/internal/services/testutil_pg_test.go
+++ b/backend/internal/services/testutil_pg_test.go
@@ -132,6 +132,40 @@ func migratePGTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at TIMESTAMPTZ
 		)`,
+		`CREATE TABLE IF NOT EXISTS claims (
+			id UUID PRIMARY KEY,
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			wallet_addr VARCHAR(42) NOT NULL,
+			amount BIGINT NOT NULL CHECK (amount > 0),
+			status VARCHAR(20) NOT NULL CHECK (status IN ('pending', 'broadcast', 'confirmed', 'failed')),
+			tx_hash VARCHAR(66),
+			error_message TEXT,
+			broadcast_at TIMESTAMPTZ,
+			confirmed_at TIMESTAMPTZ,
+			failed_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
+			ON claims (user_id, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
+			ON claims (status, created_at DESC)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_tx_hash_not_null
+			ON claims (tx_hash)
+			WHERE tx_hash IS NOT NULL`,
+		`CREATE TABLE IF NOT EXISTS claim_items (
+			id UUID PRIMARY KEY,
+			claim_id UUID NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+			ledger_id UUID NOT NULL REFERENCES points_ledgers(id),
+			points_transaction_id UUID NOT NULL REFERENCES points_transactions(id),
+			amount BIGINT NOT NULL CHECK (amount > 0),
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (points_transaction_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id
+			ON claim_items (claim_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_claim_items_ledger_id
+			ON claim_items (ledger_id)`,
 	}
 
 	for _, stmt := range stmts {

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -188,8 +188,8 @@ func migrateTestDB(db *gorm.DB) error {
 			broadcast_at DATETIME,
 			confirmed_at DATETIME,
 			failed_at DATETIME,
-			created_at DATETIME,
-			updated_at DATETIME
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
 			ON claims (user_id, created_at DESC)`,
@@ -204,7 +204,7 @@ func migrateTestDB(db *gorm.DB) error {
 			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
 			points_transaction_id TEXT NOT NULL REFERENCES points_transactions(id),
 			amount INTEGER NOT NULL CHECK (amount > 0),
-			created_at DATETIME,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			UNIQUE (points_transaction_id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -177,6 +177,40 @@ func migrateTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at DATETIME
 		)`,
+		`CREATE TABLE IF NOT EXISTS claims (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			wallet_addr TEXT NOT NULL,
+			amount INTEGER NOT NULL CHECK (amount > 0),
+			status TEXT NOT NULL CHECK (status IN ('pending', 'broadcast', 'confirmed', 'failed')),
+			tx_hash TEXT,
+			error_message TEXT,
+			broadcast_at DATETIME,
+			confirmed_at DATETIME,
+			failed_at DATETIME,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
+			ON claims (user_id, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
+			ON claims (status, created_at DESC)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_tx_hash_not_null
+			ON claims (tx_hash)
+			WHERE tx_hash IS NOT NULL`,
+		`CREATE TABLE IF NOT EXISTS claim_items (
+			id TEXT PRIMARY KEY,
+			claim_id TEXT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
+			points_transaction_id TEXT NOT NULL REFERENCES points_transactions(id),
+			amount INTEGER NOT NULL CHECK (amount > 0),
+			created_at DATETIME,
+			UNIQUE (points_transaction_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id
+			ON claim_items (claim_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_claim_items_ledger_id
+			ON claim_items (ledger_id)`,
 		`CREATE TABLE IF NOT EXISTS watch_time_stats (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL,

--- a/backend/migrations/015_claims.sql
+++ b/backend/migrations/015_claims.sql
@@ -1,0 +1,42 @@
+-- Creates claim lifecycle tables used to track pending/broadcast/confirmed/failed states.
+
+CREATE TABLE IF NOT EXISTS claims (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    wallet_addr   VARCHAR(42) NOT NULL,
+    amount        BIGINT NOT NULL CHECK (amount > 0),
+    status        VARCHAR(20) NOT NULL CHECK (status IN ('pending', 'broadcast', 'confirmed', 'failed')),
+    tx_hash       VARCHAR(66),
+    error_message TEXT,
+    broadcast_at  TIMESTAMPTZ,
+    confirmed_at  TIMESTAMPTZ,
+    failed_at     TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
+    ON claims (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
+    ON claims (status, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_tx_hash_not_null
+    ON claims (tx_hash)
+    WHERE tx_hash IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS claim_items (
+    id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    claim_id               UUID NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+    ledger_id              UUID NOT NULL REFERENCES points_ledgers(id),
+    points_transaction_id  UUID NOT NULL REFERENCES points_transactions(id),
+    amount                 BIGINT NOT NULL CHECK (amount > 0),
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (points_transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id
+    ON claim_items (claim_id);
+
+CREATE INDEX IF NOT EXISTS idx_claim_items_ledger_id
+    ON claim_items (ledger_id);


### PR DESCRIPTION
## 什麼改動
- 新增 claims / claim_items schema（含狀態、tx hash、錯誤資訊、必要索引與約束）
- 新增 Claim / ClaimItem / ClaimStatus model
- 同步 SQLite / Postgres 測試 schema，並補 claim schema 存在性測試
- server AutoMigrate 納入 Claim、ClaimItem

## 為什麼
- refs #258
- 這是 #258 三段拆分中的第一段 PR（Schema & Model Foundation），先建立狀態機資料基礎，讓後續 PR2/PR3 可在不改 API contract 的前提下接續實作。

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#258（issue comment 的 PR 1/3 規劃）
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 claim service 行為
  - 不改 contract wrapper
  - 不改 handler/router API contract
  - 不做 reconciliation job

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 建立 #258 所需的 claims 狀態機 schema 與 model 基礎，並讓測試環境 schema 對齊。
- Approx changed lines：~292
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [x] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試 schema 同步與 AutoMigrate 接線是 schema/model foundation 落地所需的最小配套；未引入 service 行為變更。
- 若已拆分，相關 PR：
  - 後續 PR2：Contract internal mint staging（待開）
  - 後續 PR3：Claim state machine + compensation（待開）

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

執行：
- `go test ./internal/models/... ./internal/services/... ./internal/handlers/... ./internal/router/...`

## 備註
- 本 PR 僅完成 #258 第一部分（foundation），不含行為改動。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 新增声明（Claim）功能的数据库模型和生命周期管理，支持待处理、广播、确认和失败等多个状态
* 创建关联数据库表和优化索引，以支持声明处理流程和查询性能

<!-- end of auto-generated comment: release notes by coderabbit.ai -->