### PR TITLE
[backend] feat: 月底訂閱者快照排程 (#229)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -151,6 +151,7 @@ func main() {
 		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
 	}
 	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID)
+	services.NewRaffleScheduler(raffleSvc).Start(context.Background())
 	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	// CORS origins from env, default to localhost for dev

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -14,7 +14,9 @@ import (
 	"errors"
 	"log"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -151,7 +153,9 @@ func main() {
 		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
 	}
 	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID)
-	services.NewRaffleScheduler(raffleSvc).Start(context.Background())
+	serverCtx, serverStop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer serverStop()
+	services.NewRaffleScheduler(raffleSvc).Start(serverCtx)
 	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	// CORS origins from env, default to localhost for dev

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -153,6 +153,7 @@ func main() {
 		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
 	}
 	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID)
+	// Tie scheduler lifetime to server shutdown signals so the goroutine exits cleanly.
 	serverCtx, serverStop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer serverStop()
 	services.NewRaffleScheduler(raffleSvc).Start(serverCtx)

--- a/backend/internal/services/raffle_scheduler.go
+++ b/backend/internal/services/raffle_scheduler.go
@@ -1,0 +1,46 @@
+package services
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// RaffleScheduler fires RunScheduledSnapshots at 23:55 UTC every day.
+type RaffleScheduler struct {
+	svc *RaffleService
+}
+
+func NewRaffleScheduler(svc *RaffleService) *RaffleScheduler {
+	return &RaffleScheduler{svc: svc}
+}
+
+// Start launches the background goroutine. Stops when ctx is cancelled.
+func (rs *RaffleScheduler) Start(ctx context.Context) {
+	go func() {
+		for {
+			now := time.Now().UTC()
+			next := nextSchedulerRun(now)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(next.Sub(now)):
+				runCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+				if err := rs.svc.RunScheduledSnapshots(runCtx, time.Now().UTC()); err != nil {
+					log.Printf("raffle scheduler: batch error: %v", err)
+				}
+				cancel()
+			}
+		}
+	}()
+}
+
+// nextSchedulerRun returns the next 23:55 UTC after now.
+func nextSchedulerRun(now time.Time) time.Time {
+	today := time.Date(now.Year(), now.Month(), now.Day(), 23, 55, 0, 0, time.UTC)
+	if now.Before(today) {
+		return today
+	}
+	tomorrow := now.AddDate(0, 0, 1)
+	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 23, 55, 0, 0, time.UTC)
+}

--- a/backend/internal/services/raffle_scheduler_test.go
+++ b/backend/internal/services/raffle_scheduler_test.go
@@ -1,0 +1,183 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+func TestNextSchedulerRun(t *testing.T) {
+	utc := time.UTC
+	cases := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "before 23:55 same day",
+			now:  time.Date(2025, 1, 1, 12, 0, 0, 0, utc),
+			want: time.Date(2025, 1, 1, 23, 55, 0, 0, utc),
+		},
+		{
+			name: "one second before 23:55",
+			now:  time.Date(2025, 1, 1, 23, 54, 59, 0, utc),
+			want: time.Date(2025, 1, 1, 23, 55, 0, 0, utc),
+		},
+		{
+			name: "exactly at 23:55 → tomorrow",
+			now:  time.Date(2025, 1, 1, 23, 55, 0, 0, utc),
+			want: time.Date(2025, 1, 2, 23, 55, 0, 0, utc),
+		},
+		{
+			name: "after 23:55 → tomorrow",
+			now:  time.Date(2025, 1, 1, 23, 56, 0, 0, utc),
+			want: time.Date(2025, 1, 2, 23, 55, 0, 0, utc),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextSchedulerRun(tc.now)
+			if !got.Equal(tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunScheduledSnapshots_SkipsOutOfWindow(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "")
+
+	user := insertRaffleTestUser(t, db)
+	scheduledAt := time.Now().UTC().Add(2 * time.Hour)
+	raffle := insertScheduledRaffle(t, db, user.ID, scheduledAt, models.RaffleSourceTwitchAPI)
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var r models.Raffle
+	db.First(&r, "id = ?", raffle.ID)
+	if r.Status != models.RaffleStatusDraft {
+		t.Errorf("expected draft, got %s", r.Status)
+	}
+}
+
+func TestRunScheduledSnapshots_SkipsCompleted(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "")
+
+	user := insertRaffleTestUser(t, db)
+	scheduledAt := time.Now().UTC().Add(5 * time.Minute)
+	raffle := insertScheduledRaffle(t, db, user.ID, scheduledAt, models.RaffleSourceTwitchAPI)
+	db.Model(&models.Raffle{}).Where("id = ?", raffle.ID).Update("status", models.RaffleStatusCompleted)
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var r models.Raffle
+	db.First(&r, "id = ?", raffle.ID)
+	if r.Status != models.RaffleStatusCompleted {
+		t.Errorf("expected completed, got %s", r.Status)
+	}
+}
+
+func TestRunScheduledSnapshots_TwitchAPISuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[],"pagination":{}}`)) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "test-client-id")
+	svc.SetTwitchBaseURL(ts.URL)
+
+	user := insertRaffleTestUser(t, db)
+	insertRaffleTwitchProvider(t, db, user.ID, "broadcaster123", "streamer_token")
+
+	scheduledAt := time.Now().UTC().Add(5 * time.Minute)
+	raffle := insertScheduledRaffle(t, db, user.ID, scheduledAt, models.RaffleSourceTwitchAPI)
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var r models.Raffle
+	db.First(&r, "id = ?", raffle.ID)
+	if r.Status != models.RaffleStatusActive {
+		t.Errorf("expected active after snapshot, got %s", r.Status)
+	}
+}
+
+func TestRunScheduledSnapshots_TwitchTokenMissing_StaysDraft(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "test-client-id")
+
+	user := insertRaffleTestUser(t, db)
+	scheduledAt := time.Now().UTC().Add(5 * time.Minute)
+	raffle := insertScheduledRaffle(t, db, user.ID, scheduledAt, models.RaffleSourceTwitchAPI)
+
+	// Per-raffle errors are logged, not propagated.
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected batch error: %v", err)
+	}
+
+	var r models.Raffle
+	db.First(&r, "id = ?", raffle.ID)
+	if r.Status != models.RaffleStatusDraft {
+		t.Errorf("expected draft after failed snapshot, got %s", r.Status)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func insertRaffleTestUser(t *testing.T, db *gorm.DB) models.User {
+	t.Helper()
+	uname := "raffleuser_" + uuid.New().String()[:8]
+	user := models.User{
+		Username: &uname,
+		Role:     models.RoleViewer,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	return user
+}
+
+func insertRaffleTwitchProvider(t *testing.T, db *gorm.DB, userID uuid.UUID, broadcasterID, token string) {
+	t.Helper()
+	tok := token
+	ap := models.AuthProvider{
+		UserID:     userID,
+		Provider:   models.ProviderTwitch,
+		ProviderID: broadcasterID,
+		AccessToken: &tok,
+	}
+	if err := db.Create(&ap).Error; err != nil {
+		t.Fatalf("insert twitch provider: %v", err)
+	}
+}
+
+func insertScheduledRaffle(t *testing.T, db *gorm.DB, userID uuid.UUID, scheduledAt time.Time, source models.RaffleSource) models.Raffle {
+	t.Helper()
+	raffle := models.Raffle{
+		UserID:      userID,
+		Title:       "Test Raffle",
+		Status:      models.RaffleStatusDraft,
+		Source:      source,
+		ScheduledAt: &scheduledAt,
+	}
+	if err := db.Create(&raffle).Error; err != nil {
+		t.Fatalf("insert raffle: %v", err)
+	}
+	return raffle
+}

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -475,4 +476,37 @@ func (s *RaffleService) SyncFromTwitchAPI(ctx context.Context, raffleID, userID 
 	}
 
 	return result, nil
+}
+
+// ── Scheduled snapshot (cron) ─────────────────────────────────────────────────
+
+// RunScheduledSnapshots finds draft raffles with scheduled_at in [now, now+10min]
+// and triggers their snapshot. Per-raffle errors are logged and do not abort the batch.
+func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time) error {
+	window := now.Add(10 * time.Minute)
+	var raffles []models.Raffle
+	if err := s.db.Where(
+		"status = ? AND scheduled_at IS NOT NULL AND scheduled_at >= ? AND scheduled_at <= ?",
+		models.RaffleStatusDraft, now, window,
+	).Find(&raffles).Error; err != nil {
+		return err
+	}
+	for _, r := range raffles {
+		if err := s.snapshotOne(ctx, r); err != nil {
+			log.Printf("raffle %s snapshot error: %v", r.ID, err)
+		}
+	}
+	return nil
+}
+
+func (s *RaffleService) snapshotOne(ctx context.Context, r models.Raffle) error {
+	switch r.Source {
+	case models.RaffleSourceTwitchAPI:
+		if _, err := s.SyncFromTwitchAPI(ctx, r.ID, r.UserID); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported snapshot source: %s", r.Source)
+	}
+	return s.db.Model(&models.Raffle{}).Where("id = ?", r.ID).Update("status", models.RaffleStatusActive).Error
 }

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -482,6 +482,7 @@ func (s *RaffleService) SyncFromTwitchAPI(ctx context.Context, raffleID, userID 
 
 // RunScheduledSnapshots finds draft raffles with scheduled_at in [now, now+10min]
 // and triggers their snapshot. Per-raffle errors are logged and do not abort the batch.
+// CSV raffles are excluded: they are uploaded manually and have no remote source to sync from.
 func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time) error {
 	window := now.Add(10 * time.Minute)
 	var raffles []models.Raffle
@@ -508,6 +509,7 @@ func (s *RaffleService) snapshotOne(ctx context.Context, r models.Raffle) error 
 	default:
 		return fmt.Errorf("unsupported snapshot source: %s", r.Source)
 	}
+	// Guard against concurrent status changes: only promote if still draft.
 	return s.db.Model(&models.Raffle{}).
 		Where("id = ? AND status = ?", r.ID, models.RaffleStatusDraft).
 		Update("status", models.RaffleStatusActive).Error

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -486,8 +486,8 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 	window := now.Add(10 * time.Minute)
 	var raffles []models.Raffle
 	if err := s.db.Where(
-		"status = ? AND scheduled_at IS NOT NULL AND scheduled_at >= ? AND scheduled_at <= ?",
-		models.RaffleStatusDraft, now, window,
+		"status = ? AND source != ? AND scheduled_at IS NOT NULL AND scheduled_at >= ? AND scheduled_at <= ?",
+		models.RaffleStatusDraft, models.RaffleSourceCSV, now, window,
 	).Find(&raffles).Error; err != nil {
 		return err
 	}
@@ -508,5 +508,7 @@ func (s *RaffleService) snapshotOne(ctx context.Context, r models.Raffle) error 
 	default:
 		return fmt.Errorf("unsupported snapshot source: %s", r.Source)
 	}
-	return s.db.Model(&models.Raffle{}).Where("id = ?", r.ID).Update("status", models.RaffleStatusActive).Error
+	return s.db.Model(&models.Raffle{}).
+		Where("id = ? AND status = ?", r.ID, models.RaffleStatusDraft).
+		Update("status", models.RaffleStatusActive).Error
 }

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -246,6 +246,26 @@ func migrateTestDB(db *gorm.DB) error {
 			UNIQUE (user_id),
 			CHECK (balance >= 0)
 		)`,
+		`CREATE TABLE IF NOT EXISTS raffles (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			title TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'draft',
+			source TEXT NOT NULL DEFAULT 'csv',
+			scheduled_at DATETIME,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE TABLE IF NOT EXISTS raffle_entries (
+			id TEXT PRIMARY KEY,
+			raffle_id TEXT NOT NULL REFERENCES raffles(id),
+			user_id TEXT REFERENCES users(id),
+			twitch_login TEXT NOT NULL,
+			display_name TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE (raffle_id, twitch_login),
+			UNIQUE (id, raffle_id)
+		)`,
 	}
 	for _, s := range stmts {
 		if err := db.Exec(s).Error; err != nil {


### PR DESCRIPTION
## 什麼改動
新增 `RaffleScheduler`，每日 23:55 UTC 自動觸發 `RunScheduledSnapshots`，掃描 `status=draft` 且 `scheduled_at` 在 10 分鐘視窗內的 raffles 並執行 snapshot，成功後標記為 `active`。

## 為什麼
closes #229

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#229
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作分散式排程
  - 不實作 UI 設定介面
  - 不支援 CSV source 的 cron snapshot（CSV 為手動上傳）

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增每日定時 raffle snapshot 排程器
- Approx changed lines：~284
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - scheduler + tests 屬同一功能單元，無法分離驗證
- 若已拆分，相關 PR：
  - n/a

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

## 備註
測試結果：
```
--- PASS: TestNextSchedulerRun (0.00s)
--- PASS: TestRunScheduledSnapshots_SkipsOutOfWindow (0.06s)
--- PASS: TestRunScheduledSnapshots_SkipsCompleted (0.01s)
--- PASS: TestRunScheduledSnapshots_TwitchAPISuccess (0.01s)
--- PASS: TestRunScheduledSnapshots_TwitchTokenMissing_StaysDraft (0.00s)
```