### PR TITLE
[infra] Backend quality gate

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -10,6 +10,17 @@ const workflowPath = path.join(currentDir, 'ci.yml')
 const scopePolicePath = path.join(currentDir, 'pr-scope-police.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 
+function workflowJobBlock(workflow, jobName) {
+  const escapedJobName = jobName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(
+    `^  ${escapedJobName}:\\n[\\s\\S]*?(?=^  [A-Za-z0-9_-]+:\\n|(?![\\s\\S]))`,
+    'm',
+  )
+  const match = workflow.match(pattern)
+  assert.ok(match, `expected workflow to include ${jobName} job`)
+  return match[0]
+}
+
 test('frontend CI job runs the frontend test command', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
 
@@ -26,15 +37,35 @@ test('frontend CI job runs the frontend test command', async () => {
 
 test('backend CI job runs go test and go vet', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
+  const backendJob = workflowJobBlock(workflow, 'backend')
 
   assert.match(
-    workflow,
-    /backend:\n[\s\S]*?- name: Run tests\n\s+run: docker compose run --pull never --no-deps --rm app go test \.\/\.\.\./,
+    backendJob,
+    /- name: Run tests\n\s+run: docker compose run --pull never --no-deps --rm app go test \.\/\.\.\./,
   )
 
   assert.match(
-    workflow,
-    /backend:\n[\s\S]*?- name: Run vet\n\s+run: docker compose run --pull never --no-deps --rm app go vet \.\/\.\.\./,
+    backendJob,
+    /- name: Run vet\n\s+run: docker compose run --pull never --no-deps --rm app go vet \.\/\.\.\./,
+  )
+})
+
+test('backend CI vet assertion does not match vet steps from later jobs', () => {
+  const workflow = `  backend:
+    steps:
+      - name: Run tests
+        run: docker compose run --pull never --no-deps --rm app go test ./...
+
+  frontend:
+    steps:
+      - name: Run vet
+        run: docker compose run --pull never --no-deps --rm app go vet ./...
+`
+  const backendJob = workflowJobBlock(workflow, 'backend')
+
+  assert.doesNotMatch(
+    backendJob,
+    /- name: Run vet\n\s+run: docker compose run --pull never --no-deps --rm app go vet \.\/\.\.\./,
   )
 })
 

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -24,6 +24,20 @@ test('frontend CI job runs the frontend test command', async () => {
   )
 })
 
+test('backend CI job runs go test and go vet', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+
+  assert.match(
+    workflow,
+    /backend:\n[\s\S]*?- name: Run tests\n\s+run: docker compose run --pull never --no-deps --rm app go test \.\/\.\.\./,
+  )
+
+  assert.match(
+    workflow,
+    /backend:\n[\s\S]*?- name: Run vet\n\s+run: docker compose run --pull never --no-deps --rm app go vet \.\/\.\.\./,
+  )
+})
+
 test('PR size thresholds match CLAUDE.md', async () => {
   const claude = await readFile(claudePath, 'utf8')
   const workflow = await readFile(workflowPath, 'utf8')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,9 @@ jobs:
       - name: Run tests
         run: docker compose run --pull never --no-deps --rm app go test ./...
 
+      - name: Run vet
+        run: docker compose run --pull never --no-deps --rm app go vet ./...
+
   backend-integration:
     name: Backend integration tests
     needs: [scope-gate]


### PR DESCRIPTION
## Summary

補上 backend CI quality gate 的 `go vet ./...`，讓 backend job 同時執行 unit tests 與 vet 檢查。

## 改動

- `.github/workflows/ci.yml`：backend job 在 `go test ./...` 後新增 `go vet ./...`
- `.github/workflows/ci.test.mjs`：新增 workflow regression test，防止 backend CI 遺漏 `go test` 或 `go vet`

## 為什麼

#206 剩餘缺口是 backend CI 尚未加入 `go vet ./...`。integration tests 與 PostgreSQL setup 已由既有 develop 內容完成，本 PR 只補齊最後一個 quality gate。

## Scope 對齊

Source of truth：#206 — Backend quality gate

Depends on PR：none

Backend contract already in develop:
- [ ] yes
- [x] no（infra-only CI 變更，無 backend contract）

本 PR 是否完全在 source of truth 範圍內？
- [x] 是
- [ ] 否，已另開 issue / PR 處理超出部分

## 本 PR 明確不做

- 不導入 staticcheck
- 不導入 govulncheck
- 不重寫 backend 測試架構
- 不修改 backend production code
- 不修改 tachimint / dashboard / contracts

## 驗證

- `node --test .github/workflows/ci.test.mjs`：3/3 pass
- `docker compose run --pull never --no-deps --rm app go vet ./...`：exit 0

closes #206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 完善后端持续集成流程，新增Go代码静态分析检查步骤。
  * 添加工作流验证测试，自动检查CI配置的正确执行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->