### PR TITLE
[backend] Fix production Docker runtime image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,7 +30,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o bin/tachigo ./cmd/serv
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 # distroless/static includes ca-certificates but not tzdata.
 # Copy the timezone database from the builder so time.LoadLocation works.
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /app/bin/tachigo /tachigo

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ CMD ["air"]
 # ── Build stage ───────────────────────────────────────────────────────────────
 FROM golang:1.25-alpine AS builder
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git tzdata
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o bin/tachigo ./cmd/serv
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 # distroless/static includes ca-certificates but not tzdata.
 # Copy the timezone database from the builder so time.LoadLocation works.
-FROM gcr.io/distroless/static-nonroot:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /app/bin/tachigo /tachigo


### PR DESCRIPTION
## 什麼改動

- backend production Docker builder stage 安裝 `tzdata`，讓 `/usr/share/zoneinfo` 可被 runtime stage 複製。
- production runtime image 改用存在 manifest 的 `gcr.io/distroless/static-debian12:nonroot`。

## 為什麼

- 修正 #282 記錄的 production Dockerfile 問題：原 runtime image tag 不存在，且 builder 沒有安裝 `tzdata` 卻複製 zoneinfo。
- 這不影響 dev target，但會影響 production runtime image build。

closes #282

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth: #282
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不變更 backend API、handler、service 或 schema。
  - 不變更 dashboard / tachimint / contracts。
  - 不調整 CI workflow 或 release 流程。

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - 修正 backend production Docker runtime image build 所需的 base image 與 timezone database。
- Approx changed lines：~4
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## 超出範圍內容

- 無

## 測試方式

- [x] 本地測試過
  - `docker build -f backend/Dockerfile backend`
- [ ] 有寫 / 更新測試
  - n/a，這是 Dockerfile production image build 修正，以 production Docker build 驗證。

## 備註

- refs #282


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **杂项变更（Chores）**
  * 更新了后端 Docker 镜像配置，优化了容器运行时环境。
  * 添加了时区数据支持，确保容器内的时间操作更加可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->