### PR TITLE
[chore] Document non-interactive git and gh rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,13 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - 若使用者在當輪訊息已明確要求修改檔案，視為已授權該次 Edit；但公開可見操作（Change Request / Approve / Merge / comment / push）仍需再次確認。
 - 在 Codex sandbox 中執行任何 `git` 指令時，預設直接使用提權執行；不要先嘗試 sandbox 版本再重跑。
 
+### Non-interactive 指令規則
+
+- 不得執行 interactive commands；所有 `git` / `gh` 指令都必須是 non-interactive。
+- 若 `gh` 指令需要 auth、login、device code、browser flow 或任何互動式授權，必須立即停止並回報，不得嘗試互動式登入。
+- 執行 `git` / `gh` 指令前，必須先在回覆中列出該步驟要執行的指令與目的，再執行。
+- 在 mixed worktree 中不得使用 `git add -A` 或 `git add .`；只能 stage 明確屬於本次任務的檔案。
+
 ### PR Label
 
 | Label | 用途 |


### PR DESCRIPTION
## 什麼改動
- 在 AGENTS.md 新增 Non-interactive 指令規則。
- 明確要求 git/gh 指令使用 non-interactive 流程。
- 補上 gh auth 需求時停止回報、執行前先列指令與目的、mixed worktree 只 stage 明確檔案等規則。

## 為什麼
這是從 #318 review 中拆出的 agent workflow 文件更新。規則本身有用，但不屬於 Dependabot 降噪 PR 的 scope，因此獨立成 docs PR。

closes #319

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#319
- Depends on PR：none
- Backend contract already in develop:
  - [ ] yes
  - [x] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 Dependabot 設定
  - 不修改 CI workflow
  - 不修改產品 runtime code

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 記錄 agent 使用 non-interactive git/gh 指令的規則。
- Approx changed lines：~7
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #318 Dependabot 設定變更

## 超出範圍內容
無

## 測試方式
- [ ] 本地測試過
- [ ] 有寫 / 更新測試

文件-only 變更，未執行測試。

## 備註
- PR 只包含 AGENTS.md。
- 未包含本機未追蹤的 .omc/、根目錄 go.mod、package.json。