### PR TITLE
[chore] Run frontend Dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: npm
     directory: /dashboard
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: "09:30"
       timezone: Asia/Taipei
@@ -60,7 +60,7 @@ updates:
   - package-ecosystem: npm
     directory: /tachimint
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: "10:00"
       timezone: Asia/Taipei


### PR DESCRIPTION
## 什麼改動
- 將 dashboard 的 npm Dependabot schedule 從 weekly 改成 monthly。
- 將 tachimint 的 npm Dependabot schedule 從 weekly 改成 monthly。
- 保留 backend Go Dependabot weekly。
- 保留既有 open-pull-requests-limit 設定。

## 為什麼
目前前端 Dependabot 仍然太頻繁。將 npm 更新改成 monthly 可以降低例行 PR 噪音，同時保留 backend Go weekly 更新與既有 PR limit。

refs #317

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#317
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 backend Go Dependabot schedule
  - 不修改 open-pull-requests-limit
  - 不修改 dependency versions
  - 不修改 CI workflow 或產品 runtime code

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 將 frontend npm Dependabot 更新頻率降為 monthly。
- Approx changed lines：4
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

驗證指令：ruby YAML parser 讀取 .github/dependabot.yml。

結果：yaml ok

## 備註
- PR 只包含 .github/dependabot.yml。
- 未包含本機未追蹤的 go.mod、package.json。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **维护**
  * 调整依赖项自动更新的检查频率（从每周改为每月）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->