### PR TITLE
[chore] Add local PR metadata preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev up down logs
+.PHONY: setup dev up down logs pr-meta-check pr-open
 
 # ── Setup (run once after cloning) ────────────────────────────────────────────
 setup:
@@ -20,3 +20,14 @@ down:
 
 logs:
 	docker compose logs -f
+
+# ── PR preflight ──────────────────────────────────────────────────────────────
+pr-meta-check:
+	@test -n "$(TITLE)" || (echo "TITLE is required"; exit 2)
+	@test -n "$(BODY_FILE)" || (echo "BODY_FILE is required"; exit 2)
+	@./scripts/pr-metadata-check.sh --title "$(TITLE)" --body-file "$(BODY_FILE)" --base "$(or $(BASE),develop)" $(if $(HEAD),--head "$(HEAD)",)
+
+pr-open:
+	@test -n "$(TITLE)" || (echo "TITLE is required"; exit 2)
+	@test -n "$(BODY_FILE)" || (echo "BODY_FILE is required"; exit 2)
+	@./scripts/pr-open.sh --title "$(TITLE)" --body-file "$(BODY_FILE)" --base "$(or $(BASE),develop)" $(if $(HEAD),--head "$(HEAD)",) $(if $(filter 1,$(DRAFT)),--draft,)

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -157,6 +157,35 @@ repo 的 CI 目前改成：
 - 若 `[frontend]` PR 依賴尚未 merge 的 backend contract，重型 CI 會直接跳過
 - 若 PR 是正式 `[release]` 的 `develop -> main` promotion，重型 CI 會照常執行，不因 diff 過大而被 scope gate 跳過
 
+## 本地 PR preflight
+
+開 PR 前可以先在本地跑 metadata preflight，提早檢查 PR title、body template 欄位、dependency PR、backend contract 與 product surface 是否符合上方 Scope Police 規則。
+
+直接檢查既有 PR body 檔案：
+
+```bash
+make pr-meta-check TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md
+```
+
+開 PR 前先檢查，通過後才呼叫 `gh pr create`：
+
+```bash
+make pr-open TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md
+```
+
+可選參數：
+
+- `BASE`：預設 `develop`
+- `HEAD`：預設目前 branch
+- `DRAFT=1`：建立 draft PR
+
+底層腳本：
+
+- `scripts/pr-metadata-check.sh`
+- `scripts/pr-open.sh`
+
+這組本地 preflight 只檢查 PR metadata 與目前 branch diff 的基本 surface 規則；push 前的大型 diff 檢查仍由 `.githooks/pre-push` 負責，GitHub 上的最終 gate 仍是 `.github/workflows/pr-scope-police.yml`。
+
 ## GitHub 設定
 
 建議在 GitHub repo settings 這樣設定：

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pr-metadata-check.sh --title "<pr title>" --body-file <path> [--base develop] [--head <branch>] [--repo owner/name]
+
+Checks local PR metadata against the current PR Scope Police rules before opening a PR.
+EOF
+}
+
+parse_repo_from_remote() {
+  local remote_url
+  remote_url=$(git remote get-url origin)
+
+  case "$remote_url" in
+    git@github.com:*)
+      remote_url="${remote_url#git@github.com:}"
+      printf '%s\n' "${remote_url%.git}"
+      ;;
+    https://github.com/*)
+      remote_url="${remote_url#https://github.com/}"
+      printf '%s\n' "${remote_url%.git}"
+      ;;
+    *)
+      echo "無法從 origin remote 解析 GitHub repo：$remote_url" >&2
+      return 1
+      ;;
+  esac
+}
+
+is_docs_or_template_path() {
+  local name="$1"
+
+  case "$name" in
+    docs/*|plans/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md|.gitignore|.gitattributes)
+      return 0
+      ;;
+    *.md)
+      [ "${name#*/}" = "$name" ]
+      return
+      ;;
+  esac
+
+  return 1
+}
+
+checked_item() {
+  local section="$1"
+  local label="$2"
+  local file="$3"
+
+  awk -v section="$section" -v label="$label" '
+    BEGIN {
+      in_section = 0
+      found = 0
+      pattern = "^[[:space:]]*-[[:space:]]*\\[[xX]\\][[:space:]]+" label "([[:space:]]|$)"
+    }
+    $0 ~ "^[[:space:]]*[-]*[[:space:]]*" section "[：:][[:space:]]*$" {
+      in_section = 1
+      next
+    }
+    in_section && $0 ~ /^##[[:space:]]/ { exit }
+    in_section && $0 ~ /^[[:space:]]*$/ { exit }
+    in_section && $0 ~ pattern {
+      found = 1
+      exit
+    }
+    END {
+      exit(found ? 0 : 1)
+    }
+  ' "$file"
+}
+
+main() {
+  local title=""
+  local body_file=""
+  local base_branch="develop"
+  local head_branch=""
+  local repo=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --title)
+        title="${2:-}"
+        shift 2
+        ;;
+      --body-file)
+        body_file="${2:-}"
+        shift 2
+        ;;
+      --base)
+        base_branch="${2:-}"
+        shift 2
+        ;;
+      --head)
+        head_branch="${2:-}"
+        shift 2
+        ;;
+      --repo)
+        repo="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        echo "未知參數：$1" >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  [ -n "$title" ] || { echo "--title 為必填" >&2; exit 2; }
+  [ -n "$body_file" ] || { echo "--body-file 為必填" >&2; exit 2; }
+  [ -f "$body_file" ] || { echo "找不到 body file：$body_file" >&2; exit 2; }
+
+  if [ -z "$head_branch" ]; then
+    head_branch=$(git branch --show-current)
+  fi
+  [ -n "$head_branch" ] || { echo "無法判斷目前 branch，請用 --head 指定。" >&2; exit 2; }
+
+  local allowed_prefixes="[backend] [frontend] [contract] [discussion] [release] [infra] [chore]"
+  local title_prefix=""
+  local prefix
+  for prefix in $allowed_prefixes; do
+    case "$title" in
+      "$prefix"*) title_prefix="$prefix"; break ;;
+    esac
+  done
+
+  local failures=()
+  [ -n "$title_prefix" ] || failures+=("PR title 必須以其中一個 prefix 開頭：$allowed_prefixes")
+
+  local base_ref=""
+  local head_ref="refs/heads/$head_branch"
+  local base_sha head_sha merge_base
+  local base_candidates=(
+    "refs/remotes/origin/$base_branch"
+    "refs/remotes/$base_branch"
+  )
+  local candidate
+  for candidate in "${base_candidates[@]}"; do
+    base_sha=$(git rev-parse "$candidate^{commit}" 2>/dev/null || true)
+    if [ -n "$base_sha" ]; then
+      base_ref="$candidate"
+      break
+    fi
+  done
+  [ -n "$base_ref" ] || {
+    echo "找不到 base branch。已嘗試：${base_candidates[*]}" >&2
+    exit 2
+  }
+  head_sha=$(git rev-parse "$head_ref^{commit}" 2>/dev/null) || {
+    echo "找不到 head branch：$head_branch" >&2
+    exit 2
+  }
+  merge_base=$(git merge-base "$base_sha" "$head_sha" 2>/dev/null) || {
+    echo "無法計算 merge-base：$base_branch vs $head_branch" >&2
+    exit 2
+  }
+
+  local changed_files
+  changed_files=$(git diff --name-only "$merge_base" "$head_sha")
+
+  local touches_backend=0 touches_dashboard=0 touches_tachimint=0 touches_contracts=0 docs_only=1
+  local file
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    case "$file" in
+      backend/*) touches_backend=1 ;;
+      dashboard/*) touches_dashboard=1 ;;
+      tachimint/*) touches_tachimint=1 ;;
+      contracts/*) touches_contracts=1 ;;
+    esac
+    if ! is_docs_or_template_path "$file"; then
+      docs_only=0
+    fi
+  done <<< "$changed_files"
+
+  local product_surface_count=0
+  [ "$touches_backend" -eq 1 ] && product_surface_count=$((product_surface_count + 1))
+  [ "$touches_dashboard" -eq 1 ] && product_surface_count=$((product_surface_count + 1))
+  [ "$touches_tachimint" -eq 1 ] && product_surface_count=$((product_surface_count + 1))
+  [ "$touches_contracts" -eq 1 ] && product_surface_count=$((product_surface_count + 1))
+
+  local is_release_promotion=0
+  if [ "$base_branch" = "main" ] && [ "$head_branch" = "develop" ]; then
+    is_release_promotion=1
+  fi
+
+  local is_infra_or_chore=0
+  if [ "$title_prefix" = "[infra]" ] || [ "$title_prefix" = "[chore]" ]; then
+    is_infra_or_chore=1
+  fi
+
+  if [ "$is_release_promotion" -eq 1 ] && [ "$title_prefix" != "[release]" ]; then
+    failures+=("develop -> main release PR 必須使用 [release] title prefix")
+  fi
+  if [ "$is_release_promotion" -eq 0 ] && [ "$title_prefix" = "[release]" ]; then
+    failures+=("[release] 只能用於 develop -> main release promotion PR")
+  fi
+
+  local depends_on_raw=""
+  depends_on_raw=$(sed -nE 's/^[[:space:]-]*Depends on PR[：:][[:space:]]*(.+)$/\1/ip' "$body_file" | head -n1 | sed 's/[[:space:]]*$//')
+
+  if [ "$is_infra_or_chore" -eq 0 ] && [ "$is_release_promotion" -eq 0 ]; then
+    grep -Eq '#[0-9]+' "$body_file" || failures+=("PR body 必須引用至少一個 issue 或 PR 編號，例如 #123")
+  fi
+
+  if [ "$is_infra_or_chore" -eq 0 ]; then
+    grep -Eq '(^|[[:space:]-])Source of truth[：:]' "$body_file" || failures+=("PR body 必須包含 Source of truth")
+    grep -Eq '本 PR 明確不做' "$body_file" || failures+=("PR body 必須包含 本 PR 明確不做")
+    grep -Eq '(^|[[:space:]-])Depends on PR[：:]' "$body_file" || failures+=("PR body 必須包含 Depends on PR")
+
+    if [ -n "$depends_on_raw" ]; then
+      if [ "$(printf '%s' "$depends_on_raw" | tr '[:upper:]' '[:lower:]')" != "none" ] && [[ ! "$depends_on_raw" =~ ^#[0-9]+$ ]]; then
+        failures+=("Depends on PR 必須是 none 或單一 PR 編號，例如 #123")
+      fi
+    else
+      failures+=("Depends on PR 必須填 none 或 #123")
+    fi
+  fi
+
+  local backend_contract_yes=0 backend_contract_no=0
+  checked_item "Backend contract already in develop" "yes" "$body_file" && backend_contract_yes=1
+  checked_item "Backend contract already in develop" "no" "$body_file" && backend_contract_no=1
+
+  local stacked_on_dependency=0 intentionally_blocked=0
+  checked_item "If no, this PR is" "stacked on dependency branch" "$body_file" && stacked_on_dependency=1
+  checked_item "If no, this PR is" "intentionally blocked until dependency merges" "$body_file" && intentionally_blocked=1
+
+  if [ "$is_infra_or_chore" -eq 0 ] && [ "$docs_only" -eq 0 ]; then
+    if [ "$backend_contract_yes" -eq 0 ] && [ "$backend_contract_no" -eq 0 ]; then
+      failures+=("產品程式碼 PR 必須標記 Backend contract already in develop")
+    fi
+    if [ "$backend_contract_yes" -eq 1 ] && [ "$backend_contract_no" -eq 1 ]; then
+      failures+=("Backend contract already in develop 不可同時勾 yes 與 no")
+    fi
+    if [ "$backend_contract_no" -eq 1 ] && [ "$stacked_on_dependency" -eq 0 ] && [ "$intentionally_blocked" -eq 0 ]; then
+      failures+=("Backend contract 不在 develop 時，必須標記 stacked 或 intentionally blocked")
+    fi
+    if [ "$is_release_promotion" -eq 1 ] && [ "$backend_contract_yes" -eq 0 ]; then
+      failures+=("develop -> main release PR 必須標記 Backend contract already in develop 為 yes")
+    fi
+  fi
+
+  if [ "$title_prefix" = "[backend]" ] && { [ "$touches_dashboard" -eq 1 ] || [ "$touches_tachimint" -eq 1 ]; }; then
+    failures+=("[backend] PR 不可修改 dashboard/ 或 tachimint/")
+  fi
+  if [ "$title_prefix" = "[frontend]" ] && [ "$touches_backend" -eq 1 ]; then
+    failures+=("[frontend] PR 不可修改 backend/")
+  fi
+  if [ "$title_prefix" = "[contract]" ] && { [ "$touches_backend" -eq 1 ] || [ "$touches_dashboard" -eq 1 ] || [ "$touches_tachimint" -eq 1 ]; }; then
+    failures+=("[contract] PR 不可修改 backend/、dashboard/ 或 tachimint/")
+  fi
+  if [ "$is_release_promotion" -eq 0 ] && [ "$product_surface_count" -gt 1 ]; then
+    failures+=("PR 不可同時修改多個 product surface")
+  fi
+
+  if [ "$title_prefix" = "[frontend]" ] && [[ "$depends_on_raw" =~ ^#([0-9]+)$ ]] && [ "$backend_contract_no" -eq 1 ]; then
+    command -v gh >/dev/null 2>&1 || { echo "需要 gh 才能檢查 dependency PR 狀態。" >&2; exit 2; }
+    gh auth status >/dev/null 2>&1 || { echo "gh 尚未認證；請先處理 gh auth，再重跑。" >&2; exit 2; }
+    [ -n "$repo" ] || repo=$(parse_repo_from_remote)
+
+    local dep_number="${BASH_REMATCH[1]}"
+    local dep_state
+    dep_state=$(gh pr view "$dep_number" --repo "$repo" --json state --jq '.state' 2>/dev/null || true)
+    if [ -z "$dep_state" ]; then
+      failures+=("無法讀取 dependency PR #$dep_number")
+    else
+      failures+=("[frontend] PR depends on #$dep_number, but backend contract is not in develop. Dependency PR state: $dep_state")
+    fi
+  fi
+
+  if [ "${#failures[@]}" -gt 0 ]; then
+    echo "PR metadata check failed:"
+    local failure
+    for failure in "${failures[@]}"; do
+      echo "  - $failure"
+    done
+    exit 1
+  fi
+
+  echo "PR metadata check passed: title=$title_prefix base=$base_branch head=$head_branch docs_only=$docs_only"
+}
+
+main "$@"

--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pr-open.sh --title "<pr title>" --body-file <path> [--base develop] [--head <branch>] [--draft]
+
+Runs local PR metadata checks, then opens a PR with gh.
+EOF
+}
+
+main() {
+  local title=""
+  local body_file=""
+  local base_branch="develop"
+  local head_branch=""
+  local draft=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --title)
+        title="${2:-}"
+        shift 2
+        ;;
+      --body-file)
+        body_file="${2:-}"
+        shift 2
+        ;;
+      --base)
+        base_branch="${2:-}"
+        shift 2
+        ;;
+      --head)
+        head_branch="${2:-}"
+        shift 2
+        ;;
+      --draft)
+        draft=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        echo "未知參數：$1" >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  [ -n "$title" ] || { echo "--title 為必填" >&2; exit 2; }
+  [ -n "$body_file" ] || { echo "--body-file 為必填" >&2; exit 2; }
+  [ -f "$body_file" ] || { echo "找不到 body file：$body_file" >&2; exit 2; }
+
+  if [ -z "$head_branch" ]; then
+    head_branch=$(git branch --show-current)
+  fi
+  [ -n "$head_branch" ] || { echo "無法判斷目前 branch，請用 --head 指定。" >&2; exit 2; }
+
+  command -v gh >/dev/null 2>&1 || { echo "需要 gh 才能開 PR。" >&2; exit 2; }
+  gh auth status >/dev/null 2>&1 || { echo "gh 尚未認證；請先處理 gh auth，再重跑。" >&2; exit 2; }
+
+  local root_dir
+  root_dir="$(cd "$(dirname "$0")/.." && pwd)"
+
+  "$root_dir/scripts/pr-metadata-check.sh" \
+    --title "$title" \
+    --body-file "$body_file" \
+    --base "$base_branch" \
+    --head "$head_branch"
+
+  local cmd=(gh pr create --base "$base_branch" --head "$head_branch" --title "$title" --body-file "$body_file")
+  if [ "$draft" -eq 1 ]; then
+    cmd+=(--draft)
+  fi
+
+  echo "Opening PR with gh..."
+  "${cmd[@]}"
+}
+
+main "$@"


### PR DESCRIPTION
## 什麼改動
- 新增 scripts/pr-metadata-check.sh，在本地檢查 PR title prefix、body metadata、backend contract、dependency PR 與 product surface 基本規則。
- 新增 scripts/pr-open.sh，包裝 gh pr create，開 PR 前先跑 metadata preflight，預設 base 為 develop。
- 新增 Makefile targets：pr-meta-check / pr-open。
- 在 docs/pr-scope-policy.md 補上本地 preflight 使用方式，並連回現有 PR Scope Police 流程。

## 為什麼
#136 曾完整實作 local guardrails，但當時 merge 到 chore/pr-local-guardrails-base，沒有進入 develop。develop 目前已有 GitHub Actions scope gate、PR template 與 pre-push 基本檢查，因此 #133 不需要整張重做；這支 PR 只補最小 gap：開 PR 前的本地 metadata / preflight wrapper。

closes #133

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#133
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不搬回 #136 的 pr-scope-check.sh
  - 不改 .githooks/pre-push
  - 不修改 GitHub Actions PR Scope Police
  - 不修改產品 runtime code

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 補上開 PR 前可本地執行的 PR metadata/preflight wrapper。
- Approx changed lines：~383
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - scripts、Makefile target 與 docs 是同一個本地 PR preflight workflow；拆開會讓使用方式或入口不完整。
- 若已拆分，相關 PR：
  - #136 為歷史實作參考，但未進 develop。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

驗證指令：
- bash -n scripts/pr-metadata-check.sh scripts/pr-open.sh
- make pr-meta-check TITLE="[chore] Local PR metadata preflight" BODY_FILE=.github/PULL_REQUEST_TEMPLATE.md BASE=develop HEAD=chore/local-pr-metadata-preflight

結果：metadata preflight pass。

## 備註
- PR 只包含 Makefile、docs/pr-scope-policy.md、scripts/pr-metadata-check.sh、scripts/pr-open.sh。
- 未包含本機未追蹤的 go.mod、package.json。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增本地 PR 预检与一键打开命令（Make 目标），可在提交前验证标题、正文模板和依赖状态并选择草稿模式。

* **文档**
  * 添加使用说明，描述本地预检流程、可选参数（基线、分支、草稿）及两步操作（先检查再创建）。

* **杂项**
  * 新增本地自动化脚本以支持上述流程并在失败时给出详尽错误信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->