### PR TITLE
[backend] SpendService burn 成功後呼叫 Tachiya API 建立 voucher

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,7 @@ TWITCH_EXTENSION_SECRET=
 # ── Internal API ──────────────────────────────────────────────────────────────
 # Shared secret for tachiya -> tachigo server-to-server internal requests.
 TACHIYA_INTERNAL_SHARED_SECRET=
+TACHIYA_BASE_URL=http://localhost:8001
 
 # ── Google OAuth ──────────────────────────────────────────────────────────────
 # Register at https://console.cloud.google.com/apis/credentials

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -146,7 +146,8 @@ func main() {
 		}
 	}
 	claimSvc := services.NewClaimService(db, cfg.Contract, ethClient)
-	spendSvc := services.NewSpendService(db, cfg.Contract, ethClient)
+	tachiyaClient := services.NewTachiyaHTTPClient(cfg.Internal.TachiyaBaseURL, cfg.Internal.TachiyaSharedSecret)
+	spendSvc := services.NewSpendService(db, cfg.Contract, ethClient, tachiyaClient)
 	if cfg.Server.Env == "production" && cfg.OAuth.Twitch.ClientID == "" {
 		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
 	}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -24,6 +24,7 @@ type ContractConfig struct {
 
 type InternalConfig struct {
 	TachiyaSharedSecret string // TACHIYA_INTERNAL_SHARED_SECRET
+	TachiyaBaseURL      string // TACHIYA_BASE_URL
 }
 
 type SMTPConfig struct {
@@ -120,6 +121,7 @@ func Load() *Config {
 		},
 		Internal: InternalConfig{
 			TachiyaSharedSecret: getEnv("TACHIYA_INTERNAL_SHARED_SECRET", ""),
+			TachiyaBaseURL:      getEnv("TACHIYA_BASE_URL", "http://localhost:8001"),
 		},
 	}
 }

--- a/backend/internal/handlers/spend_handler.go
+++ b/backend/internal/handlers/spend_handler.go
@@ -19,11 +19,13 @@ func NewSpendHandler(spendSvc *services.SpendService) *SpendHandler {
 }
 
 type redeemRequest struct {
-	Amount int64 `json:"amount" binding:"required,min=1"`
+	CouponID string `json:"coupon_id" binding:"required"`
+	Amount   int64  `json:"amount" binding:"required,min=1"`
 }
 
 type redeemResponse struct {
-	Balance int64 `json:"balance"`
+	Balance     int64  `json:"balance"`
+	VoucherCode string `json:"voucher_code,omitempty"`
 }
 
 // Redeem godoc
@@ -52,7 +54,7 @@ func (h *SpendHandler) Redeem(c *gin.Context) {
 		return
 	}
 
-	newBalance, err := h.spendSvc.Redeem(c.Request.Context(), userID, req.Amount)
+	newBalance, voucherCode, err := h.spendSvc.Redeem(c.Request.Context(), userID, req.CouponID, req.Amount)
 	if err != nil {
 		if errors.Is(err, services.ErrSpendInsufficientBalance) {
 			badRequest(c, err.Error())
@@ -71,5 +73,5 @@ func (h *SpendHandler) Redeem(c *gin.Context) {
 		return
 	}
 
-	ok(c, redeemResponse{Balance: newBalance})
+	ok(c, redeemResponse{Balance: newBalance, VoucherCode: voucherCode})
 }

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -85,7 +85,7 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
-	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
+	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil, nil)
 	raffleSvc := services.NewRaffleService(db, "")
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
@@ -475,7 +475,7 @@ func TestInternalRouter_SkipsRouteWhenSharedSecretMissing(t *testing.T) {
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
-	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
+	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil, nil)
 	raffleSvc := services.NewRaffleService(db, "")
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
@@ -556,7 +556,7 @@ func TestInternalRouter_WithSecretSet_MiddlewareRejectsAndRouteRegistered(t *tes
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
-	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil)
+	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil, nil)
 	raffleSvc := services.NewRaffleService(db, "")
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 

--- a/backend/internal/services/spend_service.go
+++ b/backend/internal/services/spend_service.go
@@ -102,7 +102,7 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 	voucherCode := ""
 	if s.tachiyaClient != nil {
 		var tachiyaErr error
-		voucherCode, tachiyaErr = s.tachiyaClient.RedeemCoupon(couponID, reservation.amount)
+		voucherCode, tachiyaErr = s.tachiyaClient.RedeemCoupon(ctx, couponID, reservation.amount)
 		if tachiyaErr != nil {
 			log.Printf("warning: tachiya redeem coupon failed for coupon_id=%s user_id=%s: %v", couponID, userID, tachiyaErr)
 			voucherCode = ""

--- a/backend/internal/services/spend_service.go
+++ b/backend/internal/services/spend_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -30,10 +31,11 @@ type BurnCaller interface {
 }
 
 type SpendService struct {
-	db          *gorm.DB
-	contractCfg config.ContractConfig
-	tachiToken  *contractpkg.TachiToken
-	burnCaller  BurnCaller
+	db            *gorm.DB
+	contractCfg   config.ContractConfig
+	tachiToken    *contractpkg.TachiToken
+	burnCaller    BurnCaller
+	tachiyaClient TachiyaClient
 }
 
 type spendReservation struct {
@@ -42,10 +44,11 @@ type spendReservation struct {
 	newBalance int64
 }
 
-func NewSpendService(db *gorm.DB, contractCfg config.ContractConfig, ethClient *ethclient.Client) *SpendService {
+func NewSpendService(db *gorm.DB, contractCfg config.ContractConfig, ethClient *ethclient.Client, tachiyaClient TachiyaClient) *SpendService {
 	svc := &SpendService{
-		db:          db,
-		contractCfg: contractCfg,
+		db:            db,
+		contractCfg:   contractCfg,
+		tachiyaClient: tachiyaClient,
 	}
 	if ethClient != nil && contractCfg.TachiContractAddress != "" && contractCfg.SepoliaSignerKey != "" {
 		if common.IsHexAddress(contractCfg.TachiContractAddress) {
@@ -64,9 +67,9 @@ func (s *SpendService) SetBurnCallerForTest(bc BurnCaller) { s.burnCaller = bc }
 
 // Redeem burns `amount` $TACHI from the user's on-chain wallet and deducts
 // the same amount from tachi_balances. Returns the new balance.
-func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, amount int64) (int64, error) {
+func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID string, amount int64) (int64, string, error) {
 	if amount <= 0 {
-		return 0, ErrSpendAmountInvalid
+		return 0, "", ErrSpendAmountInvalid
 	}
 
 	var reservation spendReservation
@@ -75,7 +78,7 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, amount int6
 		reservation, err = s.reserveSpend(tx, userID, amount)
 		return err
 	}); err != nil {
-		return 0, err
+		return 0, "", err
 	}
 
 	burnCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -85,18 +88,28 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, amount int6
 		if txHash != "" {
 			// Tx was broadcast but receipt is unknown (e.g. context deadline, RPC error).
 			// Do NOT roll back: the chain may have already burned the tokens.
-			return 0, fmt.Errorf("burn tx broadcast (txHash=%s) but receipt unknown: %w", txHash, err)
+			return 0, "", fmt.Errorf("burn tx broadcast (txHash=%s) but receipt unknown: %w", txHash, err)
 		}
 		rollbackErr := s.db.Transaction(func(tx *gorm.DB) error {
 			return s.rollbackSpendReservation(tx, userID, reservation.amount)
 		})
 		if rollbackErr != nil {
-			return 0, fmt.Errorf("%w; rollback spend reservation: %v", err, rollbackErr)
+			return 0, "", fmt.Errorf("%w; rollback spend reservation: %v", err, rollbackErr)
 		}
-		return 0, err
+		return 0, "", err
 	}
 
-	return reservation.newBalance, nil
+	voucherCode := ""
+	if s.tachiyaClient != nil {
+		var tachiyaErr error
+		voucherCode, tachiyaErr = s.tachiyaClient.RedeemCoupon(couponID, reservation.amount)
+		if tachiyaErr != nil {
+			log.Printf("warning: tachiya redeem coupon failed for coupon_id=%s user_id=%s: %v", couponID, userID, tachiyaErr)
+			voucherCode = ""
+		}
+	}
+
+	return reservation.newBalance, voucherCode, nil
 }
 
 func (s *SpendService) reserveSpend(tx *gorm.DB, userID uuid.UUID, amount int64) (spendReservation, error) {

--- a/backend/internal/services/spend_service_test.go
+++ b/backend/internal/services/spend_service_test.go
@@ -40,7 +40,7 @@ type tachiyaCall struct {
 	tcgCost  int64
 }
 
-func (m *mockTachiyaClient) RedeemCoupon(couponID string, tcgCost int64) (string, error) {
+func (m *mockTachiyaClient) RedeemCoupon(_ context.Context, couponID string, tcgCost int64) (string, error) {
 	m.calls = append(m.calls, tachiyaCall{couponID: couponID, tcgCost: tcgCost})
 	return m.voucherCode, m.err
 }

--- a/backend/internal/services/spend_service_test.go
+++ b/backend/internal/services/spend_service_test.go
@@ -27,6 +27,24 @@ func (m *mockBurnCaller) BurnOnChain(_ context.Context, fromAddr string, amount 
 	return m.txHash, m.err
 }
 
+// ── mock TachiyaClient ───────────────────────────────────────────────────────
+
+type mockTachiyaClient struct {
+	voucherCode string
+	err         error
+	calls       []tachiyaCall
+}
+
+type tachiyaCall struct {
+	couponID string
+	tcgCost  int64
+}
+
+func (m *mockTachiyaClient) RedeemCoupon(couponID string, tcgCost int64) (string, error) {
+	m.calls = append(m.calls, tachiyaCall{couponID: couponID, tcgCost: tcgCost})
+	return m.voucherCode, m.err
+}
+
 // ── seed helpers ─────────────────────────────────────────────────────────────
 
 func seedTachiBalance(t *testing.T, db *gorm.DB, userID uuid.UUID, balance int64) {
@@ -44,18 +62,22 @@ func seedTachiBalance(t *testing.T, db *gorm.DB, userID uuid.UUID, balance int64
 func TestRedeem_Success(t *testing.T) {
 	db := newTestDB(t)
 	burnCaller := &mockBurnCaller{txHash: "0xburn123"}
-	svc := &SpendService{db: db, burnCaller: burnCaller}
+	tachiyaClient := &mockTachiyaClient{voucherCode: "VOUCHER-XYZ"}
+	svc := &SpendService{db: db, burnCaller: burnCaller, tachiyaClient: tachiyaClient}
 
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
 	seedTachiBalance(t, db, userID, 500)
 
-	newBal, err := svc.Redeem(context.Background(), userID, 100)
+	newBal, voucherCode, err := svc.Redeem(context.Background(), userID, "coupon-123", 100)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if newBal != 400 {
 		t.Fatalf("expected newBalance=400, got %d", newBal)
+	}
+	if voucherCode != "VOUCHER-XYZ" {
+		t.Fatalf("expected voucherCode=VOUCHER-XYZ, got %s", voucherCode)
 	}
 	if len(burnCaller.calls) != 1 {
 		t.Fatalf("expected 1 burn call, got %d", len(burnCaller.calls))
@@ -65,6 +87,15 @@ func TestRedeem_Success(t *testing.T) {
 	}
 	if burnCaller.calls[0].fromAddr != "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" {
 		t.Fatalf("unexpected burn fromAddr: %s", burnCaller.calls[0].fromAddr)
+	}
+	if len(tachiyaClient.calls) != 1 {
+		t.Fatalf("expected 1 tachiya call, got %d", len(tachiyaClient.calls))
+	}
+	if tachiyaClient.calls[0].couponID != "coupon-123" {
+		t.Fatalf("expected couponID=coupon-123, got %s", tachiyaClient.calls[0].couponID)
+	}
+	if tachiyaClient.calls[0].tcgCost != 100 {
+		t.Fatalf("expected tcgCost=100, got %d", tachiyaClient.calls[0].tcgCost)
 	}
 
 	var dbBal int64
@@ -81,7 +112,7 @@ func TestRedeem_InsufficientBalance(t *testing.T) {
 	userID := userIDForClaim(t, db)
 	seedTachiBalance(t, db, userID, 50)
 
-	_, err := svc.Redeem(context.Background(), userID, 100)
+	_, _, err := svc.Redeem(context.Background(), userID, "", 100)
 	if !errors.Is(err, ErrSpendInsufficientBalance) {
 		t.Fatalf("expected ErrSpendInsufficientBalance, got %v", err)
 	}
@@ -101,7 +132,7 @@ func TestRedeem_WalletNotLinked(t *testing.T) {
 	seedTachiBalance(t, db, userID, 200)
 	// no web3 provider seeded
 
-	_, err := svc.Redeem(context.Background(), userID, 100)
+	_, _, err := svc.Redeem(context.Background(), userID, "", 100)
 	if !errors.Is(err, ErrSpendWalletNotLinked) {
 		t.Fatalf("expected ErrSpendWalletNotLinked, got %v", err)
 	}
@@ -123,7 +154,7 @@ func TestRedeem_BurnBroadcastedButReceiptUnknown(t *testing.T) {
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
 	seedTachiBalance(t, db, userID, 300)
 
-	_, err := svc.Redeem(context.Background(), userID, 100)
+	_, _, err := svc.Redeem(context.Background(), userID, "", 100)
 	if err == nil {
 		t.Fatal("expected error but got nil")
 	}
@@ -145,7 +176,7 @@ func TestRedeem_BurnFailureRollback(t *testing.T) {
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
 	seedTachiBalance(t, db, userID, 300)
 
-	_, err := svc.Redeem(context.Background(), userID, 100)
+	_, _, err := svc.Redeem(context.Background(), userID, "", 100)
 	if err == nil {
 		t.Fatal("expected error but got nil")
 	}
@@ -154,5 +185,30 @@ func TestRedeem_BurnFailureRollback(t *testing.T) {
 	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
 	if dbBal != 300 {
 		t.Fatalf("expected balance rolled back to 300, got %d", dbBal)
+	}
+}
+
+func TestRedeem_TachiyaFailureIsNonBlocking(t *testing.T) {
+	db := newTestDB(t)
+	burnCaller := &mockBurnCaller{txHash: "0xburn123"}
+	tachiyaClient := &mockTachiyaClient{err: errors.New("tachiya unavailable")}
+	svc := &SpendService{db: db, burnCaller: burnCaller, tachiyaClient: tachiyaClient}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 300)
+
+	newBal, voucherCode, err := svc.Redeem(context.Background(), userID, "coupon-123", 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if newBal != 200 {
+		t.Fatalf("expected newBalance=200, got %d", newBal)
+	}
+	if voucherCode != "" {
+		t.Fatalf("expected empty voucherCode, got %s", voucherCode)
+	}
+	if len(tachiyaClient.calls) != 1 {
+		t.Fatalf("expected 1 tachiya call, got %d", len(tachiyaClient.calls))
 	}
 }

--- a/backend/internal/services/tachiya_client.go
+++ b/backend/internal/services/tachiya_client.go
@@ -2,15 +2,17 @@ package services
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 )
 
 type TachiyaClient interface {
-	RedeemCoupon(couponID string, tcgCost int64) (string, error)
+	RedeemCoupon(ctx context.Context, couponID string, tcgCost int64) (string, error)
 }
 
 type TachiyaHTTPClient struct {
@@ -29,7 +31,7 @@ func NewTachiyaHTTPClient(baseURL, secret string) *TachiyaHTTPClient {
 	}
 }
 
-func (c *TachiyaHTTPClient) RedeemCoupon(couponID string, tcgCost int64) (string, error) {
+func (c *TachiyaHTTPClient) RedeemCoupon(ctx context.Context, couponID string, tcgCost int64) (string, error) {
 	reqBody := struct {
 		CouponID string `json:"coupon_id"`
 		TCGCost  int64  `json:"tcg_cost"`
@@ -43,7 +45,7 @@ func (c *TachiyaHTTPClient) RedeemCoupon(couponID string, tcgCost int64) (string
 		return "", err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/coupons/redeem", &body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/coupons/redeem", &body)
 	if err != nil {
 		return "", err
 	}
@@ -57,6 +59,7 @@ func (c *TachiyaHTTPClient) RedeemCoupon(couponID string, tcgCost int64) (string
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return "", fmt.Errorf("tachiya redeem coupon failed with status %d", resp.StatusCode)
 	}
 

--- a/backend/internal/services/tachiya_client.go
+++ b/backend/internal/services/tachiya_client.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type TachiyaClient interface {
+	RedeemCoupon(couponID string, tcgCost int64) (string, error)
+}
+
+type TachiyaHTTPClient struct {
+	baseURL    string
+	secret     string
+	httpClient *http.Client
+}
+
+func NewTachiyaHTTPClient(baseURL, secret string) *TachiyaHTTPClient {
+	return &TachiyaHTTPClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		secret:  secret,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (c *TachiyaHTTPClient) RedeemCoupon(couponID string, tcgCost int64) (string, error) {
+	reqBody := struct {
+		CouponID string `json:"coupon_id"`
+		TCGCost  int64  `json:"tcg_cost"`
+	}{
+		CouponID: couponID,
+		TCGCost:  tcgCost,
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(reqBody); err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/coupons/redeem", &body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tachiya-Internal-Secret", c.secret)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("tachiya redeem coupon failed with status %d", resp.StatusCode)
+	}
+
+	var respBody struct {
+		VoucherCode string `json:"voucher_code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return "", err
+	}
+
+	return respBody.VoucherCode, nil
+}

--- a/backend/internal/services/tachiya_client_test.go
+++ b/backend/internal/services/tachiya_client_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,7 @@ func TestTachiyaHTTPClient_RedeemCoupon_Success(t *testing.T) {
 
 	client := NewTachiyaHTTPClient(server.URL, "shared-secret")
 
-	voucherCode, err := client.RedeemCoupon("coupon-123", 100)
+	voucherCode, err := client.RedeemCoupon(context.Background(), "coupon-123", 100)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -59,7 +60,7 @@ func TestTachiyaHTTPClient_RedeemCoupon_NonOKStatus(t *testing.T) {
 
 	client := NewTachiyaHTTPClient(server.URL, "shared-secret")
 
-	if _, err := client.RedeemCoupon("coupon-123", 100); err == nil {
+	if _, err := client.RedeemCoupon(context.Background(), "coupon-123", 100); err == nil {
 		t.Fatal("expected error but got nil")
 	}
 }

--- a/backend/internal/services/tachiya_client_test.go
+++ b/backend/internal/services/tachiya_client_test.go
@@ -1,0 +1,65 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTachiyaHTTPClient_RedeemCoupon_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/coupons/redeem" {
+			t.Fatalf("expected /coupons/redeem, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Tachiya-Internal-Secret"); got != "shared-secret" {
+			t.Fatalf("expected internal secret header, got %q", got)
+		}
+
+		var req struct {
+			CouponID string `json:"coupon_id"`
+			TCGCost  int64  `json:"tcg_cost"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.CouponID != "coupon-123" {
+			t.Fatalf("expected coupon_id=coupon-123, got %s", req.CouponID)
+		}
+		if req.TCGCost != 100 {
+			t.Fatalf("expected tcg_cost=100, got %d", req.TCGCost)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"voucher_code": "VOUCHER-XYZ",
+		})
+	}))
+	defer server.Close()
+
+	client := NewTachiyaHTTPClient(server.URL, "shared-secret")
+
+	voucherCode, err := client.RedeemCoupon("coupon-123", 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if voucherCode != "VOUCHER-XYZ" {
+		t.Fatalf("expected voucher code VOUCHER-XYZ, got %s", voucherCode)
+	}
+}
+
+func TestTachiyaHTTPClient_RedeemCoupon_NonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewTachiyaHTTPClient(server.URL, "shared-secret")
+
+	if _, err := client.RedeemCoupon("coupon-123", 100); err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}


### PR DESCRIPTION
## Scope 對齊

Source of truth: https://github.com/nurockplayer/tachigo/issues/194

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 這張 PR 做了什麼

closes #194

- 新增 `TachiyaClient` interface + `TachiyaHTTPClient`（`POST {TACHIYA_BASE_URL}/coupons/redeem`）
- `SpendService.Redeem()` 注入 `TachiyaClient`，burn 成功後呼叫 `RedeemCoupon()`；Tachiya 失敗只 log warning，不影響 burn 結果
- `redeemRequest` 加 `coupon_id`（required），`redeemResponse` 加 `voucher_code`（omitempty）
- `TACHIYA_BASE_URL` env var，預設 `http://localhost:8001`

## 本 PR 明確不做

- 不實作 Tachiya API server 端
- 不修改 burn 失敗的 rollback 邏輯
- 不擴張到其他 endpoint 或 service

## PR size

267 行（9 檔），落在 200–400 最佳區間。

## Test plan

- [x] `go build ./...` 通過
- [x] `go test ./internal/services/ -run "TestRedeem|TestTachiyaHTTPClient"` 全過（8 tests）
- [x] `TestRedeem_TachiyaFailureIsNonBlocking`：Tachiya 失敗不影響 burn 結果
- [x] `TestTachiyaHTTPClient_RedeemCoupon_Success`：HTTP body、header、response 正確解析

🤖 Generated with [Claude Code](https://claude.com/claude-code)