### PR TITLE
[backend] feat: 抽獎中獎者 Email 通知 (#230)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -153,7 +153,7 @@ func main() {
 	if cfg.Server.Env == "production" && cfg.OAuth.Twitch.ClientID == "" {
 		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
 	}
-	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID)
+	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID, cfg.App.FrontendURL, mailer)
 	// Tie scheduler lifetime to server shutdown signals so the goroutine exits cleanly.
 	serverCtx, serverStop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer serverStop()

--- a/backend/internal/handlers/raffle_handler_test.go
+++ b/backend/internal/handlers/raffle_handler_test.go
@@ -60,7 +60,7 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 
 	cfg := testConfig()
 	authSvc := services.NewAuthService(db, cfg)
-	raffleSvc := services.NewRaffleService(db, "")
+	raffleSvc := services.NewRaffleService(db, "", "", nil)
 	raffleH := handlers.NewRaffleHandler(raffleSvc)
 
 	r := gin.New()

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -86,7 +86,7 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
 	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil, nil)
-	raffleSvc := services.NewRaffleService(db, "")
+	raffleSvc := services.NewRaffleService(db, "", "", nil)
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(
@@ -476,7 +476,7 @@ func TestInternalRouter_SkipsRouteWhenSharedSecretMissing(t *testing.T) {
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
 	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil, nil)
-	raffleSvc := services.NewRaffleService(db, "")
+	raffleSvc := services.NewRaffleService(db, "", "", nil)
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(
@@ -557,7 +557,7 @@ func TestInternalRouter_WithSecretSet_MiddlewareRejectsAndRouteRegistered(t *tes
 	agencySvc := services.NewAgencyService(db)
 	claimSvc := services.NewClaimService(db, config.ContractConfig{}, nil)
 	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil, nil)
-	raffleSvc := services.NewRaffleService(db, "")
+	raffleSvc := services.NewRaffleService(db, "", "", nil)
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	engine := router.New(

--- a/backend/internal/services/raffle_scheduler_test.go
+++ b/backend/internal/services/raffle_scheduler_test.go
@@ -53,7 +53,7 @@ func TestNextSchedulerRun(t *testing.T) {
 
 func TestRunScheduledSnapshots_SkipsOutOfWindow(t *testing.T) {
 	db := newTestDB(t)
-	svc := NewRaffleService(db, "")
+	svc := NewRaffleService(db, "", "", nil)
 
 	user := insertRaffleTestUser(t, db)
 	scheduledAt := time.Now().UTC().Add(2 * time.Hour)
@@ -72,7 +72,7 @@ func TestRunScheduledSnapshots_SkipsOutOfWindow(t *testing.T) {
 
 func TestRunScheduledSnapshots_SkipsCompleted(t *testing.T) {
 	db := newTestDB(t)
-	svc := NewRaffleService(db, "")
+	svc := NewRaffleService(db, "", "", nil)
 
 	user := insertRaffleTestUser(t, db)
 	scheduledAt := time.Now().UTC().Add(5 * time.Minute)
@@ -98,7 +98,7 @@ func TestRunScheduledSnapshots_TwitchAPISuccess(t *testing.T) {
 	defer ts.Close()
 
 	db := newTestDB(t)
-	svc := NewRaffleService(db, "test-client-id")
+	svc := NewRaffleService(db, "test-client-id", "", nil)
 	svc.SetTwitchBaseURL(ts.URL)
 
 	user := insertRaffleTestUser(t, db)
@@ -120,7 +120,7 @@ func TestRunScheduledSnapshots_TwitchAPISuccess(t *testing.T) {
 
 func TestRunScheduledSnapshots_TwitchTokenMissing_StaysDraft(t *testing.T) {
 	db := newTestDB(t)
-	svc := NewRaffleService(db, "test-client-id")
+	svc := NewRaffleService(db, "test-client-id", "", nil)
 
 	user := insertRaffleTestUser(t, db)
 	scheduledAt := time.Now().UTC().Add(5 * time.Minute)

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -233,7 +233,16 @@ func (s *RaffleService) DrawNext(raffleID, userID uuid.UUID) (*models.RaffleDraw
 		return nil
 	})
 	if err == nil && s.mailer != nil {
-		go s.sendWinnerEmail(result)
+		go func(d *models.RaffleDraw) {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("raffle sendWinnerEmail panic (draw %s): %v", d.ID, r)
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			s.sendWinnerEmail(ctx, d)
+		}(result)
 	}
 	return result, err
 }
@@ -526,13 +535,13 @@ func (s *RaffleService) snapshotOne(ctx context.Context, r models.Raffle) error 
 
 // sendWinnerEmail is called async after DrawNext succeeds.
 // If the winner has no linked user account or no email, it logs and skips silently.
-func (s *RaffleService) sendWinnerEmail(draw *models.RaffleDraw) {
+func (s *RaffleService) sendWinnerEmail(ctx context.Context, draw *models.RaffleDraw) {
 	if draw.Entry.UserID == nil {
 		log.Printf("raffle draw %s: winner has no user_id, skipping email", draw.ID)
 		return
 	}
 	var user models.User
-	if err := s.db.First(&user, "id = ?", *draw.Entry.UserID).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&user, "id = ?", *draw.Entry.UserID).Error; err != nil {
 		log.Printf("raffle draw %s: failed to look up winner user: %v", draw.ID, err)
 		return
 	}

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -549,7 +549,7 @@ func (s *RaffleService) sendWinnerEmail(ctx context.Context, draw *models.Raffle
 		log.Printf("raffle draw %s: winner has no email, skipping", draw.ID)
 		return
 	}
-	link := fmt.Sprintf("%s/claim/%s", s.frontendURL, draw.ClaimToken)
+	link := fmt.Sprintf("%s/claim/%s", strings.TrimRight(s.frontendURL, "/"), draw.ClaimToken)
 	body := raffleWinnerEmailBody(draw.ClaimExpiresAt, link)
 	if err := s.mailer.Send(*user.Email, "恭喜中獎！領取你的 Tachigo 抽獎獎品", body); err != nil {
 		log.Printf("raffle draw %s: failed to send winner email to %s: %v", draw.ID, *user.Email, err)

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -40,14 +40,18 @@ type RaffleService struct {
 	twitchClientID string
 	twitchBaseURL  string
 	httpClient     *http.Client
+	mailer         Mailer
+	frontendURL    string
 }
 
-func NewRaffleService(db *gorm.DB, twitchClientID string) *RaffleService {
+func NewRaffleService(db *gorm.DB, twitchClientID, frontendURL string, mailer Mailer) *RaffleService {
 	return &RaffleService{
 		db:             db,
 		twitchClientID: twitchClientID,
 		twitchBaseURL:  "https://api.twitch.tv",
 		httpClient:     &http.Client{Timeout: 10 * time.Second},
+		mailer:         mailer,
+		frontendURL:    frontendURL,
 	}
 }
 
@@ -228,6 +232,9 @@ func (s *RaffleService) DrawNext(raffleID, userID uuid.UUID) (*models.RaffleDraw
 		result = draw
 		return nil
 	})
+	if err == nil && s.mailer != nil {
+		go s.sendWinnerEmail(result)
+	}
 	return result, err
 }
 
@@ -513,4 +520,47 @@ func (s *RaffleService) snapshotOne(ctx context.Context, r models.Raffle) error 
 	return s.db.Model(&models.Raffle{}).
 		Where("id = ? AND status = ?", r.ID, models.RaffleStatusDraft).
 		Update("status", models.RaffleStatusActive).Error
+}
+
+// ── Winner email notification ─────────────────────────────────────────────────
+
+// sendWinnerEmail is called async after DrawNext succeeds.
+// If the winner has no linked user account or no email, it logs and skips silently.
+func (s *RaffleService) sendWinnerEmail(draw *models.RaffleDraw) {
+	if draw.Entry.UserID == nil {
+		log.Printf("raffle draw %s: winner has no user_id, skipping email", draw.ID)
+		return
+	}
+	var user models.User
+	if err := s.db.First(&user, "id = ?", *draw.Entry.UserID).Error; err != nil {
+		log.Printf("raffle draw %s: failed to look up winner user: %v", draw.ID, err)
+		return
+	}
+	if user.Email == nil {
+		log.Printf("raffle draw %s: winner has no email, skipping", draw.ID)
+		return
+	}
+	link := fmt.Sprintf("%s/claim/%s", s.frontendURL, draw.ClaimToken)
+	body := raffleWinnerEmailBody(draw.ClaimExpiresAt, link)
+	if err := s.mailer.Send(*user.Email, "恭喜中獎！領取你的 Tachigo 抽獎獎品", body); err != nil {
+		log.Printf("raffle draw %s: failed to send winner email to %s: %v", draw.ID, *user.Email, err)
+	}
+}
+
+func raffleWinnerEmailBody(expiresAt time.Time, claimLink string) string {
+	expiry := expiresAt.UTC().Format("2006-01-02 15:04 UTC")
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<body style="font-family:sans-serif;color:#333;max-width:480px;margin:auto;padding:24px">
+  <h2>恭喜中獎！</h2>
+  <p>你已在 Tachigo 抽獎中中獎！請點擊下方按鈕填寫收件資訊以領取獎品。</p>
+  <p>領獎期限：<strong>%s</strong></p>
+  <p style="margin:32px 0">
+    <a href="%s" style="background:#6441a5;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:bold">
+      領取獎品
+    </a>
+  </p>
+  <p style="font-size:12px;color:#999">若你認為這封郵件有誤，請忽略。</p>
+</body>
+</html>`, expiry, claimLink)
 }

--- a/backend/internal/services/raffle_service_email_test.go
+++ b/backend/internal/services/raffle_service_email_test.go
@@ -1,0 +1,220 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// captureMailer records the most recent Send call via a buffered channel.
+type captureMailer struct {
+	ch chan sentEmail
+}
+
+type sentEmail struct {
+	to, subject, body string
+}
+
+func newCaptureMailer() *captureMailer {
+	return &captureMailer{ch: make(chan sentEmail, 1)}
+}
+
+func (m *captureMailer) Send(to, subject, body string) error {
+	m.ch <- sentEmail{to, subject, body}
+	return nil
+}
+
+// expectEmail waits up to 2 s for an email and returns it.
+func (m *captureMailer) expectEmail(t *testing.T) sentEmail {
+	t.Helper()
+	select {
+	case e := <-m.ch:
+		return e
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: no email received")
+		return sentEmail{}
+	}
+}
+
+// noEmailMailer fails the test if Send is ever called.
+type noEmailMailer struct{ t *testing.T }
+
+func (m *noEmailMailer) Send(_, _, _ string) error {
+	m.t.Error("Send called unexpectedly")
+	return nil
+}
+
+// ── seed helpers ──────────────────────────────────────────────────────────────
+
+func seedUserWithEmail(t *testing.T, db *gorm.DB, email string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := db.Exec(`
+		INSERT INTO users (id, username, email, role, is_active, email_verified, created_at, updated_at)
+		VALUES (?, ?, ?, 'viewer', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, id.String(), "user_"+id.String()[:8], email).Error; err != nil {
+		t.Fatalf("seedUserWithEmail: %v", err)
+	}
+	return id
+}
+
+func seedUserWithoutEmail(t *testing.T, db *gorm.DB) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := db.Exec(`
+		INSERT INTO users (id, username, role, is_active, email_verified, created_at, updated_at)
+		VALUES (?, ?, 'viewer', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, id.String(), "user_"+id.String()[:8]).Error; err != nil {
+		t.Fatalf("seedUserWithoutEmail: %v", err)
+	}
+	return id
+}
+
+func seedRaffle(t *testing.T, db *gorm.DB, ownerID uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := db.Exec(`
+		INSERT INTO raffles (id, user_id, title, status, source, created_at, updated_at)
+		VALUES (?, ?, 'Test Raffle', 'active', 'csv', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, id.String(), ownerID.String()).Error; err != nil {
+		t.Fatalf("seedRaffle: %v", err)
+	}
+	return id
+}
+
+func seedEntry(t *testing.T, db *gorm.DB, raffleID uuid.UUID, userID *uuid.UUID, login string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	var uid interface{}
+	if userID != nil {
+		uid = userID.String()
+	}
+	if err := db.Exec(`
+		INSERT INTO raffle_entries (id, raffle_id, user_id, twitch_login, display_name, created_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	`, id.String(), raffleID.String(), uid, login, login).Error; err != nil {
+		t.Fatalf("seedEntry: %v", err)
+	}
+	return id
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestDrawNext_SendsEmailToWinner(t *testing.T) {
+	db := newTestDB(t)
+	mailer := newCaptureMailer()
+
+	ownerID := seedUserWithEmail(t, db, "owner@example.com")
+	winnerID := seedUserWithEmail(t, db, "winner@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, &winnerID, "winner_twitch")
+
+	svc := &RaffleService{db: db, mailer: mailer, frontendURL: "http://localhost:3000"}
+
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+	if draw == nil {
+		t.Fatal("expected draw, got nil")
+	}
+
+	email := mailer.expectEmail(t)
+	if email.to != "winner@example.com" {
+		t.Errorf("expected to=winner@example.com, got %s", email.to)
+	}
+	if !strings.Contains(email.body, draw.ClaimToken) {
+		t.Errorf("email body should contain claim token")
+	}
+	if !strings.Contains(email.body, "http://localhost:3000/claim/") {
+		t.Errorf("email body should contain claim link")
+	}
+}
+
+func TestDrawNext_SkipsEmailWhenNoUserID(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "owner@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, nil, "anonymous_twitch") // no linked account
+
+	svc := &RaffleService{db: db, mailer: &noEmailMailer{t: t}, frontendURL: "http://localhost:3000"}
+
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+	if draw == nil {
+		t.Fatal("expected draw, got nil")
+	}
+	// noEmailMailer will call t.Error if Send is called; give goroutine time to run
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestDrawNext_SkipsEmailWhenNoEmail(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "owner@example.com")
+	winnerID := seedUserWithoutEmail(t, db)
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, &winnerID, "noemail_twitch")
+
+	svc := &RaffleService{db: db, mailer: &noEmailMailer{t: t}, frontendURL: "http://localhost:3000"}
+
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+	if draw == nil {
+		t.Fatal("expected draw, got nil")
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestDrawNext_EmailFailureDoesNotBlockDraw(t *testing.T) {
+	db := newTestDB(t)
+	// errMailer always returns an error
+	errMailer := &errSendMailer{}
+	ownerID := seedUserWithEmail(t, db, "owner@example.com")
+	winnerID := seedUserWithEmail(t, db, "winner@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, &winnerID, "winner_twitch")
+
+	svc := &RaffleService{db: db, mailer: errMailer, frontendURL: "http://localhost:3000"}
+
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext should succeed even if email fails: %v", err)
+	}
+	if draw == nil {
+		t.Fatal("expected draw, got nil")
+	}
+}
+
+func TestDrawNext_NoEmailWhenMailerNil(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "owner@example.com")
+	winnerID := seedUserWithEmail(t, db, "winner@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, &winnerID, "winner_twitch")
+
+	svc := &RaffleService{db: db, mailer: nil} // no mailer configured
+
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+	if draw == nil {
+		t.Fatal("expected draw, got nil")
+	}
+}
+
+// ── helper types ──────────────────────────────────────────────────────────────
+
+type errSendMailer struct{}
+
+func (m *errSendMailer) Send(_, _, _ string) error {
+	return context.DeadlineExceeded
+}

--- a/backend/internal/services/raffle_service_email_test.go
+++ b/backend/internal/services/raffle_service_email_test.go
@@ -40,12 +40,32 @@ func (m *captureMailer) expectEmail(t *testing.T) sentEmail {
 	}
 }
 
-// noEmailMailer fails the test if Send is ever called.
-type noEmailMailer struct{ t *testing.T }
+// noEmailMailer records unexpected Send calls via a buffered channel so the
+// calling goroutine never blocks and t.Error is only called from the test goroutine.
+type noEmailMailer struct {
+	ch chan struct{}
+}
+
+func newNoEmailMailer() *noEmailMailer {
+	return &noEmailMailer{ch: make(chan struct{}, 1)}
+}
 
 func (m *noEmailMailer) Send(_, _, _ string) error {
-	m.t.Error("Send called unexpectedly")
+	select {
+	case m.ch <- struct{}{}:
+	default:
+	}
 	return nil
+}
+
+// assertNoEmail waits up to 100 ms and fails if Send was called.
+func (m *noEmailMailer) assertNoEmail(t *testing.T) {
+	t.Helper()
+	select {
+	case <-m.ch:
+		t.Error("Send called unexpectedly")
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 // ── seed helpers ──────────────────────────────────────────────────────────────
@@ -141,7 +161,8 @@ func TestDrawNext_SkipsEmailWhenNoUserID(t *testing.T) {
 	raffleID := seedRaffle(t, db, ownerID)
 	seedEntry(t, db, raffleID, nil, "anonymous_twitch") // no linked account
 
-	svc := &RaffleService{db: db, mailer: &noEmailMailer{t: t}, frontendURL: "http://localhost:3000"}
+	mailer := newNoEmailMailer()
+	svc := &RaffleService{db: db, mailer: mailer, frontendURL: "http://localhost:3000"}
 
 	draw, err := svc.DrawNext(raffleID, ownerID)
 	if err != nil {
@@ -150,8 +171,7 @@ func TestDrawNext_SkipsEmailWhenNoUserID(t *testing.T) {
 	if draw == nil {
 		t.Fatal("expected draw, got nil")
 	}
-	// noEmailMailer will call t.Error if Send is called; give goroutine time to run
-	time.Sleep(50 * time.Millisecond)
+	mailer.assertNoEmail(t)
 }
 
 func TestDrawNext_SkipsEmailWhenNoEmail(t *testing.T) {
@@ -161,7 +181,8 @@ func TestDrawNext_SkipsEmailWhenNoEmail(t *testing.T) {
 	raffleID := seedRaffle(t, db, ownerID)
 	seedEntry(t, db, raffleID, &winnerID, "noemail_twitch")
 
-	svc := &RaffleService{db: db, mailer: &noEmailMailer{t: t}, frontendURL: "http://localhost:3000"}
+	mailer := newNoEmailMailer()
+	svc := &RaffleService{db: db, mailer: mailer, frontendURL: "http://localhost:3000"}
 
 	draw, err := svc.DrawNext(raffleID, ownerID)
 	if err != nil {
@@ -170,7 +191,7 @@ func TestDrawNext_SkipsEmailWhenNoEmail(t *testing.T) {
 	if draw == nil {
 		t.Fatal("expected draw, got nil")
 	}
-	time.Sleep(50 * time.Millisecond)
+	mailer.assertNoEmail(t)
 }
 
 func TestDrawNext_EmailFailureDoesNotBlockDraw(t *testing.T) {

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -266,6 +266,15 @@ func migrateTestDB(db *gorm.DB) error {
 			UNIQUE (raffle_id, twitch_login),
 			UNIQUE (id, raffle_id)
 		)`,
+		`CREATE TABLE IF NOT EXISTS raffle_draws (
+			id TEXT PRIMARY KEY,
+			raffle_id TEXT NOT NULL REFERENCES raffles(id),
+			entry_id TEXT NOT NULL,
+			claim_token TEXT NOT NULL UNIQUE,
+			claim_expires_at DATETIME NOT NULL,
+			drawn_at DATETIME NOT NULL,
+			UNIQUE (raffle_id, entry_id)
+		)`,
 	}
 	for _, s := range stmts {
 		if err := db.Exec(s).Error; err != nil {


### PR DESCRIPTION
## 什麼改動
- `RaffleService` 新增 `mailer`、`frontendURL` 欄位，`NewRaffleService` 更新對應參數
- `DrawNext` 成功後非同步觸發 `sendWinnerEmail`（goroutine，不阻塞抽獎回應）
- `sendWinnerEmail`：查 `entry.UserID` → 取 `users.email` → 若無 user_id 或無 email 則 log 並跳過，email 送失敗只 log warning
- `raffleWinnerEmailBody` HTML template，包含領獎連結與期限

## 為什麼
closes #230

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#230
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作 Discord 通知
  - 不實作重送機制
  - 不修改 DrawNext 的抽獎邏輯

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 中獎後非同步寄出 Email 通知給中獎者
- Approx changed lines：~285
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service + tests 為同一功能單元，無法分離驗證
- 若已拆分，相關 PR：
  - n/a

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過（build 通過）
- [x] 有寫 / 更新測試

5 個測試案例：
- `TestDrawNext_SendsEmailToWinner`：中獎者有 email，確認寄出、收件人、body 含 claim link
- `TestDrawNext_SkipsEmailWhenNoUserID`：entry 無 user_id，不寄信
- `TestDrawNext_SkipsEmailWhenNoEmail`：user 無 email，不寄信
- `TestDrawNext_EmailFailureDoesNotBlockDraw`：mailer 失敗，draw 仍成功回傳
- `TestDrawNext_NoEmailWhenMailerNil`：未注入 mailer，draw 正常執行

本地因 Windows 無 CGO，SQLite tests 需在 CI Docker 執行（與既有測試一致）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 抽奖获胜者现在会自动收到电子邮件通知，邮件中包含专属领取链接和过期时间。系统确保仅向有有效邮箱的获胜者发送通知，邮件发送失败不会影响抽奖结果的确认。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->