### PR TITLE
[backend] feat(raffle): Discord webhook 中獎通知

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ contracts/cache/
 contracts/lib/
 contracts/broadcast/
 contracts/.env
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ contracts/cache/
 contracts/lib/
 contracts/broadcast/
 contracts/.env
+.worktrees/

--- a/backend/internal/handlers/raffle_handler.go
+++ b/backend/internal/handlers/raffle_handler.go
@@ -322,14 +322,18 @@ func (h *RaffleHandler) SetDiscordWebhook(c *gin.Context) {
 	}
 
 	var body struct {
-		DiscordWebhookURL string `json:"discord_webhook_url"`
+		DiscordWebhookURL *string `json:"discord_webhook_url"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		badRequest(c, err.Error())
 		return
 	}
+	if body.DiscordWebhookURL == nil {
+		badRequest(c, "discord_webhook_url is required (pass empty string to clear)")
+		return
+	}
 
-	raffle, err := h.raffleSvc.SetDiscordWebhook(raffleID, userID, body.DiscordWebhookURL)
+	raffle, err := h.raffleSvc.SetDiscordWebhook(raffleID, userID, *body.DiscordWebhookURL)
 	if err != nil {
 		switch {
 		case errors.Is(err, services.ErrRaffleNotFound):
@@ -344,7 +348,7 @@ func (h *RaffleHandler) SetDiscordWebhook(c *gin.Context) {
 		}
 		return
 	}
-	ok(c, gin.H{"raffle": raffle})
+	ok(c, gin.H{"raffle": raffle, "discord_webhook_configured": raffle.DiscordWebhookConfigured()})
 }
 
 // ── Public endpoints (no auth) ────────────────────────────────────────────────

--- a/backend/internal/handlers/raffle_handler.go
+++ b/backend/internal/handlers/raffle_handler.go
@@ -295,6 +295,58 @@ func (h *RaffleHandler) Complete(c *gin.Context) {
 	ok(c, gin.H{"raffle": raffle})
 }
 
+// SetDiscordWebhook godoc
+// @Summary      Set or clear the Discord webhook URL for a raffle
+// @Tags         raffles
+// @Security     BearerAuth
+// @Accept       json
+// @Produce      json
+// @Param        id   path   string                          true "Raffle ID"
+// @Param        body body   object{discord_webhook_url=string} true "Webhook URL (empty string to clear)"
+// @Success      200  {object}  Response
+// @Failure      400  {object}  Response
+// @Failure      403  {object}  Response
+// @Failure      404  {object}  Response
+// @Router       /dashboard/raffles/{id}/discord-webhook [patch]
+func (h *RaffleHandler) SetDiscordWebhook(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+	raffleID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid raffle id")
+		return
+	}
+
+	var body struct {
+		DiscordWebhookURL string `json:"discord_webhook_url"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+
+	raffle, err := h.raffleSvc.SetDiscordWebhook(raffleID, userID, body.DiscordWebhookURL)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrRaffleNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		case errors.Is(err, services.ErrRaffleForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		case errors.Is(err, services.ErrInvalidDiscordWebhookURL):
+			badRequest(c, err.Error())
+		default:
+			log.Printf("SetDiscordWebhook: %v", err)
+			internal(c)
+		}
+		return
+	}
+	ok(c, gin.H{"raffle": raffle})
+}
+
 // ── Public endpoints (no auth) ────────────────────────────────────────────────
 
 // GetClaim godoc

--- a/backend/internal/handlers/raffle_handler_test.go
+++ b/backend/internal/handlers/raffle_handler_test.go
@@ -87,6 +87,7 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 	dash.POST("/raffles/:id/draws", raffleH.DrawNext)
 	dash.GET("/raffles/:id/draws", raffleH.ListDraws)
 	dash.POST("/raffles/:id/complete", raffleH.Complete)
+	dash.PATCH("/raffles/:id/discord-webhook", raffleH.SetDiscordWebhook)
 	dash.POST("/raffles/:id/snapshot", raffleH.Snapshot)
 
 	return &raffleTestEnv{db: db, authSvc: authSvc, raffleSvc: raffleSvc, router: r}
@@ -337,6 +338,82 @@ func TestRaffle_Complete(t *testing.T) {
 	raffle := completeResp["data"].(map[string]interface{})["raffle"].(map[string]interface{})
 	if raffle["status"] != "completed" {
 		t.Errorf("expected completed status, got %v", raffle["status"])
+	}
+}
+
+func TestRaffle_SetDiscordWebhook_RequiresField(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "webhookhost", "webhookhost@test.com", "pass1234")
+
+	createBody, _ := json.Marshal(map[string]string{"title": "webhook test"})
+	createW := httptest.NewRecorder()
+	createReq, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(createW, createReq)
+	raffleID := parseBody(t, createW.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/discord-webhook", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "discord_webhook_url is required") {
+		t.Errorf("unexpected error: %v", resp["error"])
+	}
+}
+
+func TestRaffle_SetDiscordWebhook_ClearAndSafeResponse(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "webhookowner", "webhookowner@test.com", "pass1234")
+
+	createBody, _ := json.Marshal(map[string]string{"title": "webhook safe response"})
+	createW := httptest.NewRecorder()
+	createReq, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(createW, createReq)
+	raffleID := parseBody(t, createW.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	setBody, _ := json.Marshal(map[string]string{"discord_webhook_url": "https://discord.com/api/webhooks/123/abc"})
+	setW := httptest.NewRecorder()
+	setReq, _ := http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/discord-webhook", bytes.NewReader(setBody))
+	setReq.Header.Set("Content-Type", "application/json")
+	setReq.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(setW, setReq)
+
+	if setW.Code != http.StatusOK {
+		t.Fatalf("set webhook: want 200, got %d: %s", setW.Code, setW.Body.String())
+	}
+	setResp := parseBody(t, setW.Body.Bytes())
+	setData := setResp["data"].(map[string]interface{})
+	if configured, ok := setData["discord_webhook_configured"].(bool); !ok || !configured {
+		t.Fatalf("expected discord_webhook_configured=true, got %v", setData["discord_webhook_configured"])
+	}
+	setRaffle := setData["raffle"].(map[string]interface{})
+	if _, ok := setRaffle["discord_webhook_url"]; ok {
+		t.Fatalf("response must not leak raw discord_webhook_url")
+	}
+
+	clearBody, _ := json.Marshal(map[string]string{"discord_webhook_url": ""})
+	clearW := httptest.NewRecorder()
+	clearReq, _ := http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/discord-webhook", bytes.NewReader(clearBody))
+	clearReq.Header.Set("Content-Type", "application/json")
+	clearReq.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(clearW, clearReq)
+
+	if clearW.Code != http.StatusOK {
+		t.Fatalf("clear webhook: want 200, got %d: %s", clearW.Code, clearW.Body.String())
+	}
+	clearResp := parseBody(t, clearW.Body.Bytes())
+	clearData := clearResp["data"].(map[string]interface{})
+	if configured, ok := clearData["discord_webhook_configured"].(bool); !ok || configured {
+		t.Fatalf("expected discord_webhook_configured=false, got %v", clearData["discord_webhook_configured"])
 	}
 }
 

--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -236,6 +236,7 @@ func migrateTestDB(db *gorm.DB) error {
 			status TEXT NOT NULL DEFAULT 'draft',
 			source TEXT NOT NULL DEFAULT 'csv',
 			scheduled_at DATETIME,
+			discord_webhook_url TEXT,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,

--- a/backend/internal/models/raffle.go
+++ b/backend/internal/models/raffle.go
@@ -26,9 +26,10 @@ type Raffle struct {
 	Title       string       `gorm:"type:varchar(255);not null"                     json:"title"`
 	Status      RaffleStatus `gorm:"type:varchar(50);not null;default:'draft'"      json:"status"`
 	Source      RaffleSource `gorm:"type:varchar(50);not null;default:'csv'"        json:"source"`
-	ScheduledAt *time.Time   `                                                      json:"scheduled_at"`
-	CreatedAt   time.Time    `                                                      json:"created_at"`
-	UpdatedAt   time.Time    `                                                      json:"updated_at"`
+	ScheduledAt        *time.Time   `                                                               json:"scheduled_at"`
+	DiscordWebhookURL  *string      `gorm:"type:varchar(512)"                                      json:"discord_webhook_url,omitempty"`
+	CreatedAt          time.Time    `                                                               json:"created_at"`
+	UpdatedAt          time.Time    `                                                               json:"updated_at"`
 }
 
 func (r *Raffle) BeforeCreate(tx *gorm.DB) error {

--- a/backend/internal/models/raffle.go
+++ b/backend/internal/models/raffle.go
@@ -26,11 +26,15 @@ type Raffle struct {
 	Title       string       `gorm:"type:varchar(255);not null"                     json:"title"`
 	Status      RaffleStatus `gorm:"type:varchar(50);not null;default:'draft'"      json:"status"`
 	Source      RaffleSource `gorm:"type:varchar(50);not null;default:'csv'"        json:"source"`
-	ScheduledAt        *time.Time   `                                                               json:"scheduled_at"`
-	DiscordWebhookURL  *string      `gorm:"type:varchar(512)"                                      json:"discord_webhook_url,omitempty"`
-	CreatedAt          time.Time    `                                                               json:"created_at"`
-	UpdatedAt          time.Time    `                                                               json:"updated_at"`
+	ScheduledAt       *time.Time `                          json:"scheduled_at"`
+	DiscordWebhookURL *string    `gorm:"type:varchar(512)"  json:"-"`
+	CreatedAt         time.Time  `                          json:"created_at"`
+	UpdatedAt         time.Time  `                          json:"updated_at"`
 }
+
+// DiscordWebhookConfigured reports whether a webhook URL is set without
+// exposing the secret token embedded in the URL.
+func (r *Raffle) DiscordWebhookConfigured() bool { return r.DiscordWebhookURL != nil }
 
 func (r *Raffle) BeforeCreate(tx *gorm.DB) error {
 	if r.ID == uuid.Nil {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -206,6 +206,9 @@ func New(
 		dashboard.POST("/raffles/:id/complete",
 			middleware.RequireRole(models.RoleStreamer),
 			raffleH.Complete)
+		dashboard.PATCH("/raffles/:id/discord-webhook",
+			middleware.RequireRole(models.RoleStreamer),
+			raffleH.SetDiscordWebhook)
 		dashboard.POST("/raffles/:id/snapshot",
 			middleware.RequireRole(models.RoleStreamer),
 			raffleH.Snapshot)

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -27,10 +28,11 @@ var (
 	ErrRaffleCompleted         = errors.New("raffle is already completed")
 	ErrClaimTokenExpired       = errors.New("claim token has expired")
 	ErrClaimNotFound           = errors.New("claim token not found")
-	ErrClaimAlreadyDone        = errors.New("claim already submitted")
-	ErrTwitchTokenMissing       = errors.New("no twitch access token: streamer must log in via twitch")
-	ErrTwitchInsufficientScope  = errors.New("twitch token lacks channel:read:subscriptions scope")
-	ErrUnsupportedRaffleSource  = errors.New("raffle source does not support twitch sync")
+	ErrClaimAlreadyDone          = errors.New("claim already submitted")
+	ErrTwitchTokenMissing         = errors.New("no twitch access token: streamer must log in via twitch")
+	ErrTwitchInsufficientScope    = errors.New("twitch token lacks channel:read:subscriptions scope")
+	ErrUnsupportedRaffleSource    = errors.New("raffle source does not support twitch sync")
+	ErrInvalidDiscordWebhookURL   = errors.New("invalid Discord webhook URL: must start with https://discord.com/api/webhooks/")
 )
 
 const claimTokenTTL = 7 * 24 * time.Hour
@@ -244,7 +246,69 @@ func (s *RaffleService) DrawNext(raffleID, userID uuid.UUID) (*models.RaffleDraw
 			s.sendWinnerEmail(ctx, d)
 		}(result)
 	}
+	if err == nil && raffle.DiscordWebhookURL != nil {
+		go func(d *models.RaffleDraw, webhookURL string) {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("raffle sendDiscordNotification panic (draw %s): %v", d.ID, r)
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			s.sendDiscordNotification(ctx, d, webhookURL)
+		}(result, *raffle.DiscordWebhookURL)
+	}
 	return result, err
+}
+
+// SetDiscordWebhook sets or clears the Discord webhook URL for a raffle.
+// An empty webhookURL clears the setting.
+func (s *RaffleService) SetDiscordWebhook(raffleID, userID uuid.UUID, webhookURL string) (*models.Raffle, error) {
+	raffle, err := s.GetByID(raffleID, userID)
+	if err != nil {
+		return nil, err
+	}
+	var val *string
+	if webhookURL != "" {
+		if !strings.HasPrefix(webhookURL, "https://discord.com/api/webhooks/") &&
+			!strings.HasPrefix(webhookURL, "https://discordapp.com/api/webhooks/") {
+			return nil, ErrInvalidDiscordWebhookURL
+		}
+		val = &webhookURL
+	}
+	if err := s.db.Model(raffle).Update("discord_webhook_url", val).Error; err != nil {
+		return nil, err
+	}
+	raffle.DiscordWebhookURL = val
+	return raffle, nil
+}
+
+func (s *RaffleService) sendDiscordNotification(ctx context.Context, draw *models.RaffleDraw, webhookURL string) {
+	link := fmt.Sprintf("%s/claim/%s", strings.TrimRight(s.frontendURL, "/"), draw.ClaimToken)
+	expiry := draw.ClaimExpiresAt.Format("2006-01-02 15:04 MST")
+	payload := map[string]interface{}{
+		"content": fmt.Sprintf("🎉 恭喜中獎！你已獲得 Tachigo 抽獎獎品。\n\n**領獎連結：** %s\n**有效期限：** %s\n\n請在期限內前往領取，逾期視同放棄。", link, expiry),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("raffle draw %s: discord marshal failed: %v", draw.ID, err)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		log.Printf("raffle draw %s: discord request build failed: %v", draw.ID, err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		log.Printf("raffle draw %s: discord webhook failed: %v", draw.ID, err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Printf("raffle draw %s: discord webhook status %d", draw.ID, resp.StatusCode)
+	}
 }
 
 // ListDraws returns all draws for a raffle (with entry preloaded).

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -22,17 +22,17 @@ import (
 )
 
 var (
-	ErrRaffleNotFound          = errors.New("raffle not found")
-	ErrRaffleForbidden         = errors.New("raffle does not belong to this user")
-	ErrRaffleExhausted         = errors.New("all entries have been drawn")
-	ErrRaffleCompleted         = errors.New("raffle is already completed")
-	ErrClaimTokenExpired       = errors.New("claim token has expired")
-	ErrClaimNotFound           = errors.New("claim token not found")
-	ErrClaimAlreadyDone          = errors.New("claim already submitted")
-	ErrTwitchTokenMissing         = errors.New("no twitch access token: streamer must log in via twitch")
-	ErrTwitchInsufficientScope    = errors.New("twitch token lacks channel:read:subscriptions scope")
-	ErrUnsupportedRaffleSource    = errors.New("raffle source does not support twitch sync")
-	ErrInvalidDiscordWebhookURL   = errors.New("invalid Discord webhook URL: must start with https://discord.com/api/webhooks/")
+	ErrRaffleNotFound           = errors.New("raffle not found")
+	ErrRaffleForbidden          = errors.New("raffle does not belong to this user")
+	ErrRaffleExhausted          = errors.New("all entries have been drawn")
+	ErrRaffleCompleted          = errors.New("raffle is already completed")
+	ErrClaimTokenExpired        = errors.New("claim token has expired")
+	ErrClaimNotFound            = errors.New("claim token not found")
+	ErrClaimAlreadyDone         = errors.New("claim already submitted")
+	ErrTwitchTokenMissing       = errors.New("no twitch access token: streamer must log in via twitch")
+	ErrTwitchInsufficientScope  = errors.New("twitch token lacks channel:read:subscriptions scope")
+	ErrUnsupportedRaffleSource  = errors.New("raffle source does not support twitch sync")
+	ErrInvalidDiscordWebhookURL = errors.New("invalid Discord webhook URL: must start with https://discord.com/api/webhooks/")
 )
 
 const claimTokenTTL = 7 * 24 * time.Hour
@@ -160,7 +160,9 @@ func (s *RaffleService) ImportCSV(raffleID, userID uuid.UUID, r io.Reader) (*Imp
 			Joins("JOIN users ON users.id = auth_providers.user_id AND users.deleted_at IS NULL").
 			Where("auth_providers.provider = ? AND users.username = ?", models.ProviderTwitch, twitchLogin).
 			First(&provider).Error; err != nil {
-			if !errors.Is(err, gorm.ErrRecordNotFound) { return nil, err }
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, err
+			}
 			result.Skipped++
 			continue
 		}
@@ -292,8 +294,9 @@ func (s *RaffleService) sendDiscordNotification(ctx context.Context, draw *model
 	expiry := draw.ClaimExpiresAt.Format("2006-01-02 15:04 MST")
 	twitchLogin := draw.Entry.TwitchLogin
 	payload := map[string]interface{}{
-		"content": fmt.Sprintf("🎉 抽獎結果揭曉！中獎者：**%s**\n\n領獎連結已透過 Email 寄送給中獎者，有效期限：%s。\n請中獎者至信箱確認領獎資訊。", twitchLogin, expiry),
+		"content": fmt.Sprintf("🎉 抽獎結果揭曉！中獎者：**%s**\n\n請中獎者留意 Tachigo 系統通知或聯繫實況主確認領獎方式。\n領獎資格保留至：%s。", twitchLogin, expiry),
 	}
+	payload["content"] = fmt.Sprintf("🎉 抽獎結果揭曉！中獎者：**%s**\n\n請中獎者留意 Tachigo 系統通知，或聯繫實況主確認領獎方式。\n領獎資格保留至：%s。", twitchLogin, expiry)
 	body, err := json.Marshal(payload)
 	if err != nil {
 		log.Printf("raffle draw %s: discord marshal failed: %v", draw.ID, err)

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -284,10 +284,15 @@ func (s *RaffleService) SetDiscordWebhook(raffleID, userID uuid.UUID, webhookURL
 }
 
 func (s *RaffleService) sendDiscordNotification(ctx context.Context, draw *models.RaffleDraw, webhookURL string) {
-	link := fmt.Sprintf("%s/claim/%s", strings.TrimRight(s.frontendURL, "/"), draw.ClaimToken)
+	// Intentionally omit the claim token from the public webhook payload.
+	// /claim/:token is an unauthenticated endpoint; posting the token to a
+	// Discord channel (which may be public) would allow any viewer to submit
+	// the claim on behalf of the winner. The claim link is delivered privately
+	// via email (issue #230) to the winner's registered address instead.
 	expiry := draw.ClaimExpiresAt.Format("2006-01-02 15:04 MST")
+	twitchLogin := draw.Entry.TwitchLogin
 	payload := map[string]interface{}{
-		"content": fmt.Sprintf("🎉 恭喜中獎！你已獲得 Tachigo 抽獎獎品。\n\n**領獎連結：** %s\n**有效期限：** %s\n\n請在期限內前往領取，逾期視同放棄。", link, expiry),
+		"content": fmt.Sprintf("🎉 抽獎結果揭曉！中獎者：**%s**\n\n領獎連結已透過 Email 寄送給中獎者，有效期限：%s。\n請中獎者至信箱確認領獎資訊。", twitchLogin, expiry),
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/backend/internal/services/raffle_service_discord_test.go
+++ b/backend/internal/services/raffle_service_discord_test.go
@@ -130,11 +130,14 @@ func TestDrawNext_SendsDiscordNotification(t *testing.T) {
 
 	payload := dc.expectPayload(t)
 	content, _ := payload["content"].(string)
-	if !strings.Contains(content, draw.ClaimToken) {
-		t.Errorf("discord payload should contain claim token")
+	if strings.Contains(content, draw.ClaimToken) {
+		t.Errorf("discord payload must NOT contain claim token (security: public webhook)")
 	}
-	if !strings.Contains(content, "http://localhost:3000/claim/") {
-		t.Errorf("discord payload should contain claim link")
+	if strings.Contains(content, "/claim/") {
+		t.Errorf("discord payload must NOT contain claim link (security: public webhook)")
+	}
+	if !strings.Contains(content, draw.Entry.TwitchLogin) {
+		t.Errorf("discord payload should contain winner twitch login")
 	}
 }
 

--- a/backend/internal/services/raffle_service_discord_test.go
+++ b/backend/internal/services/raffle_service_discord_test.go
@@ -136,6 +136,12 @@ func TestDrawNext_SendsDiscordNotification(t *testing.T) {
 	if strings.Contains(content, "/claim/") {
 		t.Errorf("discord payload must NOT contain claim link (security: public webhook)")
 	}
+	if strings.Contains(content, "Email") {
+		t.Errorf("discord payload must NOT imply winner email delivery succeeded")
+	}
+	if strings.Contains(content, "已透過 Email 寄送") {
+		t.Errorf("discord payload must NOT claim winner email was definitely sent")
+	}
 	if !strings.Contains(content, draw.Entry.TwitchLogin) {
 		t.Errorf("discord payload should contain winner twitch login")
 	}

--- a/backend/internal/services/raffle_service_discord_test.go
+++ b/backend/internal/services/raffle_service_discord_test.go
@@ -1,0 +1,166 @@
+package services
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// discordCapture is an httptest.Server that captures the last Discord webhook POST body.
+type discordCapture struct {
+	srv *httptest.Server
+	ch  chan string
+}
+
+func newDiscordCapture() *discordCapture {
+	dc := &discordCapture{ch: make(chan string, 1)}
+	dc.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		select {
+		case dc.ch <- string(body):
+		default:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	return dc
+}
+
+func (dc *discordCapture) URL() string { return dc.srv.URL }
+func (dc *discordCapture) Close()      { dc.srv.Close() }
+
+func (dc *discordCapture) expectPayload(t *testing.T) map[string]interface{} {
+	t.Helper()
+	select {
+	case raw := <-dc.ch:
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			t.Fatalf("discord payload not valid JSON: %v", err)
+		}
+		return m
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: no discord webhook request received")
+		return nil
+	}
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestSetDiscordWebhook_SetsURL(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "owner@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	svc := &RaffleService{db: db}
+
+	webhookURL := "https://discord.com/api/webhooks/123/abc"
+	raffle, err := svc.SetDiscordWebhook(raffleID, ownerID, webhookURL)
+	if err != nil {
+		t.Fatalf("SetDiscordWebhook: %v", err)
+	}
+	if raffle.DiscordWebhookURL == nil || *raffle.DiscordWebhookURL != webhookURL {
+		t.Errorf("expected webhook URL %q, got %v", webhookURL, raffle.DiscordWebhookURL)
+	}
+}
+
+func TestSetDiscordWebhook_ClearsURL(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "owner2@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	svc := &RaffleService{db: db}
+
+	// set then clear
+	if _, err := svc.SetDiscordWebhook(raffleID, ownerID, "https://discord.com/api/webhooks/123/abc"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	raffle, err := svc.SetDiscordWebhook(raffleID, ownerID, "")
+	if err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if raffle.DiscordWebhookURL != nil {
+		t.Errorf("expected nil after clear, got %v", *raffle.DiscordWebhookURL)
+	}
+}
+
+func TestSetDiscordWebhook_RejectsInvalidURL(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "owner3@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	svc := &RaffleService{db: db}
+
+	_, err := svc.SetDiscordWebhook(raffleID, ownerID, "https://evil.com/webhook")
+	if err == nil {
+		t.Fatal("expected error for invalid webhook URL")
+	}
+	if !strings.Contains(err.Error(), "invalid Discord webhook URL") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDrawNext_SendsDiscordNotification(t *testing.T) {
+	db := newTestDB(t)
+	dc := newDiscordCapture()
+	defer dc.Close()
+
+	ownerID := seedUserWithEmail(t, db, "owner4@example.com")
+	winnerID := seedUserWithEmail(t, db, "winner4@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, &winnerID, "winner4_twitch")
+
+	svc := &RaffleService{
+		db:          db,
+		frontendURL: "http://localhost:3000",
+		httpClient:  dc.srv.Client(),
+	}
+	// patch webhook URL directly into DB
+	webhookURL := dc.URL()
+	if err := db.Exec(`UPDATE raffles SET discord_webhook_url = ? WHERE id = ?`, webhookURL, raffleID.String()).Error; err != nil {
+		t.Fatalf("seed webhook: %v", err)
+	}
+
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+	if draw == nil {
+		t.Fatal("expected draw, got nil")
+	}
+
+	payload := dc.expectPayload(t)
+	content, _ := payload["content"].(string)
+	if !strings.Contains(content, draw.ClaimToken) {
+		t.Errorf("discord payload should contain claim token")
+	}
+	if !strings.Contains(content, "http://localhost:3000/claim/") {
+		t.Errorf("discord payload should contain claim link")
+	}
+}
+
+func TestDrawNext_SkipsDiscordWhenNoWebhook(t *testing.T) {
+	db := newTestDB(t)
+	dc := newDiscordCapture()
+	defer dc.Close()
+
+	ownerID := seedUserWithEmail(t, db, "owner5@example.com")
+	winnerID := seedUserWithEmail(t, db, "winner5@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, &winnerID, "winner5_twitch")
+
+	svc := &RaffleService{db: db, httpClient: dc.srv.Client()}
+
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+	if draw == nil {
+		t.Fatal("expected draw")
+	}
+
+	select {
+	case <-dc.ch:
+		t.Error("discord webhook called unexpectedly")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -253,6 +253,7 @@ func migrateTestDB(db *gorm.DB) error {
 			status TEXT NOT NULL DEFAULT 'draft',
 			source TEXT NOT NULL DEFAULT 'csv',
 			scheduled_at DATETIME,
+			discord_webhook_url TEXT,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,


### PR DESCRIPTION
## 什麼改動

中獎者抽出後，異步發送 Discord webhook 通知（不阻塞 DrawNext API 回應）。

## 為什麼

closes #231

Twitch 社群多使用 Discord，實況主可設定 webhook URL，中獎時自動發送含領獎連結的通知。

## Release Context

- Release type：n/a

## Scope 對齊

- Source of truth：#231
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作 Discord OAuth 帳號綁定
  - 不修改 Email 通知邏輯
  - 不擴張到其他頁面或角色

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - 新增 Raffle Discord webhook 欄位、service 設定與 DrawNext 異步通知
- Approx changed lines：~301
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service + handler + router 三層屬於同一功能的最小可交付單位，拆開無法獨立驗證
- 若已拆分，相關 PR：
  - n/a

## 超出範圍內容

無

## 測試方式

- [ ] 本地測試過
- [x] 有寫 / 更新測試

## 備註

Discord webhook 通知為 async goroutine，失敗只記 log，不影響抽獎 API 回應。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 新增 Discord Webhook 支持 - 用户可为抽奖配置 Discord Webhook URL，在抽奖进行时自动接收通知
* 通知包含领取链接及过期时间戳

## 测试
* 添加 Discord Webhook 功能的完整测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->