### PR TITLE
[backend] claim_items 跨表一致性強化（composite FK）

### DIFF
--- a/backend/internal/handlers/testutil_test.go
+++ b/backend/internal/handlers/testutil_test.go
@@ -149,6 +149,8 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_user_channel
 			ON points_ledgers (user_id, channel_id)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_id_user_id
+			ON points_ledgers (id, user_id)`,
 		`CREATE TABLE IF NOT EXISTS points_transactions (
 			id TEXT PRIMARY KEY,
 			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
@@ -160,6 +162,8 @@ func migrateTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_transactions_id_ledger_id
+			ON points_transactions (id, ledger_id)`,
 		`CREATE TABLE IF NOT EXISTS claims (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -174,6 +178,8 @@ func migrateTestDB(db *gorm.DB) error {
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_id_user_id
+			ON claims (id, user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
 			ON claims (user_id, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
@@ -183,11 +189,15 @@ func migrateTestDB(db *gorm.DB) error {
 			WHERE tx_hash IS NOT NULL`,
 		`CREATE TABLE IF NOT EXISTS claim_items (
 			id TEXT PRIMARY KEY,
-			claim_id TEXT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
-			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
-			points_transaction_id TEXT NOT NULL REFERENCES points_transactions(id),
+			claim_id TEXT NOT NULL,
+			claim_user_id TEXT NOT NULL,
+			ledger_id TEXT NOT NULL,
+			points_transaction_id TEXT NOT NULL,
 			amount INTEGER NOT NULL CHECK (amount > 0),
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (claim_id, claim_user_id) REFERENCES claims(id, user_id) ON DELETE CASCADE,
+			FOREIGN KEY (ledger_id, claim_user_id) REFERENCES points_ledgers(id, user_id),
+			FOREIGN KEY (points_transaction_id, ledger_id) REFERENCES points_transactions(id, ledger_id),
 			UNIQUE (points_transaction_id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id

--- a/backend/internal/models/claim.go
+++ b/backend/internal/models/claim.go
@@ -52,6 +52,7 @@ func (c *Claim) BeforeCreate(tx *gorm.DB) error {
 type ClaimItem struct {
 	ID                  uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"                 json:"id"`
 	ClaimID             uuid.UUID `gorm:"type:uuid;not null;index"                                        json:"claim_id"`
+	ClaimUserID         uuid.UUID `gorm:"type:uuid;not null;index"                                        json:"claim_user_id"`
 	LedgerID            uuid.UUID `gorm:"type:uuid;not null;index"                                        json:"ledger_id"`
 	PointsTransactionID uuid.UUID `gorm:"type:uuid;not null;uniqueIndex"                                  json:"points_transaction_id"`
 	Amount              int64     `gorm:"not null;check:chk_claim_item_amount_gt_0,amount > 0"           json:"amount"`

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -242,6 +242,8 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_user_channel
 			ON points_ledgers (user_id, channel_id)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_id_user_id
+			ON points_ledgers (id, user_id)`,
 		`CREATE TABLE IF NOT EXISTS points_transactions (
 			id TEXT PRIMARY KEY,
 			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
@@ -253,6 +255,8 @@ func migrateTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_transactions_id_ledger_id
+			ON points_transactions (id, ledger_id)`,
 		`CREATE TABLE IF NOT EXISTS claims (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -267,6 +271,8 @@ func migrateTestDB(db *gorm.DB) error {
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_id_user_id
+			ON claims (id, user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
 			ON claims (user_id, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
@@ -276,11 +282,15 @@ func migrateTestDB(db *gorm.DB) error {
 			WHERE tx_hash IS NOT NULL`,
 		`CREATE TABLE IF NOT EXISTS claim_items (
 			id TEXT PRIMARY KEY,
-			claim_id TEXT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
-			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
-			points_transaction_id TEXT NOT NULL REFERENCES points_transactions(id),
+			claim_id TEXT NOT NULL,
+			claim_user_id TEXT NOT NULL,
+			ledger_id TEXT NOT NULL,
+			points_transaction_id TEXT NOT NULL,
 			amount INTEGER NOT NULL CHECK (amount > 0),
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (claim_id, claim_user_id) REFERENCES claims(id, user_id) ON DELETE CASCADE,
+			FOREIGN KEY (ledger_id, claim_user_id) REFERENCES points_ledgers(id, user_id),
+			FOREIGN KEY (points_transaction_id, ledger_id) REFERENCES points_transactions(id, ledger_id),
 			UNIQUE (points_transaction_id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id

--- a/backend/internal/services/claim_schema_test.go
+++ b/backend/internal/services/claim_schema_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -39,9 +40,94 @@ func TestMigrateTestDB_CreatesClaimTables(t *testing.T) {
 	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'claim_items'").Scan(&claimItemsDDL).Error; err != nil {
 		t.Fatalf("query claim_items ddl: %v", err)
 	}
+	assertContains(t, claimItemsDDL, "claim_user_id")
 	assertContains(t, claimItemsDDL, "UNIQUE (points_transaction_id)")
 
 	assertIndexExists(t, db, "idx_claims_tx_hash_not_null")
+}
+
+func TestMigrateTestDB_RejectsClaimItemWhenTransactionLedgerMismatch(t *testing.T) {
+	db := newTestDB(t)
+
+	mustExec(t, db, `
+		INSERT INTO users (id) VALUES
+			('u1')
+	`)
+	mustExec(t, db, `
+		INSERT INTO points_ledgers (id, user_id, channel_id, spendable_balance, cumulative_total, created_at, updated_at) VALUES
+			('l1', 'u1', 'c1', 100, 100, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+			('l2', 'u1', 'c2', 100, 100, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`)
+	mustExec(t, db, `
+		INSERT INTO points_transactions (id, ledger_id, source, delta, balance_after, created_at) VALUES
+			('tx2', 'l2', 'claim', -10, 90, CURRENT_TIMESTAMP)
+	`)
+	mustExec(t, db, `
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, created_at, updated_at) VALUES
+			('c1', 'u1', '0x1111111111111111111111111111111111111111', 10, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`)
+
+	err := db.Exec(`
+		INSERT INTO claim_items (id, claim_id, claim_user_id, ledger_id, points_transaction_id, amount, created_at)
+		VALUES ('ci1', 'c1', 'u1', 'l1', 'tx2', 10, CURRENT_TIMESTAMP)
+	`).Error
+	assertForeignKeyRejected(t, err)
+}
+
+func TestMigrateTestDB_AllowsClaimItemWhenCompositeKeysMatch(t *testing.T) {
+	db := newTestDB(t)
+
+	mustExec(t, db, `
+		INSERT INTO users (id) VALUES
+			('u1')
+	`)
+	mustExec(t, db, `
+		INSERT INTO points_ledgers (id, user_id, channel_id, spendable_balance, cumulative_total, created_at, updated_at) VALUES
+			('l1', 'u1', 'c1', 100, 100, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`)
+	mustExec(t, db, `
+		INSERT INTO points_transactions (id, ledger_id, source, delta, balance_after, created_at) VALUES
+			('tx1', 'l1', 'claim', -10, 90, CURRENT_TIMESTAMP)
+	`)
+	mustExec(t, db, `
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, created_at, updated_at) VALUES
+			('c1', 'u1', '0x1111111111111111111111111111111111111111', 10, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`)
+
+	if err := db.Exec(`
+		INSERT INTO claim_items (id, claim_id, claim_user_id, ledger_id, points_transaction_id, amount, created_at)
+		VALUES ('ci-ok', 'c1', 'u1', 'l1', 'tx1', 10, CURRENT_TIMESTAMP)
+	`).Error; err != nil {
+		t.Fatalf("expected valid claim_item insert to succeed, got: %v", err)
+	}
+}
+
+func TestMigrateTestDB_RejectsClaimItemWhenClaimUserLedgerUserMismatch(t *testing.T) {
+	db := newTestDB(t)
+
+	mustExec(t, db, `
+		INSERT INTO users (id) VALUES
+			('u1'),
+			('u2')
+	`)
+	mustExec(t, db, `
+		INSERT INTO points_ledgers (id, user_id, channel_id, spendable_balance, cumulative_total, created_at, updated_at) VALUES
+			('l2', 'u2', 'c2', 100, 100, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`)
+	mustExec(t, db, `
+		INSERT INTO points_transactions (id, ledger_id, source, delta, balance_after, created_at) VALUES
+			('tx2', 'l2', 'claim', -10, 90, CURRENT_TIMESTAMP)
+	`)
+	mustExec(t, db, `
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, created_at, updated_at) VALUES
+			('c1', 'u1', '0x1111111111111111111111111111111111111111', 10, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`)
+
+	err := db.Exec(`
+		INSERT INTO claim_items (id, claim_id, claim_user_id, ledger_id, points_transaction_id, amount, created_at)
+		VALUES ('ci2', 'c1', 'u1', 'l2', 'tx2', 10, CURRENT_TIMESTAMP)
+	`).Error
+	assertForeignKeyRejected(t, err)
 }
 
 func assertIndexExists(t *testing.T, db *gorm.DB, name string) {
@@ -61,4 +147,25 @@ func assertContains(t *testing.T, got, want string) {
 	if !strings.Contains(got, want) {
 		t.Fatalf("expected DDL to contain %q\nDDL=%s", want, got)
 	}
+}
+
+func mustExec(t *testing.T, db *gorm.DB, sql string) {
+	t.Helper()
+	if err := db.Exec(sql).Error; err != nil {
+		t.Fatalf("exec sql failed: %v\nSQL=%s", err, sql)
+	}
+}
+
+func assertForeignKeyRejected(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected foreign key rejection, got nil error")
+	}
+	if errors.Is(err, gorm.ErrForeignKeyViolated) {
+		return
+	}
+	if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+		return
+	}
+	t.Fatalf("expected foreign key rejection, got: %v", err)
 }

--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -39,10 +39,11 @@ type ClaimService struct {
 }
 
 type claimReservation struct {
-	userID uuid.UUID
-	toAddr string
-	amount int64
-	items  []claimReservationItem
+	userID  uuid.UUID
+	toAddr  string
+	amount  int64
+	claimID uuid.UUID
+	items   []claimReservationItem
 }
 
 type claimReservationItem struct {
@@ -105,7 +106,8 @@ func (s *ClaimService) Claim(ctx context.Context, userID uuid.UUID, amount int64
 
 	mintCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if _, err := mintCaller.MintOnChain(mintCtx, reservation.toAddr, reservation.amount); err != nil {
+	mintTxHash, err := mintCaller.MintOnChain(mintCtx, reservation.toAddr, reservation.amount)
+	if err != nil {
 		rollbackErr := s.db.Transaction(func(tx *gorm.DB) error {
 			return s.rollbackClaimReservation(tx, reservation)
 		})
@@ -116,9 +118,9 @@ func (s *ClaimService) Claim(ctx context.Context, userID uuid.UUID, amount int64
 	}
 
 	var newBalance int64
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err = s.db.Transaction(func(tx *gorm.DB) error {
 		var err error
-		newBalance, err = s.finalizeClaim(tx, reservation.userID, reservation.amount)
+		newBalance, err = s.finalizeClaim(tx, reservation, mintTxHash)
 		return err
 	})
 	if err != nil {
@@ -185,6 +187,16 @@ func (s *ClaimService) reserveClaim(tx *gorm.DB, userID uuid.UUID, amount int64)
 		amount: claimAmount,
 		items:  make([]claimReservationItem, 0, len(ledgers)),
 	}
+	claim := &models.Claim{
+		UserID:     userID,
+		WalletAddr: toAddr,
+		Amount:     claimAmount,
+		Status:     models.ClaimStatusPending,
+	}
+	if err := tx.Create(claim).Error; err != nil {
+		return claimReservation{}, err
+	}
+	reservation.claimID = claim.ID
 	remaining := claimAmount
 	now := time.Now()
 	for _, ledger := range ledgers {
@@ -212,6 +224,16 @@ func (s *ClaimService) reserveClaim(tx *gorm.DB, userID uuid.UUID, amount int64)
 		if err := tx.Create(txRecord).Error; err != nil {
 			return claimReservation{}, err
 		}
+		claimItem := &models.ClaimItem{
+			ClaimID:             claim.ID,
+			ClaimUserID:         userID,
+			LedgerID:            ledger.ID,
+			PointsTransactionID: txRecord.ID,
+			Amount:              deduct,
+		}
+		if err := tx.Create(claimItem).Error; err != nil {
+			return claimReservation{}, err
+		}
 		reservation.items = append(reservation.items, claimReservationItem{
 			ledgerID:      ledger.ID,
 			transactionID: txRecord.ID,
@@ -224,6 +246,12 @@ func (s *ClaimService) reserveClaim(tx *gorm.DB, userID uuid.UUID, amount int64)
 }
 
 func (s *ClaimService) rollbackClaimReservation(tx *gorm.DB, reservation claimReservation) error {
+	if reservation.claimID != uuid.Nil {
+		if err := tx.Delete(&models.Claim{}, "id = ?", reservation.claimID).Error; err != nil {
+			return err
+		}
+	}
+
 	now := time.Now()
 	for _, item := range reservation.items {
 		if err := tx.Model(&models.PointsLedger{}).
@@ -241,20 +269,34 @@ func (s *ClaimService) rollbackClaimReservation(tx *gorm.DB, reservation claimRe
 	return nil
 }
 
-func (s *ClaimService) finalizeClaim(tx *gorm.DB, userID uuid.UUID, claimAmount int64) (int64, error) {
+func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, mintTxHash string) (int64, error) {
 	now := time.Now()
+	claimUpdates := map[string]interface{}{
+		"status":       models.ClaimStatusConfirmed,
+		"confirmed_at": now,
+		"updated_at":   now,
+	}
+	if mintTxHash != "" {
+		claimUpdates["tx_hash"] = mintTxHash
+	}
+	if err := tx.Model(&models.Claim{}).
+		Where("id = ? AND user_id = ?", reservation.claimID, reservation.userID).
+		Updates(claimUpdates).Error; err != nil {
+		return 0, err
+	}
+
 	if err := tx.Exec(`
 		INSERT INTO tachi_balances (id, user_id, balance, updated_at)
 		VALUES (?, ?, ?, ?)
 		ON CONFLICT (user_id) DO UPDATE SET
 			balance    = tachi_balances.balance + EXCLUDED.balance,
 			updated_at = EXCLUDED.updated_at
-	`, newUUID(), userID, claimAmount, now).Error; err != nil {
+	`, newUUID(), reservation.userID, reservation.amount, now).Error; err != nil {
 		return 0, err
 	}
 
 	var tb models.TachiBalance
-	if err := tx.Where("user_id = ?", userID).First(&tb).Error; err != nil {
+	if err := tx.Where("user_id = ?", reservation.userID).First(&tb).Error; err != nil {
 		return 0, err
 	}
 

--- a/backend/internal/services/claim_service_test.go
+++ b/backend/internal/services/claim_service_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 type mockMintCaller struct {
-	txHash string
-	err    error
-	calls  []mintCall
+	txHash   string
+	txHashes []string
+	err      error
+	calls    []mintCall
 }
 
 type mintCall struct {
@@ -31,6 +32,10 @@ func (m *mockMintCaller) MintOnChain(_ context.Context, toAddr string, amount in
 	m.calls = append(m.calls, mintCall{toAddr: toAddr, amount: amount})
 	if m.err != nil {
 		return "", m.err
+	}
+	callIdx := len(m.calls) - 1
+	if callIdx < len(m.txHashes) {
+		return m.txHashes[callIdx], nil
 	}
 	return m.txHash, nil
 }
@@ -221,7 +226,7 @@ func TestClaim_NoLedgers(t *testing.T) {
 
 func TestClaim_AccumulatesOnSecondClaim(t *testing.T) {
 	db := newTestDB(t)
-	mintCaller := &mockMintCaller{txHash: "0x987"}
+	mintCaller := &mockMintCaller{txHashes: []string{"0x987a", "0x987b"}}
 	svc := &ClaimService{db: db, mintCaller: mintCaller}
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
@@ -271,6 +276,44 @@ func TestClaim_MintSuccessUpdatesDB(t *testing.T) {
 	}
 	if remaining != 30 {
 		t.Fatalf("expected remaining spendable=30, got %d", remaining)
+	}
+}
+
+func TestClaim_PersistsClaimAndClaimItems(t *testing.T) {
+	db := newTestDB(t)
+	mintCaller := &mockMintCaller{txHash: "0xclaimtx"}
+	svc := &ClaimService{db: db, mintCaller: mintCaller}
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedLedger(t, db, userID, "ch1", 70)
+	seedLedger(t, db, userID, "ch2", 40)
+
+	if _, err := svc.Claim(context.Background(), userID, 100); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var claimCount int64
+	if err := db.Model(&models.Claim{}).Where("user_id = ?", userID).Count(&claimCount).Error; err != nil {
+		t.Fatalf("count claims: %v", err)
+	}
+	if claimCount != 1 {
+		t.Fatalf("expected 1 claim row, got %d", claimCount)
+	}
+
+	var itemCount int64
+	if err := db.Model(&models.ClaimItem{}).Joins("JOIN claims ON claims.id = claim_items.claim_id").Where("claims.user_id = ?", userID).Count(&itemCount).Error; err != nil {
+		t.Fatalf("count claim_items: %v", err)
+	}
+	if itemCount != 2 {
+		t.Fatalf("expected 2 claim_items rows, got %d", itemCount)
+	}
+
+	var wrongUserCount int64
+	if err := db.Model(&models.ClaimItem{}).Where("claim_user_id <> ?", userID).Count(&wrongUserCount).Error; err != nil {
+		t.Fatalf("count wrong claim_user_id rows: %v", err)
+	}
+	if wrongUserCount != 0 {
+		t.Fatalf("expected all claim_items.claim_user_id = user_id, got %d mismatches", wrongUserCount)
 	}
 }
 

--- a/backend/internal/services/testutil_pg_test.go
+++ b/backend/internal/services/testutil_pg_test.go
@@ -166,6 +166,8 @@ func migratePGTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_user_channel
 			ON points_ledgers (user_id, channel_id)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_id_user_id
+			ON points_ledgers (id, user_id)`,
 		`CREATE TABLE IF NOT EXISTS points_transactions (
 			id UUID PRIMARY KEY,
 			ledger_id UUID NOT NULL,
@@ -177,6 +179,8 @@ func migratePGTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at TIMESTAMPTZ
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_transactions_id_ledger_id
+			ON points_transactions (id, ledger_id)`,
 		`CREATE TABLE IF NOT EXISTS claims (
 			id UUID PRIMARY KEY,
 			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -191,6 +195,8 @@ func migratePGTestDB(db *gorm.DB) error {
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_id_user_id
+			ON claims (id, user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
 			ON claims (user_id, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
@@ -200,11 +206,15 @@ func migratePGTestDB(db *gorm.DB) error {
 			WHERE tx_hash IS NOT NULL`,
 		`CREATE TABLE IF NOT EXISTS claim_items (
 			id UUID PRIMARY KEY,
-			claim_id UUID NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
-			ledger_id UUID NOT NULL REFERENCES points_ledgers(id),
-			points_transaction_id UUID NOT NULL REFERENCES points_transactions(id),
+			claim_id UUID NOT NULL,
+			claim_user_id UUID NOT NULL,
+			ledger_id UUID NOT NULL,
+			points_transaction_id UUID NOT NULL,
 			amount BIGINT NOT NULL CHECK (amount > 0),
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			FOREIGN KEY (claim_id, claim_user_id) REFERENCES claims(id, user_id) ON DELETE CASCADE,
+			FOREIGN KEY (ledger_id, claim_user_id) REFERENCES points_ledgers(id, user_id),
+			FOREIGN KEY (points_transaction_id, ledger_id) REFERENCES points_transactions(id, ledger_id),
 			UNIQUE (points_transaction_id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -166,6 +166,8 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_user_channel
 			ON points_ledgers (user_id, channel_id)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_id_user_id
+			ON points_ledgers (id, user_id)`,
 		`CREATE TABLE IF NOT EXISTS points_transactions (
 			id TEXT PRIMARY KEY,
 			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
@@ -177,6 +179,8 @@ func migrateTestDB(db *gorm.DB) error {
 			note TEXT,
 			created_at DATETIME
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_points_transactions_id_ledger_id
+			ON points_transactions (id, ledger_id)`,
 		`CREATE TABLE IF NOT EXISTS claims (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -191,6 +195,8 @@ func migrateTestDB(db *gorm.DB) error {
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_id_user_id
+			ON claims (id, user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_user_created_at
 			ON claims (user_id, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_claims_status_created_at
@@ -200,11 +206,15 @@ func migrateTestDB(db *gorm.DB) error {
 			WHERE tx_hash IS NOT NULL`,
 		`CREATE TABLE IF NOT EXISTS claim_items (
 			id TEXT PRIMARY KEY,
-			claim_id TEXT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
-			ledger_id TEXT NOT NULL REFERENCES points_ledgers(id),
-			points_transaction_id TEXT NOT NULL REFERENCES points_transactions(id),
+			claim_id TEXT NOT NULL,
+			claim_user_id TEXT NOT NULL,
+			ledger_id TEXT NOT NULL,
+			points_transaction_id TEXT NOT NULL,
 			amount INTEGER NOT NULL CHECK (amount > 0),
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (claim_id, claim_user_id) REFERENCES claims(id, user_id) ON DELETE CASCADE,
+			FOREIGN KEY (ledger_id, claim_user_id) REFERENCES points_ledgers(id, user_id),
+			FOREIGN KEY (points_transaction_id, ledger_id) REFERENCES points_transactions(id, ledger_id),
 			UNIQUE (points_transaction_id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_claim_items_claim_id

--- a/backend/migrations/016_claims_composite_fk.sql
+++ b/backend/migrations/016_claims_composite_fk.sql
@@ -1,0 +1,63 @@
+-- Strengthens cross-table consistency for claim_items by enforcing
+-- claim-user-ledger-transaction alignment with composite foreign keys.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_id_user_id
+    ON claims (id, user_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_points_ledgers_id_user_id
+    ON points_ledgers (id, user_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_points_transactions_id_ledger_id
+    ON points_transactions (id, ledger_id);
+
+ALTER TABLE claim_items
+    ADD COLUMN IF NOT EXISTS claim_user_id UUID;
+
+UPDATE claim_items ci
+SET claim_user_id = c.user_id
+FROM claims c
+WHERE ci.claim_id = c.id
+  AND ci.claim_user_id IS NULL;
+
+ALTER TABLE claim_items
+    ALTER COLUMN claim_user_id SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_claim_items_claim_user'
+    ) THEN
+        ALTER TABLE claim_items
+            ADD CONSTRAINT fk_claim_items_claim_user
+            FOREIGN KEY (claim_id, claim_user_id)
+            REFERENCES claims (id, user_id)
+            ON DELETE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_claim_items_ledger_user'
+    ) THEN
+        ALTER TABLE claim_items
+            ADD CONSTRAINT fk_claim_items_ledger_user
+            FOREIGN KEY (ledger_id, claim_user_id)
+            REFERENCES points_ledgers (id, user_id);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_claim_items_tx_ledger'
+    ) THEN
+        ALTER TABLE claim_items
+            ADD CONSTRAINT fk_claim_items_tx_ledger
+            FOREIGN KEY (points_transaction_id, ledger_id)
+            REFERENCES points_transactions (id, ledger_id);
+    END IF;
+END $$;

--- a/backend/migrations/016_claims_composite_fk.sql
+++ b/backend/migrations/016_claims_composite_fk.sql
@@ -13,6 +13,55 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_points_transactions_id_ledger_id
 ALTER TABLE claim_items
     ADD COLUMN IF NOT EXISTS claim_user_id UUID;
 
+DO $$
+DECLARE
+    missing_claim_count INTEGER;
+    missing_ledger_count INTEGER;
+    missing_tx_count INTEGER;
+    claim_ledger_user_mismatch_count INTEGER;
+    tx_ledger_mismatch_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO missing_claim_count
+    FROM claim_items ci
+    LEFT JOIN claims c ON c.id = ci.claim_id
+    WHERE c.id IS NULL;
+
+    SELECT COUNT(*) INTO missing_ledger_count
+    FROM claim_items ci
+    LEFT JOIN points_ledgers pl ON pl.id = ci.ledger_id
+    WHERE pl.id IS NULL;
+
+    SELECT COUNT(*) INTO missing_tx_count
+    FROM claim_items ci
+    LEFT JOIN points_transactions pt ON pt.id = ci.points_transaction_id
+    WHERE pt.id IS NULL;
+
+    SELECT COUNT(*) INTO claim_ledger_user_mismatch_count
+    FROM claim_items ci
+    JOIN claims c ON c.id = ci.claim_id
+    JOIN points_ledgers pl ON pl.id = ci.ledger_id
+    WHERE c.user_id <> pl.user_id;
+
+    SELECT COUNT(*) INTO tx_ledger_mismatch_count
+    FROM claim_items ci
+    JOIN points_transactions pt ON pt.id = ci.points_transaction_id
+    WHERE pt.ledger_id <> ci.ledger_id;
+
+    IF missing_claim_count > 0
+       OR missing_ledger_count > 0
+       OR missing_tx_count > 0
+       OR claim_ledger_user_mismatch_count > 0
+       OR tx_ledger_mismatch_count > 0 THEN
+        RAISE EXCEPTION
+            'migration 016 blocked: inconsistent claim_items rows detected (missing_claim=%, missing_ledger=%, missing_tx=%, claim_ledger_user_mismatch=%, tx_ledger_mismatch=%). resolve data before re-running migration',
+            missing_claim_count,
+            missing_ledger_count,
+            missing_tx_count,
+            claim_ledger_user_mismatch_count,
+            tx_ledger_mismatch_count;
+    END IF;
+END $$;
+
 UPDATE claim_items ci
 SET claim_user_id = c.user_id
 FROM claims c


### PR DESCRIPTION
## 什麼改動
- 新增 `backend/migrations/016_claims_composite_fk.sql`，為 claims / points_ledgers / points_transactions 補複合唯一鍵，並在 `claim_items` 新增 `claim_user_id` 與三條複合 FK。
- 更新 `backend/internal/models/claim.go`，`ClaimItem` 新增 `ClaimUserID` 欄位。
- 同步更新 SQLite/PG 測試 schema（services / handlers / router 的 testutil）以對齊 migration。
- 補上 claim schema 驗收測試（合法資料可寫入、跨 ledger/跨 user 不一致會被 DB 拒絕）。

## 為什麼
- 修正 `claim_items` 目前僅單欄 FK 無法在 schema 層阻擋跨 user / 跨 ledger 錯誤關聯的問題。
- closes #306

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#306
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 claim service/handler 行為，不新增 UI 或 dashboard 變更。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 以複合 FK 在 DB schema 層強化 claim_items 的跨表一致性。
- Approx changed lines：~235
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [x] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試 schema 與驗收測試需同步反映 migration，否則無法驗證 #306 的 DB 約束行為。
- 若已拆分，相關 PR：
  - n/a

## 超出範圍內容
- 無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

- `go test ./internal/services -run 'TestMigrateTestDB_(CreatesClaimTables|AllowsClaimItem|RejectsClaimItem)'`
- `go test ./internal/models ./internal/services ./internal/handlers ./internal/router`
- `go test ./cmd/server -run 'Test.*Migration'`

## 備註
- 工作樹中的 `AGENTS.md` 與 `backend/docs/*` 為本次 PR 之外的既有本地變更，未納入本 PR commits。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 加强了声明项目的数据完整性验证，通过改进数据库关系约束。
  * 声明项目现在包含新的用户标识字段，用于更准确的数据关联。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->