### PR TITLE
[backend] feat(claim): Mint 廣播與 receipt staging wrapper（PR 2/3）

### DIFF
--- a/backend/internal/contract/tachi_token.go
+++ b/backend/internal/contract/tachi_token.go
@@ -3,10 +3,12 @@ package contract
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 	"sync"
+	"time"
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -40,6 +42,20 @@ func NewTachiToken(address common.Address, client *ethclient.Client) (*TachiToke
 }
 
 func (t *TachiToken) Mint(ctx context.Context, toAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (string, error) {
+	txHash, err := t.MintBroadcast(ctx, toAddr, amount, signerKey)
+	if err != nil {
+		return "", err
+	}
+	if err := t.WaitMintReceipt(ctx, txHash); err != nil {
+		// Preserve backward-compatible wrapper behavior while exposing tx hash
+		// when receipt is unknown.
+		return txHash, err
+	}
+	return txHash, nil
+}
+
+// MintBroadcast signs and sends the mint tx without waiting for receipt.
+func (t *TachiToken) MintBroadcast(ctx context.Context, toAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (string, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -115,15 +131,28 @@ func (t *TachiToken) Mint(ctx context.Context, toAddr common.Address, amount *bi
 	if err := t.client.SendTransaction(ctx, signedTx); err != nil {
 		return "", fmt.Errorf("send mint tx: %w", err)
 	}
-	receipt, err := bind.WaitMined(ctx, t.client, signedTx)
-	if err != nil {
-		return "", fmt.Errorf("wait mint receipt: %w", err)
-	}
-	if receipt.Status != types.ReceiptStatusSuccessful {
-		return "", fmt.Errorf("mint tx failed: %s", signedTx.Hash().Hex())
-	}
 
 	return signedTx.Hash().Hex(), nil
+}
+
+// WaitMintReceipt waits for tx receipt and verifies successful status.
+func (t *TachiToken) WaitMintReceipt(ctx context.Context, txHash string) error {
+	if t.client == nil {
+		return fmt.Errorf("eth client is nil")
+	}
+	if !common.IsHexHash(txHash) {
+		return fmt.Errorf("invalid tx hash: %s", txHash)
+	}
+
+	receipt, err := waitMinedByHash(ctx, t.client, common.HexToHash(txHash))
+	if err != nil {
+		return fmt.Errorf("wait mint receipt: %w", err)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("mint tx failed: %s", txHash)
+	}
+
+	return nil
 }
 
 func (t *TachiToken) Burn(ctx context.Context, fromAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (string, error) {
@@ -213,4 +242,25 @@ func (t *TachiToken) Burn(ctx context.Context, fromAddr common.Address, amount *
 	}
 
 	return signedTx.Hash().Hex(), nil
+}
+
+func waitMinedByHash(ctx context.Context, client *ethclient.Client, txHash common.Hash) (*types.Receipt, error) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		receipt, err := client.TransactionReceipt(ctx, txHash)
+		if err == nil {
+			return receipt, nil
+		}
+		if !errors.Is(err, ethereum.NotFound) {
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }

--- a/backend/internal/contract/tachi_token.go
+++ b/backend/internal/contract/tachi_token.go
@@ -19,6 +19,40 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+var ErrMintReceiptStatusFailed = errors.New("mint receipt status failed")
+
+// MintReceiptError keeps tx hash machine-readable for downstream handling.
+type MintReceiptError struct {
+	TxHash string
+	Op     string
+	Err    error
+}
+
+func (e *MintReceiptError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("%s (txHash=%s)", e.Op, e.TxHash)
+	}
+	return fmt.Sprintf("%s (txHash=%s): %v", e.Op, e.TxHash, e.Err)
+}
+
+func (e *MintReceiptError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func wrapMintReceiptError(txHash, op string, err error) error {
+	return &MintReceiptError{
+		TxHash: txHash,
+		Op:     op,
+		Err:    err,
+	}
+}
+
 const tachiTokenABI = `[{"type":"constructor","inputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"MAX_SUPPLY","inputs":[],"outputs":[{"name":"","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"allowance","inputs":[{"name":"owner","type":"address","internalType":"address"},{"name":"spender","type":"address","internalType":"address"}],"outputs":[{"name":"","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"approve","inputs":[{"name":"","type":"address","internalType":"address"},{"name":"","type":"uint256","internalType":"uint256"}],"outputs":[{"name":"","type":"bool","internalType":"bool"}],"stateMutability":"pure"},{"type":"function","name":"balanceOf","inputs":[{"name":"account","type":"address","internalType":"address"}],"outputs":[{"name":"","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"burn","inputs":[{"name":"from","type":"address","internalType":"address"},{"name":"amount","type":"uint256","internalType":"uint256"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"decimals","inputs":[],"outputs":[{"name":"","type":"uint8","internalType":"uint8"}],"stateMutability":"view"},{"type":"function","name":"mint","inputs":[{"name":"to","type":"address","internalType":"address"},{"name":"amount","type":"uint256","internalType":"uint256"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"name","inputs":[],"outputs":[{"name":"","type":"string","internalType":"string"}],"stateMutability":"view"},{"type":"function","name":"owner","inputs":[],"outputs":[{"name":"","type":"address","internalType":"address"}],"stateMutability":"view"},{"type":"function","name":"renounceOwnership","inputs":[],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"symbol","inputs":[],"outputs":[{"name":"","type":"string","internalType":"string"}],"stateMutability":"view"},{"type":"function","name":"totalSupply","inputs":[],"outputs":[{"name":"","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"transfer","inputs":[{"name":"","type":"address","internalType":"address"},{"name":"","type":"uint256","internalType":"uint256"}],"outputs":[{"name":"","type":"bool","internalType":"bool"}],"stateMutability":"pure"},{"type":"function","name":"transferFrom","inputs":[{"name":"","type":"address","internalType":"address"},{"name":"","type":"address","internalType":"address"},{"name":"","type":"uint256","internalType":"uint256"}],"outputs":[{"name":"","type":"bool","internalType":"bool"}],"stateMutability":"pure"},{"type":"function","name":"transferOwnership","inputs":[{"name":"newOwner","type":"address","internalType":"address"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"event","name":"Approval","inputs":[{"name":"owner","type":"address","indexed":true,"internalType":"address"},{"name":"spender","type":"address","indexed":true,"internalType":"address"},{"name":"value","type":"uint256","indexed":false,"internalType":"uint256"}],"anonymous":false},{"type":"event","name":"OwnershipTransferred","inputs":[{"name":"previousOwner","type":"address","indexed":true,"internalType":"address"},{"name":"newOwner","type":"address","indexed":true,"internalType":"address"}],"anonymous":false},{"type":"event","name":"Transfer","inputs":[{"name":"from","type":"address","indexed":true,"internalType":"address"},{"name":"to","type":"address","indexed":true,"internalType":"address"},{"name":"value","type":"uint256","indexed":false,"internalType":"uint256"}],"anonymous":false},{"type":"error","name":"ERC20InsufficientAllowance","inputs":[{"name":"spender","type":"address","internalType":"address"},{"name":"allowance","type":"uint256","internalType":"uint256"},{"name":"needed","type":"uint256","internalType":"uint256"}]},{"type":"error","name":"ERC20InsufficientBalance","inputs":[{"name":"sender","type":"address","internalType":"address"},{"name":"balance","type":"uint256","internalType":"uint256"},{"name":"needed","type":"uint256","internalType":"uint256"}]},{"type":"error","name":"ERC20InvalidApprover","inputs":[{"name":"approver","type":"address","internalType":"address"}]},{"type":"error","name":"ERC20InvalidReceiver","inputs":[{"name":"receiver","type":"address","internalType":"address"}]},{"type":"error","name":"ERC20InvalidSender","inputs":[{"name":"sender","type":"address","internalType":"address"}]},{"type":"error","name":"ERC20InvalidSpender","inputs":[{"name":"spender","type":"address","internalType":"address"}]},{"type":"error","name":"OwnableInvalidOwner","inputs":[{"name":"owner","type":"address","internalType":"address"}]},{"type":"error","name":"OwnableUnauthorizedAccount","inputs":[{"name":"account","type":"address","internalType":"address"}]}]`
 
 type TachiToken struct {
@@ -146,10 +180,10 @@ func (t *TachiToken) WaitMintReceipt(ctx context.Context, txHash string) error {
 
 	receipt, err := waitMinedByHash(ctx, t.client, common.HexToHash(txHash))
 	if err != nil {
-		return fmt.Errorf("wait mint receipt: %w", err)
+		return wrapMintReceiptError(txHash, "wait mint receipt", err)
 	}
 	if receipt.Status != types.ReceiptStatusSuccessful {
-		return fmt.Errorf("mint tx failed: %s", txHash)
+		return wrapMintReceiptError(txHash, "mint tx failed", ErrMintReceiptStatusFailed)
 	}
 
 	return nil

--- a/backend/internal/contract/tachi_token_test.go
+++ b/backend/internal/contract/tachi_token_test.go
@@ -1,0 +1,39 @@
+package contract
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMintReceiptError_AsAndIs(t *testing.T) {
+	txHash := "0x1111111111111111111111111111111111111111111111111111111111111111"
+	err := wrapMintReceiptError(txHash, "mint tx failed", ErrMintReceiptStatusFailed)
+
+	var receiptErr *MintReceiptError
+	if !errors.As(err, &receiptErr) {
+		t.Fatal("expected errors.As to extract *MintReceiptError")
+	}
+	if receiptErr.TxHash != txHash {
+		t.Fatalf("expected tx hash %s, got %s", txHash, receiptErr.TxHash)
+	}
+	if !errors.Is(err, ErrMintReceiptStatusFailed) {
+		t.Fatal("expected errors.Is to match ErrMintReceiptStatusFailed")
+	}
+}
+
+func TestMintReceiptError_WrapsUnderlyingWaitError(t *testing.T) {
+	baseErr := errors.New("context deadline exceeded")
+	txHash := "0x2222222222222222222222222222222222222222222222222222222222222222"
+	err := wrapMintReceiptError(txHash, "wait mint receipt", baseErr)
+
+	var receiptErr *MintReceiptError
+	if !errors.As(err, &receiptErr) {
+		t.Fatal("expected errors.As to extract *MintReceiptError")
+	}
+	if receiptErr.TxHash != txHash {
+		t.Fatalf("expected tx hash %s, got %s", txHash, receiptErr.TxHash)
+	}
+	if !errors.Is(err, baseErr) {
+		t.Fatal("expected errors.Is to match wrapped wait error")
+	}
+}

--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -116,8 +116,13 @@ func (s *ClaimService) Claim(ctx context.Context, userID uuid.UUID, amount int64
 	mintTxHash, err := mintCaller.MintOnChain(mintCtx, reservation.toAddr, reservation.amount)
 	if err != nil {
 		if mintTxHash != "" {
+			logMsg := "claim mint receipt unknown"
+			if errors.Is(err, contractpkg.ErrMintReceiptStatusFailed) {
+				logMsg = "claim mint receipt failed"
+			}
 			log.Printf(
-				"claim mint receipt unknown: claim_id=%s user_id=%s tx_hash=%s err=%v",
+				"%s: claim_id=%s user_id=%s tx_hash=%s err=%v",
+				logMsg,
 				reservation.claimID,
 				reservation.userID,
 				mintTxHash,

--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"log"
 	"math/big"
 	"strings"
 	"time"
@@ -114,6 +115,15 @@ func (s *ClaimService) Claim(ctx context.Context, userID uuid.UUID, amount int64
 	defer cancel()
 	mintTxHash, err := mintCaller.MintOnChain(mintCtx, reservation.toAddr, reservation.amount)
 	if err != nil {
+		if mintTxHash != "" {
+			log.Printf(
+				"claim mint receipt unknown: claim_id=%s user_id=%s tx_hash=%s err=%v",
+				reservation.claimID,
+				reservation.userID,
+				mintTxHash,
+				err,
+			)
+		}
 		rollbackErr := s.db.Transaction(func(tx *gorm.DB) error {
 			return s.rollbackClaimReservation(tx, reservation)
 		})

--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 	"time"
 
@@ -31,10 +32,15 @@ type MintCaller interface {
 	MintOnChain(ctx context.Context, toAddr string, amount int64) (txHash string, err error)
 }
 
+type mintContract interface {
+	MintBroadcast(ctx context.Context, toAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (txHash string, err error)
+	WaitMintReceipt(ctx context.Context, txHash string) error
+}
+
 type ClaimService struct {
 	db          *gorm.DB
 	contractCfg config.ContractConfig
-	tachiToken  *contractpkg.TachiToken
+	tachiToken  mintContract
 	mintCaller  MintCaller
 }
 
@@ -131,6 +137,18 @@ func (s *ClaimService) Claim(ctx context.Context, userID uuid.UUID, amount int64
 }
 
 func (s *ClaimService) MintOnChain(ctx context.Context, toAddr string, amount int64) (string, error) {
+	txHash, err := s.MintBroadcastOnChain(ctx, toAddr, amount)
+	if err != nil {
+		return "", err
+	}
+	if err := s.WaitMintReceiptOnChain(ctx, txHash); err != nil {
+		return txHash, err
+	}
+	return txHash, nil
+}
+
+// MintBroadcastOnChain only broadcasts mint tx; receipt waiting is separate.
+func (s *ClaimService) MintBroadcastOnChain(ctx context.Context, toAddr string, amount int64) (string, error) {
 	if s.tachiToken == nil {
 		return "", ErrClaimContractConfig
 	}
@@ -146,8 +164,15 @@ func (s *ClaimService) MintOnChain(ctx context.Context, toAddr string, amount in
 		return "", err
 	}
 
-	// TODO: wait for receipt status == 1 before committing DB (fire-and-forget for now)
-	return s.tachiToken.Mint(ctx, common.HexToAddress(toAddr), tachiWholeTokensToRawUnits(amount), signerKey)
+	return s.tachiToken.MintBroadcast(ctx, common.HexToAddress(toAddr), tachiWholeTokensToRawUnits(amount), signerKey)
+}
+
+// WaitMintReceiptOnChain waits receipt for a previously broadcast mint tx.
+func (s *ClaimService) WaitMintReceiptOnChain(ctx context.Context, txHash string) error {
+	if s.tachiToken == nil {
+		return ErrClaimContractConfig
+	}
+	return s.tachiToken.WaitMintReceipt(ctx, txHash)
 }
 
 func (s *ClaimService) reserveClaim(tx *gorm.DB, userID uuid.UUID, amount int64) (claimReservation, error) {

--- a/backend/internal/services/claim_service_test.go
+++ b/backend/internal/services/claim_service_test.go
@@ -3,12 +3,14 @@ package services
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"errors"
 	"math/big"
 	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/google/uuid"
 	"gorm.io/driver/sqlite"
@@ -90,7 +92,14 @@ func (m *inspectingMintCaller) MintOnChain(_ context.Context, _ string, _ int64)
 	return "0xreserved", nil
 }
 
-const testSepoliaSignerKey = "4f3edf983ac636a65a842ce7c78d9aa706d3b113bce036f7f6ad8d8f5795d7e0"
+func testSignerKeyHex(t *testing.T) string {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate test signer key: %v", err)
+	}
+	return hex.EncodeToString(crypto.FromECDSA(key))
+}
 
 func newFileClaimTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
@@ -396,7 +405,7 @@ func TestMintOnChain_BroadcastFailureReturnsEmptyHash(t *testing.T) {
 		broadcastErr: errors.New("send mint tx: rpc unavailable"),
 	}
 	svc := &ClaimService{
-		contractCfg: config.ContractConfig{SepoliaSignerKey: testSepoliaSignerKey},
+		contractCfg: config.ContractConfig{SepoliaSignerKey: testSignerKeyHex(t)},
 		tachiToken:  token,
 	}
 
@@ -418,7 +427,7 @@ func TestMintOnChain_WaitFailureReturnsBroadcastHash(t *testing.T) {
 		waitErr:       errors.New("wait mint receipt: context deadline exceeded"),
 	}
 	svc := &ClaimService{
-		contractCfg: config.ContractConfig{SepoliaSignerKey: testSepoliaSignerKey},
+		contractCfg: config.ContractConfig{SepoliaSignerKey: testSignerKeyHex(t)},
 		tachiToken:  token,
 	}
 
@@ -442,7 +451,7 @@ func TestMintOnChain_Success(t *testing.T) {
 		broadcastHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
 	}
 	svc := &ClaimService{
-		contractCfg: config.ContractConfig{SepoliaSignerKey: testSepoliaSignerKey},
+		contractCfg: config.ContractConfig{SepoliaSignerKey: testSignerKeyHex(t)},
 		tachiToken:  token,
 	}
 

--- a/backend/internal/services/claim_service_test.go
+++ b/backend/internal/services/claim_service_test.go
@@ -2,10 +2,13 @@ package services
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"errors"
+	"math/big"
 	"path/filepath"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/google/uuid"
 	"gorm.io/driver/sqlite"
@@ -49,6 +52,32 @@ type inspectingMintCaller struct {
 	observedMatches bool
 }
 
+type mockMintContract struct {
+	broadcastHash  string
+	broadcastErr   error
+	waitErr        error
+	broadcastCalls []mintContractCall
+	waitCalls      []string
+}
+
+type mintContractCall struct {
+	toAddr string
+	amount string
+}
+
+func (m *mockMintContract) MintBroadcast(_ context.Context, toAddr common.Address, amount *big.Int, _ *ecdsa.PrivateKey) (string, error) {
+	m.broadcastCalls = append(m.broadcastCalls, mintContractCall{
+		toAddr: toAddr.Hex(),
+		amount: amount.String(),
+	})
+	return m.broadcastHash, m.broadcastErr
+}
+
+func (m *mockMintContract) WaitMintReceipt(_ context.Context, txHash string) error {
+	m.waitCalls = append(m.waitCalls, txHash)
+	return m.waitErr
+}
+
 func (m *inspectingMintCaller) MintOnChain(_ context.Context, _ string, _ int64) (string, error) {
 	if err := m.db.Raw(
 		"SELECT spendable_balance FROM points_ledgers WHERE user_id = ? AND channel_id = ?",
@@ -60,6 +89,8 @@ func (m *inspectingMintCaller) MintOnChain(_ context.Context, _ string, _ int64)
 	m.observedMatches = m.observed == m.wantSpendable
 	return "0xreserved", nil
 }
+
+const testSepoliaSignerKey = "4f3edf983ac636a65a842ce7c78d9aa706d3b113bce036f7f6ad8d8f5795d7e0"
 
 func newFileClaimTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
@@ -357,5 +388,75 @@ func TestNewClaimService_InvalidContractAddressDoesNotInitializeToken(t *testing
 
 	if svc.tachiToken != nil {
 		t.Fatal("expected invalid contract address to leave tachiToken nil")
+	}
+}
+
+func TestMintOnChain_BroadcastFailureReturnsEmptyHash(t *testing.T) {
+	token := &mockMintContract{
+		broadcastErr: errors.New("send mint tx: rpc unavailable"),
+	}
+	svc := &ClaimService{
+		contractCfg: config.ContractConfig{SepoliaSignerKey: testSepoliaSignerKey},
+		tachiToken:  token,
+	}
+
+	txHash, err := svc.MintOnChain(context.Background(), "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 10)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if txHash != "" {
+		t.Fatalf("expected empty txHash on broadcast failure, got %s", txHash)
+	}
+	if len(token.waitCalls) != 0 {
+		t.Fatalf("wait should not be called when broadcast fails, got %d calls", len(token.waitCalls))
+	}
+}
+
+func TestMintOnChain_WaitFailureReturnsBroadcastHash(t *testing.T) {
+	token := &mockMintContract{
+		broadcastHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+		waitErr:       errors.New("wait mint receipt: context deadline exceeded"),
+	}
+	svc := &ClaimService{
+		contractCfg: config.ContractConfig{SepoliaSignerKey: testSepoliaSignerKey},
+		tachiToken:  token,
+	}
+
+	txHash, err := svc.MintOnChain(context.Background(), "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 10)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if txHash != token.broadcastHash {
+		t.Fatalf("expected txHash %s, got %s", token.broadcastHash, txHash)
+	}
+	if len(token.waitCalls) != 1 {
+		t.Fatalf("expected 1 wait call, got %d", len(token.waitCalls))
+	}
+	if token.waitCalls[0] != token.broadcastHash {
+		t.Fatalf("expected wait hash %s, got %s", token.broadcastHash, token.waitCalls[0])
+	}
+}
+
+func TestMintOnChain_Success(t *testing.T) {
+	token := &mockMintContract{
+		broadcastHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+	}
+	svc := &ClaimService{
+		contractCfg: config.ContractConfig{SepoliaSignerKey: testSepoliaSignerKey},
+		tachiToken:  token,
+	}
+
+	txHash, err := svc.MintOnChain(context.Background(), "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if txHash != token.broadcastHash {
+		t.Fatalf("expected txHash %s, got %s", token.broadcastHash, txHash)
+	}
+	if len(token.broadcastCalls) != 1 {
+		t.Fatalf("expected 1 broadcast call, got %d", len(token.broadcastCalls))
+	}
+	if len(token.waitCalls) != 1 {
+		t.Fatalf("expected 1 wait call, got %d", len(token.waitCalls))
 	}
 }


### PR DESCRIPTION
## 什麼改動
- 將 claim mint internal wrapper 拆成兩段能力：`MintBroadcast`（只廣播）與 `WaitMintReceipt`（等 receipt）
- `ClaimService` 新增對應 staged internal 能力：`MintBroadcastOnChain`、`WaitMintReceiptOnChain`
- 保留 `MintOnChain` 相容包裝（不破壞既有呼叫端）
- 補最小測試，確認錯誤語義可分辨：
  - 廣播前失敗（`txHash == ""`）
  - 已廣播但 receipt unknown（`txHash != ""` + error）

## 為什麼
- source issue：refs #258
- 目標是先完成 PR 2/3 的 contract wrapper mint staging，讓 service 層可區分「未送出」與「已送出但 receipt 未知」

## Release Context
- Release type：n/a

## Scope 對齊
Source of truth: #258
Depends on PR: none
Backend contract already in develop:
- [x] yes
- [ ] no
If no, this PR is:
- [ ] stacked on dependency branch
- [ ] intentionally blocked until dependency merges
本 PR 是否完全在 source of truth 範圍內？
- [x] 是
- [ ] 否，已另開 issue / PR 處理超出部分
本 PR 明確不做:
- 不改對外 API contract
- 不改 claim 狀態機主流程
- 不做 reconciliation job

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 將 mint wrapper 拆成 broadcast/receipt wait 兩段 internal 能力，並保留相容入口。
- Approx changed lines：~190
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 這次是同一個 wrapper staging 行為變更所需的最小組合（service + contract wrapper + 對應語義測試）。
- 若已拆分，相關 PR：
  - #305（PR 1/3：claims schema/model foundation）

## 超出範圍內容
- 無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試
- 執行：`go test ./internal/services ./internal/contract`

## 備註
- 本 PR 不包含 `backend/docs/*` 與 `AGENTS.md` 變更。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 铸币交易现已立即返回交易哈希值，支持实时跟踪

* **重构**
  * 优化交易确认流程，改进错误处理和交易收据验证机制
  * 增强错误信息，提供更详细的交易状态和诊断信息

* **测试**
  * 新增单元测试覆盖铸币工作流和错误场景，确保系统可靠性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->