### PR TITLE
[chore] CI reliability baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   scope-gate:
+    timeout-minutes: 5
     name: Scope gate
     runs-on: ubuntu-latest
     outputs:
@@ -143,6 +144,7 @@ jobs:
             }
 
   check-cache-wiring:
+    timeout-minutes: 5
     name: Check backend CI cache wiring
     needs: [scope-gate]
     if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
@@ -154,6 +156,7 @@ jobs:
         run: bash scripts/check-backend-ci-cache.sh
 
   workflow-regression:
+    timeout-minutes: 5
     name: Workflow regression tests
     runs-on: ubuntu-latest
     steps:
@@ -167,6 +170,7 @@ jobs:
         run: node --test .github/workflows/ci.test.mjs
 
   backend-build:
+    timeout-minutes: 15
     name: Build backend image
     needs: [scope-gate]
     if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
@@ -201,6 +205,7 @@ jobs:
           retention-days: 1
 
   backend:
+    timeout-minutes: 10
     name: Backend tests
     needs: [scope-gate, backend-build]
     if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
@@ -223,6 +228,7 @@ jobs:
         run: docker compose run --pull never --no-deps --rm app go vet ./...
 
   backend-integration:
+    timeout-minutes: 20
     name: Backend integration tests
     needs: [scope-gate]
     runs-on: ubuntu-latest
@@ -240,6 +246,7 @@ jobs:
         run: go test -tags integration -v ./... -count=1
 
   frontend:
+    timeout-minutes: 15
     name: Frontend build
     needs: [scope-gate]
     if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
@@ -262,6 +269,7 @@ jobs:
         run: docker compose run --no-deps --rm frontend pnpm build
 
   dashboard:
+    timeout-minutes: 15
     name: Dashboard build
     needs: [scope-gate]
     if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
@@ -282,6 +290,7 @@ jobs:
         run: docker compose run --no-deps --rm dashboard pnpm build
 
   contracts:
+    timeout-minutes: 20
     name: Contracts build
     runs-on: ubuntu-latest
     steps:
@@ -303,6 +312,7 @@ jobs:
         run: forge test
 
   backend-ci:
+    timeout-minutes: 5
     name: Backend CI (gate)
     needs: [backend-build, backend, backend-integration]
     if: always()
@@ -329,6 +339,7 @@ jobs:
           echo "✓ Backend CI passed"
 
   notify-discord:
+    timeout-minutes: 5
     name: Notify Discord on failure
     needs: [workflow-regression, check-cache-wiring, backend-ci, frontend, dashboard, contracts]
     if: failure()


### PR DESCRIPTION
## Scope 對齊

Source of truth: https://github.com/nurockplayer/tachigo/issues/207

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 這張 PR 做了什麼

對應 issue #207，為 `.github/workflows/ci.yml` 補上四項 reliability baseline：

1. `workflow_dispatch`：可從 GitHub UI 手動觸發 CI
2. `concurrency`（group + cancel-in-progress）：同 PR 新 push 自動取消舊 run
3. workflow-level 最小 `permissions`（contents: read, pull-requests: read）：收斂 token 權限
4. 所有主要 job 加 `timeout-minutes`（5–20 分鐘依 job 類型）：防止 job 無限卡住

## 本 PR 明確不做

- 不改測試內容或 scope gate 規則
- 不加入 deploy / production 流程
- 不修改 contracts / security scanner 設定（屬 #213、#210）

closes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂项 (Chores)**
  * 优化持续集成流程配置，增强工作流可靠性和效率。
  * 强化构建管道的权限安全控制。
  * 为所有CI任务设置明确的执行超时限制，确保及时反馈和资源管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->