### PR TITLE
[chore] Contracts quality gate

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -82,3 +82,13 @@ test('PR size thresholds match CLAUDE.md', async () => {
   assert.match(scopePolice, /const hardMaxDiffLines = 1000/)
   assert.match(scopePolice, /const exceptionMaxDiffLines = 1500/)
 })
+
+test('contracts CI job includes forge fmt --check', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const contractsJob = workflowJobBlock(workflow, 'contracts')
+
+  assert.match(
+    contractsJob,
+    /- name: Format check\n\s+working-directory: contracts\n\s+run: forge fmt --check/,
+  )
+})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,14 @@ jobs:
         working-directory: contracts
         run: forge install OpenZeppelin/openzeppelin-contracts@v5.6.1 --no-git
 
+      - name: Verify clean working tree after install
+        run: |
+          if ! git diff --quiet; then
+            echo "forge install dirtied the working tree:"
+            git diff --stat
+            exit 1
+          fi
+
       - name: Build
         working-directory: contracts
         run: forge build
@@ -292,6 +300,10 @@ jobs:
       - name: Test
         working-directory: contracts
         run: forge test
+
+      - name: Format check
+        working-directory: contracts
+        run: forge fmt --check
 
   backend-ci:
     name: Backend CI (gate)

--- a/contracts/test/TachiToken.t.sol
+++ b/contracts/test/TachiToken.t.sol
@@ -11,7 +11,7 @@ contract TachiTokenTest is Test {
 
     function setUp() public {
         alice = address(0xA1);
-        bob   = address(0xB0);
+        bob = address(0xB0);
         token = new TachiToken();
     }
 


### PR DESCRIPTION
## Scope 對齊

Source of truth: https://github.com/nurockplayer/tachigo/issues/213

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 這張 PR 做了什麼

對應 issue #213，為 contracts CI job 補上兩項防護：

1. **`forge fmt --check`**（Format check step）：格式錯誤會讓 CI fail，確保合約程式碼格式一致
2. **Verify clean working tree after install**：`forge install --no-git` 執行後驗證 git working tree 沒有被污染

同步在 `ci.test.mjs` 新增 regression assertion，確保 `forge fmt --check` 永遠存在於 contracts job。

## 本 PR 明確不做

- 不導入 Slither 或其他安全 scanner（屬 #210）
- 不導入 gas snapshot gate（屬 #210）
- 不處理 deploy / verify workflow（屬 #212）
- 不修改 scope gate 或 path-aware CI 邏輯（屬 #209）

closes #213