### PR TITLE
[backend] feat(claim): Claim mint 狀態機與失敗補償（PR 3/3）

### DIFF
--- a/backend/internal/handlers/claim_handler_test.go
+++ b/backend/internal/handlers/claim_handler_test.go
@@ -21,8 +21,12 @@ import (
 // mockMintOK always succeeds; used to bypass on-chain call in handler tests.
 type mockMintOK struct{}
 
-func (m *mockMintOK) MintOnChain(_ context.Context, _ string, _ int64) (string, error) {
+func (m *mockMintOK) MintBroadcastOnChain(_ context.Context, _ string, _ int64) (string, error) {
 	return "0xtesthash", nil
+}
+
+func (m *mockMintOK) WaitMintReceiptOnChain(_ context.Context, _ string) error {
+	return nil
 }
 
 func seedWeb3ProviderForHandler(t *testing.T, env *testEnv, userID uuid.UUID) {

--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -29,8 +29,38 @@ var (
 	ErrClaimContractConfig      = errors.New("claim contract config is incomplete")
 )
 
+// ClaimBroadcastRecordError preserves the tx hash when the chain tx was
+// broadcast but the DB failed before recording the broadcast state.
+type ClaimBroadcastRecordError struct {
+	ClaimID uuid.UUID
+	UserID  uuid.UUID
+	TxHash  string
+	Err     error
+}
+
+func (e *ClaimBroadcastRecordError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf(
+		"record claim broadcast failed: claim_id=%s user_id=%s tx_hash=%s: %v",
+		e.ClaimID,
+		e.UserID,
+		e.TxHash,
+		e.Err,
+	)
+}
+
+func (e *ClaimBroadcastRecordError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 type MintCaller interface {
-	MintOnChain(ctx context.Context, toAddr string, amount int64) (txHash string, err error)
+	MintBroadcastOnChain(ctx context.Context, toAddr string, amount int64) (txHash string, err error)
+	WaitMintReceiptOnChain(ctx context.Context, txHash string) error
 }
 
 type mintContract interface {
@@ -113,27 +143,65 @@ func (s *ClaimService) Claim(ctx context.Context, userID uuid.UUID, amount int64
 
 	mintCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	mintTxHash, err := mintCaller.MintOnChain(mintCtx, reservation.toAddr, reservation.amount)
+	mintTxHash, err := mintCaller.MintBroadcastOnChain(mintCtx, reservation.toAddr, reservation.amount)
 	if err != nil {
-		if mintTxHash != "" {
-			logMsg := "claim mint receipt unknown"
-			if errors.Is(err, contractpkg.ErrMintReceiptStatusFailed) {
-				logMsg = "claim mint receipt failed"
-			}
-			log.Printf(
-				"%s: claim_id=%s user_id=%s tx_hash=%s err=%v",
-				logMsg,
-				reservation.claimID,
-				reservation.userID,
-				mintTxHash,
-				err,
-			)
-		}
 		rollbackErr := s.db.Transaction(func(tx *gorm.DB) error {
 			return s.rollbackClaimReservation(tx, reservation)
 		})
 		if rollbackErr != nil {
 			return 0, fmt.Errorf("%w; rollback claim reservation: %v", err, rollbackErr)
+		}
+		return 0, err
+	}
+
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		return s.markClaimBroadcast(tx, reservation, mintTxHash)
+	}); err != nil {
+		recordErr := &ClaimBroadcastRecordError{
+			ClaimID: reservation.claimID,
+			UserID:  reservation.userID,
+			TxHash:  mintTxHash,
+			Err:     err,
+		}
+		log.Printf(
+			"claim broadcast record failed: claim_id=%s user_id=%s tx_hash=%s err=%v",
+			reservation.claimID,
+			reservation.userID,
+			mintTxHash,
+			err,
+		)
+		return 0, recordErr
+	}
+
+	if err := mintCaller.WaitMintReceiptOnChain(mintCtx, mintTxHash); err != nil {
+		logMsg := "claim mint receipt unknown"
+		if errors.Is(err, contractpkg.ErrMintReceiptStatusFailed) {
+			logMsg = "claim mint receipt failed"
+		}
+		log.Printf(
+			"%s: claim_id=%s user_id=%s tx_hash=%s err=%v",
+			logMsg,
+			reservation.claimID,
+			reservation.userID,
+			mintTxHash,
+			err,
+		)
+
+		if errors.Is(err, contractpkg.ErrMintReceiptStatusFailed) {
+			failedErr := s.db.Transaction(func(tx *gorm.DB) error {
+				return s.markClaimFailedAndCompensate(tx, reservation, mintTxHash, err)
+			})
+			if failedErr != nil {
+				return 0, fmt.Errorf("%w; mark claim failed: %v", err, failedErr)
+			}
+			return 0, err
+		}
+
+		recordErr := s.db.Transaction(func(tx *gorm.DB) error {
+			return s.recordClaimReceiptUnknown(tx, reservation, mintTxHash, err)
+		})
+		if recordErr != nil {
+			return 0, fmt.Errorf("%w; record claim receipt unknown: %v", err, recordErr)
 		}
 		return 0, err
 	}
@@ -285,6 +353,20 @@ func (s *ClaimService) reserveClaim(tx *gorm.DB, userID uuid.UUID, amount int64)
 	return reservation, nil
 }
 
+func (s *ClaimService) markClaimBroadcast(tx *gorm.DB, reservation claimReservation, mintTxHash string) error {
+	now := time.Now()
+	updates := map[string]interface{}{
+		"status":        models.ClaimStatusBroadcast,
+		"tx_hash":       mintTxHash,
+		"broadcast_at":  now,
+		"error_message": nil,
+		"updated_at":    now,
+	}
+	return tx.Model(&models.Claim{}).
+		Where("id = ? AND user_id = ?", reservation.claimID, reservation.userID).
+		Updates(updates).Error
+}
+
 func (s *ClaimService) rollbackClaimReservation(tx *gorm.DB, reservation claimReservation) error {
 	if reservation.claimID != uuid.Nil {
 		if err := tx.Delete(&models.Claim{}, "id = ?", reservation.claimID).Error; err != nil {
@@ -309,12 +391,70 @@ func (s *ClaimService) rollbackClaimReservation(tx *gorm.DB, reservation claimRe
 	return nil
 }
 
+func (s *ClaimService) recordClaimReceiptUnknown(tx *gorm.DB, reservation claimReservation, mintTxHash string, waitErr error) error {
+	return tx.Model(&models.Claim{}).
+		Where("id = ? AND user_id = ?", reservation.claimID, reservation.userID).
+		Updates(map[string]interface{}{
+			"status":        models.ClaimStatusBroadcast,
+			"tx_hash":       mintTxHash,
+			"error_message": waitErr.Error(),
+			"updated_at":    time.Now(),
+		}).Error
+}
+
+func (s *ClaimService) markClaimFailedAndCompensate(tx *gorm.DB, reservation claimReservation, mintTxHash string, mintErr error) error {
+	now := time.Now()
+	if err := tx.Model(&models.Claim{}).
+		Where("id = ? AND user_id = ?", reservation.claimID, reservation.userID).
+		Updates(map[string]interface{}{
+			"status":        models.ClaimStatusFailed,
+			"tx_hash":       mintTxHash,
+			"error_message": mintErr.Error(),
+			"failed_at":     now,
+			"updated_at":    now,
+		}).Error; err != nil {
+		return err
+	}
+
+	for _, item := range reservation.items {
+		var ledger models.PointsLedger
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", item.ledgerID).
+			First(&ledger).Error; err != nil {
+			return err
+		}
+
+		balanceAfter := ledger.SpendableBalance + item.amount
+		if err := tx.Model(&ledger).Updates(map[string]interface{}{
+			"spendable_balance": balanceAfter,
+			"updated_at":        now,
+		}).Error; err != nil {
+			return err
+		}
+
+		note := fmt.Sprintf("claim failed compensation for claim %s", reservation.claimID)
+		txRecord := &models.PointsTransaction{
+			LedgerID:     item.ledgerID,
+			Source:       models.TxSourceClaim,
+			Delta:        item.amount,
+			BalanceAfter: balanceAfter,
+			Note:         &note,
+		}
+		if err := tx.Create(txRecord).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, mintTxHash string) (int64, error) {
 	now := time.Now()
 	claimUpdates := map[string]interface{}{
-		"status":       models.ClaimStatusConfirmed,
-		"confirmed_at": now,
-		"updated_at":   now,
+		"status":        models.ClaimStatusConfirmed,
+		"confirmed_at":  now,
+		"error_message": nil,
+		"updated_at":    now,
 	}
 	if mintTxHash != "" {
 		claimUpdates["tx_hash"] = mintTxHash

--- a/backend/internal/services/claim_service_test.go
+++ b/backend/internal/services/claim_service_test.go
@@ -18,14 +18,17 @@ import (
 	"gorm.io/gorm/logger"
 
 	"github.com/tachigo/tachigo/internal/config"
+	contractpkg "github.com/tachigo/tachigo/internal/contract"
 	"github.com/tachigo/tachigo/internal/models"
 )
 
 type mockMintCaller struct {
-	txHash   string
-	txHashes []string
-	err      error
-	calls    []mintCall
+	broadcastHash   string
+	broadcastHashes []string
+	broadcastErr    error
+	waitErr         error
+	broadcastCalls  []mintCall
+	waitCalls       []string
 }
 
 type mintCall struct {
@@ -33,16 +36,21 @@ type mintCall struct {
 	amount int64
 }
 
-func (m *mockMintCaller) MintOnChain(_ context.Context, toAddr string, amount int64) (string, error) {
-	m.calls = append(m.calls, mintCall{toAddr: toAddr, amount: amount})
-	if m.err != nil {
-		return "", m.err
+func (m *mockMintCaller) MintBroadcastOnChain(_ context.Context, toAddr string, amount int64) (string, error) {
+	m.broadcastCalls = append(m.broadcastCalls, mintCall{toAddr: toAddr, amount: amount})
+	if m.broadcastErr != nil {
+		return "", m.broadcastErr
 	}
-	callIdx := len(m.calls) - 1
-	if callIdx < len(m.txHashes) {
-		return m.txHashes[callIdx], nil
+	callIdx := len(m.broadcastCalls) - 1
+	if callIdx < len(m.broadcastHashes) {
+		return m.broadcastHashes[callIdx], nil
 	}
-	return m.txHash, nil
+	return m.broadcastHash, nil
+}
+
+func (m *mockMintCaller) WaitMintReceiptOnChain(_ context.Context, txHash string) error {
+	m.waitCalls = append(m.waitCalls, txHash)
+	return m.waitErr
 }
 
 type inspectingMintCaller struct {
@@ -80,7 +88,7 @@ func (m *mockMintContract) WaitMintReceipt(_ context.Context, txHash string) err
 	return m.waitErr
 }
 
-func (m *inspectingMintCaller) MintOnChain(_ context.Context, _ string, _ int64) (string, error) {
+func (m *inspectingMintCaller) MintBroadcastOnChain(_ context.Context, _ string, _ int64) (string, error) {
 	if err := m.db.Raw(
 		"SELECT spendable_balance FROM points_ledgers WHERE user_id = ? AND channel_id = ?",
 		m.userID,
@@ -90,6 +98,10 @@ func (m *inspectingMintCaller) MintOnChain(_ context.Context, _ string, _ int64)
 	}
 	m.observedMatches = m.observed == m.wantSpendable
 	return "0xreserved", nil
+}
+
+func (m *inspectingMintCaller) WaitMintReceiptOnChain(_ context.Context, _ string) error {
+	return nil
 }
 
 func testSignerKeyHex(t *testing.T) string {
@@ -164,7 +176,7 @@ func TestGetTachiBalance_Zero(t *testing.T) {
 
 func TestClaim_All(t *testing.T) {
 	db := newTestDB(t)
-	mintCaller := &mockMintCaller{txHash: "0xabc"}
+	mintCaller := &mockMintCaller{broadcastHash: "0xabc"}
 	svc := &ClaimService{db: db, mintCaller: mintCaller}
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
@@ -185,17 +197,17 @@ func TestClaim_All(t *testing.T) {
 	if total != 0 {
 		t.Fatalf("expected spendable_balance=0, got %d", total)
 	}
-	if len(mintCaller.calls) != 1 {
-		t.Fatalf("expected 1 mint call, got %d", len(mintCaller.calls))
+	if len(mintCaller.broadcastCalls) != 1 {
+		t.Fatalf("expected 1 mint call, got %d", len(mintCaller.broadcastCalls))
 	}
-	if mintCaller.calls[0].amount != 150 {
-		t.Fatalf("expected mint amount=150, got %d", mintCaller.calls[0].amount)
+	if mintCaller.broadcastCalls[0].amount != 150 {
+		t.Fatalf("expected mint amount=150, got %d", mintCaller.broadcastCalls[0].amount)
 	}
 }
 
 func TestClaim_PartialAmount(t *testing.T) {
 	db := newTestDB(t)
-	mintCaller := &mockMintCaller{txHash: "0xdef"}
+	mintCaller := &mockMintCaller{broadcastHash: "0xdef"}
 	svc := &ClaimService{db: db, mintCaller: mintCaller}
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
@@ -266,7 +278,7 @@ func TestClaim_NoLedgers(t *testing.T) {
 
 func TestClaim_AccumulatesOnSecondClaim(t *testing.T) {
 	db := newTestDB(t)
-	mintCaller := &mockMintCaller{txHashes: []string{"0x987a", "0x987b"}}
+	mintCaller := &mockMintCaller{broadcastHashes: []string{"0x987a", "0x987b"}}
 	svc := &ClaimService{db: db, mintCaller: mintCaller}
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
@@ -290,7 +302,7 @@ func TestClaim_AccumulatesOnSecondClaim(t *testing.T) {
 
 func TestClaim_MintSuccessUpdatesDB(t *testing.T) {
 	db := newTestDB(t)
-	mintCaller := &mockMintCaller{txHash: "0x123"}
+	mintCaller := &mockMintCaller{broadcastHash: "0x123"}
 	svc := &ClaimService{db: db, mintCaller: mintCaller}
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
@@ -303,11 +315,11 @@ func TestClaim_MintSuccessUpdatesDB(t *testing.T) {
 	if newBal != 50 {
 		t.Fatalf("expected tachi_balance=50, got %d", newBal)
 	}
-	if len(mintCaller.calls) != 1 {
-		t.Fatalf("expected 1 mint call, got %d", len(mintCaller.calls))
+	if len(mintCaller.broadcastCalls) != 1 {
+		t.Fatalf("expected 1 mint call, got %d", len(mintCaller.broadcastCalls))
 	}
-	if mintCaller.calls[0].toAddr != "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" {
-		t.Fatalf("unexpected mint address: %s", mintCaller.calls[0].toAddr)
+	if mintCaller.broadcastCalls[0].toAddr != "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" {
+		t.Fatalf("unexpected mint address: %s", mintCaller.broadcastCalls[0].toAddr)
 	}
 
 	var remaining int64
@@ -321,7 +333,7 @@ func TestClaim_MintSuccessUpdatesDB(t *testing.T) {
 
 func TestClaim_PersistsClaimAndClaimItems(t *testing.T) {
 	db := newTestDB(t)
-	mintCaller := &mockMintCaller{txHash: "0xclaimtx"}
+	mintCaller := &mockMintCaller{broadcastHash: "0xclaimtx"}
 	svc := &ClaimService{db: db, mintCaller: mintCaller}
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
@@ -357,9 +369,9 @@ func TestClaim_PersistsClaimAndClaimItems(t *testing.T) {
 	}
 }
 
-func TestClaim_MintFailureLeavesDBUnchanged(t *testing.T) {
+func TestClaim_BroadcastFailureLeavesDBUnchanged(t *testing.T) {
 	db := newTestDB(t)
-	mintCaller := &mockMintCaller{err: errors.New("mint reverted")}
+	mintCaller := &mockMintCaller{broadcastErr: errors.New("send mint tx: rpc unavailable")}
 	svc := &ClaimService{db: db, mintCaller: mintCaller}
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
@@ -384,6 +396,154 @@ func TestClaim_MintFailureLeavesDBUnchanged(t *testing.T) {
 	}
 	if balanceCount != 0 {
 		t.Fatalf("expected no tachi balance rows, got %d", balanceCount)
+	}
+
+	var claimCount int64
+	if err := db.Model(&models.Claim{}).Where("user_id = ?", userID).Count(&claimCount).Error; err != nil {
+		t.Fatalf("count claims: %v", err)
+	}
+	if claimCount != 0 {
+		t.Fatalf("expected no claim rows after pre-broadcast failure, got %d", claimCount)
+	}
+}
+
+func TestClaim_WaitFailureKeepsBroadcastClaimAndDoesNotRollback(t *testing.T) {
+	db := newTestDB(t)
+	mintCaller := &mockMintCaller{
+		broadcastHash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		waitErr:       errors.New("wait mint receipt: context deadline exceeded"),
+	}
+	svc := &ClaimService{db: db, mintCaller: mintCaller}
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedLedger(t, db, userID, "ch1", 80)
+
+	_, err := svc.Claim(context.Background(), userID, 50)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	var remaining int64
+	if err := db.Raw("SELECT spendable_balance FROM points_ledgers WHERE user_id = ? AND channel_id = 'ch1'", userID).Scan(&remaining).Error; err != nil {
+		t.Fatalf("query remaining: %v", err)
+	}
+	if remaining != 30 {
+		t.Fatalf("expected reserved spendable=30, got %d", remaining)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusBroadcast {
+		t.Fatalf("expected claim status broadcast, got %s", claim.Status)
+	}
+	if claim.TxHash == nil || *claim.TxHash != mintCaller.broadcastHash {
+		t.Fatalf("expected txHash %s, got %v", mintCaller.broadcastHash, claim.TxHash)
+	}
+	if claim.BroadcastAt == nil {
+		t.Fatal("expected broadcast_at to be set")
+	}
+
+	var balanceCount int64
+	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&balanceCount).Error; err != nil {
+		t.Fatalf("query balances: %v", err)
+	}
+	if balanceCount != 0 {
+		t.Fatalf("expected no tachi balance rows, got %d", balanceCount)
+	}
+}
+
+func TestClaim_BroadcastPersistFailureReturnsTxHashForReconciliation(t *testing.T) {
+	db := newTestDB(t)
+	persistErr := errors.New("persist broadcast failed")
+	errHash := "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	if err := db.Callback().Update().Before("gorm:update").Register("fail_claim_broadcast_update", func(tx *gorm.DB) {
+		if tx.Statement.Table != "claims" {
+			return
+		}
+		updates, ok := tx.Statement.Dest.(map[string]interface{})
+		if !ok || updates["status"] != models.ClaimStatusBroadcast {
+			return
+		}
+		tx.AddError(persistErr)
+	}); err != nil {
+		t.Fatalf("register update callback: %v", err)
+	}
+
+	mintCaller := &mockMintCaller{broadcastHash: errHash}
+	svc := &ClaimService{db: db, mintCaller: mintCaller}
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedLedger(t, db, userID, "ch1", 80)
+
+	_, err := svc.Claim(context.Background(), userID, 50)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	var recordErr *ClaimBroadcastRecordError
+	if !errors.As(err, &recordErr) {
+		t.Fatalf("expected ClaimBroadcastRecordError, got %T: %v", err, err)
+	}
+	if recordErr.TxHash != errHash {
+		t.Fatalf("expected txHash %s, got %s", errHash, recordErr.TxHash)
+	}
+	if recordErr.ClaimID == uuid.Nil {
+		t.Fatal("expected claim ID to be populated")
+	}
+	if recordErr.UserID != userID {
+		t.Fatalf("expected userID %s, got %s", userID, recordErr.UserID)
+	}
+	if !errors.Is(err, persistErr) {
+		t.Fatalf("expected error to wrap persistErr, got %v", err)
+	}
+	if len(mintCaller.waitCalls) != 0 {
+		t.Fatalf("receipt wait should not run when broadcast state cannot be persisted, got %d calls", len(mintCaller.waitCalls))
+	}
+}
+
+func TestClaim_ReceiptFailedMarksFailedAndCompensates(t *testing.T) {
+	db := newTestDB(t)
+	mintCaller := &mockMintCaller{
+		broadcastHash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		waitErr:       contractpkg.ErrMintReceiptStatusFailed,
+	}
+	svc := &ClaimService{db: db, mintCaller: mintCaller}
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedLedger(t, db, userID, "ch1", 80)
+
+	_, err := svc.Claim(context.Background(), userID, 50)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	var remaining int64
+	if err := db.Raw("SELECT spendable_balance FROM points_ledgers WHERE user_id = ? AND channel_id = 'ch1'", userID).Scan(&remaining).Error; err != nil {
+		t.Fatalf("query remaining: %v", err)
+	}
+	if remaining != 80 {
+		t.Fatalf("expected compensated spendable=80, got %d", remaining)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusFailed {
+		t.Fatalf("expected claim status failed, got %s", claim.Status)
+	}
+	if claim.FailedAt == nil {
+		t.Fatal("expected failed_at to be set")
+	}
+
+	var txCount int64
+	if err := db.Model(&models.PointsTransaction{}).Where("ledger_id IN (SELECT id FROM points_ledgers WHERE user_id = ?)", userID).Count(&txCount).Error; err != nil {
+		t.Fatalf("count points transactions: %v", err)
+	}
+	if txCount != 2 {
+		t.Fatalf("expected claim debit + compensation credit transactions, got %d", txCount)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
讓 claim mint 流程改成 staged state machine：先 broadcast 並落庫 `tx_hash/status=broadcast`，再等待 receipt；receipt unknown 保留 `broadcast`，receipt failed 標記 `failed` 並補償 points。

## 為什麼
closes #258

修正 `WaitMined` timeout 後鏈上可能已成功、但 DB 已 rollback reservation 的不一致風險。

## Release Context
- Release type：`n/a`

## Scope 對齊
- Source of truth：#258
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 reconciliation job
  - 不改對外 API contract
  - 不新增 router / handler 行為
  - 不擴張到前端或 dashboard

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 將 claim mint 改為可追蹤的 broadcast/receipt 狀態機，避免 timeout 時誤 rollback。
- Approx changed lines：~400
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service 行為變更必須和對應 regression tests 一起 review；`claim_handler_test` 只有測試替身介面更新，沒有對外行為變更。
- 若已拆分，相關 PR：
  - #305 schema/model foundation，#331 contract wrapper staging

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

## 備註
本 PR 額外補上 `ClaimBroadcastRecordError`，讓「鏈上已廣播但 DB 未成功記錄 broadcast 狀態」能保留 `tx_hash` 供後續 reconciliation / 人工排查。