### PR TITLE
[backend] JWT secret production guard

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -39,7 +39,7 @@ func main() {
 	_ = godotenv.Load()
 
 	cfg := config.Load()
-	if cfg.Server.Env != "development" {
+	if config.ShouldValidateProductionSecrets(cfg) {
 		if err := config.ValidateProductionSecrets(cfg); err != nil {
 			log.Fatalf("invalid secrets: %v", err)
 		}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -39,6 +39,11 @@ func main() {
 	_ = godotenv.Load()
 
 	cfg := config.Load()
+	if cfg.Server.Env != "development" {
+		if err := config.ValidateProductionSecrets(cfg); err != nil {
+			log.Fatalf("invalid secrets: %v", err)
+		}
+	}
 
 	db := database.Connect(cfg.Database.DSN)
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -47,8 +47,9 @@ type AppConfig struct {
 }
 
 type ServerConfig struct {
-	Port string
-	Env  string
+	Port   string
+	Env    string
+	EnvSet bool
 }
 
 type DatabaseConfig struct {
@@ -84,11 +85,13 @@ func Load() *Config {
 	accessTTL, _ := strconv.Atoi(getEnv("JWT_ACCESS_TTL_MINUTES", "15"))
 	refreshTTL, _ := strconv.Atoi(getEnv("JWT_REFRESH_TTL_DAYS", "30"))
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "587"))
+	appEnv, appEnvSet := getEnvWithPresence("APP_ENV", "development")
 
 	return &Config{
 		Server: ServerConfig{
-			Port: getEnv("PORT", "8080"),
-			Env:  getEnv("APP_ENV", "development"),
+			Port:   getEnv("PORT", "8080"),
+			Env:    appEnv,
+			EnvSet: appEnvSet,
 		},
 		Database: DatabaseConfig{
 			DSN: getEnv("DATABASE_URL", "host=localhost user=postgres password=postgres dbname=tachigo port=5432 sslmode=disable"),
@@ -134,10 +137,22 @@ func Load() *Config {
 }
 
 func getEnv(key, fallback string) string {
+	value, _ := getEnvWithPresence(key, fallback)
+	return value
+}
+
+func getEnvWithPresence(key, fallback string) (string, bool) {
 	if v := os.Getenv(key); v != "" {
-		return v
+		return v, true
 	}
-	return fallback
+	return fallback, false
+}
+
+func ShouldValidateProductionSecrets(cfg *Config) bool {
+	if cfg == nil {
+		return true
+	}
+	return !cfg.Server.EnvSet || cfg.Server.Env != "development"
 }
 
 func ValidateProductionSecrets(cfg *Config) error {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,9 +1,16 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"time"
+)
+
+const (
+	defaultJWTAccessSecret  = "change-me-access-secret"
+	defaultJWTRefreshSecret = "change-me-refresh-secret"
+	minJWTSecretLength      = 32
 )
 
 type Config struct {
@@ -87,8 +94,8 @@ func Load() *Config {
 			DSN: getEnv("DATABASE_URL", "host=localhost user=postgres password=postgres dbname=tachigo port=5432 sslmode=disable"),
 		},
 		JWT: JWTConfig{
-			AccessSecret:  getEnv("JWT_ACCESS_SECRET", "change-me-access-secret"),
-			RefreshSecret: getEnv("JWT_REFRESH_SECRET", "change-me-refresh-secret"),
+			AccessSecret:  getEnv("JWT_ACCESS_SECRET", defaultJWTAccessSecret),
+			RefreshSecret: getEnv("JWT_REFRESH_SECRET", defaultJWTRefreshSecret),
 			AccessTTL:     time.Duration(accessTTL) * time.Minute,
 			RefreshTTL:    time.Duration(refreshTTL) * 24 * time.Hour,
 		},
@@ -131,4 +138,35 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func ValidateProductionSecrets(cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("config is required")
+	}
+
+	if err := validateJWTSecret("JWT_ACCESS_SECRET", cfg.JWT.AccessSecret, defaultJWTAccessSecret); err != nil {
+		return err
+	}
+	if err := validateJWTSecret("JWT_REFRESH_SECRET", cfg.JWT.RefreshSecret, defaultJWTRefreshSecret); err != nil {
+		return err
+	}
+	if cfg.JWT.AccessSecret == cfg.JWT.RefreshSecret {
+		return fmt.Errorf("JWT_ACCESS_SECRET and JWT_REFRESH_SECRET must be different")
+	}
+
+	return nil
+}
+
+func validateJWTSecret(name, value, fallback string) error {
+	if value == "" {
+		return fmt.Errorf("%s must not be empty", name)
+	}
+	if value == fallback {
+		return fmt.Errorf("%s must not use the default value", name)
+	}
+	if len(value) < minJWTSecretLength {
+		return fmt.Errorf("%s must be at least %d characters", name, minJWTSecretLength)
+	}
+	return nil
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateProductionSecrets(t *testing.T) {
+	validAccess := "access-secret-with-at-least-32-chars!"
+	validRefresh := "refresh-secret-with-at-least-32-char"
+
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr string
+	}{
+		{
+			name: "accepts valid production secrets",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  validAccess,
+					RefreshSecret: validRefresh,
+				},
+			},
+		},
+		{
+			name: "rejects empty access secret",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  "",
+					RefreshSecret: validRefresh,
+				},
+			},
+			wantErr: "JWT_ACCESS_SECRET",
+		},
+		{
+			name: "rejects empty refresh secret",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  validAccess,
+					RefreshSecret: "",
+				},
+			},
+			wantErr: "JWT_REFRESH_SECRET",
+		},
+		{
+			name: "rejects default access secret",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  defaultJWTAccessSecret,
+					RefreshSecret: validRefresh,
+				},
+			},
+			wantErr: "default",
+		},
+		{
+			name: "rejects default refresh secret",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  validAccess,
+					RefreshSecret: defaultJWTRefreshSecret,
+				},
+			},
+			wantErr: "default",
+		},
+		{
+			name: "rejects short access secret",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  "short-secret",
+					RefreshSecret: validRefresh,
+				},
+			},
+			wantErr: "at least 32 characters",
+		},
+		{
+			name: "rejects short refresh secret",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  validAccess,
+					RefreshSecret: "short-secret",
+				},
+			},
+			wantErr: "at least 32 characters",
+		},
+		{
+			name: "rejects identical secrets",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  validAccess,
+					RefreshSecret: validAccess,
+				},
+			},
+			wantErr: "must be different",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateProductionSecrets(tc.cfg)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -114,3 +114,50 @@ func TestValidateProductionSecrets(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldValidateProductionSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{
+			name: "validates when APP_ENV is missing and defaults to development",
+			cfg: &Config{
+				Server: ServerConfig{
+					Env: "development",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "skips validation only for explicit development",
+			cfg: &Config{
+				Server: ServerConfig{
+					Env:    "development",
+					EnvSet: true,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "validates production",
+			cfg: &Config{
+				Server: ServerConfig{
+					Env:    "production",
+					EnvSet: true,
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShouldValidateProductionSecrets(tc.cfg)
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 什麼改動
- 在 config 載入後新增 JWT secret production guard，於非 `development` 環境拒絕弱值或預設值啟動
- 新增 `ValidateProductionSecrets` 與對應 unit test，覆蓋空值、預設值、長度不足與 access/refresh 相同情境

## 為什麼
- closes #259
- 避免部署時遺漏 `JWT_ACCESS_SECRET` / `JWT_REFRESH_SECRET` 導致使用公開 fallback，造成可偽造 JWT 的風險

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#259
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改其他 secret（DB password、Twitch client secret 等）
  - 不引入 secret manager 或 vault 整合
  - 不處理目前工作樹中的 docs / AGENTS 漂移

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 在非 development 環境阻擋不安全的 JWT secret 設定並補齊驗證測試
- Approx changed lines：~160
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試
- `go test ./internal/config`
- `go test ./internal/middleware`

## 備註
- PR 只包含 `backend/cmd/server/main.go`、`backend/internal/config/config.go`、`backend/internal/config/config_test.go` 三個檔案；未提交的 `AGENTS.md` 與 swagger/docs 漂移未納入本 PR。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复
- 添加了生产环境配置验证机制，确保 JWT 访问令牌和刷新令牌密钥符合要求（非空、非默认值、长度至少 32 字符、两个密钥不相同）。若验证失败，应用将无法启动。

## 测试
- 添加了单元测试验证配置验证的各项规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->