### PR TITLE
[frontend] dashboard auth — PR B: remove localStorage refresh token, cookie-based session restore

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -18,8 +18,13 @@ export default function Layout() {
 
   async function handleLogout() {
     setIsLoggingOut(true)
-    await logout()
-    navigate('/login')
+    try {
+      await logout()
+      navigate('/login')
+    } catch {
+      // logout request failed — cookie was not cleared; keep user logged in
+      setIsLoggingOut(false)
+    }
   }
 
   return (

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -2,9 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { restoreSession } from '@/services/auth'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+async function bootstrap() {
+  await restoreSession()
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  )
+}
+
+bootstrap()

--- a/dashboard/src/services/__tests__/api.interceptor.test.ts
+++ b/dashboard/src/services/__tests__/api.interceptor.test.ts
@@ -4,6 +4,12 @@ import client, { hasAuthToken, setAuthToken, clearAuthToken } from '@/services/a
 
 let mock: InstanceType<typeof MockAdapter>
 
+describe('api client config', () => {
+  it('設定 request timeout，避免 restoreSession 阻塞首次 render', () => {
+    expect(client.defaults.timeout).toBe(10000)
+  })
+})
+
 beforeEach(() => {
   mock = new MockAdapter(client)
   clearAuthToken()

--- a/dashboard/src/services/__tests__/api.interceptor.test.ts
+++ b/dashboard/src/services/__tests__/api.interceptor.test.ts
@@ -91,6 +91,16 @@ describe('401 interceptor', () => {
     expect(mock.history.post.filter(r => r.url === '/api/v1/auth/refresh')).toHaveLength(1)
   })
 
+  it('無 access token 時 401 不觸發 refresh（例：login 失敗）', async () => {
+    // clearAuthToken() already called in beforeEach — hasAuthToken() is false
+    mock.onPost('/api/v1/auth/login').replyOnce(401)
+
+    await expect(client.post('/api/v1/auth/login', {})).rejects.toMatchObject({
+      response: { status: 401 },
+    })
+    expect(mock.history.post.filter(r => r.url === '/api/v1/auth/refresh')).toHaveLength(0)
+  })
+
   it('非 401 錯誤不觸發 refresh', async () => {
     mock.onGet('/api/v1/some-resource').replyOnce(500)
 

--- a/dashboard/src/services/__tests__/auth.test.ts
+++ b/dashboard/src/services/__tests__/auth.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import client, { clearAuthToken, hasAuthToken } from '@/services/api'
+import { isAuthenticated, login, logout, refresh, restoreSession } from '@/services/auth'
+
+let mock: InstanceType<typeof MockAdapter>
+
+beforeEach(() => {
+  mock = new MockAdapter(client)
+  clearAuthToken()
+  localStorage.clear()
+})
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe('login()', () => {
+  it('成功時設定 Authorization header，isAuthenticated() 為 true', async () => {
+    mock.onPost('/api/v1/auth/login').replyOnce(200, {
+      data: { user: { id: 'u1' }, tokens: { access_token: 'access-abc' } },
+    })
+
+    await login('user@example.com', 'password')
+
+    expect(hasAuthToken()).toBe(true)
+    expect(isAuthenticated()).toBe(true)
+  })
+
+  it('不將 refresh_token 寫入 localStorage', async () => {
+    mock.onPost('/api/v1/auth/login').replyOnce(200, {
+      data: { user: { id: 'u1' }, tokens: { access_token: 'access-abc' } },
+    })
+
+    await login('user@example.com', 'password')
+
+    expect(localStorage.getItem('refresh_token')).toBeNull()
+  })
+
+  it('API 失敗時 throw，isAuthenticated() 仍為 false', async () => {
+    mock.onPost('/api/v1/auth/login').replyOnce(401)
+
+    await expect(login('user@example.com', 'wrong')).rejects.toBeDefined()
+    expect(isAuthenticated()).toBe(false)
+  })
+})
+
+describe('logout()', () => {
+  beforeEach(async () => {
+    mock.onPost('/api/v1/auth/login').replyOnce(200, {
+      data: { user: {}, tokens: { access_token: 'access-abc' } },
+    })
+    await login('u@e.com', 'pw')
+  })
+
+  it('清除 Authorization header，isAuthenticated() 為 false', async () => {
+    mock.onPost('/api/v1/auth/logout').replyOnce(200)
+
+    await logout()
+
+    expect(hasAuthToken()).toBe(false)
+    expect(isAuthenticated()).toBe(false)
+  })
+
+  it('不送 refresh_token body（由 cookie 處理）', async () => {
+    mock.onPost('/api/v1/auth/logout').replyOnce(200)
+
+    await logout()
+
+    const call = mock.history.post.find(r => r.url === '/api/v1/auth/logout')
+    expect(call).toBeDefined()
+    expect(call?.data ?? null).toBeFalsy()
+  })
+
+  it('API 失敗時仍清除本機狀態（fire-and-forget）', async () => {
+    mock.onPost('/api/v1/auth/logout').replyOnce(500)
+
+    await expect(logout()).resolves.toBeUndefined()
+    expect(isAuthenticated()).toBe(false)
+  })
+
+  it('不讀取也不清除 localStorage', async () => {
+    localStorage.setItem('refresh_token', 'old-token')
+    mock.onPost('/api/v1/auth/logout').replyOnce(200)
+
+    await logout()
+
+    expect(localStorage.getItem('refresh_token')).toBe('old-token')
+  })
+})
+
+describe('refresh()', () => {
+  it('成功時更新 Authorization header，isAuthenticated() 為 true', async () => {
+    mock.onPost('/api/v1/auth/refresh').replyOnce(200, {
+      data: { tokens: { access_token: 'new-token' } },
+    })
+
+    await refresh()
+
+    expect(hasAuthToken()).toBe(true)
+    expect(isAuthenticated()).toBe(true)
+  })
+
+  it('失敗時 throw，isAuthenticated() 仍為 false', async () => {
+    mock.onPost('/api/v1/auth/refresh').replyOnce(401)
+
+    await expect(refresh()).rejects.toBeDefined()
+    expect(isAuthenticated()).toBe(false)
+  })
+})
+
+describe('restoreSession()', () => {
+  it('cookie 有效時 isAuthenticated() 為 true', async () => {
+    mock.onPost('/api/v1/auth/refresh').replyOnce(200, {
+      data: { tokens: { access_token: 'restored-token' } },
+    })
+
+    await restoreSession()
+
+    expect(isAuthenticated()).toBe(true)
+  })
+
+  it('cookie 過期或不存在時靜默 resolve，isAuthenticated() 仍為 false', async () => {
+    mock.onPost('/api/v1/auth/refresh').replyOnce(401)
+
+    await expect(restoreSession()).resolves.toBeUndefined()
+    expect(isAuthenticated()).toBe(false)
+  })
+})

--- a/dashboard/src/services/__tests__/auth.test.ts
+++ b/dashboard/src/services/__tests__/auth.test.ts
@@ -72,11 +72,11 @@ describe('logout()', () => {
     expect(call?.data ?? null).toBeFalsy()
   })
 
-  it('API 失敗時仍清除本機狀態（fire-and-forget）', async () => {
+  it('API 失敗時 reject，不清除本機狀態（cookie 可能未清，不應假裝登出）', async () => {
     mock.onPost('/api/v1/auth/logout').replyOnce(500)
 
-    await expect(logout()).resolves.toBeUndefined()
-    expect(isAuthenticated()).toBe(false)
+    await expect(logout()).rejects.toBeDefined()
+    expect(isAuthenticated()).toBe(true)
   })
 
   it('不讀取也不清除 localStorage', async () => {

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -6,6 +6,7 @@ const client = axios.create({
   baseURL: BASE_URL,
   headers: { 'Content-Type': 'application/json' },
   withCredentials: true,
+  timeout: 10000,
 })
 
 let _accessToken: string | null = null

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -37,7 +37,7 @@ client.interceptors.response.use(
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean }
     const isRefreshEndpoint = (originalRequest.url ?? '').includes('/api/v1/auth/refresh')
 
-    if (error.response?.status !== 401 || originalRequest._retry || isRefreshEndpoint) {
+    if (error.response?.status !== 401 || originalRequest._retry || isRefreshEndpoint || !hasAuthToken()) {
       return Promise.reject(error)
     }
 

--- a/dashboard/src/services/auth.ts
+++ b/dashboard/src/services/auth.ts
@@ -31,7 +31,7 @@ export async function restoreSession(): Promise<void> {
 }
 
 export async function logout(): Promise<void> {
-  await client.post('/api/v1/auth/logout').catch(() => {})
+  await client.post('/api/v1/auth/logout')
   clearAuthToken()
 }
 

--- a/dashboard/src/services/auth.ts
+++ b/dashboard/src/services/auth.ts
@@ -1,41 +1,42 @@
 import { isAxiosError } from 'axios'
-import client, { setAuthToken, clearAuthToken } from '@/services/api'
-
-// 記憶體儲存，不 export
-let accessToken: string | null = null
+import client, { clearAuthToken, hasAuthToken, setAuthToken } from '@/services/api'
 
 interface LoginResponse {
   data: {
     user: Record<string, unknown>
-    tokens: {
-      access_token: string
-      refresh_token: string
-    }
+    tokens: { access_token: string }
   }
+}
+
+interface RefreshResponse {
+  data: { tokens: { access_token: string } }
 }
 
 export async function login(email: string, password: string): Promise<void> {
-  const { data } = await client.post<LoginResponse>('/api/v1/auth/login', {
-    email,
-    password,
-  })
-  accessToken = data.data.tokens.access_token
-  localStorage.setItem('refresh_token', data.data.tokens.refresh_token)
-  setAuthToken(accessToken)
+  const { data } = await client.post<LoginResponse>('/api/v1/auth/login', { email, password })
+  setAuthToken(data.data.tokens.access_token)
+}
+
+export async function refresh(): Promise<void> {
+  const { data } = await client.post<RefreshResponse>('/api/v1/auth/refresh')
+  setAuthToken(data.data.tokens.access_token)
+}
+
+export async function restoreSession(): Promise<void> {
+  try {
+    await refresh()
+  } catch {
+    // cookie 不存在或已過期；維持未登入狀態
+  }
 }
 
 export async function logout(): Promise<void> {
-  const refreshToken = localStorage.getItem('refresh_token')
-  if (refreshToken) {
-    await client.post('/api/v1/auth/logout', { refresh_token: refreshToken }).catch(() => {})
-  }
-  accessToken = null
-  localStorage.removeItem('refresh_token')
+  await client.post('/api/v1/auth/logout').catch(() => {})
   clearAuthToken()
 }
 
 export function isAuthenticated(): boolean {
-  return accessToken !== null
+  return hasAuthToken()
 }
 
 export { isAxiosError }


### PR DESCRIPTION
## 什麼改動

- `dashboard/src/services/auth.ts`：移除所有 `localStorage` 讀寫，加 `refresh()` / `restoreSession()`，`isAuthenticated()` delegate 給 `hasAuthToken()`
- `dashboard/src/main.tsx`：mount 前呼叫 `restoreSession()`，透過 httpOnly cookie 靜默還原 session
- `dashboard/src/services/api.ts`：補 `!hasAuthToken()` guard，避免 login 401 錯誤觸發 refresh（PR A Codex 建議）
- 新增 `dashboard/src/services/__tests__/auth.test.ts`（11 個測試）
- `api.interceptor.test.ts` 補 login 401 不觸發 refresh 的測試

## 為什麼

PR #338（PR A）已建立 axios 基礎設施（withCredentials、hasAuthToken、401 interceptor + dedupe）。本 PR 完成 Phase 2b：

1. **移除 localStorage**：`refresh_token` 存在 localStorage 是 XSS 攻擊面，httpOnly cookie 的後端合約（PR #220）已就緒
2. **restoreSession()**：頁面重整後 accessToken 在記憶體中消失，需在 React mount 前透過 cookie 靜默還原，否則用戶每次重整都被踢到 login 頁
3. **isAuthenticated() 單一來源**：delegate 給 `hasAuthToken()`，與 interceptor 的 token 管理保持一致
4. **!hasAuthToken() guard**：login 失敗 401 不應觸發 /auth/refresh，無 access token 時直接 reject

## Release Context

- Release type：`n/a`

## Scope 對齊

- Source of truth：#217
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否
- 本 PR 明確不做：
  - 不修改 extension auth contract
  - 不修改 streamers pages 或其他 page 元件
  - 不移除後端 body fallback（另開 follow-up）

## 測試方式

- [x] 有寫 / 更新測試（`auth.test.ts` 11 個、`api.interceptor.test.ts` +1）
- [x] `pnpm test` 全部通過（39 tests）

## 超出範圍內容

- 無

closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 优化会话恢复流程，应用启动时自动保持用户登录状态。

* **错误修复**
  * 新增API请求10秒超时配置。
  * 改进登出流程的错误处理，失败时不会强制跳转。
  * 增强认证流程的鲁棒性，未登录状态下请求刷新时处理更加可靠。

* **测试**
  * 新增认证服务全面测试覆盖。
  * 新增API拦截器测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->