### PR TITLE
[chore] clarify AI role division — Claude as PM, Codex as engineer

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -136,7 +136,10 @@ if command -v git-lfs >/dev/null 2>&1; then
     [ -z "$local_sha" ] && continue
     [ "$local_sha" = "$ZERO_SHA" ] && continue
     if [ "$remote_sha" = "$ZERO_SHA" ]; then
-      range="$local_sha"
+      base=$(git merge-base "$local_sha" refs/remotes/origin/develop 2>/dev/null \
+             || git merge-base "$local_sha" refs/remotes/origin/main 2>/dev/null \
+             || echo "")
+      [ -n "$base" ] && range="${base}..${local_sha}" || range="${local_sha}^..${local_sha}"
     else
       range="${remote_sha}..${local_sha}"
     fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Pre-push hook: warn when diff is too large (mirrors CI hard limits)
+# Pre-push hook:
+#   1. Warn when diff is too large (mirrors CI hard limits)
+#   2. Run git-lfs pre-push only when LFS-tracked files are being pushed
 # Hard limits match pr-scope-police.yml
 MAX_FILES=35
 MAX_LINES=1800
@@ -7,6 +9,9 @@ ZERO_SHA=0000000000000000000000000000000000000000
 
 remote="$1"
 url="$2"
+
+# Save stdin — both scope police and LFS checks need the ref list
+stdin_data=$(cat)
 
 resolve_candidate_ref() {
   local candidate="$1"
@@ -121,10 +126,30 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     echo "Push aborted."
     exit 1
   fi
-done
+done <<< "$stdin_data"
 
-if [ "$violations" -eq 0 ]; then
-  exit 0
+# ── LFS pre-push (skip if no LFS-tracked files in pushed commits) ────────────
+# LFS patterns mirror .gitattributes
+if command -v git-lfs >/dev/null 2>&1; then
+  has_lfs=0
+  while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+    [ -z "$local_sha" ] && continue
+    [ "$local_sha" = "$ZERO_SHA" ] && continue
+    if [ "$remote_sha" = "$ZERO_SHA" ]; then
+      range="$local_sha"
+    else
+      range="${remote_sha}..${local_sha}"
+    fi
+    if git log --pretty=format: --name-only "$range" 2>/dev/null \
+       | grep -qE '\.(png|jpg|jpeg|webp|gif|ttf|otf|woff|woff2)$'; then
+      has_lfs=1
+      break
+    fi
+  done <<< "$stdin_data"
+
+  if [ "$has_lfs" -eq 1 ]; then
+    printf '%s\n' "$stdin_data" | git lfs pre-push "$@"
+  fi
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -116,12 +116,12 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   echo "╚══════════════════════════════════════════════════════╝"
   echo ""
 
-  if [ ! -t 0 ]; then
+  if [ ! -e /dev/tty ]; then
     echo "Non-interactive mode detected; refusing oversized push."
     exit 1
   fi
 
-  read -p "Push anyway? [y/N] " -r reply
+  read -p "Push anyway? [y/N] " -r reply </dev/tty
   if [[ ! "$reply" =~ ^[Yy]$ ]]; then
     echo "Push aborted."
     exit 1
@@ -136,8 +136,8 @@ if command -v git-lfs >/dev/null 2>&1; then
     [ -z "$local_sha" ] && continue
     [ "$local_sha" = "$ZERO_SHA" ] && continue
     if [ "$remote_sha" = "$ZERO_SHA" ]; then
-      base=$(git merge-base "$local_sha" refs/remotes/origin/develop 2>/dev/null \
-             || git merge-base "$local_sha" refs/remotes/origin/main 2>/dev/null \
+      base=$(git merge-base "$local_sha" "refs/remotes/$remote/develop" 2>/dev/null \
+             || git merge-base "$local_sha" "refs/remotes/$remote/main" 2>/dev/null \
              || echo "")
       [ -n "$base" ] && range="${base}..${local_sha}" || range="${local_sha}^..${local_sha}"
     else
@@ -150,9 +150,12 @@ if command -v git-lfs >/dev/null 2>&1; then
     fi
   done <<< "$stdin_data"
 
+  lfs_exit=0
   if [ "$has_lfs" -eq 1 ]; then
     printf '%s\n' "$stdin_data" | git lfs pre-push "$@"
+    lfs_exit=$?
   fi
+  exit $lfs_exit
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -73,6 +73,39 @@ detect_base_ref() {
   return 1
 }
 
+detect_lfs_range() {
+  local local_ref="$1"
+  local local_sha="$2"
+  local remote_ref="$3"
+  local remote_sha="$4"
+  local branch_name base_ref base_sha base
+
+  if [ "$remote_sha" != "$ZERO_SHA" ]; then
+    printf '%s\n' "${remote_sha}..${local_sha}"
+    return 0
+  fi
+
+  case "$local_ref" in
+    refs/heads/*)
+      branch_name="${local_ref#refs/heads/}"
+      base_ref=$(detect_base_ref "$branch_name" "$remote_ref" 2>/dev/null || true)
+      if [ -n "$base_ref" ]; then
+        base_sha=$(git rev-parse "$base_ref^{commit}" 2>/dev/null || true)
+        if [ -n "$base_sha" ]; then
+          base=$(git merge-base "$local_sha" "$base_sha" 2>/dev/null || true)
+        fi
+      fi
+      ;;
+  esac
+
+  if [ -n "${base:-}" ]; then
+    printf '%s\n' "${base}..${local_sha}"
+    return 0
+  fi
+
+  printf '%s\n' "${local_sha}^..${local_sha}"
+}
+
 violations=0
 
 while read -r local_ref local_sha remote_ref remote_sha; do
@@ -128,6 +161,70 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   fi
 done <<< "$stdin_data"
 
+# ── PR metadata preflight (existing open PR only) ─────────────────────────────
+# Fetches the current PR title + body from GitHub and runs pr-metadata-check.sh
+# locally so metadata failures surface before CI, avoiding fixup commit cycles.
+_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+_meta_script="$_repo_root/scripts/pr-metadata-check.sh"
+
+if [ -x "$_meta_script" ] && command -v gh >/dev/null 2>&1; then
+  while IFS=' ' read -r local_ref local_sha _r _s; do
+    [ -n "$local_ref" ] || continue
+    [ "$local_sha" != "$ZERO_SHA" ] || continue
+    case "$local_ref" in refs/heads/*) ;; *) continue ;; esac
+
+    branch_name="${local_ref#refs/heads/}"
+    case "$branch_name" in develop|main) continue ;; esac
+
+    pr_number=$(gh pr view "$branch_name" --json number --jq '.number' 2>/dev/null || true)
+    [ -n "$pr_number" ] || continue
+
+    pr_title=$(gh pr view "$branch_name" --json title --jq '.title' 2>/dev/null || true)
+    _tmpbody=$(mktemp)
+    _tmpwarn=$(mktemp)
+    gh pr view "$branch_name" --json body --jq '.body // ""' > "$_tmpbody" 2>/dev/null || true
+
+    _meta_exit=0
+    _meta_out=$("$_meta_script" \
+      --title "$pr_title" \
+      --body-file "$_tmpbody" \
+      --head "$branch_name" 2>"$_tmpwarn") || _meta_exit=$?
+    _meta_warn=$(cat "$_tmpwarn")
+    rm -f "$_tmpbody" "$_tmpwarn"
+
+    if [ -n "$_meta_warn" ]; then
+      printf '\n%s\n' "$_meta_warn"
+    fi
+
+    [ "$_meta_exit" -eq 0 ] && continue
+
+    echo ""
+    echo "╔══════════════════════════════════════════════════════╗"
+    echo "║  PR metadata preflight — failed                     ║"
+    echo "╠══════════════════════════════════════════════════════╣"
+    printf "║  PR #%-48s║\n" "$pr_number  ($branch_name)"
+    echo "╠══════════════════════════════════════════════════════╣"
+    while IFS= read -r _line; do
+      printf "║  %-52.52s║\n" "$_line"
+    done <<< "$_meta_out"
+    echo "╠══════════════════════════════════════════════════════╣"
+    echo "║  Fix the above to avoid CI scope police blocks.     ║"
+    echo "╚══════════════════════════════════════════════════════╝"
+    echo ""
+
+    if [ ! -e /dev/tty ]; then
+      echo "Non-interactive mode; refusing push with metadata failures."
+      exit 1
+    fi
+
+    read -p "Push anyway? [y/N] " -r _reply </dev/tty
+    if [[ ! "$_reply" =~ ^[Yy]$ ]]; then
+      echo "Push aborted."
+      exit 1
+    fi
+  done <<< "$stdin_data"
+fi
+
 # ── LFS pre-push (skip if no LFS-tracked files in pushed commits) ────────────
 # LFS patterns mirror .gitattributes
 if command -v git-lfs >/dev/null 2>&1; then
@@ -135,14 +232,8 @@ if command -v git-lfs >/dev/null 2>&1; then
   while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     [ -z "$local_sha" ] && continue
     [ "$local_sha" = "$ZERO_SHA" ] && continue
-    if [ "$remote_sha" = "$ZERO_SHA" ]; then
-      base=$(git merge-base "$local_sha" "refs/remotes/$remote/develop" 2>/dev/null \
-             || git merge-base "$local_sha" "refs/remotes/$remote/main" 2>/dev/null \
-             || echo "")
-      [ -n "$base" ] && range="${base}..${local_sha}" || range="${local_sha}^..${local_sha}"
-    else
-      range="${remote_sha}..${local_sha}"
-    fi
+
+    range=$(detect_lfs_range "$local_ref" "$local_sha" "$remote_ref" "$remote_sha")
     if git log --pretty=format: --name-only "$range" 2>/dev/null \
        | grep -qE '\.(png|jpg|jpeg|webp|gif|ttf|otf|woff|woff2)$'; then
       has_lfs=1

--- a/.github/ISSUE_TEMPLATE/codex-task.yml
+++ b/.github/ISSUE_TEMPLATE/codex-task.yml
@@ -1,0 +1,124 @@
+name: Codex Task
+description: Claude Code 以 PM 身份替 Codex 撰寫的實作 issue。
+title: "Task: "
+labels:
+  - feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        給 Codex 的任務 issue。Claude Code 負責填寫規格，Codex 依此開發。
+        Issue 必須自給自足——Codex 不應需要查閱 chat history 才能理解任務。
+
+  - type: dropdown
+    id: task_level
+    attributes:
+      label: Task Level
+      description: 選擇這張 issue 的任務等級。
+      options:
+        - Small / Medium
+        - Test-Driven / Debug Loop
+        - Architecture / High Risk
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景
+      description: 為什麼要做這件事？目前狀態是什麼？
+      placeholder: |
+        例：
+        目前 PointsService 缺少雙帳本記帳，導致點數異動無法被稽核。
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: 目標
+      description: 這張 issue 要達成的單一主要目標。
+      placeholder: |
+        例：
+        實作 PointsService 的雙帳本記帳邏輯，讓每次點數異動都有對應的 ledger entry。
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 範圍
+      description: 明確列出 Codex 可以動哪些檔案或模組。
+      placeholder: |
+        例：
+        只改 backend/internal/points/，不動 tachimint/ 與 dashboard/。
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: 逐條列出可驗收條件。PR merge 前必須全部達成。
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: 限制
+      description: 明確列出不能做的事、格式要求、相依條件。
+      placeholder: |
+        - 不可修改 schema 以外的 migration 檔案
+        - commit message 必須含 refs #<issue號碼>
+        - 不進行與本票無關的重構
+    validations:
+      required: true
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 交付物
+      description: 完成後預期 Codex 要交付哪些具體產出。
+      placeholder: |
+        - 實作檔案（路徑）
+        - 測試檔案
+        - PR（closes #本票號碼）
+    validations:
+      required: true
+
+  - type: input
+    id: branch_name
+    attributes:
+      label: Branch 名稱
+      description: 指定 Codex 應從 develop 開出的 branch 名稱。
+      placeholder: "feat/points-ledger"
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 驗證方式
+      description: 完成前需要做哪些檢查。對 Test-Driven / Debug Loop 任務尤其重要。
+      placeholder: |
+        - docker compose run --no-deps --rm app go test ./...
+        - 確認 ledger entry 存在於 DB
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 參考資料
+      description: 相關文件、issue、PR、URL。
+      placeholder: |
+        - backend/internal/points/service.go（現有範本）
+        - issue #...
+        - docs/architecture.md
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/codex-task.yml
+++ b/.github/ISSUE_TEMPLATE/codex-task.yml
@@ -1,6 +1,5 @@
 name: Codex Task
 description: Claude Code 以 PM 身份替 Codex 撰寫的實作 issue。
-title: "Task: "
 labels:
   - feature
 body:
@@ -9,6 +8,9 @@ body:
       value: |
         給 Codex 的任務 issue。Claude Code 負責填寫規格，Codex 依此開發。
         Issue 必須自給自足——Codex 不應需要查閱 chat history 才能理解任務。
+
+        **Issue 標題必須以下列 prefix 之一開頭：** `[backend]`、`[frontend]`、`[discussion]`
+        範例：`[backend] ClaimService — finalize_failed 狀態流轉`
 
   - type: dropdown
     id: task_level

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,12 @@
 <!-- 若這是正式 release PR，請填：`develop -> main`；否則填 `n/a` -->
 - Release type：<!-- `develop -> main` 或 `n/a` -->
 
+## Workflow Type
+<!-- Codex task PR 請勾選；非 Codex task 填 n/a -->
+- [ ] Small / Medium
+- [ ] Test-Driven / Debug Loop
+- [ ] Architecture / High Risk
+
 ## Scope 對齊
 <!-- 一般 feature PR 若超過約 35 個檔案、diff 過大、同時改多個 product surface，或依賴尚未 merge 的 backend contract，會被 PR Scope Police 自動擋下。正式 `develop -> main` release PR 請使用 `[release]` title prefix，並在上方 Release Context 填 `develop -> main`。 -->
 - Source of truth：<!-- issue / PR / 文件，例如 #115 -->
@@ -45,6 +51,12 @@
 - 若已拆分，相關 PR：
   - <!-- 例：#123 migration, #124 service；若無請填 n/a -->
 
+## Acceptance Criteria
+<!-- 對應 source issue 的 AC，逐條勾選；非 Codex task 填 n/a -->
+- [ ] AC 1
+- [ ] AC 2
+- [ ] AC 3
+
 ## 超出範圍內容
 <!-- 若有額外重構、future work、design exploration、順手修正，請寫在這裡；若無請填「無」 -->
 
@@ -52,5 +64,15 @@
 - [ ] 本地測試過
 - [ ] 有寫 / 更新測試
 
+**驗證結果**
+<!-- 貼上關鍵指令的執行結果或摘要；若無測試填 n/a -->
+```
+（貼上驗證輸出）
+```
+
 ## 備註
 <!-- 其他需要 reviewer 注意的事情（可留空） -->
+
+## Notes for Claude Code Review
+<!-- Codex 填寫：有哪些地方需要 Claude 特別注意、不確定的假設、已知風險 -->
+- 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,37 @@
 
 收到任務時判斷是哪種模式，若不確定就直接問。遇到需要架構決策的岔路，先回報給 Claude Code，不要自行決定。
 
+### 預設工作流程（Issue-driven）
+
+**角色分工：**
+- **Claude Code** = PM：架構規劃、issue 撰寫、最終 PR 審查
+- **Codex（你）** = 工程師：實作、debug、patch、跑測試、推 PR
+
+> **核心原則：Codex 適合確定性高的任務，Claude 適合模糊性高的任務。**
+
+**任務規模路由：**
+
+| 任務規模 | 誰執行 |
+|---|---|
+| Trivial（< 10 行、config 調整、typo）| Claude 直接 patch |
+| Small-Medium（功能、API、元件）| Claude 寫 issue → **Codex 實作** → Claude review |
+| 需要迭代測試（跑測試直到過）| **Codex**，Claude 只寫 issue |
+| 架構重構 / 高風險改動 | Claude 設計拆分 → **Codex** 逐 issue 實作 |
+
+本專案的預設 AI 協作流程：
+
+1. **Claude Code** 將規格寫入 GitHub issue（含背景、任務 checklist、介面規格、完成條件）
+2. **Codex（你）** 認領 issue，依規格實作，推 branch，開 PR 到 `develop`
+3. **Claude Code** 在 GitHub 上做最終 PR 審查
+
+收到 issue 後的執行步驟：
+
+1. 讀 issue 確認規格與完成條件
+2. 從 `develop` 開新 branch（命名依 branch 命名規範）
+3. 逐步實作，commit 用 `refs #<issue號碼>`
+4. 推 branch，開 PR 到 `develop`，PR body 用 `closes #<issue號碼>`
+5. 等待 Claude Code 在 GitHub 上審查
+
 ## 專案結構
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,17 @@ docker compose run --no-deps --rm app go test ./...
 
 例：`feat/points-service`、`fix/bits-receipt`、`docs/architecture`
 
-### Commit 訊息格式
+### Merge 策略
+
+本專案使用 **squash merge**：一張 PR = develop 上的一個 commit。
+
+- **PR title** 就是 squash commit message，必須精確
+- **PR body** 放 `closes #號碼`，merge 後自動關閉 issue
+- PR 內的 commit 用 `refs #號碼`，供 review 期間追溯
+
+fixup commit（修 CodeRabbit 意見、修 scope police）是正常的，不必 rebase 清理。
+
+### Commit 訊息格式（PR 內）
 
 ```
 <type>: <short description>
@@ -83,9 +93,6 @@ refs #<issue號碼>
 
 Co-Authored-By: Codex <codex[bot]@openai.com>
 ```
-
-- 實作過程中的 commit 用 `refs #號碼`
-- PR 的最後一個 commit 或 PR 描述用 `closes #號碼`
 
 Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,10 +129,12 @@
 
 ### Commit
 
-- 原子化：每個 commit 應該是獨立的工作單位，可以單獨 revert、cherry-pick、bisect
-- 避免「一次性 commit」（如一次改 schema + service + handler + 前端四個層）
-- 按邏輯層或步驟分割：schema migration → service 實作 → API 路由 → 前端整合，各為一個 commit
-- 細粒度 commit 讓 code review 和問題追蹤更精確
+本專案使用 squash merge，PR 內的 commit **不會**直接進 develop history，目的是讓 review 過程清楚，不是追求能獨立 cherry-pick / bisect。
+
+- 按邏輯步驟分割有助於 reviewer 理解實作脈絡
+- fixup commit（修 CodeRabbit 意見、修 scope police）是正常的，不必 rebase 清理
+- 避免「一次性 commit」把不相關的層混在一起（會讓 review 難以跟進）
+- 進 develop 的 commit 來自 PR title（squash message），所以 **PR title 要精確**
 
 ### PR
 
@@ -212,9 +214,17 @@
 
 例：`feat/points-service`、`fix/bits-receipt`、`docs/architecture`
 
-## Commit 訊息格式
+## Merge 策略
 
-每個 commit 必須用 `refs #<issue號碼>` 標記相關 issue，方便日後追溯當初的規格與討論。
+本專案使用 **squash merge**：一張 PR 對應 develop 上的一個 commit。
+
+- **PR title** 就是 squash commit message，必須精確描述這張 PR 做了什麼
+- **PR body** 放 `closes #號碼`，merge 後自動關閉 issue
+- PR 內的 individual commit 用 `refs #號碼` 標記，供 review 期間追溯用
+
+## Commit 訊息格式（PR 內）
+
+每個 commit 必須用 `refs #<issue號碼>` 標記，方便 review 期間追溯規格與討論。
 
 ```
 <type>: <short description>
@@ -223,9 +233,6 @@ refs #27
 
 Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@anthropic.com>
 ```
-
-- 實作過程中的 commit 用 `refs #號碼`
-- PR 的最後一個 commit 或 PR 描述用 `closes #號碼`（merge 後自動關閉 issue）
 
 Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,12 +129,12 @@
 
 ### Commit
 
-本專案使用 squash merge，PR 內的 commit **不會**直接進 develop history，目的是讓 review 過程清楚，不是追求能獨立 cherry-pick / bisect。
+本專案使用 merge commit（--no-ff），PR 內的所有 commit **會直接進 develop history**，feature branch 的分支結構保留在 git graph 上。
 
-- 按邏輯步驟分割有助於 reviewer 理解實作脈絡
+- 按邏輯步驟分割 commit，方便 reviewer 追蹤實作脈絡，也方便日後 bisect
 - fixup commit（修 CodeRabbit 意見、修 scope police）是正常的，不必 rebase 清理
 - 避免「一次性 commit」把不相關的層混在一起（會讓 review 難以跟進）
-- 進 develop 的 commit 來自 PR title（squash message），所以 **PR title 要精確**
+- **PR title 仍要精確**，merge commit 會引用它
 
 ### PR
 
@@ -216,11 +216,11 @@
 
 ## Merge 策略
 
-本專案使用 **squash merge**：一張 PR 對應 develop 上的一個 commit。
+本專案使用 **merge commit（--no-ff）**：feature branch 進 develop 時保留分支結構，git graph 看得到每條 branch 的進出。
 
-- **PR title** 就是 squash commit message，必須精確描述這張 PR 做了什麼
 - **PR body** 放 `closes #號碼`，merge 後自動關閉 issue
 - PR 內的 individual commit 用 `refs #號碼` 標記，供 review 期間追溯用
+- **PR title 要精確**，GitHub merge commit 會引用它
 
 ## Commit 訊息格式（PR 內）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,10 +238,24 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 **預設工作流程：**
 
 1. 大範圍掃描 / 重複性工作 → 先交給 **Gemini**
-2. 推理、架構決策、最終實作 → **Claude**
-3. 需要跑測試並根據失敗迭代修改 → **Codex**
+2. 架構規劃、issue 撰寫（PM 角色）→ **Claude Code**
+3. 實作、debug、patch（工程師角色）→ **Codex**
+4. 最終 PR 審查 → **Claude Code**
 
 絕不用 Claude token 做重複性搜尋。
+
+### 任務規模路由
+
+> **核心原則：Codex 適合確定性高的任務，Claude 適合模糊性高的任務。**
+
+| 任務規模 | 流程 |
+|---|---|
+| **Trivial**（< 10 行、config 調整、typo）| Claude 直接 patch，不走 issue 流程 |
+| **Small-Medium**（功能、API、元件）| Claude 寫 issue → Codex 實作 → Claude review |
+| **需要迭代測試**（跑測試直到過）| 一定走 Codex；Claude 只負責寫 issue |
+| **架構重構 / 高風險改動**| Claude 先設計方案，拆成多個 issue 再交 Codex |
+
+預設路由：收到實作需求先判斷規模，Trivial 以外一律寫 issue 交 Codex。
 
 ### Gemini 專責任務
 
@@ -259,9 +273,8 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 | 操作 | 誰執行 |
 |---|---|
 | 摘要大量檔案、生成樣板、審查 log、搜尋 pattern、草擬測試 | Gemini（`gemini -p "<task>"`；確認無風險時可加 `--yolo`） |
-| 架構決策、安全審查、重構策略、最終 code review | Claude Code |
-| 需要跑測試並根據失敗迭代修改的任務 | Codex（`/test-with-codex`） |
-| `git` / `gh` / 檔案操作 / 實作 / 決策 | Claude Code |
+| 架構規劃、issue 撰寫、技術決策、最終 PR 審查 | Claude Code（PM 角色） |
+| 實作、debug、patch、跑測試、推 branch、開 PR | Codex（工程師角色） |
 
 ## PR 審查流程
 

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -165,7 +165,10 @@ main() {
   }
 
   local changed_files
-  changed_files=$(git diff --name-only "$merge_base" "$head_sha")
+  changed_files=$(git diff --name-only "$merge_base" "$head_sha") || {
+    echo "無法計算 diff：$merge_base vs $head_sha" >&2
+    exit 2
+  }
 
   local touches_backend=0 touches_dashboard=0 touches_tachimint=0 touches_contracts=0 docs_only=1
   local file
@@ -206,7 +209,7 @@ main() {
   fi
 
   local depends_on_raw=""
-  depends_on_raw=$(sed -nE 's/^[[:space:]-]*Depends on PR[：:][[:space:]]*(.+)$/\1/ip' "$body_file" | head -n1 | sed 's/[[:space:]]*$//')
+  depends_on_raw=$(grep -iE '^[[:space:]-]*Depends on PR[：:][[:space:]]' "$body_file" | head -n1 | sed -E 's/^[^：:]*[：:][[:space:]]*//' | sed 's/[[:space:]]*$//')
 
   if [ "$is_infra_or_chore" -eq 0 ] && [ "$is_release_promotion" -eq 0 ]; then
     grep -Eq '#[0-9]+' "$body_file" || failures+=("PR body 必須引用至少一個 issue 或 PR 編號，例如 #123")
@@ -272,8 +275,10 @@ main() {
     dep_state=$(gh pr view "$dep_number" --repo "$repo" --json state --jq '.state' 2>/dev/null || true)
     if [ -z "$dep_state" ]; then
       failures+=("無法讀取 dependency PR #$dep_number")
+    elif [ "$dep_state" = "MERGED" ]; then
+      failures+=("[frontend] Backend contract PR #$dep_number is already MERGED into develop; please check 'Backend contract already in develop: yes'")
     else
-      failures+=("[frontend] PR depends on #$dep_number, but backend contract is not in develop. Dependency PR state: $dep_state")
+      echo "[info] Dependency PR #$dep_number state: $dep_state (stacked or blocked, OK)" >&2
     fi
   fi
 

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -134,6 +134,7 @@ main() {
   done
 
   local failures=()
+  local warn_surfaces=()
   [ -n "$title_prefix" ] || failures+=("PR title 必須以其中一個 prefix 開頭：$allowed_prefixes")
 
   local base_ref=""
@@ -265,6 +266,22 @@ main() {
     failures+=("PR 不可同時修改多個 product surface")
   fi
 
+  # Warn when [infra]/[chore] touches product surface code.
+  # Common cause: conflict-resolution commits sneak in code changes.
+  # Reviewer will block if PR body promises "不動程式碼" but diff says otherwise.
+  if [ "$is_infra_or_chore" -eq 1 ] && [ "$docs_only" -eq 0 ]; then
+    [ "$touches_backend" -eq 1 ]   && warn_surfaces+=("backend/")
+    [ "$touches_dashboard" -eq 1 ] && warn_surfaces+=("dashboard/")
+    [ "$touches_tachimint" -eq 1 ] && warn_surfaces+=("tachimint/")
+    [ "$touches_contracts" -eq 1 ] && warn_surfaces+=("contracts/")
+  fi
+
+  if [ "${#warn_surfaces[@]}" -gt 0 ]; then
+    local _ws
+    _ws=$(IFS=,; printf '%s' "${warn_surfaces[*]}")
+    failures+=("$title_prefix PR 改動了 product surface 程式碼（${_ws}）—— 若 PR body「本 PR 明確不做」承諾了不動程式碼，請先更新再 push；若屬刻意改動，請改用對應的 [backend]/[frontend] prefix")
+  fi
+
   if [ "$title_prefix" = "[frontend]" ] && [[ "$depends_on_raw" =~ ^#([0-9]+)$ ]] && [ "$backend_contract_no" -eq 1 ]; then
     command -v gh >/dev/null 2>&1 || { echo "需要 gh 才能檢查 dependency PR 狀態。" >&2; exit 2; }
     gh auth status >/dev/null 2>&1 || { echo "gh 尚未認證；請先處理 gh auth，再重跑。" >&2; exit 2; }
@@ -277,8 +294,12 @@ main() {
       failures+=("無法讀取 dependency PR #$dep_number")
     elif [ "$dep_state" = "MERGED" ]; then
       failures+=("[frontend] Backend contract PR #$dep_number is already MERGED into develop; please check 'Backend contract already in develop: yes'")
-    else
+    elif [ "$dep_state" = "CLOSED" ]; then
+      failures+=("[frontend] Dependency PR #$dep_number is CLOSED and not merged; please rebase or update dependency")
+    elif [ "$dep_state" = "OPEN" ]; then
       echo "[info] Dependency PR #$dep_number state: $dep_state (stacked or blocked, OK)" >&2
+    else
+      failures+=("未知 dependency PR 狀態：$dep_state (#$dep_number)")
     fi
   fi
 

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -134,7 +134,7 @@ main() {
   done
 
   local failures=()
-  local warn_surfaces=()
+  local surface_failures=()
   [ -n "$title_prefix" ] || failures+=("PR title 必須以其中一個 prefix 開頭：$allowed_prefixes")
 
   local base_ref=""
@@ -266,19 +266,19 @@ main() {
     failures+=("PR 不可同時修改多個 product surface")
   fi
 
-  # Warn when [infra]/[chore] touches product surface code.
+  # Block when [infra]/[chore] touches product surface code.
   # Common cause: conflict-resolution commits sneak in code changes.
   # Reviewer will block if PR body promises "不動程式碼" but diff says otherwise.
   if [ "$is_infra_or_chore" -eq 1 ] && [ "$docs_only" -eq 0 ]; then
-    [ "$touches_backend" -eq 1 ]   && warn_surfaces+=("backend/")
-    [ "$touches_dashboard" -eq 1 ] && warn_surfaces+=("dashboard/")
-    [ "$touches_tachimint" -eq 1 ] && warn_surfaces+=("tachimint/")
-    [ "$touches_contracts" -eq 1 ] && warn_surfaces+=("contracts/")
+    [ "$touches_backend" -eq 1 ]   && surface_failures+=("backend/")
+    [ "$touches_dashboard" -eq 1 ] && surface_failures+=("dashboard/")
+    [ "$touches_tachimint" -eq 1 ] && surface_failures+=("tachimint/")
+    [ "$touches_contracts" -eq 1 ] && surface_failures+=("contracts/")
   fi
 
-  if [ "${#warn_surfaces[@]}" -gt 0 ]; then
+  if [ "${#surface_failures[@]}" -gt 0 ]; then
     local _ws
-    _ws=$(IFS=,; printf '%s' "${warn_surfaces[*]}")
+    _ws=$(IFS=,; printf '%s' "${surface_failures[*]}")
     failures+=("$title_prefix PR 改動了 product surface 程式碼（${_ws}）—— 若 PR body「本 PR 明確不做」承諾了不動程式碼，請先更新再 push；若屬刻意改動，請改用對應的 [backend]/[frontend] prefix")
   fi
 

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -209,7 +209,7 @@ main() {
   fi
 
   local depends_on_raw=""
-  depends_on_raw=$(grep -iE '^[[:space:]-]*Depends on PR[：:][[:space:]]' "$body_file" | head -n1 | sed -E 's/^[^：:]*[：:][[:space:]]*//' | sed 's/[[:space:]]*$//')
+  depends_on_raw=$(grep -iE '^[[:space:]-]*Depends on PR[：:][[:space:]]*' "$body_file" | head -n1 | sed -E 's/^[^：:]*[：:][[:space:]]*//' | sed 's/[[:space:]]*$//')
 
   if [ "$is_infra_or_chore" -eq 0 ] && [ "$is_release_promotion" -eq 0 ]; then
     grep -Eq '#[0-9]+' "$body_file" || failures+=("PR body 必須引用至少一個 issue 或 PR 編號，例如 #123")

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -308,6 +308,9 @@ main() {
     elif [ "$dep_state" = "CLOSED" ]; then
       failures+=("[frontend] Dependency PR #$dep_number 已被 CLOSED 但未 merge；不應 stack 在已放棄的 backend contract 上，請重新評估 dependency")
     elif [ "$dep_state" = "OPEN" ]; then
+      # OPEN 視為合法：支援 stacked PR 場景（frontend PR stacks on an open backend contract PR）。
+      # 作者需在 PR body 標記 "stacked on dependency branch" 或 "intentionally blocked"，
+      # scope police 會另行驗證這兩個欄位；此處只確認 dep PR 存在且未放棄。
       echo "[info] Dependency PR #$dep_number state: $dep_state (stacked or blocked, OK)" >&2
     else
       failures+=("未知 dependency PR 狀態：$dep_state (#$dep_number)")

--- a/scripts/pr-metadata-check.test.sh
+++ b/scripts/pr-metadata-check.test.sh
@@ -8,12 +8,52 @@ head_branch="tmp-pr-metadata-check-test"
 tmpdir="$(mktemp -d)"
 trap 'git branch -D "$head_branch" >/dev/null 2>&1 || true; rm -rf "$tmpdir"' EXIT
 
-git branch -f "$head_branch" origin/develop >/dev/null 2>&1
+resolve_base_ref() {
+  if git show-ref --verify --quiet refs/remotes/origin/develop; then
+    printf '%s\n' "origin/develop"
+    return 0
+  fi
+
+  if git show-ref --verify --quiet refs/heads/develop; then
+    echo "warning: refs/remotes/origin/develop not found; falling back to local develop" >&2
+    printf '%s\n' "develop"
+    return 0
+  fi
+
+  echo "warning: refs/remotes/origin/develop and local develop not found; falling back to HEAD" >&2
+  printf '%s\n' "HEAD"
+}
+
+base_ref="$(resolve_base_ref)"
+git branch -f "$head_branch" "$base_ref" >/dev/null 2>&1
 
 run_case() {
   local name="$1"
-  local depends_line="$2"
+  local title="$2"
+  local depends_line="$3"
+  local extra_body="${4:-}"
+  local fake_gh_state="${5:-}"
+  local expected_exit="${6:-0}"
   local body_file="$tmpdir/$name.md"
+  local fakebin="$tmpdir/$name-bin"
+
+  mkdir -p "$fakebin"
+  cat > "$fakebin/gh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "auth" ] && [ "\${2:-}" = "status" ]; then
+  exit 0
+fi
+if [ "\${1:-}" = "pr" ] && [ "\${2:-}" = "view" ]; then
+  if [ -n "${fake_gh_state}" ]; then
+    printf '%s\n' "${fake_gh_state}"
+    exit 0
+  fi
+  exit 1
+fi
+exit 1
+EOF
+  chmod +x "$fakebin/gh"
 
   cat > "$body_file" <<EOF
 refs #123
@@ -22,19 +62,38 @@ refs #123
 
 - Source of truth：test
 - $depends_line
+- Backend contract already in develop:
+  - [ ] yes
+  - [x] no
+- If no, this PR is:
+  - [x] stacked on dependency branch
+  - [ ] intentionally blocked until dependency merges
 - 本 PR 明確不做：
   - no-op
+$extra_body
 EOF
 
-  "$root_dir/scripts/pr-metadata-check.sh" \
-    --title "[discussion] metadata parser regression" \
+  set +e
+  PATH="$fakebin:$PATH" "$root_dir/scripts/pr-metadata-check.sh" \
+    --title "$title" \
     --body-file "$body_file" \
     --base develop \
     --head "$head_branch" \
-    >/dev/null
+    >/dev/null 2>"$tmpdir/$name.stderr"
+  exit_code=$?
+  set -e
+
+  if [ "$exit_code" -ne "$expected_exit" ]; then
+    echo "expected exit $expected_exit for case $name but got $exit_code" >&2
+    cat "$tmpdir/$name.stderr" >&2
+    exit 1
+  fi
 }
 
-run_case fullwidth_no_space "Depends on PR：none"
-run_case halfwidth_no_space "Depends on PR:none"
+run_case fullwidth_no_space "[discussion] metadata parser regression" "Depends on PR：none"
+run_case halfwidth_no_space "[discussion] metadata parser regression" "Depends on PR:none"
+run_case closed_dependency "[frontend] metadata parser regression" "Depends on PR:#123" "" "CLOSED" 1
+run_case open_dependency "[frontend] metadata parser regression" "Depends on PR:#123" "" "OPEN" 0
+run_case invalid_dependency_value "[discussion] metadata parser regression" "Depends on PR：foobar" "" "" 1
 
 echo "pr-metadata-check regression tests passed"

--- a/scripts/pr-metadata-check.test.sh
+++ b/scripts/pr-metadata-check.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "$0")/.." && pwd)"
+head_branch="tmp-pr-metadata-check-test"
+
+tmpdir="$(mktemp -d)"
+trap 'git branch -D "$head_branch" >/dev/null 2>&1 || true; rm -rf "$tmpdir"' EXIT
+
+git branch -f "$head_branch" origin/develop >/dev/null 2>&1
+
+run_case() {
+  local name="$1"
+  local depends_line="$2"
+  local body_file="$tmpdir/$name.md"
+
+  cat > "$body_file" <<EOF
+refs #123
+
+## Scope 對齊
+
+- Source of truth：test
+- $depends_line
+- 本 PR 明確不做：
+  - no-op
+EOF
+
+  "$root_dir/scripts/pr-metadata-check.sh" \
+    --title "[discussion] metadata parser regression" \
+    --body-file "$body_file" \
+    --base develop \
+    --head "$head_branch" \
+    >/dev/null
+}
+
+run_case fullwidth_no_space "Depends on PR：none"
+run_case halfwidth_no_space "Depends on PR:none"
+
+echo "pr-metadata-check regression tests passed"

--- a/scripts/pr-metadata-check.test.sh
+++ b/scripts/pr-metadata-check.test.sh
@@ -96,4 +96,16 @@ run_case closed_dependency "[frontend] metadata parser regression" "Depends on P
 run_case open_dependency "[frontend] metadata parser regression" "Depends on PR:#123" "" "OPEN" 0
 run_case invalid_dependency_value "[discussion] metadata parser regression" "Depends on PR：foobar" "" "" 1
 
+# [chore] × product surface: must block (exit=1)
+git branch -f "$head_branch" "$base_ref" >/dev/null 2>&1
+_surface_wt="$tmpdir/surface-wt"
+git worktree add -q "$_surface_wt" "$head_branch"
+mkdir -p "$_surface_wt/backend"
+printf '// surface test\n' > "$_surface_wt/backend/_pr_meta_surface_test.go"
+git -C "$_surface_wt" add backend/_pr_meta_surface_test.go
+git -C "$_surface_wt" commit -q -m "test: chore touches backend"
+git worktree remove -f "$_surface_wt"
+run_case chore_product_surface "[chore] update ci config" "Depends on PR：none" "" "" 1
+git branch -f "$head_branch" "$base_ref" >/dev/null 2>&1
+
 echo "pr-metadata-check regression tests passed"

--- a/scripts/pre-push.test.sh
+++ b/scripts/pre-push.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "$0")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo_dir="$tmpdir/repo"
+mkdir -p "$repo_dir"
+cd "$repo_dir"
+
+git init -q
+git config user.name "Codex Test"
+git config user.email "codex@example.com"
+
+mkdir -p tachimint/src/assets
+printf 'seed\n' > README.md
+git add README.md
+git commit -q -m "seed"
+
+git branch -M develop
+git checkout -q -b feature/lfs-scan
+git config branch.feature/lfs-scan.merge refs/heads/develop
+
+printf 'not really png\n' > tachimint/src/assets/hero.png
+git add tachimint/src/assets/hero.png
+git commit -q -m "add lfs asset"
+
+printf 'follow-up\n' >> README.md
+git add README.md
+git commit -q -m "follow-up change"
+
+fakebin="$tmpdir/bin"
+mkdir -p "$fakebin"
+
+cat > "$fakebin/git-lfs" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${LFS_LOG_FILE:?}"
+exit 0
+EOF
+chmod +x "$fakebin/git-lfs"
+
+cat > "$fakebin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$fakebin/gh"
+
+lfs_log="$tmpdir/lfs.log"
+stdin_line="refs/heads/feature/lfs-scan $(git rev-parse HEAD) refs/heads/feature/lfs-scan 0000000000000000000000000000000000000000"
+
+set +e
+printf '%s\n' "$stdin_line" | PATH="$fakebin:$PATH" LFS_LOG_FILE="$lfs_log" \
+  bash "$root_dir/.githooks/pre-push" fork https://example.com/fork.git >/dev/null 2>"$tmpdir/pre-push.stderr"
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+  echo "pre-push hook exited with $exit_code" >&2
+  cat "$tmpdir/pre-push.stderr" >&2
+  exit 1
+fi
+
+if [ ! -s "$lfs_log" ]; then
+  echo "expected git lfs pre-push to run for earlier LFS commit on new branch push" >&2
+  cat "$tmpdir/pre-push.stderr" >&2
+  exit 1
+fi
+
+echo "pre-push regression tests passed"


### PR DESCRIPTION
## 什麼改動

釐清 Claude Code 與 Codex 的角色分工，建立 Issue-driven 工作流程規範，並補上對應的 GitHub issue / PR template。

## 為什麼

原本 CLAUDE.md / AGENTS.md 對角色分工的描述模糊。新流程明確 Claude Code 只當 PM，Codex 負責所有實作，refs #341。

## Release Context

- Release type：n/a

## Workflow Type

n/a（文件 / template 變更）

## Scope 對齊

- Source of truth：本次對話討論結果
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes（無 backend contract 變更）
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不動任何程式碼
  - 不改 CI workflow
  - 不建立 docs/codex-workflow.md（另開 issue 處理）

## PR 拆分檢查

- 這個 PR 的單一句子目的：更新 AI 協作角色分工文件與 GitHub templates
- Approx changed lines：~473（含新增的 codex-task.yml template）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [x] docs
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？n/a

## Acceptance Criteria

n/a

## 超出範圍內容

無

## 測試方式

- [x] 文件變更，無需測試

**驗證結果**

```
n/a
```

## 備註

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 新增结构化 GitHub 问题模板与扩展的拉取请求模板，标准化任务规格与验收字段
  * 钩子增强：在推送前校验开放 PR 元数据并按需询问交互确认，且仅在检测到疑似 LFS 文件时调用 LFS 预推送

* **修复与改进**
  * 改善元数据/依赖检查的错误处理与状态判定，增强非交互环境的行为明确定义

* **文档**
  * 更新协作与贡献流程文档，明确角色与合并约定

* **测试**
  * 新增针对 PR 元数据和 pre-push 钩子的回归测试脚本
<!-- end of auto-generated comment: release notes by coderabbit.ai -->