### PR TITLE
[frontend][backend] streamers page spec gaps — #257

### DIFF
--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -138,7 +138,36 @@ func (h *StreamerHandler) List(c *gin.Context) {
 		return
 	}
 
-	ok(c, gin.H{"streamers": streamers})
+	channelIDs := make([]string, 0, len(streamers))
+	for _, s := range streamers {
+		channelIDs = append(channelIDs, s.ChannelID)
+	}
+
+	summaryMap, err := h.streamerSvc.GetSummaryStats(channelIDs)
+	if err != nil {
+		internal(c)
+		return
+	}
+
+	type streamerWithSummary struct {
+		models.Streamer
+		DailySeconds     int64 `json:"daily_seconds"`
+		UniqueMiners     int64 `json:"unique_miners"`
+		TotalTokenMinted int64 `json:"total_token_minted"`
+	}
+
+	items := make([]streamerWithSummary, 0, len(streamers))
+	for _, s := range streamers {
+		item := streamerWithSummary{Streamer: s}
+		if sm, ok := summaryMap[s.ChannelID]; ok {
+			item.DailySeconds = sm.DailySeconds
+			item.UniqueMiners = sm.UniqueMiners
+			item.TotalTokenMinted = sm.TotalTokenMinted
+		}
+		items = append(items, item)
+	}
+
+	ok(c, gin.H{"streamers": items})
 }
 
 func (h *StreamerHandler) GetChannelStats(c *gin.Context) {

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -146,6 +147,83 @@ func (s *StreamerService) GetByID(id uuid.UUID) (*models.Streamer, error) {
 		return nil, err
 	}
 	return &streamer, nil
+}
+
+// StreamerSummary holds the three list-level metrics for one streamer.
+type StreamerSummary struct {
+	DailySeconds     int64 `json:"daily_seconds"`
+	UniqueMiners     int64 `json:"unique_miners"`
+	TotalTokenMinted int64 `json:"total_token_minted"`
+}
+
+// GetSummaryStats returns list-level summary metrics for the given channel IDs
+// using three batch queries to avoid N+1.
+func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*StreamerSummary, error) {
+	result := make(map[string]*StreamerSummary, len(channelIDs))
+	for _, id := range channelIDs {
+		result[id] = &StreamerSummary{}
+	}
+	if len(channelIDs) == 0 {
+		return result, nil
+	}
+
+	startOfDay := time.Now().Truncate(24 * time.Hour)
+
+	var dailyRows []struct {
+		ChannelID string `gorm:"column:channel_id"`
+		Total     int64  `gorm:"column:total"`
+	}
+	if err := s.db.Raw(`
+		SELECT channel_id, COALESCE(SUM(seconds), 0) AS total
+		FROM broadcast_time_logs
+		WHERE channel_id IN ? AND recorded_at >= ?
+		GROUP BY channel_id
+	`, channelIDs, startOfDay).Scan(&dailyRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range dailyRows {
+		if s, ok := result[row.ChannelID]; ok {
+			s.DailySeconds = row.Total
+		}
+	}
+
+	var minerRows []struct {
+		ChannelID    string `gorm:"column:channel_id"`
+		UniqueMiners int64  `gorm:"column:unique_miners"`
+	}
+	if err := s.db.Raw(`
+		SELECT channel_id, COUNT(DISTINCT user_id) AS unique_miners
+		FROM watch_sessions
+		WHERE channel_id IN ?
+		GROUP BY channel_id
+	`, channelIDs).Scan(&minerRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range minerRows {
+		if s, ok := result[row.ChannelID]; ok {
+			s.UniqueMiners = row.UniqueMiners
+		}
+	}
+
+	var tokenRows []struct {
+		ChannelID        string `gorm:"column:channel_id"`
+		TotalTokenMinted int64  `gorm:"column:total_token_minted"`
+	}
+	if err := s.db.Raw(`
+		SELECT channel_id, COALESCE(SUM(cumulative_total), 0) AS total_token_minted
+		FROM points_ledgers
+		WHERE channel_id IN ?
+		GROUP BY channel_id
+	`, channelIDs).Scan(&tokenRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range tokenRows {
+		if s, ok := result[row.ChannelID]; ok {
+			s.TotalTokenMinted = row.TotalTokenMinted
+		}
+	}
+
+	return result, nil
 }
 
 func (s *StreamerService) ListAll() ([]models.Streamer, error) {

--- a/dashboard/src/pages/StreamerDetailPage.tsx
+++ b/dashboard/src/pages/StreamerDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   type ChannelConfig,
   type StreamerStats,
 } from '@/services/channels'
+import { getUserRole } from '@/services/auth'
 
 function formatHours(seconds?: number) {
   if (seconds === undefined) return '—'
@@ -52,35 +53,46 @@ export default function StreamerDetailPage() {
   const navigate = useNavigate()
   const [stats, setStats] = useState<StreamerStats | null>(null)
   const [config, setConfig] = useState<ChannelConfig | null>(null)
+  const [configLoading, setConfigLoading] = useState(false)
   const [resolvedStreamerId, setResolvedStreamerId] = useState<string | null>(null)
   const [failedStreamerId, setFailedStreamerId] = useState<string | null>(null)
+
+  const role = getUserRole()
+  const canGoBack = role !== 'streamer'
 
   useEffect(() => {
     if (!streamerId) return
 
     let mounted = true
 
+    setConfig(null)
+    setConfigLoading(true)
+
     getStreamerStats(streamerId)
-      .then(async ({ stats, channelId }) => {
+      .then(({ stats, channelId }) => {
         if (!mounted) return
         setStats(stats)
-
-        try {
-          const cfg = await getChannelConfig(channelId)
-          if (!mounted) return
-          setConfig(cfg)
-        } catch {
-          if (!mounted) return
-          setConfig(null)
-        }
-
-        if (!mounted) return
         setFailedStreamerId(null)
         setResolvedStreamerId(streamerId)
+
+        getChannelConfig(channelId)
+          .then((cfg) => {
+            if (!mounted) return
+            setConfig(cfg)
+          })
+          .catch(() => {
+            if (!mounted) return
+            setConfig(null)
+          })
+          .finally(() => {
+            if (!mounted) return
+            setConfigLoading(false)
+          })
       })
       .catch(() => {
         if (!mounted) return
         setFailedStreamerId(streamerId)
+        setConfigLoading(false)
       })
 
     return () => {
@@ -109,12 +121,14 @@ export default function StreamerDetailPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <button
-            onClick={() => navigate('/streamers')}
-            className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-          >
-            ← 返回列表
-          </button>
+          {canGoBack && (
+            <button
+              onClick={() => navigate('/streamers')}
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              ← 返回列表
+            </button>
+          )}
           <h1 className="text-2xl font-bold text-foreground">{streamerId}</h1>
         </div>
         <div className="flex gap-2">
@@ -165,24 +179,32 @@ export default function StreamerDetailPage() {
             <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
               挖礦倍率設定
             </h2>
-            <div className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">每秒點數基準</span>
-                <span className="font-medium text-foreground">
-                  {config ? `${config.seconds_per_point} 秒 / 點` : '—'}
-                </span>
+            {configLoading ? (
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-full" />
+                <Skeleton className="h-5 w-full" />
+                <Skeleton className="h-5 w-3/4" />
               </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">目前倍率</span>
-                <span className="font-medium text-foreground">
-                  {config ? `${config.multiplier}x` : '—'}
-                </span>
+            ) : (
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">每秒點數基準</span>
+                  <span className="font-medium text-foreground">
+                    {config ? `${config.seconds_per_point} 秒 / 點` : '—'}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">目前倍率</span>
+                  <span className="font-medium text-foreground">
+                    {config ? `${config.multiplier}x` : '—'}
+                  </span>
+                </div>
+                <div className="mt-2 flex justify-between border-t border-border pt-2">
+                  <span className="text-muted-foreground">每分鐘產出</span>
+                  <span className="font-semibold text-primary">{calcPerMinute(config)}</span>
+                </div>
               </div>
-              <div className="mt-2 flex justify-between border-t border-border pt-2">
-                <span className="text-muted-foreground">每分鐘產出</span>
-                <span className="font-semibold text-primary">{calcPerMinute(config)}</span>
-              </div>
-            </div>
+            )}
           </section>
         </>
       )}

--- a/dashboard/src/pages/StreamersPage.tsx
+++ b/dashboard/src/pages/StreamersPage.tsx
@@ -88,9 +88,16 @@ export default function StreamersPage() {
                 <th className="px-4 py-3 text-left font-medium text-muted-foreground">
                   直播主名稱
                 </th>
-                <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                  Channel ID
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                  本日開台
                 </th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                  挖礦觀眾
+                </th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                  總產出點數
+                </th>
+                <th className="w-8" />
               </tr>
             </thead>
             <tbody>
@@ -112,7 +119,22 @@ export default function StreamersPage() {
                   <td className="px-4 py-3 font-medium text-foreground">
                     {streamer.display_name || streamer.channel_id}
                   </td>
-                  <td className="px-4 py-3 text-muted-foreground">{streamer.channel_id}</td>
+                  <td className="px-4 py-3 text-right text-muted-foreground">
+                    {streamer.daily_seconds !== undefined
+                      ? `${(streamer.daily_seconds / 3600).toFixed(1)} hr`
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right text-muted-foreground">
+                    {streamer.unique_miners !== undefined
+                      ? streamer.unique_miners.toLocaleString()
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right text-muted-foreground">
+                    {streamer.total_token_minted !== undefined
+                      ? streamer.total_token_minted.toLocaleString()
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right text-muted-foreground">→</td>
                 </tr>
               ))}
             </tbody>

--- a/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
+++ b/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
@@ -6,10 +6,15 @@ import StreamerDetailPage from '@/pages/StreamerDetailPage'
 
 const getStreamerStatsMock = vi.fn()
 const getChannelConfigMock = vi.fn()
+const getUserRoleMock = vi.fn()
 
 vi.mock('@/services/channels', () => ({
   getStreamerStats: (...args: unknown[]) => getStreamerStatsMock(...args),
   getChannelConfig: (...args: unknown[]) => getChannelConfigMock(...args),
+}))
+
+vi.mock('@/services/auth', () => ({
+  getUserRole: () => getUserRoleMock(),
 }))
 
 function RoutedApp() {
@@ -107,6 +112,8 @@ describe('StreamerDetailPage', () => {
   beforeEach(() => {
     getStreamerStatsMock.mockReset()
     getChannelConfigMock.mockReset()
+    getUserRoleMock.mockReset()
+    getUserRoleMock.mockReturnValue('agency')
     getStreamerStatsMock.mockResolvedValue({
       stats: defaultStats,
       channelId: 'channel-1',
@@ -134,12 +141,35 @@ describe('StreamerDetailPage', () => {
     cleanupRoot(root, container)
   })
 
-  it('顯示返回列表按鈕', async () => {
+  it('Agency 顯示返回列表按鈕', async () => {
+    getUserRoleMock.mockReturnValue('agency')
     const { container, root } = await renderAt('/streamers/uuid-1')
     await flush()
     await flush()
 
     expect(container.textContent).toContain('返回列表')
+
+    cleanupRoot(root, container)
+  })
+
+  it('Admin 顯示返回列表按鈕', async () => {
+    getUserRoleMock.mockReturnValue('admin')
+    const { container, root } = await renderAt('/streamers/uuid-1')
+    await flush()
+    await flush()
+
+    expect(container.textContent).toContain('返回列表')
+
+    cleanupRoot(root, container)
+  })
+
+  it('Streamer 不顯示返回列表按鈕', async () => {
+    getUserRoleMock.mockReturnValue('streamer')
+    const { container, root } = await renderAt('/streamers/uuid-1')
+    await flush()
+    await flush()
+
+    expect(container.textContent).not.toContain('返回列表')
 
     cleanupRoot(root, container)
   })
@@ -165,6 +195,29 @@ describe('StreamerDetailPage', () => {
     expect(container.textContent).toContain('1.5 小時')
     expect(container.textContent).toContain('挖礦倍率設定')
     expect(container.textContent).toContain('—')
+
+    cleanupRoot(root, container)
+  })
+
+  it('stats 成功後立即顯示主內容，不等 config', async () => {
+    let resolveConfig: ((value: typeof defaultConfig) => void) | null = null
+    getChannelConfigMock.mockImplementation(
+      () => new Promise((resolve) => { resolveConfig = resolve }),
+    )
+
+    const { container, root } = await renderAt('/streamers/uuid-1')
+    await flush()
+
+    // stats 已載入，主內容可見；config 尚未 resolve
+    expect(container.textContent).toContain('1.5 小時')
+    expect(container.textContent).toContain('挖礦倍率設定')
+
+    await act(async () => {
+      resolveConfig?.(defaultConfig)
+    })
+    await flush()
+
+    expect(container.textContent).toContain('30 秒 / 點')
 
     cleanupRoot(root, container)
   })

--- a/dashboard/src/pages/__tests__/StreamersPage.test.tsx
+++ b/dashboard/src/pages/__tests__/StreamersPage.test.tsx
@@ -85,7 +85,46 @@ describe('StreamersPage', () => {
     await flush()
 
     expect(container.textContent).toContain('Alice')
-    expect(container.textContent).toContain('channel-2')
+    expect(container.textContent).toContain('Bob')
+
+    cleanupRoot(root, container)
+  })
+
+  it('顯示 summary metrics 欄位（本日開台、挖礦觀眾、總產出點數）', async () => {
+    getMyChannelsMock.mockRejectedValue(axiosError(401))
+    getStreamersMock.mockResolvedValue([
+      {
+        id: 'uuid-1',
+        channel_id: 'channel-1',
+        display_name: 'Alice',
+        daily_seconds: 12600,
+        unique_miners: 1240,
+        total_token_minted: 3200,
+      },
+    ])
+
+    const { container, root } = await renderAt('/streamers')
+    await flush()
+
+    expect(container.textContent).toContain('3.5 hr')
+    expect(container.textContent).toContain('1,240')
+    expect(container.textContent).toContain('3,200')
+
+    cleanupRoot(root, container)
+  })
+
+  it('summary metrics 為 undefined 時顯示破折號', async () => {
+    getMyChannelsMock.mockRejectedValue(axiosError(401))
+    getStreamersMock.mockResolvedValue([
+      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+    ])
+
+    const { container, root } = await renderAt('/streamers')
+    await flush()
+
+    // 三欄都顯示破折號
+    const dashes = (container.textContent?.match(/—/g) ?? []).length
+    expect(dashes).toBeGreaterThanOrEqual(3)
 
     cleanupRoot(root, container)
   })

--- a/dashboard/src/services/auth.ts
+++ b/dashboard/src/services/auth.ts
@@ -38,4 +38,16 @@ export function isAuthenticated(): boolean {
   return accessToken !== null
 }
 
+export function getUserRole(): string | null {
+  if (!accessToken) return null
+  try {
+    const b64 = accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4)
+    const payload = JSON.parse(atob(padded)) as Record<string, unknown>
+    return typeof payload.role === 'string' ? payload.role : null
+  } catch {
+    return null
+  }
+}
+
 export { isAxiosError }

--- a/dashboard/src/services/channels.ts
+++ b/dashboard/src/services/channels.ts
@@ -11,6 +11,9 @@ export interface Streamer {
   agency_user_id?: string
   channel_id: string
   display_name: string
+  daily_seconds?: number
+  unique_miners?: number
+  total_token_minted?: number
 }
 
 export interface StreamerStats {


### PR DESCRIPTION
## Summary

補齊 #257 四個規格缺口：

- **config/stats 解耦**：`StreamerDetailPage` stats 成功後立即顯示主內容；config 以獨立 `configLoading` state 跟進，失敗時倍率區塊降級顯示破折號，不阻塞 stats 主畫面
- **Streamer 角色隱藏返回列表**：解碼 JWT `role` 欄位，`streamer` 不顯示「← 返回列表」，agency / admin 正常顯示
- **Backend summary stats**：`GET /api/v1/dashboard/streamers` 新增三個欄位（`daily_seconds` / `unique_miners` / `total_token_minted`），以三支 batch query 避免 N+1
- **StreamersPage 欄位**：Agency/Admin 列表補上本日開台、挖礦觀眾、總產出點數三欄（對應 #69 第一層規格）

## Commits

1. `feat(dashboard): decouple config loading and hide back button by role`
2. `feat(backend): include daily summary stats in streamers list response`
3. `feat(dashboard): add summary metrics columns to streamers list`

## Test plan

- [ ] 32 dashboard frontend tests pass (`npm test -- --run`)
- [ ] `go build ./...` 通過（Docker 未啟動，CI 跑完整測試）
- [ ] Agency/Admin 登入 → `/streamers` 看到三個 summary 欄位
- [ ] Streamer 登入 → detail page 不顯示「返回列表」，agency/admin 可見
- [ ] config API 慢或失敗時，stats 仍先顯示，倍率區塊顯示 skeleton / 破折號

closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 發佈說明

* **新功能**
  * 主播列表中新增三項實時統計指標：本日開台時長、挖礦觀眾數、總產出點數。
  * 主播詳情頁面新增角色權限管理，限制特定用戶角色的功能可見性。
  * 優化配置加載狀態顯示，提升用戶體驗。

* **測試**
  * 新增與更新測試覆蓋範圍，驗證統計指標顯示和角色權限邏輯。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->