### PR TITLE
[backend] streamers list — include summary stats in response

### DIFF
--- a/backend/internal/handlers/streamer_handler.go
+++ b/backend/internal/handlers/streamer_handler.go
@@ -138,7 +138,36 @@ func (h *StreamerHandler) List(c *gin.Context) {
 		return
 	}
 
-	ok(c, gin.H{"streamers": streamers})
+	channelIDs := make([]string, 0, len(streamers))
+	for _, s := range streamers {
+		channelIDs = append(channelIDs, s.ChannelID)
+	}
+
+	summaryMap, err := h.streamerSvc.GetSummaryStats(channelIDs)
+	if err != nil {
+		internal(c)
+		return
+	}
+
+	type streamerWithSummary struct {
+		models.Streamer
+		DailySeconds     int64 `json:"daily_seconds"`
+		UniqueMiners     int64 `json:"unique_miners"`
+		TotalTokenMinted int64 `json:"total_token_minted"`
+	}
+
+	items := make([]streamerWithSummary, 0, len(streamers))
+	for _, s := range streamers {
+		item := streamerWithSummary{Streamer: s}
+		if sm, ok := summaryMap[s.ChannelID]; ok {
+			item.DailySeconds = sm.DailySeconds
+			item.UniqueMiners = sm.UniqueMiners
+			item.TotalTokenMinted = sm.TotalTokenMinted
+		}
+		items = append(items, item)
+	}
+
+	ok(c, gin.H{"streamers": items})
 }
 
 func (h *StreamerHandler) GetChannelStats(c *gin.Context) {

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -146,6 +147,83 @@ func (s *StreamerService) GetByID(id uuid.UUID) (*models.Streamer, error) {
 		return nil, err
 	}
 	return &streamer, nil
+}
+
+// StreamerSummary holds the three list-level metrics for one streamer.
+type StreamerSummary struct {
+	DailySeconds     int64 `json:"daily_seconds"`
+	UniqueMiners     int64 `json:"unique_miners"`
+	TotalTokenMinted int64 `json:"total_token_minted"`
+}
+
+// GetSummaryStats returns list-level summary metrics for the given channel IDs
+// using three batch queries to avoid N+1.
+func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*StreamerSummary, error) {
+	result := make(map[string]*StreamerSummary, len(channelIDs))
+	for _, id := range channelIDs {
+		result[id] = &StreamerSummary{}
+	}
+	if len(channelIDs) == 0 {
+		return result, nil
+	}
+
+	startOfDay := time.Now().Truncate(24 * time.Hour)
+
+	var dailyRows []struct {
+		ChannelID string `gorm:"column:channel_id"`
+		Total     int64  `gorm:"column:total"`
+	}
+	if err := s.db.Raw(`
+		SELECT channel_id, COALESCE(SUM(seconds), 0) AS total
+		FROM broadcast_time_logs
+		WHERE channel_id IN ? AND recorded_at >= ?
+		GROUP BY channel_id
+	`, channelIDs, startOfDay).Scan(&dailyRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range dailyRows {
+		if s, ok := result[row.ChannelID]; ok {
+			s.DailySeconds = row.Total
+		}
+	}
+
+	var minerRows []struct {
+		ChannelID    string `gorm:"column:channel_id"`
+		UniqueMiners int64  `gorm:"column:unique_miners"`
+	}
+	if err := s.db.Raw(`
+		SELECT channel_id, COUNT(DISTINCT user_id) AS unique_miners
+		FROM watch_sessions
+		WHERE channel_id IN ?
+		GROUP BY channel_id
+	`, channelIDs).Scan(&minerRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range minerRows {
+		if s, ok := result[row.ChannelID]; ok {
+			s.UniqueMiners = row.UniqueMiners
+		}
+	}
+
+	var tokenRows []struct {
+		ChannelID        string `gorm:"column:channel_id"`
+		TotalTokenMinted int64  `gorm:"column:total_token_minted"`
+	}
+	if err := s.db.Raw(`
+		SELECT channel_id, COALESCE(SUM(cumulative_total), 0) AS total_token_minted
+		FROM points_ledgers
+		WHERE channel_id IN ?
+		GROUP BY channel_id
+	`, channelIDs).Scan(&tokenRows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range tokenRows {
+		if s, ok := result[row.ChannelID]; ok {
+			s.TotalTokenMinted = row.TotalTokenMinted
+		}
+	}
+
+	return result, nil
 }
 
 func (s *StreamerService) ListAll() ([]models.Streamer, error) {

--- a/backend/internal/services/streamer_service.go
+++ b/backend/internal/services/streamer_service.go
@@ -167,7 +167,8 @@ func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*Stre
 		return result, nil
 	}
 
-	startOfDay := time.Now().Truncate(24 * time.Hour)
+	now := time.Now().UTC()
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 
 	var dailyRows []struct {
 		ChannelID string `gorm:"column:channel_id"`
@@ -182,8 +183,8 @@ func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*Stre
 		return nil, err
 	}
 	for _, row := range dailyRows {
-		if s, ok := result[row.ChannelID]; ok {
-			s.DailySeconds = row.Total
+		if stat, ok := result[row.ChannelID]; ok {
+			stat.DailySeconds = row.Total
 		}
 	}
 
@@ -200,8 +201,8 @@ func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*Stre
 		return nil, err
 	}
 	for _, row := range minerRows {
-		if s, ok := result[row.ChannelID]; ok {
-			s.UniqueMiners = row.UniqueMiners
+		if stat, ok := result[row.ChannelID]; ok {
+			stat.UniqueMiners = row.UniqueMiners
 		}
 	}
 
@@ -218,8 +219,8 @@ func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*Stre
 		return nil, err
 	}
 	for _, row := range tokenRows {
-		if s, ok := result[row.ChannelID]; ok {
-			s.TotalTokenMinted = row.TotalTokenMinted
+		if stat, ok := result[row.ChannelID]; ok {
+			stat.TotalTokenMinted = row.TotalTokenMinted
 		}
 	}
 


### PR DESCRIPTION
## Scope 對齊

Source of truth: https://github.com/nurockplayer/tachigo/issues/257

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 這張 PR 做了什麼

`GET /api/v1/dashboard/streamers` 每筆 streamer 現在附帶三個 summary 欄位，供前端列表直接顯示，避免 N+1：

- `daily_seconds` — 本日開台秒數（from `broadcast_time_logs`，`recorded_at >= today`）
- `unique_miners` — 總挖礦觀眾不重複數（from `watch_sessions`）
- `total_token_minted` — 頻道累積產出點數（from `points_ledgers`）

以三支 batch query（`channel_id IN (?)`）取代逐筆呼叫，O(1) query 數。

新增 `GetSummaryStats(channelIDs []string)` service method，`List` handler 呼叫後嵌入 response。

## 本 PR 明確不做

- 不修改 streamer 詳細頁 stats endpoint（`/streamers/:id/stats`）
- 不調整現有欄位格式或 API contract
- 不新增任何前端改動

## Test plan

- [ ] `go build ./...` 通過
- [ ] `go vet ./...` 無警告
- [ ] Docker 啟動後 `go test ./internal/handlers/... ./internal/services/...` 通過
- [ ] Agency 帳號呼叫 `GET /api/v1/dashboard/streamers`，回傳含 `daily_seconds` / `unique_miners` / `total_token_minted`

refs #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)