### PR TITLE
[frontend] fix inherited dashboard CI regressions after restack

### DIFF
--- a/dashboard/src/pages/StreamerDetailPage.tsx
+++ b/dashboard/src/pages/StreamerDetailPage.tsx
@@ -53,9 +53,10 @@ export default function StreamerDetailPage() {
   const navigate = useNavigate()
   const [stats, setStats] = useState<StreamerStats | null>(null)
   const [config, setConfig] = useState<ChannelConfig | null>(null)
-  const [configLoading, setConfigLoading] = useState(false)
   const [resolvedStreamerId, setResolvedStreamerId] = useState<string | null>(null)
   const [failedStreamerId, setFailedStreamerId] = useState<string | null>(null)
+  const [resolvedConfigStreamerId, setResolvedConfigStreamerId] = useState<string | null>(null)
+  const [failedConfigStreamerId, setFailedConfigStreamerId] = useState<string | null>(null)
 
   const role = getUserRole()
   const canGoBack = role !== 'streamer'
@@ -65,34 +66,33 @@ export default function StreamerDetailPage() {
 
     let mounted = true
 
-    setConfig(null)
-    setConfigLoading(true)
-
     getStreamerStats(streamerId)
       .then(({ stats, channelId }) => {
         if (!mounted) return
         setStats(stats)
         setFailedStreamerId(null)
         setResolvedStreamerId(streamerId)
+        setConfig(null)
+        setResolvedConfigStreamerId(null)
+        setFailedConfigStreamerId(null)
 
         getChannelConfig(channelId)
           .then((cfg) => {
             if (!mounted) return
             setConfig(cfg)
+            setResolvedConfigStreamerId(streamerId)
+            setFailedConfigStreamerId(null)
           })
           .catch(() => {
             if (!mounted) return
             setConfig(null)
-          })
-          .finally(() => {
-            if (!mounted) return
-            setConfigLoading(false)
+            setResolvedConfigStreamerId(null)
+            setFailedConfigStreamerId(streamerId)
           })
       })
       .catch(() => {
         if (!mounted) return
         setFailedStreamerId(streamerId)
-        setConfigLoading(false)
       })
 
     return () => {
@@ -102,6 +102,13 @@ export default function StreamerDetailPage() {
 
   const loading = Boolean(streamerId) && resolvedStreamerId !== streamerId && failedStreamerId !== streamerId
   const error = failedStreamerId === streamerId
+  const configLoading =
+    Boolean(streamerId) &&
+    resolvedStreamerId === streamerId &&
+    failedStreamerId !== streamerId &&
+    resolvedConfigStreamerId !== streamerId &&
+    failedConfigStreamerId !== streamerId
+  const displayConfig = resolvedConfigStreamerId === streamerId ? config : null
 
   const timeCards = [
     { label: '本次', value: formatHours(stats?.current_session_seconds) },
@@ -190,18 +197,18 @@ export default function StreamerDetailPage() {
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">每秒點數基準</span>
                   <span className="font-medium text-foreground">
-                    {config ? `${config.seconds_per_point} 秒 / 點` : '—'}
+                    {displayConfig ? `${displayConfig.seconds_per_point} 秒 / 點` : '—'}
                   </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">目前倍率</span>
                   <span className="font-medium text-foreground">
-                    {config ? `${config.multiplier}x` : '—'}
+                    {displayConfig ? `${displayConfig.multiplier}x` : '—'}
                   </span>
                 </div>
                 <div className="mt-2 flex justify-between border-t border-border pt-2">
                   <span className="text-muted-foreground">每分鐘產出</span>
-                  <span className="font-semibold text-primary">{calcPerMinute(config)}</span>
+                  <span className="font-semibold text-primary">{calcPerMinute(displayConfig)}</span>
                 </div>
               </div>
             )}

--- a/dashboard/src/services/__tests__/auth.test.ts
+++ b/dashboard/src/services/__tests__/auth.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import MockAdapter from 'axios-mock-adapter'
 import client, { clearAuthToken, hasAuthToken } from '@/services/api'
-import { isAuthenticated, login, logout, refresh, restoreSession } from '@/services/auth'
+import { getUserRole, isAuthenticated, login, logout, refresh, restoreSession } from '@/services/auth'
 
 let mock: InstanceType<typeof MockAdapter>
 
@@ -125,5 +125,25 @@ describe('restoreSession()', () => {
 
     await expect(restoreSession()).resolves.toBeUndefined()
     expect(isAuthenticated()).toBe(false)
+  })
+})
+
+describe('getUserRole()', () => {
+  it('從 access token payload 解析 role', async () => {
+    const payload = btoa(JSON.stringify({ role: 'agency' }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '')
+
+    mock.onPost('/api/v1/auth/login').replyOnce(200, {
+      data: {
+        user: { id: 'u1' },
+        tokens: { access_token: `header.${payload}.signature` },
+      },
+    })
+
+    await login('user@example.com', 'password')
+
+    expect(getUserRole()).toBe('agency')
   })
 })

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -25,6 +25,10 @@ export function hasAuthToken(): boolean {
   return _accessToken !== null
 }
 
+export function getAuthToken(): string | null {
+  return _accessToken
+}
+
 interface RefreshResponse {
   data: { tokens: { access_token: string } }
 }

--- a/dashboard/src/services/auth.ts
+++ b/dashboard/src/services/auth.ts
@@ -1,5 +1,5 @@
 import { isAxiosError } from 'axios'
-import client, { clearAuthToken, hasAuthToken, setAuthToken } from '@/services/api'
+import client, { clearAuthToken, getAuthToken, hasAuthToken, setAuthToken } from '@/services/api'
 
 interface LoginResponse {
   data: {
@@ -40,6 +40,7 @@ export function isAuthenticated(): boolean {
 }
 
 export function getUserRole(): string | null {
+  const accessToken = getAuthToken()
   if (!accessToken) return null
   try {
     const b64 = accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')


### PR DESCRIPTION
## 什麼改動

把從 `#341` 拆出的 dashboard CI 修補集中到獨立 PR：

- 修正 `StreamerDetailPage` 在 `useEffect` 內同步 `setState` 造成的 lint failure
- 恢復 dashboard auth layer 對目前 access token 的讀取路徑，修掉 `auth.ts` 的 TypeScript build error
- 補上對應的 auth role decoding test

refs #257
refs #340
refs #341

## 為什麼

這些修補原本是為了解掉 `merge develop` 後 inherited 的 dashboard CI 紅燈，但它們不應該留在 docs/template PR `#341` 裡。

這張 PR 的目的，是把產品線修補從 `#341` 拆出，讓 docs PR 回到純 docs/template scope，同時保留 dashboard 修復本身。

## Release Context

- Release type：n/a

## Workflow Type

frontend fix

## Scope 對齊

- Source of truth：PR #341 的 review blocker 與 inherited dashboard CI failure 診斷
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes（無 backend contract 變更）
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 backend / tachimint / contracts
  - 不處理 docs/template PR 的流程規則調整
  - 不做額外 dashboard 功能重構

## PR 拆分檢查

- 這個 PR 的單一句子目的：把 inherited dashboard CI 修補拆成獨立 frontend PR
- Approx changed lines：~60
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [x] frontend integration
  - [x] tests
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？同一組 dashboard CI regression 的最小修補與回歸測試，需一起驗證

## Acceptance Criteria

- Dashboard lint 不再因 `StreamerDetailPage` 的 `react-hooks/set-state-in-effect` 失敗
- Dashboard build 不再因 `auth.ts` 的 `accessToken` 未定義而失敗
- 修補只影響 `dashboard/` 範圍

## 超出範圍內容

無

## 測試方式

- [x] 依 GitHub Actions 驗證 `Dashboard build`

**驗證結果**

```text
本機無法先跑 Docker（daemon 未啟動），改由 GitHub Actions 驗證。
```

## 備註

n/a
