### PR TITLE
[chore] prevent inherited CI loops on narrow-scope PRs

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -82,3 +82,14 @@ test('PR size thresholds match CLAUDE.md', async () => {
   assert.match(scopePolice, /const hardMaxDiffLines = 1000/)
   assert.match(scopePolice, /const exceptionMaxDiffLines = 1500/)
 })
+
+test('docs/template-only PRs skip heavy product CI in scope gate', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+
+  assert.match(workflow, /const isDocsTemplateOrMetadataOnly =/)
+  assert.match(workflow, /standardBodyValid &&\n\s+!isDocsTemplateOrMetadataOnly &&/)
+  assert.match(
+    workflow,
+    /Skipping heavy product CI because this PR only changes docs\/templates\/metadata\./,
+  )
+})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,18 @@ jobs:
 
             const filenames = files.map((file) => file.filename)
             const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
+            const isDocsOrTemplatePath = (name) =>
+              name.startsWith('docs/') ||
+              name.startsWith('plans/') ||
+              name.startsWith('.github/ISSUE_TEMPLATE/') ||
+              name === '.github/PULL_REQUEST_TEMPLATE.md' ||
+              /^[^/]+\.md$/i.test(name)
+            const isNonProductMetadataPath = (name) =>
+              isDocsOrTemplatePath(name) ||
+              name === '.gitignore' ||
+              name === '.gitattributes'
+            const isDocsTemplateOrMetadataOnly =
+              filenames.length > 0 && filenames.every(isNonProductMetadataPath)
             const body = pr.body || ''
             const title = pr.title || ''
             const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]', '[infra]', '[chore]']
@@ -116,6 +128,7 @@ jobs:
             const runCi =
               (isReleasePromotionPr && releaseBodyValid) ||
               standardBodyValid &&
+              !isDocsTemplateOrMetadataOnly &&
               (isReleasePromotionPr || filenames.length <= hardMaxChangedFiles) &&
               (isReleasePromotionPr || diffLines <= hardMaxDiffLines) &&
               (isReleasePromotionPr || productSurfaces <= 1) &&
@@ -136,7 +149,9 @@ jobs:
 
             core.setOutput('run_ci', runCi ? 'true' : 'false')
             core.setOutput('run_backend_integration', runBackendIntegration ? 'true' : 'false')
-            if (!runCi) {
+            if (isDocsTemplateOrMetadataOnly) {
+              core.notice('Skipping heavy product CI because this PR only changes docs/templates/metadata.')
+            } else if (!runCi) {
               core.notice('Skipping heavy CI because this PR does not currently pass scope rules.')
             }
             if (runCi && !runBackendIntegration) {

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -71,7 +71,12 @@ jobs:
               name === '.gitignore' ||
               name === '.gitattributes'
             const isDocsTemplateOrMetadataOnly =
-              filenames.length > 0 && filenames.every(isNonProductMetadataPath)
+              filenames.length > 0 &&
+              files.every(
+                (file) =>
+                  isNonProductMetadataPath(file.filename) &&
+                  (file.status !== 'renamed' || isNonProductMetadataPath(file.previous_filename))
+              )
 
             const touches = {
               backend: filenames.some((name) => name.startsWith('backend/')),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - GitHub 相關的 `gh` 指令（issue、PR、API）與必要的 `git` 指令可由你執行
 - 執行 `git` 時仍需遵守 branch / commit / scope 規範，不得繞過 PR 流程
 
+### Conflict / Restack 規則
+
+- docs / template / metadata-only PR，或其他單一小 scope PR，**不得**用 `merge develop` 解 conflict
+- 正確做法是：從最新 `develop` 開新 branch，將原 PR commit `cherry-pick` 過去，再更新或重開 PR
+- 若 restack 後出現 inherited 的產品線紅燈（backend / dashboard / tachimint），必須拆成獨立 product fix PR，不可把修補留在原本的小 scope PR
+- 若目前 PR 已因 inherited fix 造成 scope 汙染，應先收回原範圍，再另外處理產品線修補
+
 ### 操作權限邊界
 
 - Read-only 操作可直接執行，不需要先問使用者。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,13 @@
 
 - 正式 `[release]` 的 `develop -> main` promotion PR 不屬於這條規則的限制對象
 
+### Conflict / Restack 規則
+
+- docs / template / metadata-only PR，或其他單一小 scope PR，**不得**用 `merge develop` 解 conflict
+- 正確做法是從最新 `develop` 開新 branch，將原 PR commit `cherry-pick` 過去，再更新或重開 PR
+- 若 restack 後發現 inherited 的 backend / frontend / dashboard CI failure，必須拆成獨立 product fix PR，不可把修補留在原本的小 scope PR
+- reviewer 遇到這類 inherited fix 混入小 scope PR 時，應優先要求拆 PR，而不是接受「為了讓 CI 綠」的跨 scope 修補
+
 ### 遇到岔路時怎麼做
 
 - 如果額外內容是必要前置條件：先明確說明為什麼原 issue 缺這一塊，再決定是否調整範圍

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -88,6 +88,12 @@ Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的
 
 這類 PR 不需要填寫 backend contract 是否已經在 `develop`，因為文件 / template / metadata 改動不引入 frontend 對 backend API 的依賴。
 
+另外，這類 PR 不應再被 product surface 的 inherited 紅燈拖住 review 流程，因此：
+
+- `Scope gate` 會直接略過 backend / frontend / dashboard 的 heavy CI
+- 仍保留 `PR Scope Police`、workflow regression 與其他 metadata / policy 檢查
+- 若 docs/template PR 因為 restack 需求碰到 `develop` 上的產品線紅燈，應拆成獨立 product fix PR，不可把 inherited 修補留在 docs PR
+
 `Source of truth` 與 `Depends on PR` 可使用半形或全形冒號，例如 `Source of truth:` 或 `Source of truth：`。自動檢查不要求模板文字必須逐字完全相同，但仍要求欄位語意存在。
 
 ## 正式 release PR
@@ -156,6 +162,21 @@ repo 的 CI 目前改成：
 - 只有目前符合同一套 scope 規則、且沒有被 dependency gate 擋住的 PR，才會繼續跑 backend / frontend / dashboard 的 docker build 與測試
 - 若 `[frontend]` PR 依賴尚未 merge 的 backend contract，重型 CI 會直接跳過
 - 若 PR 是正式 `[release]` 的 `develop -> main` promotion，重型 CI 會照常執行，不因 diff 過大而被 scope gate 跳過
+- 若 PR 是 docs / template / metadata-only，重型 product CI 會直接跳過，避免 inherited product failures 造成無限循環
+
+## Conflict / Restack 規則
+
+對 docs / template / metadata-only PR，或任何單一小 scope PR：
+
+- 不要用 `merge develop` 的方式解 conflict
+- 正確做法是從最新 `develop` 開新 branch，將原 PR commit `cherry-pick` 過去後重開或更新 PR
+- 若 restack 後發現 inherited 的 backend / frontend / dashboard failure，必須拆成獨立 product fix PR，不可把修補留在原本的小 scope PR
+
+原因：
+
+- `merge develop` 會把整個 base branch 的當下狀態搬進 PR，容易把不屬於本 PR 的紅燈一起帶進來
+- 小 scope PR 為了讓 inherited CI 轉綠而修改產品程式碼，最後會落入「不修就 CI 紅、修了就 scope 污染」的死循環
+- 用最新 `develop` 重開 branch + `cherry-pick` 原 PR commit，可以把衝突處理限制在本 PR 自身範圍
 
 ## 本地 PR preflight
 

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -185,7 +185,7 @@ main() {
   local status old_path new_path
   while IFS=$'\t' read -r status old_path new_path; do
     [ -n "$status" ] || continue
-    if [[ "$status" == R* ]]; then
+    if [[ "$status" == [RC]* ]]; then
       _check_path "$old_path"
       _check_path "$new_path"
     else

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -272,8 +272,12 @@ main() {
     dep_state=$(gh pr view "$dep_number" --repo "$repo" --json state --jq '.state' 2>/dev/null || true)
     if [ -z "$dep_state" ]; then
       failures+=("無法讀取 dependency PR #$dep_number")
+    elif [ "$dep_state" = "MERGED" ]; then
+      failures+=("[frontend] Backend contract PR #$dep_number is already MERGED into develop; please check 'Backend contract already in develop: yes'")
+    elif [ "$dep_state" = "CLOSED" ]; then
+      failures+=("[frontend] Dependency PR #$dep_number 已被 CLOSED 但未 merge；不應 stack 在已放棄的 backend contract 上，請重新評估 dependency")
     else
-      failures+=("[frontend] PR depends on #$dep_number, but backend contract is not in develop. Dependency PR state: $dep_state")
+      echo "[info] Dependency PR #$dep_number state: $dep_state (stacked or blocked, OK)" >&2
     fi
   fi
 

--- a/scripts/pr-metadata-check.sh
+++ b/scripts/pr-metadata-check.sh
@@ -164,23 +164,34 @@ main() {
     exit 2
   }
 
-  local changed_files
-  changed_files=$(git diff --name-only "$merge_base" "$head_sha")
+  local changed_files_status
+  changed_files_status=$(git diff --name-status "$merge_base" "$head_sha")
 
   local touches_backend=0 touches_dashboard=0 touches_tachimint=0 touches_contracts=0 docs_only=1
-  local file
-  while IFS= read -r file; do
-    [ -n "$file" ] || continue
-    case "$file" in
+
+  _check_path() {
+    local p="$1"
+    case "$p" in
       backend/*) touches_backend=1 ;;
       dashboard/*) touches_dashboard=1 ;;
       tachimint/*) touches_tachimint=1 ;;
       contracts/*) touches_contracts=1 ;;
     esac
-    if ! is_docs_or_template_path "$file"; then
+    if ! is_docs_or_template_path "$p"; then
       docs_only=0
     fi
-  done <<< "$changed_files"
+  }
+
+  local status old_path new_path
+  while IFS=$'\t' read -r status old_path new_path; do
+    [ -n "$status" ] || continue
+    if [[ "$status" == R* ]]; then
+      _check_path "$old_path"
+      _check_path "$new_path"
+    else
+      _check_path "$old_path"
+    fi
+  done <<< "$changed_files_status"
 
   local product_surface_count=0
   [ "$touches_backend" -eq 1 ] && product_surface_count=$((product_surface_count + 1))


### PR DESCRIPTION
## 什麼改動

針對 `#341` 暴露出的死循環，補上兩層防呆：

- 在 `Scope gate` 中，讓 docs / template / metadata-only PR 直接略過 backend / frontend / dashboard heavy CI
- 在 repo 規則文件中明確禁止小 scope PR 用 `merge develop` 解 conflict，改成從最新 `develop` 開新 branch + `cherry-pick`
- 補上 workflow regression test，確保 docs-only skip 行為不被回退

refs #341

## 為什麼

這次 `#341` 的問題不是單純某一條 dashboard lint/build 失敗，而是流程本身形成死循環：

- docs/template PR 為了解 conflict 去 `merge develop`
- merge 後把 inherited product red CI 一起帶進 branch
- 不修 inherited product code，CI 紅
- 修 inherited product code，又造成 scope pollution

這張 PR 的目的，是直接把這個循環在流程上斷開。

## Release Context

- Release type：n/a

## Workflow Type

repo policy / CI guardrail

## Scope 對齊

- Source of truth：PR #341 的 review thread 與 inherited dashboard CI 死循環診斷
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes（無 backend contract 變更）
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修任何 dashboard/backend/tachimint 產品 bug
  - 不修改 release promotion 流程
  - 不調整 diff / changed files 的硬限制數值

## PR 拆分檢查

- 這個 PR 的單一句子目的：避免小 scope PR 因 inherited red CI 與 merge develop 形成死循環
- Approx changed lines：~60
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [x] docs
  - [x] tests
  - [x] workflow
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？同一組流程 guardrail 需要規則文件、workflow 與 regression test 一起收斂，否則無法完整防止回歸

## Acceptance Criteria

- docs/template/metadata-only PR 不再執行 backend / frontend / dashboard heavy CI
- repo 規則明確禁止小 scope PR 用 `merge develop` 解 conflict
- workflow regression test 覆蓋 docs-only skip 行為

## 超出範圍內容

無

## 測試方式

- [x] `node --test .github/workflows/ci.test.mjs`

**驗證結果**

```text
5 tests passed, 0 failed
```

## 備註

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加针对文档/模板/元数据专用 PR 的范围门控，自动跳过不必要的产品级持续集成检查。

* **文档更新**
  * 更新冲突解决和变基流程指南，明确处理小范围 PR 的最佳实践。
  * 澄清继承产品线修复时的职责分离流程。

* **改进**
  * 提升文件变更检测精准度，增强对重命名操作的处理。
  * 优化依赖验证逻辑，改进状态判断。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->