### PR TITLE
[chore] 後端測試改用 setup-go，與 image build 並行

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -41,12 +41,12 @@ test('backend CI job runs go test and go vet', async () => {
 
   assert.match(
     backendJob,
-    /- name: Run tests\n\s+run: docker compose run --pull never --no-deps --rm app go test \.\/\.\.\./,
+    /- name: Run tests\n\s+working-directory: backend\n\s+run: go test \.\/\.\.\./,
   )
 
   assert.match(
     backendJob,
-    /- name: Run vet\n\s+run: docker compose run --pull never --no-deps --rm app go vet \.\/\.\.\./,
+    /- name: Run vet\n\s+working-directory: backend\n\s+run: go vet \.\/\.\.\./,
   )
 })
 

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -69,6 +69,21 @@ test('backend CI vet assertion does not match vet steps from later jobs', () => 
   )
 })
 
+test('scope gate and scope police use rename-aware allFilePaths for touches', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const scopePolice = await readFile(scopePolicePath, 'utf8')
+
+  const renameAwarePattern =
+    /allFilePaths = files\.flatMap\(\(f\) =>\s*\n\s+f\.status === 'renamed' && f\.previous_filename \? \[f\.filename, f\.previous_filename\] : \[f\.filename\]/
+
+  assert.match(workflow, renameAwarePattern, 'ci.yml scope-gate must define allFilePaths with previous_filename support')
+  assert.match(scopePolice, renameAwarePattern, 'pr-scope-police.yml must define allFilePaths with previous_filename support')
+
+  assert.match(workflow, /touches = \{[\s\S]*?allFilePaths\.some/, 'ci.yml touches must use allFilePaths')
+  assert.match(scopePolice, /touches = \{[\s\S]*?allFilePaths\.some/, 'pr-scope-police.yml touches must use allFilePaths')
+  assert.match(scopePolice, /isDocsTemplateOrMetadataOnly[\s\S]*?allFilePaths\.every/, 'pr-scope-police.yml isDocsTemplateOrMetadataOnly must use allFilePaths')
+})
+
 test('PR size thresholds match CLAUDE.md', async () => {
   const claude = await readFile(claudePath, 'utf8')
   const workflow = await readFile(workflowPath, 'utf8')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,16 +69,19 @@ jobs:
             })
 
             const filenames = files.map((file) => file.filename)
+            const allFilePaths = files.flatMap((f) =>
+              f.status === 'renamed' && f.previous_filename ? [f.filename, f.previous_filename] : [f.filename]
+            )
             const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
             const body = pr.body || ''
             const title = pr.title || ''
             const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]', '[infra]', '[chore]']
             const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
             const touches = {
-              backend: filenames.some((name) => name.startsWith('backend/')),
-              dashboard: filenames.some((name) => name.startsWith('dashboard/')),
-              tachimint: filenames.some((name) => name.startsWith('tachimint/')),
-              contracts: filenames.some((name) => name.startsWith('contracts/')),
+              backend: allFilePaths.some((name) => name.startsWith('backend/')),
+              dashboard: allFilePaths.some((name) => name.startsWith('dashboard/')),
+              tachimint: allFilePaths.some((name) => name.startsWith('tachimint/')),
+              contracts: allFilePaths.some((name) => name.startsWith('contracts/')),
             }
             const productSurfaces = Object.values(touches).filter(Boolean).length
 
@@ -130,7 +133,7 @@ jobs:
               /^docker-compose(?:\..+)?\.ya?ml$/,
               /^\.github\/workflows\/ci\.yml$/,
             ]
-            const runBackendIntegration = filenames.some((name) =>
+            const runBackendIntegration = allFilePaths.some((name) =>
               backendIntegrationPaths.some((pattern) => pattern.test(name)),
             )
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,41 +191,28 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Export image artifact
-        run: |
-          set -euo pipefail
-          docker save tachigo-app:latest | gzip -c > tachigo-app.tar.gz
-          test -s tachigo-app.tar.gz
-
-      - name: Upload image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: backend-image
-          path: tachigo-app.tar.gz
-          retention-days: 1
-
   backend:
     timeout-minutes: 10
     name: Backend tests
-    needs: [scope-gate, backend-build]
+    needs: [scope-gate]
     if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download image artifact
-        uses: actions/download-artifact@v4
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          name: backend-image
-
-      - name: Load backend image
-        run: docker load < tachigo-app.tar.gz
+          go-version-file: backend/go.mod
+          cache: true
 
       - name: Run tests
-        run: docker compose run --pull never --no-deps --rm app go test ./...
+        working-directory: backend
+        run: go test ./...
 
       - name: Run vet
-        run: docker compose run --pull never --no-deps --rm app go vet ./...
+        working-directory: backend
+        run: go vet ./...
 
   backend-integration:
     timeout-minutes: 20

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -59,6 +59,9 @@ jobs:
             })
 
             const filenames = files.map((file) => file.filename)
+            const allFilePaths = files.flatMap((f) =>
+              f.status === 'renamed' && f.previous_filename ? [f.filename, f.previous_filename] : [f.filename]
+            )
             const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
             const isDocsOrTemplatePath = (name) =>
               name.startsWith('docs/') ||
@@ -71,14 +74,14 @@ jobs:
               name === '.gitignore' ||
               name === '.gitattributes'
             const isDocsTemplateOrMetadataOnly =
-              filenames.length > 0 && filenames.every(isNonProductMetadataPath)
+              filenames.length > 0 && allFilePaths.every(isNonProductMetadataPath)
 
             const touches = {
-              backend: filenames.some((name) => name.startsWith('backend/')),
-              dashboard: filenames.some((name) => name.startsWith('dashboard/')),
-              tachimint: filenames.some((name) => name.startsWith('tachimint/')),
-              contracts: filenames.some((name) => name.startsWith('contracts/')),
-              docs: filenames.some((name) => name.startsWith('docs/') || name.startsWith('plans/')),
+              backend: allFilePaths.some((name) => name.startsWith('backend/')),
+              dashboard: allFilePaths.some((name) => name.startsWith('dashboard/')),
+              tachimint: allFilePaths.some((name) => name.startsWith('tachimint/')),
+              contracts: allFilePaths.some((name) => name.startsWith('contracts/')),
+              docs: allFilePaths.some((name) => name.startsWith('docs/') || name.startsWith('plans/')),
             }
 
             const productSurfaces = Object.entries({

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -74,7 +74,7 @@ jobs:
               name === '.gitignore' ||
               name === '.gitattributes'
             const isDocsTemplateOrMetadataOnly =
-              filenames.length > 0 && allFilePaths.every(isNonProductMetadataPath)
+              allFilePaths.length > 0 && allFilePaths.every(isNonProductMetadataPath)
 
             const touches = {
               backend: allFilePaths.some((name) => name.startsWith('backend/')),


### PR DESCRIPTION
## Summary

- `backend` job 改用 `actions/setup-go` 直接跑 `go test` / `go vet`，移除對 `backend-build` 的依賴
- `backend-build` 移除 artifact export/upload（已無下游消費者），專注驗證鏡像能 build 成功
- 兩個 job 現在並行跑，預估總等待時間從 ~6 分鐘降到 ~2 分鐘（鏡像 build 時間）

## Trade-off

測試不再跑在 Docker 內，與部署環境有輕微差異。現有 backend tests 為純 Go unit test（無 CGO、無 DB），影響可忽略。

## Test plan

- [ ] CI 跑過，`Backend tests` 和 `Build backend image` 並行完成
- [ ] `backend-ci` gate 仍需兩者都過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化持续集成流程执行效率
  * 增强重命名文件的检测和追踪能力
  * 改进拉取请求范围验证准确性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->