### PR TITLE
[backend] ClaimService — finalizeClaim idempotency and failure recovery（tx 確認等待與補帳機制 PR2/2）(#185)

### DIFF
--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -112,15 +112,14 @@ func (s *ClaimService) SetMintCallerForTest(mc MintCaller) { s.mintCaller = mc }
 // GetTachiBalance returns the user's current $TACHI balance.
 // Returns 0 if no balance record exists yet.
 func (s *ClaimService) GetTachiBalance(userID uuid.UUID) (int64, error) {
-	var tb models.TachiBalance
-	err := s.db.Where("user_id = ?", userID).First(&tb).Error
+	balance, err := loadTachiBalanceValue(s.db, userID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return 0, nil
 		}
 		return 0, err
 	}
-	return tb.Balance, nil
+	return balance, nil
 }
 
 // Claim converts T-Points from all channels into $TACHI balance.
@@ -207,13 +206,19 @@ func (s *ClaimService) Claim(ctx context.Context, userID uuid.UUID, amount int64
 	}
 
 	var newBalance int64
-	err = s.db.Transaction(func(tx *gorm.DB) error {
+	finalizeErr := s.db.Transaction(func(tx *gorm.DB) error {
 		var err error
 		newBalance, err = s.finalizeClaim(tx, reservation, mintTxHash)
 		return err
 	})
-	if err != nil {
-		return 0, err
+	if finalizeErr != nil {
+		markErr := s.db.Transaction(func(tx *gorm.DB) error {
+			return s.markFinalizeFailedClaim(tx, reservation, mintTxHash, finalizeErr)
+		})
+		if markErr != nil {
+			return 0, fmt.Errorf("%w; mark finalize failed: %v", finalizeErr, markErr)
+		}
+		return 0, finalizeErr
 	}
 
 	return newBalance, nil
@@ -448,6 +453,58 @@ func (s *ClaimService) markClaimFailedAndCompensate(tx *gorm.DB, reservation cla
 	return nil
 }
 
+// markFinalizeFailedClaim records that the chain tx succeeded but the DB
+// finalization step failed. The claim is left in finalize_failed state for a
+// recovery job to retry. Points are not compensated here because the on-chain
+// mint already confirmed.
+func (s *ClaimService) markFinalizeFailedClaim(tx *gorm.DB, reservation claimReservation, mintTxHash string, finalizeErr error) error {
+	now := time.Now()
+	updates := map[string]interface{}{
+		"status":             models.ClaimStatusFinalizeFailed,
+		"error_message":      finalizeErr.Error(),
+		"finalize_failed_at": now,
+		"updated_at":         now,
+	}
+	if mintTxHash != "" {
+		updates["tx_hash"] = mintTxHash
+	}
+
+	query := tx.Model(&models.Claim{}).
+		Where(
+			"id = ? AND user_id = ? AND status IN ?",
+			reservation.claimID,
+			reservation.userID,
+			[]string{
+				string(models.ClaimStatusBroadcast),
+				string(models.ClaimStatusFinalizeFailed),
+			},
+		)
+	if mintTxHash != "" {
+		query = query.Where("(tx_hash IS NULL OR tx_hash = ?)", mintTxHash)
+	}
+
+	result := query.Updates(updates)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		var existing models.Claim
+		if err := tx.Select("status", "tx_hash").
+			Where("id = ? AND user_id = ?", reservation.claimID, reservation.userID).
+			First(&existing).Error; err != nil {
+			return fmt.Errorf("markFinalizeFailedClaim: load claim after skipped mark: %w", err)
+		}
+		if mintTxHash != "" && existing.TxHash != nil && *existing.TxHash != mintTxHash {
+			return fmt.Errorf("markFinalizeFailedClaim: tx_hash mismatch existing=%s retry=%s", *existing.TxHash, mintTxHash)
+		}
+		if existing.Status == models.ClaimStatusConfirmed {
+			return nil
+		}
+		return fmt.Errorf("markFinalizeFailedClaim: invalid claim status %s", existing.Status)
+	}
+	return nil
+}
+
 func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, mintTxHash string) (int64, error) {
 	now := time.Now()
 	claimUpdates := map[string]interface{}{
@@ -459,10 +516,47 @@ func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, 
 	if mintTxHash != "" {
 		claimUpdates["tx_hash"] = mintTxHash
 	}
-	if err := tx.Model(&models.Claim{}).
-		Where("id = ? AND user_id = ?", reservation.claimID, reservation.userID).
-		Updates(claimUpdates).Error; err != nil {
-		return 0, err
+
+	query := tx.Model(&models.Claim{}).
+		Where(
+			"id = ? AND user_id = ? AND status IN ?",
+			reservation.claimID,
+			reservation.userID,
+			[]string{
+				string(models.ClaimStatusBroadcast),
+				string(models.ClaimStatusFinalizeFailed),
+			},
+		)
+	if mintTxHash != "" {
+		query = query.Where("(tx_hash IS NULL OR tx_hash = ?)", mintTxHash)
+	}
+
+	result := query.Updates(claimUpdates)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		var existing models.Claim
+		if err := tx.Select("status", "tx_hash").
+			Where("id = ? AND user_id = ?", reservation.claimID, reservation.userID).
+			First(&existing).Error; err != nil {
+			return 0, fmt.Errorf("finalizeClaim: load claim after skipped finalize: %w", err)
+		}
+
+		if mintTxHash != "" && existing.TxHash != nil && *existing.TxHash != mintTxHash {
+			return 0, fmt.Errorf("finalizeClaim: tx_hash mismatch existing=%s retry=%s", *existing.TxHash, mintTxHash)
+		}
+
+		if existing.Status == models.ClaimStatusConfirmed {
+			balance, err := loadTachiBalanceValue(tx, reservation.userID)
+			if err != nil {
+				return 0, fmt.Errorf("finalizeClaim: confirmed claim missing tachi balance: %w", err)
+			}
+			return balance, nil
+		}
+
+		return 0, fmt.Errorf("finalizeClaim: invalid claim status %s", existing.Status)
 	}
 
 	if err := tx.Exec(`
@@ -475,12 +569,23 @@ func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, 
 		return 0, err
 	}
 
-	var tb models.TachiBalance
-	if err := tx.Where("user_id = ?", reservation.userID).First(&tb).Error; err != nil {
+	balance, err := loadTachiBalanceValue(tx, reservation.userID)
+	if err != nil {
 		return 0, err
 	}
 
-	return tb.Balance, nil
+	return balance, nil
+}
+
+func loadTachiBalanceValue(db *gorm.DB, userID uuid.UUID) (int64, error) {
+	var balance int64
+	if err := db.Raw(
+		"SELECT CAST(balance AS BIGINT) FROM tachi_balances WHERE user_id = ?",
+		userID,
+	).Scan(&balance).Error; err != nil {
+		return 0, err
+	}
+	return balance, nil
 }
 
 func (s *ClaimService) resolveWalletAddress(db *gorm.DB, userID uuid.UUID) (string, error) {

--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -581,6 +581,7 @@ func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, 
 func loadTachiBalanceValue(db *gorm.DB, userID uuid.UUID) (int64, error) {
 	var balance int64
 	err := db.Raw(
+		// Claim and spend flows currently store whole-token int64 balances.
 		"SELECT CAST(balance AS BIGINT) FROM tachi_balances WHERE user_id = ?",
 		userID,
 	).Row().Scan(&balance)

--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"crypto/ecdsa"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log"
@@ -579,10 +580,14 @@ func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, 
 
 func loadTachiBalanceValue(db *gorm.DB, userID uuid.UUID) (int64, error) {
 	var balance int64
-	if err := db.Raw(
+	err := db.Raw(
 		"SELECT CAST(balance AS BIGINT) FROM tachi_balances WHERE user_id = ?",
 		userID,
-	).Scan(&balance).Error; err != nil {
+	).Row().Scan(&balance)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, gorm.ErrRecordNotFound
+		}
 		return 0, err
 	}
 	return balance, nil

--- a/backend/internal/services/claim_service_pg_test.go
+++ b/backend/internal/services/claim_service_pg_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+package services
+
+import (
+	"sync"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+func TestClaim_FinalizeIdempotentConcurrent(t *testing.T) {
+	db := newPGTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+	claimID := newUUID()
+	txHash := "0xconcurrentHash"
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, broadcast_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), NOW())
+	`, claimID, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusBroadcast, txHash).Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	reservation := claimReservation{
+		claimID: claimID,
+		userID:  userID,
+		amount:  60,
+	}
+
+	errs := make(chan error, 2)
+	bals := make(chan int64, 2)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			err := db.Transaction(func(tx *gorm.DB) error {
+				bal, err := svc.finalizeClaim(tx, reservation, txHash)
+				if err == nil {
+					bals <- bal
+				}
+				return err
+			})
+			errs <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	close(bals)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent finalizeClaim unexpected error: %v", err)
+		}
+	}
+	for bal := range bals {
+		if bal != 60 {
+			t.Fatalf("expected concurrent balance=60, got %d", bal)
+		}
+	}
+
+	var claim models.Claim
+	if err := db.Where("id = ?", claimID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusConfirmed {
+		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
+	}
+
+	var count int64
+	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&count).Error; err != nil {
+		t.Fatalf("count balances: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 tachi balance row, got %d", count)
+	}
+
+	var balance int64
+	if err := db.Raw("SELECT CAST(balance AS BIGINT) AS balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&balance).Error; err != nil {
+		t.Fatalf("query tachi balance: %v", err)
+	}
+	if balance != 60 {
+		t.Fatalf("expected tachi_balance=60, got %d", balance)
+	}
+}

--- a/backend/internal/services/claim_service_test.go
+++ b/backend/internal/services/claim_service_test.go
@@ -547,11 +547,15 @@ func TestClaim_ReceiptFailedMarksFailedAndCompensates(t *testing.T) {
 	}
 }
 
-func TestClaim_FinalizeFailureMarksFinalizeFailedStatus(t *testing.T) {
+func TestClaim_FinalizeFailureCanRetryAndCreditsOnce(t *testing.T) {
 	db := newTestDB(t)
 	persistErr := errors.New("db finalize failed")
+	failFinalize := true
 
 	if err := db.Callback().Update().Before("gorm:update").Register("fail_finalize_update", func(tx *gorm.DB) {
+		if !failFinalize {
+			return
+		}
 		if tx.Statement.Table != "claims" {
 			return
 		}
@@ -602,6 +606,57 @@ func TestClaim_FinalizeFailureMarksFinalizeFailedStatus(t *testing.T) {
 	if spendable != 40 {
 		t.Fatalf("expected spendable=40 (deducted, not compensated), got %d", spendable)
 	}
+
+	failFinalize = false
+	reservation := claimReservation{
+		claimID: claim.ID,
+		userID:  userID,
+		amount:  60,
+	}
+	var bal1 int64
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		bal1, err = svc.finalizeClaim(tx, reservation, "0xfinalizeFailHash")
+		return err
+	}); err != nil {
+		t.Fatalf("retry finalizeClaim unexpected error: %v", err)
+	}
+	if bal1 != 60 {
+		t.Fatalf("expected tachi_balance=60 after retry, got %d", bal1)
+	}
+
+	var bal2 int64
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		bal2, err = svc.finalizeClaim(tx, reservation, "0xfinalizeFailHash")
+		return err
+	}); err != nil {
+		t.Fatalf("second retry finalizeClaim unexpected error: %v", err)
+	}
+	if bal2 != 60 {
+		t.Fatalf("expected tachi_balance=60 after second retry, got %d", bal2)
+	}
+
+	if err := db.Where("id = ?", claim.ID).First(&claim).Error; err != nil {
+		t.Fatalf("reload claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusConfirmed {
+		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
+	}
+	if claim.ConfirmedAt == nil {
+		t.Fatal("expected confirmed_at to be set")
+	}
+	if claim.FinalizeFailedAt == nil {
+		t.Fatal("expected finalize_failed_at history to remain")
+	}
+
+	var finalBal int64
+	if err := db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&finalBal).Error; err != nil {
+		t.Fatalf("query final balance: %v", err)
+	}
+	if finalBal != 60 {
+		t.Fatalf("expected final tachi_balance=60, got %d", finalBal)
+	}
 }
 
 func TestClaim_FinalizeIdempotent(t *testing.T) {
@@ -631,17 +686,16 @@ func TestClaim_FinalizeIdempotent(t *testing.T) {
 		amount:  60,
 	}
 
-	var bal2 int64
+	var retryBal int64
 	if err := db.Transaction(func(tx *gorm.DB) error {
 		var err error
-		bal2, err = svc.finalizeClaim(tx, reservation, "0xidempotentHash")
+		retryBal, err = svc.finalizeClaim(tx, reservation, "0xidempotentHash")
 		return err
 	}); err != nil {
 		t.Fatalf("second finalizeClaim unexpected error: %v", err)
 	}
-
-	if bal2 != 60 {
-		t.Fatalf("expected tachi_balance=60 after retry, got %d", bal2)
+	if retryBal != 60 {
+		t.Fatalf("expected tachi_balance=60 after retry, got %d", retryBal)
 	}
 
 	var finalBal int64
@@ -681,76 +735,6 @@ func TestClaim_FinalizeConfirmedWithoutBalanceReturnsError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected confirmed claim without tachi balance to return error")
-	}
-}
-
-func TestClaim_FinalizeFailedRetryConfirmsAndCreditsOnce(t *testing.T) {
-	db := newTestDB(t)
-	svc := &ClaimService{db: db}
-	userID := userIDForClaim(t, db)
-	txHash := "0xretryHash"
-
-	if err := db.Exec(`
-		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, error_message, broadcast_at, finalize_failed_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusFinalizeFailed, txHash, "db finalize failed").Error; err != nil {
-		t.Fatalf("insert claim: %v", err)
-	}
-
-	var claim models.Claim
-	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
-		t.Fatalf("load claim: %v", err)
-	}
-
-	reservation := claimReservation{
-		claimID: claim.ID,
-		userID:  userID,
-		amount:  60,
-	}
-
-	var bal1 int64
-	if err := db.Transaction(func(tx *gorm.DB) error {
-		var err error
-		bal1, err = svc.finalizeClaim(tx, reservation, txHash)
-		return err
-	}); err != nil {
-		t.Fatalf("retry finalizeClaim unexpected error: %v", err)
-	}
-	if bal1 != 60 {
-		t.Fatalf("expected tachi_balance=60 after retry, got %d", bal1)
-	}
-
-	var bal2 int64
-	if err := db.Transaction(func(tx *gorm.DB) error {
-		var err error
-		bal2, err = svc.finalizeClaim(tx, reservation, txHash)
-		return err
-	}); err != nil {
-		t.Fatalf("second retry finalizeClaim unexpected error: %v", err)
-	}
-	if bal2 != 60 {
-		t.Fatalf("expected tachi_balance=60 after second retry, got %d", bal2)
-	}
-
-	if err := db.Where("id = ?", claim.ID).First(&claim).Error; err != nil {
-		t.Fatalf("reload claim: %v", err)
-	}
-	if claim.Status != models.ClaimStatusConfirmed {
-		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
-	}
-	if claim.ConfirmedAt == nil {
-		t.Fatal("expected confirmed_at to be set")
-	}
-	if claim.FinalizeFailedAt == nil {
-		t.Fatal("expected finalize_failed_at history to remain")
-	}
-
-	var finalBal int64
-	if err := db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&finalBal).Error; err != nil {
-		t.Fatalf("query final balance: %v", err)
-	}
-	if finalBal != 60 {
-		t.Fatalf("expected final tachi_balance=60, got %d", finalBal)
 	}
 }
 

--- a/backend/internal/services/claim_service_test.go
+++ b/backend/internal/services/claim_service_test.go
@@ -653,6 +653,37 @@ func TestClaim_FinalizeIdempotent(t *testing.T) {
 	}
 }
 
+func TestClaim_FinalizeConfirmedWithoutBalanceReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+	txHash := "0xconfirmedMissingBalanceHash"
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, confirmed_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusConfirmed, txHash).Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		_, err := svc.finalizeClaim(tx, claimReservation{
+			claimID: claim.ID,
+			userID:  userID,
+			amount:  60,
+		}, txHash)
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected confirmed claim without tachi balance to return error")
+	}
+}
+
 func TestClaim_FinalizeFailedRetryConfirmsAndCreditsOnce(t *testing.T) {
 	db := newTestDB(t)
 	svc := &ClaimService{db: db}
@@ -723,79 +754,50 @@ func TestClaim_FinalizeFailedRetryConfirmsAndCreditsOnce(t *testing.T) {
 	}
 }
 
-func TestClaim_FinalizeRejectsFailedStatus(t *testing.T) {
-	db := newTestDB(t)
-	svc := &ClaimService{db: db}
-	userID := userIDForClaim(t, db)
-
-	if err := db.Exec(`
-		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, failed_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusFailed, "0xfailedHash").Error; err != nil {
-		t.Fatalf("insert claim: %v", err)
+func TestClaim_FinalizeRejectsNonFinalizableStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status models.ClaimStatus
+		txHash string
+	}{
+		{name: "failed", status: models.ClaimStatusFailed, txHash: "0xfailedHash"},
+		{name: "pending", status: models.ClaimStatusPending, txHash: "0xpendingHash"},
 	}
 
-	var claim models.Claim
-	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
-		t.Fatalf("load claim: %v", err)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t)
+			svc := &ClaimService{db: db}
+			userID := userIDForClaim(t, db)
 
-	err := db.Transaction(func(tx *gorm.DB) error {
-		_, err := svc.finalizeClaim(tx, claimReservation{
-			claimID: claim.ID,
-			userID:  userID,
-			amount:  60,
-		}, "0xfailedHash")
-		return err
-	})
-	if err == nil {
-		t.Fatal("expected error but got nil")
-	}
+			if err := db.Exec(`
+				INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+			`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, tc.status, tc.txHash).Error; err != nil {
+				t.Fatalf("insert claim: %v", err)
+			}
 
-	var balanceCount int64
-	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&balanceCount).Error; err != nil {
-		t.Fatalf("count tachi_balances: %v", err)
-	}
-	if balanceCount != 0 {
-		t.Fatalf("expected no tachi balance rows, got %d", balanceCount)
-	}
-}
+			var claim models.Claim
+			if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+				t.Fatalf("load claim: %v", err)
+			}
 
-func TestClaim_FinalizeRejectsPendingStatus(t *testing.T) {
-	db := newTestDB(t)
-	svc := &ClaimService{db: db}
-	userID := userIDForClaim(t, db)
+			err := db.Transaction(func(tx *gorm.DB) error {
+				_, err := svc.finalizeClaim(tx, claimReservation{claimID: claim.ID, userID: userID, amount: 60}, tc.txHash)
+				return err
+			})
+			if err == nil {
+				t.Fatal("expected error but got nil")
+			}
 
-	if err := db.Exec(`
-		INSERT INTO claims (id, user_id, wallet_addr, amount, status, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusPending).Error; err != nil {
-		t.Fatalf("insert claim: %v", err)
-	}
-
-	var claim models.Claim
-	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
-		t.Fatalf("load claim: %v", err)
-	}
-
-	err := db.Transaction(func(tx *gorm.DB) error {
-		_, err := svc.finalizeClaim(tx, claimReservation{
-			claimID: claim.ID,
-			userID:  userID,
-			amount:  60,
-		}, "0xpendingHash")
-		return err
-	})
-	if err == nil {
-		t.Fatal("expected error but got nil")
-	}
-
-	var balanceCount int64
-	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&balanceCount).Error; err != nil {
-		t.Fatalf("count tachi_balances: %v", err)
-	}
-	if balanceCount != 0 {
-		t.Fatalf("expected no tachi balance rows, got %d", balanceCount)
+			var balanceCount int64
+			if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&balanceCount).Error; err != nil {
+				t.Fatalf("count tachi_balances: %v", err)
+			}
+			if balanceCount != 0 {
+				t.Fatalf("expected no tachi balance rows, got %d", balanceCount)
+			}
+		})
 	}
 }
 

--- a/backend/internal/services/claim_service_test.go
+++ b/backend/internal/services/claim_service_test.go
@@ -567,6 +567,11 @@ func TestClaim_FinalizeFailureCanRetryAndCreditsOnce(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("register callback: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := db.Callback().Update().Before("gorm:update").Remove("fail_finalize_update"); err != nil {
+			t.Fatalf("remove callback: %v", err)
+		}
+	})
 
 	mintCaller := &mockMintCaller{broadcastHash: "0xfinalizeFailHash"}
 	svc := &ClaimService{db: db, mintCaller: mintCaller}
@@ -659,52 +664,53 @@ func TestClaim_FinalizeFailureCanRetryAndCreditsOnce(t *testing.T) {
 	}
 }
 
-func TestClaim_FinalizeIdempotent(t *testing.T) {
+func TestClaim_FinalizeEmptyTxHashPreservesExistingHash(t *testing.T) {
 	db := newTestDB(t)
-	mintCaller := &mockMintCaller{broadcastHash: "0xidempotentHash"}
-	svc := &ClaimService{db: db, mintCaller: mintCaller}
+	svc := &ClaimService{db: db}
 	userID := userIDForClaim(t, db)
-	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
-	seedLedger(t, db, userID, "ch1", 100)
 
-	bal1, err := svc.Claim(context.Background(), userID, 60)
-	if err != nil {
-		t.Fatalf("first claim unexpected error: %v", err)
-	}
-	if bal1 != 60 {
-		t.Fatalf("expected tachi_balance=60, got %d", bal1)
-	}
-
-	var claim models.Claim
-	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
-		t.Fatalf("load claim: %v", err)
+	insertClaim := func(txHash string) uuid.UUID {
+		claimID := uuid.New()
+		if err := db.Exec(`
+			INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, broadcast_at, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		`, claimID, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusBroadcast, txHash).Error; err != nil {
+			t.Fatalf("insert claim: %v", err)
+		}
+		return claimID
 	}
 
-	reservation := claimReservation{
-		claimID: claim.ID,
-		userID:  userID,
-		amount:  60,
+	assertClaim := func(claimID uuid.UUID, status models.ClaimStatus, txHash string) {
+		var claim models.Claim
+		if err := db.Where("id = ?", claimID).First(&claim).Error; err != nil {
+			t.Fatalf("load claim: %v", err)
+		}
+		if claim.Status != status {
+			t.Fatalf("expected status %s, got %s", status, claim.Status)
+		}
+		if claim.TxHash == nil || *claim.TxHash != txHash {
+			t.Fatalf("expected existing tx_hash to remain %s, got %v", txHash, claim.TxHash)
+		}
 	}
 
-	var retryBal int64
+	finalizedHash := "0xexistingFinalizeHash"
+	finalizedID := insertClaim(finalizedHash)
 	if err := db.Transaction(func(tx *gorm.DB) error {
-		var err error
-		retryBal, err = svc.finalizeClaim(tx, reservation, "0xidempotentHash")
+		_, err := svc.finalizeClaim(tx, claimReservation{claimID: finalizedID, userID: userID, amount: 60}, "")
 		return err
 	}); err != nil {
-		t.Fatalf("second finalizeClaim unexpected error: %v", err)
+		t.Fatalf("finalize with empty tx hash: %v", err)
 	}
-	if retryBal != 60 {
-		t.Fatalf("expected tachi_balance=60 after retry, got %d", retryBal)
-	}
+	assertClaim(finalizedID, models.ClaimStatusConfirmed, finalizedHash)
 
-	var finalBal int64
-	if err := db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&finalBal).Error; err != nil {
-		t.Fatalf("query final balance: %v", err)
+	markedHash := "0xexistingMarkedHash"
+	markedID := insertClaim(markedHash)
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return svc.markFinalizeFailedClaim(tx, claimReservation{claimID: markedID, userID: userID, amount: 60}, "", errors.New("finalize failed"))
+	}); err != nil {
+		t.Fatalf("mark finalize failed with empty tx hash: %v", err)
 	}
-	if finalBal != 60 {
-		t.Fatalf("expected final tachi_balance=60, got %d", finalBal)
-	}
+	assertClaim(markedID, models.ClaimStatusFinalizeFailed, markedHash)
 }
 
 func TestClaim_FinalizeConfirmedWithoutBalanceReturnsError(t *testing.T) {
@@ -735,6 +741,9 @@ func TestClaim_FinalizeConfirmedWithoutBalanceReturnsError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected confirmed claim without tachi balance to return error")
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected ErrRecordNotFound, got %v", err)
 	}
 }
 

--- a/backend/internal/services/claim_service_test.go
+++ b/backend/internal/services/claim_service_test.go
@@ -547,6 +547,359 @@ func TestClaim_ReceiptFailedMarksFailedAndCompensates(t *testing.T) {
 	}
 }
 
+func TestClaim_FinalizeFailureMarksFinalizeFailedStatus(t *testing.T) {
+	db := newTestDB(t)
+	persistErr := errors.New("db finalize failed")
+
+	if err := db.Callback().Update().Before("gorm:update").Register("fail_finalize_update", func(tx *gorm.DB) {
+		if tx.Statement.Table != "claims" {
+			return
+		}
+		updates, ok := tx.Statement.Dest.(map[string]interface{})
+		if !ok || updates["status"] != models.ClaimStatusConfirmed {
+			return
+		}
+		tx.AddError(persistErr)
+	}); err != nil {
+		t.Fatalf("register callback: %v", err)
+	}
+
+	mintCaller := &mockMintCaller{broadcastHash: "0xfinalizeFailHash"}
+	svc := &ClaimService{db: db, mintCaller: mintCaller}
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedLedger(t, db, userID, "ch1", 100)
+
+	_, err := svc.Claim(context.Background(), userID, 60)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if !errors.Is(err, persistErr) {
+		t.Fatalf("expected error to wrap persistErr, got %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusFinalizeFailed {
+		t.Fatalf("expected status finalize_failed, got %s", claim.Status)
+	}
+	if claim.FinalizeFailedAt == nil {
+		t.Fatal("expected finalize_failed_at to be set")
+	}
+	if claim.ErrorMessage == nil || *claim.ErrorMessage == "" {
+		t.Fatal("expected error_message to be populated")
+	}
+	if claim.TxHash == nil || *claim.TxHash != "0xfinalizeFailHash" {
+		t.Fatalf("expected tx_hash to be preserved, got %v", claim.TxHash)
+	}
+
+	var spendable int64
+	if err := db.Raw("SELECT spendable_balance FROM points_ledgers WHERE user_id = ? AND channel_id = 'ch1'", userID).Scan(&spendable).Error; err != nil {
+		t.Fatalf("query spendable: %v", err)
+	}
+	if spendable != 40 {
+		t.Fatalf("expected spendable=40 (deducted, not compensated), got %d", spendable)
+	}
+}
+
+func TestClaim_FinalizeIdempotent(t *testing.T) {
+	db := newTestDB(t)
+	mintCaller := &mockMintCaller{broadcastHash: "0xidempotentHash"}
+	svc := &ClaimService{db: db, mintCaller: mintCaller}
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedLedger(t, db, userID, "ch1", 100)
+
+	bal1, err := svc.Claim(context.Background(), userID, 60)
+	if err != nil {
+		t.Fatalf("first claim unexpected error: %v", err)
+	}
+	if bal1 != 60 {
+		t.Fatalf("expected tachi_balance=60, got %d", bal1)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+
+	reservation := claimReservation{
+		claimID: claim.ID,
+		userID:  userID,
+		amount:  60,
+	}
+
+	var bal2 int64
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		bal2, err = svc.finalizeClaim(tx, reservation, "0xidempotentHash")
+		return err
+	}); err != nil {
+		t.Fatalf("second finalizeClaim unexpected error: %v", err)
+	}
+
+	if bal2 != 60 {
+		t.Fatalf("expected tachi_balance=60 after retry, got %d", bal2)
+	}
+
+	var finalBal int64
+	if err := db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&finalBal).Error; err != nil {
+		t.Fatalf("query final balance: %v", err)
+	}
+	if finalBal != 60 {
+		t.Fatalf("expected final tachi_balance=60, got %d", finalBal)
+	}
+}
+
+func TestClaim_FinalizeFailedRetryConfirmsAndCreditsOnce(t *testing.T) {
+	db := newTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+	txHash := "0xretryHash"
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, error_message, broadcast_at, finalize_failed_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusFinalizeFailed, txHash, "db finalize failed").Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+
+	reservation := claimReservation{
+		claimID: claim.ID,
+		userID:  userID,
+		amount:  60,
+	}
+
+	var bal1 int64
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		bal1, err = svc.finalizeClaim(tx, reservation, txHash)
+		return err
+	}); err != nil {
+		t.Fatalf("retry finalizeClaim unexpected error: %v", err)
+	}
+	if bal1 != 60 {
+		t.Fatalf("expected tachi_balance=60 after retry, got %d", bal1)
+	}
+
+	var bal2 int64
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		bal2, err = svc.finalizeClaim(tx, reservation, txHash)
+		return err
+	}); err != nil {
+		t.Fatalf("second retry finalizeClaim unexpected error: %v", err)
+	}
+	if bal2 != 60 {
+		t.Fatalf("expected tachi_balance=60 after second retry, got %d", bal2)
+	}
+
+	if err := db.Where("id = ?", claim.ID).First(&claim).Error; err != nil {
+		t.Fatalf("reload claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusConfirmed {
+		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
+	}
+	if claim.ConfirmedAt == nil {
+		t.Fatal("expected confirmed_at to be set")
+	}
+	if claim.FinalizeFailedAt == nil {
+		t.Fatal("expected finalize_failed_at history to remain")
+	}
+
+	var finalBal int64
+	if err := db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&finalBal).Error; err != nil {
+		t.Fatalf("query final balance: %v", err)
+	}
+	if finalBal != 60 {
+		t.Fatalf("expected final tachi_balance=60, got %d", finalBal)
+	}
+}
+
+func TestClaim_FinalizeRejectsFailedStatus(t *testing.T) {
+	db := newTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, failed_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusFailed, "0xfailedHash").Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		_, err := svc.finalizeClaim(tx, claimReservation{
+			claimID: claim.ID,
+			userID:  userID,
+			amount:  60,
+		}, "0xfailedHash")
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	var balanceCount int64
+	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&balanceCount).Error; err != nil {
+		t.Fatalf("count tachi_balances: %v", err)
+	}
+	if balanceCount != 0 {
+		t.Fatalf("expected no tachi balance rows, got %d", balanceCount)
+	}
+}
+
+func TestClaim_FinalizeRejectsPendingStatus(t *testing.T) {
+	db := newTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusPending).Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		_, err := svc.finalizeClaim(tx, claimReservation{
+			claimID: claim.ID,
+			userID:  userID,
+			amount:  60,
+		}, "0xpendingHash")
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	var balanceCount int64
+	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&balanceCount).Error; err != nil {
+		t.Fatalf("count tachi_balances: %v", err)
+	}
+	if balanceCount != 0 {
+		t.Fatalf("expected no tachi balance rows, got %d", balanceCount)
+	}
+}
+
+func TestClaim_MarkFinalizeFailedDoesNotOverwriteConfirmed(t *testing.T) {
+	db := newTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+	txHash := "0xconfirmedHash"
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, confirmed_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusConfirmed, txHash).Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+	if err := db.Exec(`
+		INSERT INTO tachi_balances (id, user_id, balance, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+	`, uuid.NewString(), userID, 60).Error; err != nil {
+		t.Fatalf("insert tachi_balance: %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return svc.markFinalizeFailedClaim(tx, claimReservation{
+			claimID: claim.ID,
+			userID:  userID,
+			amount:  60,
+		}, txHash, errors.New("late finalize marker"))
+	}); err != nil {
+		t.Fatalf("markFinalizeFailedClaim unexpected error: %v", err)
+	}
+
+	if err := db.Where("id = ?", claim.ID).First(&claim).Error; err != nil {
+		t.Fatalf("reload claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusConfirmed {
+		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
+	}
+	if claim.FinalizeFailedAt != nil {
+		t.Fatal("expected finalize_failed_at to remain nil")
+	}
+
+	var balance int64
+	if err := db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&balance).Error; err != nil {
+		t.Fatalf("query tachi balance: %v", err)
+	}
+	if balance != 60 {
+		t.Fatalf("expected tachi_balance=60, got %d", balance)
+	}
+}
+
+func TestClaim_FinalizeTxHashMismatchDoesNotCredit(t *testing.T) {
+	db := newTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, broadcast_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, uuid.NewString(), userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusBroadcast, "0xhashA").Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("user_id = ?", userID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		_, err := svc.finalizeClaim(tx, claimReservation{
+			claimID: claim.ID,
+			userID:  userID,
+			amount:  60,
+		}, "0xhashB")
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected finalizeClaim error but got nil")
+	}
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return svc.markFinalizeFailedClaim(tx, claimReservation{
+			claimID: claim.ID,
+			userID:  userID,
+			amount:  60,
+		}, "0xhashB", errors.New("mismatch"))
+	}); err == nil {
+		t.Fatal("expected markFinalizeFailedClaim error but got nil")
+	}
+
+	var balanceCount int64
+	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&balanceCount).Error; err != nil {
+		t.Fatalf("count tachi_balances: %v", err)
+	}
+	if balanceCount != 0 {
+		t.Fatalf("expected no tachi balance rows, got %d", balanceCount)
+	}
+}
+
 func TestNewClaimService_InvalidContractAddressDoesNotInitializeToken(t *testing.T) {
 	db := newTestDB(t)
 

--- a/backend/internal/services/testutil_pg_test.go
+++ b/backend/internal/services/testutil_pg_test.go
@@ -222,6 +222,14 @@ func migratePGTestDB(db *gorm.DB) error {
 			ON claim_items (claim_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_claim_items_ledger_id
 			ON claim_items (ledger_id)`,
+		`CREATE TABLE IF NOT EXISTS tachi_balances (
+			id UUID PRIMARY KEY,
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			balance NUMERIC(20,6) NOT NULL DEFAULT 0,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (user_id),
+			CHECK (balance >= 0)
+		)`,
 	}
 
 	for _, stmt := range stmts {


### PR DESCRIPTION
## Summary

This is PR 2/2 for #185: **ClaimService — tx 確認等待與補帳機制（finalizeClaim idempotency）**.

本 PR 實作 `finalizeClaim` idempotency 與 finalize 失敗後的 durable recovery state。PR #345 已先建立 `finalize_failed` schema/model foundation；本 PR 在該基礎上補上 runtime behavior 與測試。

Source of truth: #185

Depends on PR: #345

Backend contract already in develop:
- [x] yes
- [ ] no

If no, this PR is:
- [ ] stacked on dependency branch
- [ ] intentionally blocked until dependency merges

## Changes

- Persist claim broadcast tx hash before waiting for receipt.
- Mark confirmed-chain / failed-DB finalization as `finalize_failed`.
- Make `finalizeClaim` retry-safe for `broadcast` and `finalize_failed` claims.
- Prevent duplicate balance credits on repeated finalize attempts.
- Preserve tx hash mismatch errors instead of crediting ambiguous retries.
- Add unit and PostgreSQL integration coverage for finalize failure, retry, and concurrent idempotency.
- Add E2E recovery coverage for `Claim()` finalize failure → `finalize_failed` → retry recovery → no duplicate credit.
- Add boundary coverage for empty `mintTxHash` fallback behavior without overwriting existing claim tx hashes.

## 本 PR 明確不做

- Does not add a reconciliation dashboard or admin UI.
- Does not implement a background recovery job.
- Does not modify `reserveClaim` / `rollbackClaimReservation` scope.
- Does not introduce a message queue or saga pattern.
- Does not add deterministic mixed concurrent success/failure PG fault-injection coverage; that is split to #352.
- Does not modify frontend, dashboard, tachimint, Swagger docs, or agent guideline files.

## Scope / Diff Policy

- Backend service/test only.
- PR diff: 4 files, 574 insertions / 13 deletions.
- Under the 600-line soft limit.
- Larger portion of the diff is targeted idempotency and recovery test coverage.

## Testing

- `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestClaim_|TestGetTachiBalance' -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了声明最终化流程的错误处理，现在在失败时会记录失败状态并保留相关元数据，支持安全重试。
  * 增强了并发最终化请求的幂等性，防止双重计费。

* **Tests**
  * 新增并发最终化场景的集成测试。
  * 新增最终化失败、重试和幂等性的单元测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->