### PR TITLE
[backend] ClaimService — 補強 finalizeClaim 混合併發失敗測試（PG race coverage）

### DIFF
--- a/backend/internal/services/claim_service.go
+++ b/backend/internal/services/claim_service.go
@@ -74,6 +74,11 @@ type ClaimService struct {
 	contractCfg config.ContractConfig
 	tachiToken  mintContract
 	mintCaller  MintCaller
+
+	// testAfterClaimUpdate, if non-nil, is called after the claim row is updated
+	// to confirmed but before the balance upsert. Used only in tests; always nil
+	// in production.
+	testAfterClaimUpdate func() error
 }
 
 type claimReservation struct {
@@ -558,6 +563,12 @@ func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, 
 		}
 
 		return 0, fmt.Errorf("finalizeClaim: invalid claim status %s", existing.Status)
+	}
+
+	if s.testAfterClaimUpdate != nil {
+		if err := s.testAfterClaimUpdate(); err != nil {
+			return 0, err
+		}
 	}
 
 	if err := tx.Exec(`

--- a/backend/internal/services/claim_service_pg_test.go
+++ b/backend/internal/services/claim_service_pg_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -152,7 +153,11 @@ func TestClaim_FinalizeConcurrent_AFailsAtBalanceUpsert_BSucceeds(t *testing.T) 
 	}
 
 	close(start)
-	<-hookReady
+	select {
+	case <-hookReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for testAfterClaimUpdate hook")
+	}
 	close(hookProceed)
 	wg.Wait()
 	close(errs)

--- a/backend/internal/services/claim_service_pg_test.go
+++ b/backend/internal/services/claim_service_pg_test.go
@@ -369,17 +369,19 @@ func TestClaim_Finalize_FromFinalizeFailedState_Succeeds(t *testing.T) {
 		amount:  60,
 	}
 
+	var finalBal int64
 	if err := db.Transaction(func(tx *gorm.DB) error {
 		bal, err := svc.finalizeClaim(tx, reservation, txHash)
 		if err != nil {
 			return err
 		}
-		if bal != 60 {
-			t.Fatalf("expected retry finalize balance=60, got %d", bal)
-		}
+		finalBal = bal
 		return nil
 	}); err != nil {
 		t.Fatalf("finalizeClaim: %v", err)
+	}
+	if finalBal != 60 {
+		t.Fatalf("expected retry finalize balance=60, got %d", finalBal)
 	}
 
 	var claim models.Claim

--- a/backend/internal/services/claim_service_pg_test.go
+++ b/backend/internal/services/claim_service_pg_test.go
@@ -3,7 +3,11 @@
 package services
 
 import (
+	"errors"
+	"fmt"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"gorm.io/gorm"
@@ -66,6 +70,316 @@ func TestClaim_FinalizeIdempotentConcurrent(t *testing.T) {
 		if bal != 60 {
 			t.Fatalf("expected concurrent balance=60, got %d", bal)
 		}
+	}
+
+	var claim models.Claim
+	if err := db.Where("id = ?", claimID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusConfirmed {
+		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
+	}
+
+	var count int64
+	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&count).Error; err != nil {
+		t.Fatalf("count balances: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 tachi balance row, got %d", count)
+	}
+
+	var balance int64
+	if err := db.Raw("SELECT CAST(balance AS BIGINT) AS balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&balance).Error; err != nil {
+		t.Fatalf("query tachi balance: %v", err)
+	}
+	if balance != 60 {
+		t.Fatalf("expected tachi_balance=60, got %d", balance)
+	}
+}
+
+func TestClaim_FinalizeConcurrent_AFailsAtBalanceUpsert_BSucceeds(t *testing.T) {
+	db := newPGTestDB(t)
+	hookReady := make(chan struct{})
+	hookProceed := make(chan struct{})
+	var hookCalls atomic.Int32
+	svc := &ClaimService{
+		db: db,
+		testAfterClaimUpdate: func() error {
+			if hookCalls.Add(1) != 1 {
+				return nil
+			}
+			hookReady <- struct{}{}
+			<-hookProceed
+			return errors.New("forced balance upsert failure")
+		},
+	}
+	userID := userIDForClaim(t, db)
+	claimID := newUUID()
+	txHash := "0xconcurrentRollbackHash"
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, broadcast_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), NOW())
+	`, claimID, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusBroadcast, txHash).Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	reservation := claimReservation{
+		claimID: claimID,
+		userID:  userID,
+		amount:  60,
+	}
+
+	errs := make(chan error, 2)
+	bals := make(chan int64, 2)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			err := db.Transaction(func(tx *gorm.DB) error {
+				bal, err := svc.finalizeClaim(tx, reservation, txHash)
+				if err == nil {
+					bals <- bal
+				}
+				return err
+			})
+			errs <- err
+		}()
+	}
+
+	close(start)
+	<-hookReady
+	close(hookProceed)
+	wg.Wait()
+	close(errs)
+	close(bals)
+
+	var failedCount, successCount int
+	for err := range errs {
+		if err != nil {
+			if !strings.Contains(err.Error(), "forced balance upsert failure") {
+				t.Fatalf("unexpected finalizeClaim error: %v", err)
+			}
+			failedCount++
+			continue
+		}
+		successCount++
+	}
+	if failedCount != 1 || successCount != 1 {
+		t.Fatalf("expected 1 failed and 1 successful finalize, got failed=%d success=%d", failedCount, successCount)
+	}
+	for bal := range bals {
+		if bal != 60 {
+			t.Fatalf("expected successful balance=60, got %d", bal)
+		}
+	}
+
+	var claim models.Claim
+	if err := db.Where("id = ?", claimID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusConfirmed {
+		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
+	}
+
+	var count int64
+	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&count).Error; err != nil {
+		t.Fatalf("count balances: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 tachi balance row, got %d", count)
+	}
+
+	var balance int64
+	if err := db.Raw("SELECT CAST(balance AS BIGINT) AS balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&balance).Error; err != nil {
+		t.Fatalf("query tachi balance: %v", err)
+	}
+	if balance != 60 {
+		t.Fatalf("expected tachi_balance=60, got %d", balance)
+	}
+}
+
+func TestClaim_FinalizeConcurrent_TxHashMismatch_NeverCredits(t *testing.T) {
+	db := newPGTestDB(t)
+	hookReady := make(chan struct{})
+	hookProceed := make(chan struct{})
+	var hookCalls atomic.Int32
+	svc := &ClaimService{
+		db: db,
+		testAfterClaimUpdate: func() error {
+			if hookCalls.Add(1) != 1 {
+				return nil
+			}
+			hookReady <- struct{}{}
+			<-hookProceed
+			return nil
+		},
+	}
+	userID := userIDForClaim(t, db)
+	claimID := newUUID()
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, broadcast_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, NULL, NOW(), NOW(), NOW())
+	`, claimID, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusBroadcast).Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	reservation := claimReservation{
+		claimID: claimID,
+		userID:  userID,
+		amount:  60,
+	}
+
+	aDone := make(chan error, 1)
+	bDone := make(chan error, 1)
+
+	go func() {
+		aDone <- db.Transaction(func(tx *gorm.DB) error {
+			bal, err := svc.finalizeClaim(tx, reservation, "0xAAAA")
+			if err != nil {
+				return err
+			}
+			if bal != 60 {
+				return fmt.Errorf("expected first finalize balance=60, got %d", bal)
+			}
+			return nil
+		})
+	}()
+
+	<-hookReady
+	go func() {
+		bDone <- db.Transaction(func(tx *gorm.DB) error {
+			_, err := svc.finalizeClaim(tx, reservation, "0xBBBB")
+			return err
+		})
+	}()
+	close(hookProceed)
+
+	if err := <-aDone; err != nil {
+		t.Fatalf("first finalizeClaim: %v", err)
+	}
+	err := <-bDone
+	if err == nil || !strings.Contains(err.Error(), "tx_hash mismatch") {
+		t.Fatalf("expected tx_hash mismatch error, got %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("id = ?", claimID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusConfirmed {
+		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
+	}
+	if claim.TxHash == nil || *claim.TxHash != "0xAAAA" {
+		t.Fatalf("expected claim tx_hash=0xAAAA, got %v", claim.TxHash)
+	}
+
+	var count int64
+	if err := db.Raw("SELECT COUNT(*) FROM tachi_balances WHERE user_id = ?", userID).Scan(&count).Error; err != nil {
+		t.Fatalf("count balances: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 tachi balance row, got %d", count)
+	}
+
+	var balance int64
+	if err := db.Raw("SELECT CAST(balance AS BIGINT) AS balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&balance).Error; err != nil {
+		t.Fatalf("query tachi balance: %v", err)
+	}
+	if balance != 60 {
+		t.Fatalf("expected tachi_balance=60, got %d", balance)
+	}
+}
+
+func TestClaim_LateMarkFinalizeFailedIsNoOp_AfterConfirmed(t *testing.T) {
+	db := newPGTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+	claimID := newUUID()
+	txHash := "0xlateFinalizeFailedNoOp"
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, broadcast_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), NOW())
+	`, claimID, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusBroadcast, txHash).Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+
+	reservation := claimReservation{
+		claimID: claimID,
+		userID:  userID,
+		amount:  60,
+	}
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		_, err := svc.finalizeClaim(tx, reservation, txHash)
+		return err
+	}); err != nil {
+		t.Fatalf("finalizeClaim: %v", err)
+	}
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return svc.markFinalizeFailedClaim(tx, reservation, txHash, errors.New("late finalize failure"))
+	}); err != nil {
+		t.Fatalf("markFinalizeFailedClaim unexpected error: %v", err)
+	}
+
+	var claim models.Claim
+	if err := db.Where("id = ?", claimID).First(&claim).Error; err != nil {
+		t.Fatalf("load claim: %v", err)
+	}
+	if claim.Status != models.ClaimStatusConfirmed {
+		t.Fatalf("expected claim status confirmed, got %s", claim.Status)
+	}
+
+	var balance int64
+	if err := db.Raw("SELECT CAST(balance AS BIGINT) AS balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&balance).Error; err != nil {
+		t.Fatalf("query tachi balance: %v", err)
+	}
+	if balance != 60 {
+		t.Fatalf("expected tachi_balance=60, got %d", balance)
+	}
+}
+
+func TestClaim_Finalize_FromFinalizeFailedState_Succeeds(t *testing.T) {
+	db := newPGTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+	claimID := newUUID()
+	txHash := "0xretryFinalizeFailed"
+
+	if err := db.Exec(`
+		INSERT INTO claims (id, user_id, wallet_addr, amount, status, tx_hash, broadcast_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), NOW())
+	`, claimID, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", 60, models.ClaimStatusBroadcast, txHash).Error; err != nil {
+		t.Fatalf("insert claim: %v", err)
+	}
+	if err := db.Exec("UPDATE claims SET status = ? WHERE id = ?", models.ClaimStatusFinalizeFailed, claimID).Error; err != nil {
+		t.Fatalf("set finalize_failed: %v", err)
+	}
+
+	reservation := claimReservation{
+		claimID: claimID,
+		userID:  userID,
+		amount:  60,
+	}
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		bal, err := svc.finalizeClaim(tx, reservation, txHash)
+		if err != nil {
+			return err
+		}
+		if bal != 60 {
+			t.Fatalf("expected retry finalize balance=60, got %d", bal)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("finalizeClaim: %v", err)
 	}
 
 	var claim models.Claim

--- a/backend/internal/services/claim_service_pg_test.go
+++ b/backend/internal/services/claim_service_pg_test.go
@@ -103,6 +103,10 @@ func TestClaim_FinalizeConcurrent_AFailsAtBalanceUpsert_BSucceeds(t *testing.T) 
 	hookReady := make(chan struct{})
 	hookProceed := make(chan struct{})
 	var hookCalls atomic.Int32
+	// PG UPDATE acquires a row-level lock, so the first goroutine to reach the
+	// hook holds the lock; the second goroutine blocks on its UPDATE until the
+	// first transaction rolls back. hookCalls guards against the second goroutine
+	// accidentally triggering the hook after it unblocks.
 	svc := &ClaimService{
 		db: db,
 		testAfterClaimUpdate: func() error {
@@ -213,6 +217,10 @@ func TestClaim_FinalizeConcurrent_TxHashMismatch_NeverCredits(t *testing.T) {
 	hookReady := make(chan struct{})
 	hookProceed := make(chan struct{})
 	var hookCalls atomic.Int32
+	// The hook here is pure timing coordination: it lets goroutine A hold the PG
+	// row lock until goroutine B is blocked on its own UPDATE, then releases A to
+	// commit. The hook does NOT simulate a failure; the tx_hash mismatch is what
+	// causes B to be rejected by production logic after A commits.
 	svc := &ClaimService{
 		db: db,
 		testAfterClaimUpdate: func() error {


### PR DESCRIPTION
closes #352

## Summary

補強 `finalizeClaim` 的 PostgreSQL mixed concurrent failure coverage，對應 #352 驗收條件。

新增 4 個 `-tags=integration` PG 測試：

- `TestClaim_FinalizeConcurrent_AFailsAtBalanceUpsert_BSucceeds`：goroutine A 在 claim UPDATE 後、balance INSERT 前失敗（tx rollback），goroutine B 取得 PG row lock 後完整執行成功；用 channel 協調 interleaving，不依賴 sleep
- `TestClaim_FinalizeConcurrent_TxHashMismatch_NeverCredits`：兩個 goroutine 帶不同 tx hash 並發，tx_hash 不符的那個不得 credit
- `TestClaim_LateMarkFinalizeFailedIsNoOp_AfterConfirmed`：claim 已 confirmed 後，遲來的 `markFinalizeFailedClaim` 必須是 no-op
- `TestClaim_Finalize_FromFinalizeFailedState_Succeeds`：從 `finalize_failed` 狀態重新 finalize 成功（補 #351 未覆蓋的 recovery path）

## Scope 對齊

- Source of truth：[Issue #352](https://github.com/nurockplayer/tachigo/issues/352)
- Depends on PR：none

Backend contract already in develop：
- [x] yes

## 本 PR 明確不做

- 不修改 production API contract 或 schema
- 不擴張到其他 service / handler / 前端
- 不補 dashboard / tachimint UI 改動
- 不重構現有測試或 service 邏輯

## Scope 說明：production code 的微小變更

Issue #352 原則為 test-only，不修改 production code。本 PR 在 `ClaimService` struct 加了一個 `testAfterClaimUpdate func() error` field（claim_service.go:74-78）。

**理由**：Test 1 需要在 `finalizeClaim` 內部特定時間點（claim UPDATE 成功後、balance INSERT 前）注入失敗，以實現可確定的 concurrent interleaving 控制。若不修改 struct，無法在不引入更大架構重構的前提下完成這個 PG 層級的測試。

**production 影響**：零。field 預設為 nil，production code path 完全不受影響，hook call 有 nil guard。

## Test plan

- [x] `docker compose run --no-deps --rm app go test -tags=integration -v -run 'TestClaim_Finalize' ./internal/services/...` — 5 個測試全過（含舊測試 `TestClaim_FinalizeIdempotentConcurrent`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 增加了并发索赔处理场景的集成测试，以验证系统可靠性
  * 扩展了状态转换、错误处理和交易验证的测试覆盖范围

<!-- end of auto-generated comment: release notes by coderabbit.ai -->