### PR TITLE
[infra] notify open PRs with conflicts after develop merge

### DIFF
--- a/.github/workflows/notify-rebase-needed.yml
+++ b/.github/workflows/notify-rebase-needed.yml
@@ -64,7 +64,7 @@ jobs:
                   `> **PR #${mergedPR.number}** ([${mergedPR.title}](${mergedPR.html_url})) 已 merge 進 \`develop\`，本 PR 目前有衝突，請 rebase。`,
                   `>`,
                   `> \`\`\`bash`,
-                  `> git fetch origin && git merge origin/develop`,
+                  `> git fetch origin && git rebase origin/develop`,
                   `> \`\`\``,
                 ].join('\n'),
               })

--- a/.github/workflows/notify-rebase-needed.yml
+++ b/.github/workflows/notify-rebase-needed.yml
@@ -1,0 +1,72 @@
+name: Notify PRs needing rebase
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  notify:
+    name: Comment on conflicting PRs
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find conflicting PRs and notify
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const mergedPR = context.payload.pull_request
+            const { owner, repo } = context.repo
+
+            // Wait for GitHub to calculate mergeability
+            await new Promise((r) => setTimeout(r, 15000))
+
+            const openPRs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              base: 'develop',
+              per_page: 100,
+            })
+
+            const targets = openPRs.filter((pr) => pr.number !== mergedPR.number)
+            if (targets.length === 0) return
+
+            // Re-fetch each PR to get fresh mergeable_state
+            const dirty = []
+            for (const pr of targets) {
+              const { data } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pr.number,
+              })
+              if (data.mergeable_state === 'dirty') {
+                dirty.push(data)
+              }
+            }
+
+            if (dirty.length === 0) {
+              core.info('No conflicting PRs found.')
+              return
+            }
+
+            for (const pr of dirty) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: [
+                  `> [!WARNING]`,
+                  `> **PR #${mergedPR.number}** ([${mergedPR.title}](${mergedPR.html_url})) 已 merge 進 \`develop\`，本 PR 目前有衝突，請 rebase。`,
+                  `>`,
+                  `> \`\`\`bash`,
+                  `> git fetch origin && git merge origin/develop`,
+                  `> \`\`\``,
+                ].join('\n'),
+              })
+              core.info(`Notified PR #${pr.number}`)
+            }


### PR DESCRIPTION
## 背景

PR 分拆後 merge 回 develop 會造成其他 open PR 有衝突，但作者不會立刻知道，需要手動發現。這個 workflow 在 PR merge 後自動偵測衝突 PR 並留言通知。

## 任務

- [x] 新增 `.github/workflows/notify-rebase-needed.yml`
- [x] 觸發條件：PR merged to develop
- [x] 等 15 秒讓 GitHub 計算 mergeability
- [x] 只對 `mergeable_state === 'dirty'` 的 PR 留言
- [x] 留言包含 merge 指令

## 本 PR 明確不做

- 不修改現有 workflow
- 不處理 `unknown` mergeability 狀態的 polling
- 不通知 main branch 的 PR