### PR TITLE
[chore] document auto-merge policy and approve semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,10 @@ Terminology:
   - `major`: important but non-blocking; mergeable with explicit risk note or follow-up issue / PR.
   - `minor`: useful improvement that should not block merge.
   - `nit`: style or readability detail only.
+- GitHub review action mapping (auto-merge is enabled on `develop`):
+  - blocker → Request changes (blocks auto-merge pipeline)
+  - major / minor / nit only → Approve + Comment describing risk or suggestion
+  - Never use Request changes for minor or nit — it stalls auto-merge at a cost disproportionate to the finding. Leave a Comment instead and let the author decide.
 
 預設使用省 token 路線：metadata-first + reduced review bundle + Gemini CLI first pass + Codex validation。
 除非使用者明確要求「不要用 Gemini」或 PR 很小，否則不要讓 Codex 一開始就完整讀整張 diff。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,16 @@ Claude Code 負責 PR 審查的驗證與決策階段。
 - `minor`：有用改善，不阻擋 merge。
 - `nit`：純風格或可讀性細節。
 
+**GitHub review 動作與分級對應（auto-merge 情境）**：
+
+| 情況 | 動作 |
+|---|---|
+| 有 blocker | Request changes（擋住 auto-merge） |
+| 只有 major / minor / nit | Approve + Comment 說明風險或建議 |
+| 只有 nit | Approve，可附 Comment 或不附 |
+
+`minor` 和 `nit` 不應使用 Request changes。在 auto-merge 開啟的情況下，Request changes 會卡住整個 pipeline，成本遠超過 nit 本身的價值。若 reviewer 有命名或風格建議，用 **Comment**（不是 Request changes）留下，由作者自行決定是否在此 PR 修或開 follow-up issue。
+
 #### 第一步：接收 Gemini 初審結果或獨立掃描
 
 - 若 Gemini 已初審，驗證其發現的 blocker（優先檢查 high 優先級問題）

--- a/docs/auto-merge-policy.md
+++ b/docs/auto-merge-policy.md
@@ -1,0 +1,40 @@
+# Auto-merge 與 Approve 語義
+
+**決定日期**：2026-04-26
+**Discussion**：https://github.com/nurockplayer/tachigo/discussions/359
+
+## 決策摘要
+
+開啟 GitHub auto-merge，設定 required 1 approving review。Approve = 授權 merge。
+
+## 問題背景
+
+Scope Police 強制分拆 PR，分拆後的 PR merge 回 develop 會造成其他 open PR 需要 rebase（merge cascade）。根本原因是 PR 在 approved 狀態停留太久——沒有人負責去按 merge。
+
+## 設定
+
+| 項目 | 值 |
+|---|---|
+| `allow_auto_merge` | `true` |
+| `required_approving_review_count` | `1` |
+
+## Approve 的意義
+
+按 approve = 「這個 PR 現在可以進 develop」。不存在「approve 但還不 merge」的中間狀態。
+
+Approve 前應確認：CI 全過、scope 正確、無 blocker。
+
+## Review 動作對應
+
+| 嚴重程度 | 動作 |
+|---|---|
+| blocker | Request changes |
+| major | Approve + Comment 說明風險 |
+| minor / nit | Approve + Comment（可選） |
+
+minor / nit 不用 Request changes——在 auto-merge 下這會卡住整個 pipeline，成本不相稱。改用 Comment，作者自行決定是否修或開 follow-up。
+
+## 詳細討論
+
+完整的方案比較、取捨分析、以及未來改回的條件，見 Discussion：
+https://github.com/nurockplayer/tachigo/discussions/359


### PR DESCRIPTION
## 背景

2026-04-26 決定開啟 auto-merge + required 1 approve，改變了 approve 的語義和 nit/minor feedback 的處理方式。這些規則需要記錄在 AI agent 和 reviewer 都會讀到的地方。

## 任務

- [x] CLAUDE.md：在問題分級後補充 GitHub review 動作對應表（blocker → Request changes；minor/nit → Approve + Comment）
- [x] AGENTS.md：同步補充相同規則的英文版

## 本 PR 明確不做

- 不修改任何程式碼或 workflow
- 不重寫現有的 review 流程段落，只在分級定義後補充說明