### PR TITLE
[frontend] feat(tachimint): raffle result display in Extension

### DIFF
--- a/tachimint/src/app/App.tsx
+++ b/tachimint/src/app/App.tsx
@@ -349,17 +349,34 @@ export default function App() {
             CLAIM
           </button>
           <span style={{ fontSize: 10, color: 'rgba(100,100,140,0.3)', fontFamily: 'var(--pixel-font-family)' }}>·</span>
+          <input
+            type="text"
+            placeholder="raffle id"
+            value={currentRaffleId}
+            onChange={(e) => setCurrentRaffleId(e.target.value)}
+            style={{
+              padding: '3px 6px',
+              borderRadius: 4,
+              border: '1px solid rgba(255,255,255,0.1)',
+              background: 'rgba(145,70,255,0.06)',
+              color: 'rgba(255,255,255,0.5)',
+              fontSize: 8,
+              fontFamily: 'var(--pixel-font-family)',
+              width: 72,
+              outline: 'none',
+            }}
+          />
           <button
-            onClick={() => { setCurrentRaffleId(''); setScreen('raffle') }}
+            onClick={() => { if (currentRaffleId.trim()) setScreen('raffle') }}
             style={{
               padding: '4px 12px',
               borderRadius: 4,
               border: '1px solid rgba(255,255,255,0.1)',
               background: screen === 'raffle' ? 'rgba(200,168,73,0.15)' : 'transparent',
-              color: screen === 'raffle' ? 'rgba(200,168,73,0.8)' : 'rgba(100,100,140,0.4)',
+              color: screen === 'raffle' ? 'rgba(200,168,73,0.8)' : currentRaffleId.trim() ? 'rgba(145,70,255,0.6)' : 'rgba(100,100,140,0.4)',
               fontSize: 9,
               fontFamily: 'var(--pixel-font-family)',
-              cursor: 'pointer',
+              cursor: currentRaffleId.trim() ? 'pointer' : 'default',
               letterSpacing: '0.08em',
             }}
           >

--- a/tachimint/src/app/App.tsx
+++ b/tachimint/src/app/App.tsx
@@ -15,6 +15,7 @@ import { LanguageSwitcher } from './components/LanguageSwitcher';
 import { MarioHUD } from './components/MarioHUD';
 import { ClaimPanel } from './components/ClaimPanel';
 import { CouponShopPanel } from './components/CouponShopPanel';
+import { RaffleResultPanel } from './components/RaffleResultPanel';
 import { useTwitch } from '../hooks/useTwitch';
 import { executeCouponRedeem, type CouponRedeemOutcome } from './couponRedeem';
 
@@ -38,6 +39,7 @@ export default function App() {
   const [tcgBalance, setTcgBalance] = useState(defaultDemoState.tcgBalance);
   const [redeemedCouponIds, setRedeemedCouponIds] = useState<string[]>(defaultDemoState.redeemedCouponIds);
   const [voucherCodes, setVoucherCodes] = useState<Record<string, string>>({});
+  const [currentRaffleId, setCurrentRaffleId] = useState('');
   const tcgBalanceRef = useRef(defaultDemoState.tcgBalance);
   const redeemedCouponIdsRef = useRef<string[]>([...defaultDemoState.redeemedCouponIds]);
 
@@ -237,6 +239,11 @@ export default function App() {
             voucherCodes={voucherCodes}
             onRedeem={handleCouponRedeem}
           />
+        ) : screen === 'raffle' ? (
+          <RaffleResultPanel
+            raffleId={currentRaffleId}
+            onBack={() => setScreen('hud')}
+          />
         ) : (
           <MarioHUD state={hudState} onStateChange={setHudState} onNavigate={(s) => setScreen(s)} />
         )}
@@ -340,6 +347,23 @@ export default function App() {
             }}
           >
             CLAIM
+          </button>
+          <span style={{ fontSize: 10, color: 'rgba(100,100,140,0.3)', fontFamily: 'var(--pixel-font-family)' }}>·</span>
+          <button
+            onClick={() => { setCurrentRaffleId(''); setScreen('raffle') }}
+            style={{
+              padding: '4px 12px',
+              borderRadius: 4,
+              border: '1px solid rgba(255,255,255,0.1)',
+              background: screen === 'raffle' ? 'rgba(200,168,73,0.15)' : 'transparent',
+              color: screen === 'raffle' ? 'rgba(200,168,73,0.8)' : 'rgba(100,100,140,0.4)',
+              fontSize: 9,
+              fontFamily: 'var(--pixel-font-family)',
+              cursor: 'pointer',
+              letterSpacing: '0.08em',
+            }}
+          >
+            RAFFLE
           </button>
           <span style={{ fontSize: 9, color: 'rgba(100,100,140,0.3)', fontFamily: 'var(--pixel-font-family)', marginLeft: 6 }}>
             320 × 600

--- a/tachimint/src/app/App.tsx
+++ b/tachimint/src/app/App.tsx
@@ -367,7 +367,7 @@ export default function App() {
             }}
           />
           <button
-            onClick={() => { if (currentRaffleId.trim()) setScreen('raffle') }}
+            onClick={() => { const id = currentRaffleId.trim(); if (id) { setCurrentRaffleId(id); setScreen('raffle') } }}
             style={{
               padding: '4px 12px',
               borderRadius: 4,

--- a/tachimint/src/app/components/RaffleResultPanel.tsx
+++ b/tachimint/src/app/components/RaffleResultPanel.tsx
@@ -106,7 +106,7 @@ export function RaffleResultPanel({ raffleId, onBack }: RaffleResultPanelProps) 
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {draws.map((draw, i) => (
+            {[...draws].sort((a, b) => a.drawn_at.localeCompare(b.drawn_at)).map((draw, i) => (
               <div
                 key={draw.id}
                 style={{

--- a/tachimint/src/app/components/RaffleResultPanel.tsx
+++ b/tachimint/src/app/components/RaffleResultPanel.tsx
@@ -78,7 +78,7 @@ export function RaffleResultPanel({ raffleId, onBack }: RaffleResultPanelProps) 
               paddingTop: 40,
             }}
           >
-            LOADING...
+            {t('raffle_result.loading')}
           </div>
         ) : error ? (
           <div
@@ -90,7 +90,7 @@ export function RaffleResultPanel({ raffleId, onBack }: RaffleResultPanelProps) 
               paddingTop: 40,
             }}
           >
-            {error}
+            {t('raffle_result.error_load_failed')}
           </div>
         ) : draws.length === 0 ? (
           <div

--- a/tachimint/src/app/components/RaffleResultPanel.tsx
+++ b/tachimint/src/app/components/RaffleResultPanel.tsx
@@ -1,0 +1,152 @@
+import { useTranslation } from 'react-i18next'
+import { useRaffleResult } from '../../hooks/useRaffleResult'
+
+interface RaffleResultPanelProps {
+  raffleId: string
+  onBack: () => void
+}
+
+export function RaffleResultPanel({ raffleId, onBack }: RaffleResultPanelProps) {
+  const { t } = useTranslation()
+  const { draws, loading, error } = useRaffleResult(raffleId || null)
+
+  return (
+    <div
+      style={{
+        width: 320,
+        height: 600,
+        background: '#0d0d1a',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'var(--pixel-font-family)',
+        userSelect: 'none',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '14px 16px',
+          borderBottom: '1px solid rgba(145,70,255,0.15)',
+        }}
+      >
+        <button
+          onClick={onBack}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#9146FF',
+            fontSize: 8,
+            cursor: 'pointer',
+            fontFamily: 'var(--pixel-font-family)',
+            letterSpacing: '0.06em',
+            padding: 0,
+          }}
+        >
+          ‹ {t('raffle_result.back')}
+        </button>
+        <span
+          style={{
+            fontSize: 8,
+            color: 'rgba(255,255,255,0.5)',
+            letterSpacing: '0.1em',
+          }}
+        >
+          {t('raffle_result.title')}
+        </span>
+      </div>
+
+      {/* Content */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: '16px',
+        }}
+      >
+        {loading ? (
+          <div
+            style={{
+              textAlign: 'center',
+              color: 'rgba(255,255,255,0.3)',
+              fontSize: 8,
+              letterSpacing: '0.08em',
+              paddingTop: 40,
+            }}
+          >
+            LOADING...
+          </div>
+        ) : error ? (
+          <div
+            style={{
+              textAlign: 'center',
+              color: '#ff4444',
+              fontSize: 7,
+              letterSpacing: '0.06em',
+              paddingTop: 40,
+            }}
+          >
+            {error}
+          </div>
+        ) : draws.length === 0 ? (
+          <div
+            style={{
+              textAlign: 'center',
+              color: 'rgba(255,255,255,0.3)',
+              fontSize: 8,
+              letterSpacing: '0.08em',
+              paddingTop: 40,
+            }}
+          >
+            {t('raffle_result.no_winners')}
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {draws.map((draw, i) => (
+              <div
+                key={draw.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  padding: '10px 12px',
+                  background: 'rgba(145,70,255,0.08)',
+                  border: '1px solid rgba(145,70,255,0.15)',
+                  borderRadius: 6,
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: '#9146FF',
+                    fontFamily: 'var(--pixel-font-family)',
+                    minWidth: 24,
+                    flexShrink: 0,
+                  }}
+                >
+                  #{i + 1}
+                </span>
+                <span
+                  style={{
+                    fontSize: 9,
+                    color: 'rgba(255,255,255,0.85)',
+                    letterSpacing: '0.06em',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {draw.entry.display_name}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/tachimint/src/extension/types.test.ts
+++ b/tachimint/src/extension/types.test.ts
@@ -52,6 +52,18 @@ test('sanitizeHudDemoState rejects non-finite numeric values', async () => {
   )
 })
 
+test('sanitizeDemoState accepts raffle as a valid screen', async () => {
+  const types = await importTypesModule()
+  const result = types.sanitizeDemoState({ screen: 'raffle' })
+  assert.equal(result.screen, 'raffle')
+})
+
+test('sanitizeDemoState falls back to login for unknown screen', async () => {
+  const types = await importTypesModule()
+  const result = types.sanitizeDemoState({ screen: 'unknown_screen' })
+  assert.equal(result.screen, 'login')
+})
+
 test('sanitizeHudDemoState normalizes negative zero to positive zero', async () => {
   const types = await importTypesModule()
 

--- a/tachimint/src/extension/types.ts
+++ b/tachimint/src/extension/types.ts
@@ -1,6 +1,19 @@
 import type { AppLanguage } from '../i18n'
 
-export type DemoScreen = 'login' | 'loading' | 'hud' | 'claim' | 'coupon'
+export type DemoScreen = 'login' | 'loading' | 'hud' | 'claim' | 'coupon' | 'raffle'
+
+export interface RaffleResultEntry {
+  id: string
+  twitch_login: string
+  display_name: string
+}
+
+export interface RaffleResultDraw {
+  id: string
+  raffle_id: string
+  drawn_at: string
+  entry: RaffleResultEntry
+}
 
 export interface HudDemoState {
   points: number
@@ -86,7 +99,7 @@ export function sanitizeDemoState(value: unknown): DemoState {
   }
 
   const candidate = value as Partial<DemoState>
-  const screen = candidate.screen === 'login' || candidate.screen === 'loading' || candidate.screen === 'hud' || candidate.screen === 'claim' || candidate.screen === 'coupon'
+  const screen = candidate.screen === 'login' || candidate.screen === 'loading' || candidate.screen === 'hud' || candidate.screen === 'claim' || candidate.screen === 'coupon' || candidate.screen === 'raffle'
     ? candidate.screen
     : defaultDemoState.screen
 

--- a/tachimint/src/hooks/useRaffleResult.ts
+++ b/tachimint/src/hooks/useRaffleResult.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react'
+import { getRaffleResult } from '../services/api'
+import type { RaffleResultDraw } from '../extension/types'
+
+const POLL_INTERVAL_MS = 5_000
+
+export function useRaffleResult(raffleId: string | null) {
+  const [draws, setDraws] = useState<RaffleResultDraw[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!raffleId) {
+      setDraws([])
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    let isDisposed = false
+    let timer: number | null = null
+
+    const fetchOnce = async () => {
+      try {
+        const result = await getRaffleResult(raffleId)
+        if (!isDisposed) {
+          setDraws(result)
+          setError(null)
+          setLoading(false)
+        }
+      } catch {
+        if (!isDisposed) {
+          setError('Failed to load raffle results')
+          setLoading(false)
+        }
+      }
+    }
+
+    const scheduleNext = () => {
+      timer = window.setTimeout(() => {
+        void pollLoop()
+      }, POLL_INTERVAL_MS)
+    }
+
+    const pollLoop = async () => {
+      await fetchOnce()
+      if (!isDisposed) {
+        scheduleNext()
+      }
+    }
+
+    setLoading(true)
+    void pollLoop()
+
+    return () => {
+      isDisposed = true
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [raffleId])
+
+  return { draws, loading, error }
+}

--- a/tachimint/src/hooks/useRaffleResult.ts
+++ b/tachimint/src/hooks/useRaffleResult.ts
@@ -10,12 +10,7 @@ export function useRaffleResult(raffleId: string | null) {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!raffleId) {
-      setDraws([])
-      setLoading(false)
-      setError(null)
-      return
-    }
+    if (!raffleId) return
 
     let isDisposed = false
     let timer: number | null = null
@@ -30,7 +25,7 @@ export function useRaffleResult(raffleId: string | null) {
         }
       } catch {
         if (!isDisposed) {
-          setError('Failed to load raffle results')
+          setError('load_failed')
           setLoading(false)
         }
       }
@@ -49,16 +44,23 @@ export function useRaffleResult(raffleId: string | null) {
       }
     }
 
-    setLoading(true)
+    const loadingTimer = window.setTimeout(() => {
+      if (!isDisposed) setLoading(true)
+    }, 0)
     void pollLoop()
 
     return () => {
       isDisposed = true
+      window.clearTimeout(loadingTimer)
       if (timer !== null) {
         window.clearTimeout(timer)
       }
     }
   }, [raffleId])
+
+  if (!raffleId) {
+    return { draws: [], loading: false, error: null }
+  }
 
   return { draws, loading, error }
 }

--- a/tachimint/src/i18n/locales/en/common.json
+++ b/tachimint/src/i18n/locales/en/common.json
@@ -95,6 +95,11 @@
       }
     }
   },
+  "raffle_result": {
+    "title": "RAFFLE RESULTS",
+    "no_winners": "No winners yet.",
+    "back": "BACK"
+  },
   "error": {
     "account": {
       "title": "Account Not Found",

--- a/tachimint/src/i18n/locales/en/common.json
+++ b/tachimint/src/i18n/locales/en/common.json
@@ -97,7 +97,9 @@
   },
   "raffle_result": {
     "title": "RAFFLE RESULTS",
+    "loading": "LOADING...",
     "no_winners": "No winners yet.",
+    "error_load_failed": "Failed to load results.",
     "back": "BACK"
   },
   "error": {

--- a/tachimint/src/i18n/locales/zh-CN/common.json
+++ b/tachimint/src/i18n/locales/zh-CN/common.json
@@ -97,7 +97,9 @@
   },
   "raffle_result": {
     "title": "抽奖结果",
+    "loading": "加载中...",
     "no_winners": "尚未抽出中奖者",
+    "error_load_failed": "载入失败",
     "back": "返回"
   },
   "error": {

--- a/tachimint/src/i18n/locales/zh-CN/common.json
+++ b/tachimint/src/i18n/locales/zh-CN/common.json
@@ -95,6 +95,11 @@
       }
     }
   },
+  "raffle_result": {
+    "title": "抽奖结果",
+    "no_winners": "尚未抽出中奖者",
+    "back": "返回"
+  },
   "error": {
     "account": {
       "title": "尚未创建账号",

--- a/tachimint/src/i18n/locales/zh-TW/common.json
+++ b/tachimint/src/i18n/locales/zh-TW/common.json
@@ -95,6 +95,11 @@
       }
     }
   },
+  "raffle_result": {
+    "title": "抽獎結果",
+    "no_winners": "尚未抽出中獎者",
+    "back": "返回"
+  },
   "error": {
     "account": {
       "title": "尚未建立帳號",

--- a/tachimint/src/i18n/locales/zh-TW/common.json
+++ b/tachimint/src/i18n/locales/zh-TW/common.json
@@ -97,7 +97,9 @@
   },
   "raffle_result": {
     "title": "抽獎結果",
+    "loading": "載入中...",
     "no_winners": "尚未抽出中獎者",
+    "error_load_failed": "載入失敗",
     "back": "返回"
   },
   "error": {

--- a/tachimint/src/services/api.ts
+++ b/tachimint/src/services/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosRequestConfig } from 'axios'
 import type { TachigoToken } from '../types/twitch'
+import type { RaffleResultDraw } from '../extension/types'
 
 const processEnv =
   typeof globalThis === 'object' && 'process' in globalThis
@@ -280,4 +281,11 @@ export async function sendHeartbeat(
       balance: Math.max(pointsEarned ?? 0, 0),
     }
   }
+}
+
+export async function getRaffleResult(raffleId: string): Promise<RaffleResultDraw[]> {
+  const { data } = await client.get<{ success: boolean; data: { draws: RaffleResultDraw[] } }>(
+    `/api/v1/extension/raffles/${raffleId}/result`,
+  )
+  return data.data.draws
 }

--- a/tachimint/tsconfig.test.json
+++ b/tachimint/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*.test.ts", "scripts/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- 新增 `useRaffleResult` hook：每 5 秒 polling `GET /api/v1/extension/raffles/{id}/result`，mounted flag 防止 unmount 後 setState
- 新增 `RaffleResultPanel` 元件：顯示中獎名單（#1/#2/...）、loading/error/空狀態、Back 按鈕
- `App.tsx` 加入 `raffle` screen 與 `RAFFLE` demo 按鈕
- `extension/types.ts` 加入 `RaffleResultEntry`、`RaffleResultDraw` 型別，`DemoScreen` 加入 `'raffle'`
- `services/api.ts` 加入 `getRaffleResult()` helper
- 三語系 i18n 補齊 `raffle_result` keys
- `tsconfig.test.json` 修正 IDE 對 `node:test` / `node:assert` 的型別錯誤（既有問題）

## Scope 對齊

- Source of truth：#233
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作動畫或特效
  - 不顯示領獎狀態（claimed / expired）
  - 不修改 MarioHUD 內部導航（raffle 只從 demo controls 進入）

## Test plan

- [x] `pnpm build` — TypeScript 無錯，vite build 成功
- [x] `node --experimental-strip-types --test src/extension/*.test.ts` — 13/13 pass（含新增的 2 個 raffle screen 測試）
- [ ] 人工：點 RAFFLE demo 按鈕 → 顯示 RaffleResultPanel，Back 返回 HUD
- [ ] 人工：有效 raffleId → 每 5 秒更新中獎名單

refs #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增抽奖结果屏幕，可查看抽奖名次与获奖者显示名
  * 支持实时刷新结果（轮询）、加载状态提示、空状态与加载失败提示
  * 在演示控制面板新增“RAFFLE”按钮，一键进入抽奖结果并支持返回主界面
* **国际化**
  * 完整支持英文、简体中文与繁体中文界面文案
<!-- end of auto-generated comment: release notes by coderabbit.ai -->