### PR TITLE
[chore] fix backend CI cache wiring: use prebuilt image in unit test job

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -35,18 +35,18 @@ test('frontend CI job runs the frontend test command', async () => {
   )
 })
 
-test('backend CI job runs go test and go vet', async () => {
+test('backend CI job runs go test and go vet via docker compose prebuilt image', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
   const backendJob = workflowJobBlock(workflow, 'backend')
 
   assert.match(
     backendJob,
-    /- name: Run tests\n\s+working-directory: backend\n\s+run: go test \.\/\.\.\./,
+    /- name: Run tests\n\s+run: docker compose run --pull never --no-deps --rm app go test \.\/\.\.\./,
   )
 
   assert.match(
     backendJob,
-    /- name: Run vet\n\s+working-directory: backend\n\s+run: go vet \.\/\.\.\./,
+    /- name: Run vet\n\s+run: docker compose run --pull never --no-deps --rm app go vet \.\/\.\.\./,
   )
 })
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,25 +212,29 @@ jobs:
   backend:
     timeout-minutes: 10
     name: Backend tests
-    needs: [scope-gate]
+    needs: [scope-gate, backend-build]
     if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore backend image from cache
+        uses: docker/build-push-action@v6
         with:
-          go-version-file: backend/go.mod
-          cache: true
+          context: ./backend
+          target: dev
+          load: true
+          tags: tachigo-app:latest
+          cache-from: type=gha
 
       - name: Run tests
-        working-directory: backend
-        run: go test ./...
+        run: docker compose run --pull never --no-deps --rm app go test ./...
 
       - name: Run vet
-        working-directory: backend
-        run: go vet ./...
+        run: docker compose run --pull never --no-deps --rm app go vet ./...
 
   backend-integration:
     timeout-minutes: 20


### PR DESCRIPTION
## Summary

`check-backend-ci-cache.sh` 要求 `ci.yml` 的 backend unit test job 使用 `docker compose run --pull never --no-deps --rm app go test ./...`，但原本的 `backend` job 直接用 `go test ./...`（不走 Docker Compose），導致 `Check backend CI cache wiring` CI 在所有通過 scope gate 的 PR 上都失敗。

此 bug 在 PR #336 觸發 scope gate 之後首次被發現。

### 改動

`backend` job（`ci.yml`）：
- `needs` 加入 `backend-build`，確保 Docker image 已建好且 layers 在 GHA cache
- 用 `build-push-action` + `cache-from: type=gha` 還原 image（不重新編譯）
- `go test` 與 `go vet` 改為 `docker compose run --pull never --no-deps --rm app`

`ci.test.mjs`：
- 更新 test #2 斷言，從 `working-directory: backend` + `go test ./...` 改為 docker compose pattern

## Scope 對齊

- Source of truth：`check-backend-ci-cache.sh` 第 37 行的 `require_in` assertion
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否
- 本 PR 明確不做：
  - 不改任何產品程式碼
  - 不調整 backend integration test job

refs #336

## Test plan

- [x] `bash scripts/check-backend-ci-cache.sh` — exit 0（本地驗證通過）
- [ ] CI `Workflow regression tests` 通過
- [ ] CI `Check backend CI cache wiring` 通過