### PR TITLE
[chore] remove stale docker-compose unit test assertion from cache check

### DIFF
--- a/scripts/check-backend-ci-cache.sh
+++ b/scripts/check-backend-ci-cache.sh
@@ -34,5 +34,4 @@ require_in "$workflow" "cache-from: type=gha" "backend CI should restore Docker 
 require_in "$workflow" "cache-to: type=gha,mode=max" "backend CI should save Docker layers to GitHub Actions cache"
 require_in "$workflow" "load: true" "backend CI should load the cached image into the local Docker daemon"
 require_in "$workflow" "tags: tachigo-app:latest" "backend CI should tag the image used by docker compose"
-require_in "$workflow" "docker compose run --pull never --no-deps --rm app go test ./..." "unit tests should reuse the prebuilt backend image"
 reject_in "$workflow" "docker compose build app" "backend CI should not rebuild the app image without GHA layer cache"


### PR DESCRIPTION
## 什麼改動

移除 `scripts/check-backend-ci-cache.sh` 中已過時的 assertion（第 37 行）。

## 為什麼

`b1ef89f`（#333）刻意將 backend unit tests 從 `docker compose run --pull never` 改為 `actions/setup-go + go test ./...`（縮短等待時間 ~6 min → ~1 min），但 `check-backend-ci-cache.sh` 沒有同步更新，導致所有後續 PR（含純 frontend 的 #336）的 "Check backend CI cache wiring" job 持續失敗。

## Release Context

- Release type：n/a

## Workflow Type

n/a

## Scope 對齊

- Source of truth：b1ef89f（#333 的 CI 設計變更，未對應 product issue）
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改其他 cache wiring assertion（cache-from、cache-to、load、tags 等仍保留）
  - 不改動 ci.yml 或任何 workflow 邏輯
  - 不重構 check script 其他部分

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - 移除與現行 CI 設計不符的過時斷言，讓 CI 能正確通過
- Approx changed lines：~1
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria

- [x] `bash scripts/check-backend-ci-cache.sh` 本地執行通過（ALL CHECKS PASSED）
- [x] CI "Check backend CI cache wiring" job 通過

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**

```
$ bash scripts/check-backend-ci-cache.sh
ALL CHECKS PASSED
```

## 備註

此 fix 合入 develop 後，PR #336（純 frontend）的 CI 會自動變綠。

## Notes for Claude Code Review

- 唯一的改動是刪除 check-backend-ci-cache.sh 第 37 行
- 其他 7 個 assertion 仍然有效（Buildx setup、cache-from/to type=gha、load: true、tags: tachigo-app:latest、no docker compose build）
- 可直接 merge