### PR TITLE
[backend] T-point 命名遷移 PR 1：後端 domain naming + DB compatibility

### DIFF
--- a/backend/internal/handlers/extension_handler.go
+++ b/backend/internal/handlers/extension_handler.go
@@ -61,7 +61,7 @@ func (h *ExtensionHandler) Login(c *gin.Context) {
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
 // @Router       /extension/bits/complete [post]
-func (h *ExtensionHandler) BitsComplete(c *gin.Context) {
+func (h *ExtensionHandler) TPointComplete(c *gin.Context) {
 	var body struct {
 		ExtensionJWT        string `json:"extension_jwt" binding:"required"`
 		TransactionReceipt  string `json:"transaction_receipt" binding:"required"`
@@ -72,7 +72,7 @@ func (h *ExtensionHandler) BitsComplete(c *gin.Context) {
 		return
 	}
 
-	user, tokens, err := h.ext.CompleteBitsTransaction(body.ExtensionJWT, body.TransactionReceipt, body.SKU)
+	user, tokens, err := h.ext.CompleteTPointTransaction(body.ExtensionJWT, body.TransactionReceipt, body.SKU)
 	if err != nil {
 		switch err {
 		case services.ErrInvalidExtJWT:

--- a/backend/internal/handlers/points_handler_test.go
+++ b/backend/internal/handlers/points_handler_test.go
@@ -256,6 +256,71 @@ func TestPointsHandler_GetHistory_ReturnsMappedTransactionsInDescendingOrder(t *
 	}
 }
 
+func TestPointsHandler_GetHistory_LegacyBitsSourceStillReadable(t *testing.T) {
+	e := newPointsEnv(t)
+	userID, token := e.registerViewer(t, "history-legacy-bits")
+	sku := "bits_100"
+
+	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 1); err != nil {
+		t.Fatalf("seed ledger: %v", err)
+	}
+
+	var ledger models.PointsLedger
+	if err := e.db.Where("user_id = ? AND channel_id = ?", userID, "ch_abc").First(&ledger).Error; err != nil {
+		t.Fatalf("load ledger: %v", err)
+	}
+
+	base := time.Date(2026, time.January, 3, 0, 0, 0, 0, time.UTC)
+	if err := e.db.Model(&models.PointsTransaction{}).
+		Where("ledger_id = ? AND source = ?", ledger.ID, models.TxSourceTPoint).
+		Update("created_at", base).Error; err != nil {
+		t.Fatalf("update seed timestamp: %v", err)
+	}
+	if err := e.db.Create(&models.PointsTransaction{
+		LedgerID:     ledger.ID,
+		Source:       models.TxSourceBits,
+		Delta:        250,
+		BalanceAfter: 251,
+		SKU:          &sku,
+		CreatedAt:    base.Add(time.Second),
+	}).Error; err != nil {
+		t.Fatalf("seed legacy bits transaction: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/points/history?channel_id=ch_abc", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resp := parseBody(t, rec.Body.Bytes())
+	if resp["success"] != true {
+		t.Fatalf("success: want true, got %v", resp["success"])
+	}
+	data := resp["data"].(map[string]interface{})
+	transactions := data["transactions"].([]interface{})
+	if len(transactions) != 2 {
+		t.Fatalf("want 2 transactions, got %d", len(transactions))
+	}
+
+	first := transactions[0].(map[string]interface{})
+	if first["type"] != "earn" {
+		t.Fatalf("type: want earn, got %v", first["type"])
+	}
+	if first["amount"] != float64(250) {
+		t.Fatalf("amount: want 250, got %v", first["amount"])
+	}
+	if first["sku"] != "bits_100" {
+		t.Fatalf("sku: want bits_100, got %v", first["sku"])
+	}
+	if _, ok := first["note"]; ok {
+		t.Fatalf("legacy bits transaction should omit note, got %v", first["note"])
+	}
+}
+
 func TestPointsHandler_GetHistory_ReturnsEmptyListWhenNoTransactions(t *testing.T) {
 	e := newPointsEnv(t)
 	_, token := e.registerViewer(t, "empty-history")

--- a/backend/internal/handlers/points_handler_test.go
+++ b/backend/internal/handlers/points_handler_test.go
@@ -52,7 +52,7 @@ func TestPointsHandler_GetBalance_ReturnsWrappedBalances(t *testing.T) {
 	e := newPointsEnv(t)
 	userID, token := e.registerViewer(t, "balance")
 
-	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceBits, 100); err != nil {
+	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 100); err != nil {
 		t.Fatalf("seed points: %v", err)
 	}
 
@@ -108,10 +108,10 @@ func TestPointsHandler_GetBalance_IsScopedToRequestedChannel(t *testing.T) {
 	e := newPointsEnv(t)
 	userID, token := e.registerViewer(t, "balance-scope")
 
-	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceBits, 100); err != nil {
+	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 100); err != nil {
 		t.Fatalf("seed ch_abc: %v", err)
 	}
-	if err := e.pointsSvc.AddPoints(userID, "ch_other", models.TxSourceBits, 999); err != nil {
+	if err := e.pointsSvc.AddPoints(userID, "ch_other", models.TxSourceTPoint, 999); err != nil {
 		t.Fatalf("seed ch_other: %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestPointsHandler_GetHistory_ReturnsMappedTransactionsInDescendingOrder(t *
 	if err := e.pointsSvc.AddPointsWithMeta(
 		userID,
 		"ch_abc",
-		models.TxSourceBits,
+		models.TxSourceTPoint,
 		100,
 		services.PointsCreditMeta{SKU: &sku},
 	); err != nil {
@@ -184,7 +184,7 @@ func TestPointsHandler_GetHistory_ReturnsMappedTransactionsInDescendingOrder(t *
 
 	base := time.Date(2026, time.January, 3, 0, 0, 0, 0, time.UTC)
 	if err := e.db.Model(&models.PointsTransaction{}).
-		Where("ledger_id = ? AND source = ?", ledger.ID, models.TxSourceBits).
+		Where("ledger_id = ? AND source = ?", ledger.ID, models.TxSourceTPoint).
 		Update("created_at", base).Error; err != nil {
 		t.Fatalf("update earn timestamp: %v", err)
 	}
@@ -284,10 +284,10 @@ func TestPointsHandler_GetHistory_IsScopedToRequestedChannel(t *testing.T) {
 	e := newPointsEnv(t)
 	userID, token := e.registerViewer(t, "history-scope")
 
-	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceBits, 100); err != nil {
+	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 100); err != nil {
 		t.Fatalf("seed ch_abc: %v", err)
 	}
-	if err := e.pointsSvc.AddPoints(userID, "ch_other", models.TxSourceBits, 999); err != nil {
+	if err := e.pointsSvc.AddPoints(userID, "ch_other", models.TxSourceTPoint, 999); err != nil {
 		t.Fatalf("seed ch_other: %v", err)
 	}
 
@@ -323,7 +323,7 @@ func TestPointsHandler_GetHistory_SkipsUnsafeSpendDeltaAndReturnsValidTransactio
 	e := newPointsEnv(t)
 	userID, token := e.registerViewer(t, "history-overflow")
 
-	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceBits, 1); err != nil {
+	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 1); err != nil {
 		t.Fatalf("seed ledger: %v", err)
 	}
 
@@ -334,7 +334,7 @@ func TestPointsHandler_GetHistory_SkipsUnsafeSpendDeltaAndReturnsValidTransactio
 
 	base := time.Date(2026, time.January, 4, 0, 0, 0, 0, time.UTC)
 	if err := e.db.Model(&models.PointsTransaction{}).
-		Where("ledger_id = ? AND source = ?", ledger.ID, models.TxSourceBits).
+		Where("ledger_id = ? AND source = ?", ledger.ID, models.TxSourceTPoint).
 		Update("created_at", base).Error; err != nil {
 		t.Fatalf("update valid tx timestamp: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestPointsHandler_GetHistory_ClaimTransactionMappedToClaimType(t *testing.T
 	userID, token := e.registerViewer(t, "history-claim")
 
 	// earn first to create the ledger row
-	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceBits, 100); err != nil {
+	if err := e.pointsSvc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 100); err != nil {
 		t.Fatalf("seed earn: %v", err)
 	}
 	var ledger models.PointsLedger

--- a/backend/internal/models/points.go
+++ b/backend/internal/models/points.go
@@ -11,7 +11,10 @@ import (
 type TxSource string
 
 const (
-	TxSourceBits      TxSource = "bits"
+	// TxSourceBits is the legacy DB value kept for backward-compat reads.
+	// Deprecated: use TxSourceTPoint for new writes.
+	TxSourceBits  TxSource = "bits"
+	TxSourceTPoint TxSource = "t_point"
 	TxSourceWatchTime TxSource = "watch_time"
 	TxSourceClick     TxSource = "click"
 	TxSourceSpend     TxSource = "spend"
@@ -43,7 +46,8 @@ func (p *PointsLedger) BeforeCreate(tx *gorm.DB) error {
 //
 // WatchSessionID rules by source:
 //   - "watch_time" → always non-nil; links to the session that triggered the reward
-//   - "bits"       → always nil; no session context
+//   - "bits"       → always nil; no session context (legacy; new writes use "t_point")
+//   - "t_point"    → always nil; no session context
 //   - "spend"      → always nil; consumption has no session context
 //
 // No FK constraint on watch_session_id — sessions may be archived or purged

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -106,7 +106,7 @@ func New(
 	ext := v1.Group("/extension")
 	{
 		ext.POST("/auth/login", extH.Login)
-		ext.POST("/bits/complete", extH.BitsComplete)
+		ext.POST("/bits/complete", extH.TPointComplete)
 
 		// Raffle result — public read (no auth required)
 		ext.GET("/raffles/:id/result", raffleH.GetResult)

--- a/backend/internal/services/extension_service.go
+++ b/backend/internal/services/extension_service.go
@@ -34,7 +34,7 @@ type ReceiptClaims struct {
 		TransactionID string `json:"transactionId"`
 		SKU           string `json:"sku"`
 		Amount        int    `json:"amount"`
-		Type          string `json:"type"` // "bits"
+		Type          string `json:"type"` // "bits" — Twitch SDK contract, do not rename
 	} `json:"data"`
 	jwt.RegisteredClaims
 }
@@ -74,7 +74,7 @@ func (s *ExtensionService) VerifyExtJWT(tokenStr string) (*ExtensionClaims, erro
 	return claims, nil
 }
 
-// VerifyReceiptJWT verifies a Bits transaction receipt JWT.
+// VerifyReceiptJWT verifies a Twitch transaction receipt JWT.
 func (s *ExtensionService) VerifyReceiptJWT(receiptStr string) (*ReceiptClaims, error) {
 	secret := s.cfg.OAuth.Twitch.ExtensionSecret
 	if secret == "" {
@@ -142,9 +142,9 @@ func (s *ExtensionService) LoginWithExtension(extJWT string) (*models.User, *Tok
 	return &user, tokens, nil
 }
 
-// CompleteBitsTransaction verifies the Extension JWT + receipt, then issues a
+// CompleteTPointTransaction verifies the Extension JWT + receipt, then issues a
 // tachigo token pair for the already-linked viewer.
-func (s *ExtensionService) CompleteBitsTransaction(extJWT, receipt, sku string) (*models.User, *TokenPair, error) {
+func (s *ExtensionService) CompleteTPointTransaction(extJWT, receipt, sku string) (*models.User, *TokenPair, error) {
 	extClaims, err := s.VerifyExtJWT(extJWT)
 	if err != nil {
 		return nil, nil, err

--- a/backend/internal/services/points_service_test.go
+++ b/backend/internal/services/points_service_test.go
@@ -146,7 +146,7 @@ func TestPointsService_AddPoints_IncreasesBothBalances(t *testing.T) {
 	svc, _ := newPointsSvc(t)
 	userID := seedViewer(t, svc)
 
-	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceBits, 500); err != nil {
+	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 500); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -161,7 +161,7 @@ func TestPointsService_AddPoints_RejectsNonPositiveAmount(t *testing.T) {
 	userID := seedViewer(t, svc)
 
 	for _, amount := range []int64{0, -1} {
-		err := svc.AddPoints(userID, "ch_abc", models.TxSourceBits, amount)
+		err := svc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, amount)
 		if !errors.Is(err, ErrInvalidPointsAmount) {
 			t.Fatalf("amount %d: want ErrInvalidPointsAmount, got %v", amount, err)
 		}
@@ -176,7 +176,7 @@ func TestPointsService_AddPointsWithMeta_PersistsSKU(t *testing.T) {
 	if err := svc.AddPointsWithMeta(
 		userID,
 		"ch_abc",
-		models.TxSourceBits,
+		models.TxSourceTPoint,
 		100,
 		PointsCreditMeta{SKU: &sku},
 	); err != nil {
@@ -202,7 +202,7 @@ func TestPointsService_AddPointsWithMeta_RejectsNonPositiveAmount(t *testing.T) 
 	err := svc.AddPointsWithMeta(
 		userID,
 		"ch_abc",
-		models.TxSourceBits,
+		models.TxSourceTPoint,
 		0,
 		PointsCreditMeta{},
 	)
@@ -219,7 +219,7 @@ func TestPointsService_AddPointsWithMeta_RejectsTooLongSKU(t *testing.T) {
 	err := svc.AddPointsWithMeta(
 		userID,
 		"ch_abc",
-		models.TxSourceBits,
+		models.TxSourceTPoint,
 		100,
 		PointsCreditMeta{SKU: &sku},
 	)
@@ -247,7 +247,7 @@ func TestPointsService_ListTransactions_RecordsDeduction(t *testing.T) {
 	svc, _ := newPointsSvc(t)
 	userID := seedViewer(t, svc)
 
-	svc.AddPoints(userID, "ch_abc", models.TxSourceBits, 100)
+	svc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 100)
 	svc.DeductPoints(userID, "ch_abc", 30, "spend test")
 
 	txs, err := svc.ListTransactions(userID, "ch_abc")
@@ -263,10 +263,10 @@ func TestPointsService_ListTransactions_IsScopedToRequestedChannel(t *testing.T)
 	svc, _ := newPointsSvc(t)
 	userID := seedViewer(t, svc)
 
-	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceBits, 100); err != nil {
+	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 100); err != nil {
 		t.Fatalf("seed ch_abc: %v", err)
 	}
-	if err := svc.AddPoints(userID, "ch_other", models.TxSourceBits, 999); err != nil {
+	if err := svc.AddPoints(userID, "ch_other", models.TxSourceTPoint, 999); err != nil {
 		t.Fatalf("seed ch_other: %v", err)
 	}
 
@@ -289,7 +289,7 @@ func TestPointsService_ListTransactions_ReturnsLatest50NewestFirst(t *testing.T)
 	svc, _ := newPointsSvc(t)
 	userID := seedViewer(t, svc)
 
-	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceBits, 1); err != nil {
+	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 1); err != nil {
 		t.Fatalf("seed first point: %v", err)
 	}
 
@@ -307,7 +307,7 @@ func TestPointsService_ListTransactions_ReturnsLatest50NewestFirst(t *testing.T)
 		if err := svc.db.Exec(
 			`INSERT INTO points_transactions (id, ledger_id, source, delta, balance_after, created_at)
 			 VALUES (?, ?, ?, ?, ?, ?)`,
-			uuid.New().String(), ledger.ID, string(models.TxSourceBits), 1, int64(i+1), ts,
+			uuid.New().String(), ledger.ID, string(models.TxSourceTPoint), 1, int64(i+1), ts,
 		).Error; err != nil {
 			t.Fatalf("seed tx %d: %v", i, err)
 		}
@@ -340,7 +340,7 @@ func TestPointsService_ListTransactions_UsesIDAsTieBreakerWhenCreatedAtMatches(t
 	svc, _ := newPointsSvc(t)
 	userID := seedViewer(t, svc)
 
-	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceBits, 1); err != nil {
+	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 1); err != nil {
 		t.Fatalf("seed first point: %v", err)
 	}
 
@@ -362,7 +362,7 @@ func TestPointsService_ListTransactions_UsesIDAsTieBreakerWhenCreatedAtMatches(t
 		{
 			ID:           lowID,
 			LedgerID:     ledger.ID,
-			Source:       models.TxSourceBits,
+			Source:       models.TxSourceTPoint,
 			Delta:        1,
 			BalanceAfter: 1,
 			Note:         &lowNote,
@@ -371,7 +371,7 @@ func TestPointsService_ListTransactions_UsesIDAsTieBreakerWhenCreatedAtMatches(t
 		{
 			ID:           highID,
 			LedgerID:     ledger.ID,
-			Source:       models.TxSourceBits,
+			Source:       models.TxSourceTPoint,
 			Delta:        1,
 			BalanceAfter: 2,
 			Note:         &highNote,


### PR DESCRIPTION
## Scope 對齊

- Source of truth：#316
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分

## Summary

- 新增 `TxSourceTPoint = "t_point"` 常數，標記 `TxSourceBits` 為 deprecated（向後相容讀取，新寫入改用 TxSourceTPoint）
- 將 `CompleteBitsTransaction` rename 為 `CompleteTPointTransaction`（service + handler）
- Handler function `BitsComplete` rename 為 `TPointComplete`；router 路由 path `/bits/complete` 暫時保留，指向 `TPointComplete`（API path 更新是 PR 2 的工作）
- Backend tests 全部 `models.TxSourceBits` 改為 `models.TxSourceTPoint`；`bits_100` SKU 字串未動（Twitch 外部 SKU）

## Migration Decision（此 PR 涵蓋）

| Area | 策略 |
|---|---|
| DB source | 既有 `"bits"` 記錄保留，新寫入使用 `"t_point"` |
| Go function | `CompleteBitsTransaction` → `CompleteTPointTransaction` |
| Twitch SDK calls | `ext.bits.*` 不改（Twitch API contract） |

## 本 PR 明確不做

- 不變更 API path；`/bits/complete` 暫時保留，API path 更新留到後續 PR
- 不變更 Swagger / OpenAPI 文件
- 不變更 tachimint frontend 或 dashboard
- 不修改 Twitch 外部 SKU（例如 `bits_100`）或 Twitch SDK `ext.bits.*` contract
- 不做既有 DB `source = "bits"` 資料 migration

## Test plan

- [ ] `go build ./...` PASS
- [ ] `go test ./...` PASS（所有 backend tests）
- [ ] 確認 `bits_100` SKU fixture 未被修改
- [ ] 確認 `ext.bits` / Twitch SDK 相關字串未被異動

## Related

closes #316（部分）— 後續：PR 2（API path + Swagger）、PR 3（tachimint frontend）、PR 4（docs cleanup）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 积分交易系统已更新至新的交易源标准。

* **改进**
  * 完善了交易完成流程的相关逻辑和处理机制。
  * 更新了积分交易记录的数据源标识。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->