### PR TITLE
[backend] T-point 命名遷移 PR 2：Extension API route + handler

### DIFF
--- a/backend/internal/handlers/extension_handler.go
+++ b/backend/internal/handlers/extension_handler.go
@@ -51,16 +51,17 @@ func (h *ExtensionHandler) Login(c *gin.Context) {
 	ok(c, gin.H{"user": user, "tokens": tokens})
 }
 
-// BitsComplete godoc
-// @Summary      Complete a Bits transaction
+// TPointComplete godoc
+// @Summary      Complete a T-point transaction
+// @Description  Verifies Twitch Extension JWT and transaction receipt, then awards T-points to the viewer.
 // @Tags         extension
 // @Accept       json
 // @Produce      json
-// @Param        body body object{extension_jwt=string,transaction_receipt=string,sku=string} true "Bits transaction payload"
+// @Param        body body object{extension_jwt=string,transaction_receipt=string,sku=string} true "T-point transaction payload"
 // @Success      200  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
-// @Router       /extension/bits/complete [post]
+// @Router       /extension/t-point/complete [post]
 func (h *ExtensionHandler) TPointComplete(c *gin.Context) {
 	var body struct {
 		ExtensionJWT        string `json:"extension_jwt" binding:"required"`
@@ -89,3 +90,17 @@ func (h *ExtensionHandler) TPointComplete(c *gin.Context) {
 
 	ok(c, gin.H{"user": user, "tokens": tokens})
 }
+
+// BitsComplete godoc
+// @Summary      [Deprecated] Complete a Bits transaction
+// @Description  Deprecated alias for /extension/t-point/complete. Use the new endpoint instead.
+// @Tags         extension
+// @Accept       json
+// @Produce      json
+// @Param        body body object{extension_jwt=string,transaction_receipt=string,sku=string} true "Bits transaction payload"
+// @Success      200  {object}  Response{data=AuthResponse}
+// @Failure      400  {object}  Response
+// @Failure      401  {object}  Response
+// @Router       /extension/bits/complete [post]
+// @Deprecated
+func (h *ExtensionHandler) BitsComplete(c *gin.Context) { h.TPointComplete(c) }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -106,7 +106,8 @@ func New(
 	ext := v1.Group("/extension")
 	{
 		ext.POST("/auth/login", extH.Login)
-		ext.POST("/bits/complete", extH.TPointComplete)
+		ext.POST("/t-point/complete", extH.TPointComplete)
+		ext.POST("/bits/complete", extH.BitsComplete) // deprecated alias
 
 		// Raffle result — public read (no auth required)
 		ext.GET("/raffles/:id/result", raffleH.GetResult)


### PR DESCRIPTION
## Summary

- 新增 `/api/v1/extension/t-point/complete` 作為 canonical T-point 交易路由
- 保留 `/api/v1/extension/bits/complete` 作為 deprecated alias（指向 `BitsComplete`，轉發至 `TPointComplete`）
- 更新 `TPointComplete` Swagger annotation（route 從 `/bits/complete` 改為 `/t-point/complete`）
- 新增 `BitsComplete` deprecated alias function（`@Deprecated` 標注）
- Swagger docs 重新產生另開獨立 PR

## Scope 對齊

Source of truth：#316

Depends on PR：none

Backend contract already in develop:
- [x] yes
- [ ] no

## 本 PR 明確不做

- 不更新 swagger docs 檔案（`docs/swagger.*`）— 另開獨立 PR
- 不修改任何業務邏輯（handler 內部邏輯不變）
- 不移除 `/bits/complete` 路由
- 不修改 tachimint frontend（PR 3）
- 不修改 DB source 常數（PR 1 已完成）

## Test plan

- [ ] `go build ./...` PASS
- [ ] `go test ./...` PASS
- [ ] `/t-point/complete` 與 `/bits/complete` 路由均可接受請求

## Related

refs #316 — 後續：swagger docs PR、PR 3（tachimint frontend）、PR 4（docs cleanup）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增T点交易完成接口

* **弃用**
  * Bits交易完成接口已标记为弃用，现有集成仍保持兼容，但建议迁移至新的T点接口

<!-- end of auto-generated comment: release notes by coderabbit.ai -->