### PR TITLE
[backend] T-point 命名遷移 PR 4：docs/plans 清理

### DIFF
--- a/docs/watch-to-points-design.md
+++ b/docs/watch-to-points-design.md
@@ -111,8 +111,8 @@ finished: is_active = false, ended_at = <timestamp>
 |---|---|---|
 | `id` | UUID PK | |
 | `ledger_id` | UUID FK → points_ledgers.id | |
-| `watch_session_id` | UUID NULL | `watch_time` 來源必填，`bits` / `spend` 為 NULL |
-| `source` | VARCHAR(50) | `watch_time` / `bits` / `spend` |
+| `watch_session_id` | UUID NULL | `watch_time` 來源必填，`t_point` / `spend` 為 NULL |
+| `source` | VARCHAR(50) | `watch_time` / `t_point` / `spend`（舊記錄可能為 `bits`，詳見 #316） |
 | `delta` | BIGINT | 變動量（正 = 獲得，負 = 消費） |
 | `balance_after` | BIGINT | 交易後餘額快照（查歷史不用重算） |
 | `note` | TEXT NULL | 備註 |
@@ -124,7 +124,7 @@ finished: is_active = false, ended_at = <timestamp>
 | source | watch_session_id |
 |---|---|
 | `watch_time` | 一定有值（指向觸發這次發點的 session） |
-| `bits` | NULL |
+| `t_point` | NULL |
 | `spend` | NULL |
 
 ---
@@ -288,7 +288,7 @@ ON CONFLICT (user_id, channel_id) DO UPDATE SET
 - 前端 Extension UI：顯示餘額、heartbeat 狀態
 - `GET /api/v1/points/balance`：一般帳號查詢端點
 - `GET /api/v1/points/transactions`：交易記錄
-- Bits 發點整合（`source = "bits"`）
+- T-point 發點整合（`source = "t_point"`）
 - Claim 上鏈（`spendable_balance → Soulbound ERC-20 mint`）
 
 ---

--- a/plans/click-boost.md
+++ b/plans/click-boost.md
@@ -27,7 +27,7 @@
 | 預設冷卻時間 | 5 秒 / 觀眾 | 體感即時但防止 macro 暴力點擊 |
 | 每次點擊獎勵 | 固定 1 點（MVP），後續可接 ChannelConfig | 先驗證流程，再做可調參數 |
 | 速率拒絕行為 | 回傳 `429`，附帶 `retry_after_ms` | 前端可據此控制 UI 冷卻倒數 |
-| TxSource | 新增 `"click"` 值 | 帳本可區分 watch_time / bits / click / spend 來源 |
+| TxSource | 新增 `"click"` 值 | 帳本可區分 watch_time / t_point / click / spend 來源 |
 | 前端冷卻控制 | 樂觀 UI：點擊後立即灰掉按鈕並倒數，不等 API 回應 | 降低延遲感，API 429 時重置倒數即可 |
 | 視覺反饋 | 浮字（+1）+ CSS keyframe 動畫，不引入新套件 | 與現有 `isAnimating` 模式一致 |
 
@@ -56,7 +56,9 @@ ALTER TABLE watch_sessions
 ```go
 const (
     TxSourceWatchTime TxSource = "watch_time"
+    // TxSourceBits is deprecated; use TxSourceTPoint for new writes.
     TxSourceBits      TxSource = "bits"
+    TxSourceTPoint    TxSource = "t_point"
     TxSourceClick     TxSource = "click"   // 新增
     TxSourceSpend     TxSource = "spend"
 )


### PR DESCRIPTION
## Summary

- `docs/watch-to-points-design.md`：`source` 欄位說明從 `bits` 改為 `t_point`，並加注舊記錄相容說明；Phase 2 預告改為 T-point 發點整合
- `plans/click-boost.md`：TxSource 架構決策表從 `bits` 改為 `t_point`；code 範例加入 `TxSourceTPoint` 並標注 `TxSourceBits` 為 deprecated

## Scope 對齊

Source of truth：#316

Depends on PR：none

Backend contract already in develop:
- [x] yes
- [ ] no

## 本 PR 明確不做

- 不修改任何程式碼
- 不修改 `docs/` 以外、`plans/` 以外的檔案
- 不更新 swagger docs（另開獨立 PR）
- 不修改 tachimint frontend（PR 3）

## Test plan

- [ ] 確認兩份文件的 `bits` / `Bits` 僅剩 Twitch SDK 相關說明或 backward-compat 說明

## Related

refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)