### PR TITLE
[frontend] T-point 命名遷移 PR 3：tachimint internal naming

### DIFF
--- a/tachimint/src/TwitchApp.tsx
+++ b/tachimint/src/TwitchApp.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTwitch } from './hooks/useTwitch'
-import { useBits } from './hooks/useBits'
+import { useTPoint } from './hooks/useTPoint'
 import { useHeartbeat } from './hooks/useHeartbeat'
 import { useClickBoost } from './hooks/useClickBoost'
 import { claimPoints, getTachiBalance } from './services/api'
@@ -10,8 +10,8 @@ type ClaimErrorKey = 'loadBalanceFailed' | 'claimFailed'
 
 export default function App() {
   const { t } = useTranslation()
-  const { context, jwt, products, bitsEnabled, authError, backendReady } = useTwitch()
-  const { buyWithBits, status, error } = useBits(jwt)
+  const { context, jwt, products, tPointEnabled, authError, backendReady } = useTwitch()
+  const { buyWithTPoint, status, error } = useTPoint(jwt)
   const isViewer = context?.role === 'viewer'
   const [tachiBalance, setTachiBalance] = useState<number | null>(null)
   const [claimStatus, setClaimStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle')
@@ -94,7 +94,7 @@ export default function App() {
         </header>
         <div className="ext-broadcaster">
           <p>Broadcaster view</p>
-          <p className="ext-hint">Viewers can spend Bits to earn rewards.</p>
+          <p className="ext-hint">Viewers can spend T-points to earn rewards.</p>
         </div>
       </div>
     )
@@ -175,7 +175,7 @@ export default function App() {
 
         {status !== 'success' && (
           <>
-            {bitsEnabled && products.length > 0 ? (
+            {tPointEnabled && products.length > 0 ? (
               <ul className="ext-products">
                 {products.map((product) => (
                   <li key={product.sku} className="ext-product">
@@ -186,14 +186,14 @@ export default function App() {
                       )}
                     </div>
                     <button
-                      className="ext-btn ext-btn--bits"
+                      className="ext-btn ext-btn--tpoint"
                       disabled={status === 'pending'}
-                      onClick={() => buyWithBits(product.sku)}
+                      onClick={() => buyWithTPoint(product.sku)}
                     >
                       <img
                         src="https://static-cdn.jtvnw.net/bits/dark/animated/purple/1"
                         alt=""
-                        className="ext-bits-icon"
+                        className="ext-tpoint-icon"
                       />
                       {status === 'pending' ? '…' : product.cost.amount.toLocaleString()}
                     </button>
@@ -202,7 +202,7 @@ export default function App() {
               </ul>
             ) : (
               <p className="ext-hint">
-                {bitsEnabled ? 'No products available.' : 'Bits not available.'}
+                {tPointEnabled ? 'No products available.' : 'T-points not available.'}
               </p>
             )}
 

--- a/tachimint/src/hooks/useTPoint.ts
+++ b/tachimint/src/hooks/useTPoint.ts
@@ -1,14 +1,14 @@
 import { useCallback, useState } from 'react'
-import type { BitsTransaction } from '../types/twitch'
-import { completeBitsTransaction } from '../services/api'
+import type { TPointTransaction } from '../types/twitch'
+import { completeTPointTransaction } from '../services/api'
 
 type Status = 'idle' | 'pending' | 'success' | 'error'
 
-export function useBits(jwt: string) {
+export function useTPoint(jwt: string) {
   const [status, setStatus] = useState<Status>('idle')
   const [error, setError] = useState<string | null>(null)
 
-  const buyWithBits = useCallback(
+  const buyWithTPoint = useCallback(
     (sku: string) => {
       const ext = window.Twitch?.ext
       if (!ext?.bits) return
@@ -16,9 +16,9 @@ export function useBits(jwt: string) {
       setStatus('pending')
       setError(null)
 
-      ext.bits.onTransactionComplete(async (tx: BitsTransaction) => {
+      ext.bits.onTransactionComplete(async (tx: TPointTransaction) => {
         try {
-          await completeBitsTransaction(jwt, tx.transactionReceipt, tx.product.sku)
+          await completeTPointTransaction(jwt, tx.transactionReceipt, tx.product.sku)
           setStatus('success')
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
@@ -36,5 +36,5 @@ export function useBits(jwt: string) {
     [jwt],
   )
 
-  return { buyWithBits, status, error }
+  return { buyWithTPoint, status, error }
 }

--- a/tachimint/src/hooks/useTwitch.ts
+++ b/tachimint/src/hooks/useTwitch.ts
@@ -19,7 +19,7 @@ export function useTwitch() {
   const [context, setContext] = useState<TwitchContext | null>(null)
   const [jwt, setJwt] = useState<string>('')
   const [products, setProducts] = useState<TwitchBitsProduct[]>([])
-  const [bitsEnabled, setBitsEnabled] = useState(false)
+  const [tPointEnabled, setTPointEnabled] = useState(false)
   const [authError, setAuthError] = useState<string | null>(null)
   const [backendReady, setBackendReady] = useState(false)
 
@@ -73,9 +73,9 @@ export function useTwitch() {
         ext.bits.getProducts()
           .then((p) => {
             setProducts(p as TwitchBitsProduct[])
-            setBitsEnabled(true)
+            setTPointEnabled(true)
           })
-          .catch(() => setBitsEnabled(false))
+          .catch(() => setTPointEnabled(false))
       }
     })
 
@@ -116,5 +116,5 @@ export function useTwitch() {
     }
   }, [backendReady, jwt])
 
-  return { context, jwt, products, bitsEnabled, authError, backendReady }
+  return { context, jwt, products, tPointEnabled, authError, backendReady }
 }

--- a/tachimint/src/hooks/useTwitch.ts
+++ b/tachimint/src/hooks/useTwitch.ts
@@ -8,7 +8,7 @@ import {
 } from '../services/api'
 import i18n, { mapTwitchLocaleToAppLanguage } from '../i18n'
 
-export interface TwitchBitsProduct {
+export interface TwitchTPointProduct {
   sku: string
   displayName: string
   cost: { amount: number; type: 'bits' }
@@ -18,7 +18,7 @@ export interface TwitchBitsProduct {
 export function useTwitch() {
   const [context, setContext] = useState<TwitchContext | null>(null)
   const [jwt, setJwt] = useState<string>('')
-  const [products, setProducts] = useState<TwitchBitsProduct[]>([])
+  const [products, setProducts] = useState<TwitchTPointProduct[]>([])
   const [tPointEnabled, setTPointEnabled] = useState(false)
   const [authError, setAuthError] = useState<string | null>(null)
   const [backendReady, setBackendReady] = useState(false)
@@ -62,17 +62,17 @@ export function useTwitch() {
           setAuthError(null)
         }
       } catch {
-        // Non-fatal: bits flow still works via extension JWT directly
+        // Non-fatal: t-point flow still works via extension JWT directly
         clearAuthToken()
         setBackendReady(false)
         setAuthError('Backend unavailable')
       }
 
-      // Fetch bits products
+      // Fetch T-point products
       if (ext.bits?.getProducts) {
         ext.bits.getProducts()
           .then((p) => {
-            setProducts(p as TwitchBitsProduct[])
+            setProducts(p as TwitchTPointProduct[])
             setTPointEnabled(true)
           })
           .catch(() => setTPointEnabled(false))

--- a/tachimint/src/index.css
+++ b/tachimint/src/index.css
@@ -11,7 +11,7 @@
   --accent-hover: #bf93ff;
   --success: #00c853;
   --error: #ff5252;
-  --bits: #f5a623;
+  --tpoint: #f5a623;
 
   --radius: 8px;
   --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
@@ -313,7 +313,7 @@ p  { margin: 0; }
   cursor: not-allowed;
 }
 
-.ext-btn--bits {
+.ext-btn--tpoint {
   padding: 5px 10px;
   background: var(--accent);
   color: #fff;
@@ -322,7 +322,7 @@ p  { margin: 0; }
   flex-shrink: 0;
 }
 
-.ext-btn--bits:hover:not(:disabled) { background: var(--accent-hover); }
+.ext-btn--tpoint:hover:not(:disabled) { background: var(--accent-hover); }
 
 .ext-btn--ghost {
   padding: 6px 14px;
@@ -333,7 +333,7 @@ p  { margin: 0; }
 
 .ext-btn--ghost:hover:not(:disabled) { background: #3a3a45; }
 
-.ext-bits-icon {
+.ext-tpoint-icon {
   width: 16px;
   height: 16px;
   vertical-align: middle;

--- a/tachimint/src/index.css
+++ b/tachimint/src/index.css
@@ -295,7 +295,7 @@ p  { margin: 0; }
   white-space: nowrap;
 }
 
-/* ── Bits button ────────────────────────────────────────────────────────────── */
+/* ── T-point button ─────────────────────────────────────────────────────────── */
 .ext-btn {
   display: inline-flex;
   align-items: center;

--- a/tachimint/src/mock/twitch-ext.ts
+++ b/tachimint/src/mock/twitch-ext.ts
@@ -1,4 +1,4 @@
-import type { BitsTransaction } from '../types/twitch'
+import type { TPointTransaction } from '../types/twitch'
 
 /**
  * Injects a fake window.Twitch.ext when running outside of a real Twitch iframe.
@@ -12,7 +12,7 @@ export function injectTwitchExtMock() {
   // In that case, we force-inject the mock to make localhost development usable.
   const isInIFrame = window.self !== window.top
   if (window.Twitch?.ext && isInIFrame) return
-  let onTransactionComplete: ((tx: BitsTransaction) => void) | null = null
+  let onTransactionComplete: ((tx: TPointTransaction) => void) | null = null
 
   window.Twitch = {
     ext: {

--- a/tachimint/src/services/api.ts
+++ b/tachimint/src/services/api.ts
@@ -53,12 +53,12 @@ export function setExtensionJwtForRecovery(token: string | null) {
 /**
  * Exchange a Twitch Extension JWT + transaction receipt for a tachigo token.
  */
-export async function completeBitsTransaction(
+export async function completeTPointTransaction(
   extensionJwt: string,
   transactionReceipt: string,
   sku: string,
 ): Promise<TachigoToken> {
-  const { data } = await client.post<TachigoToken>('/api/v1/extension/bits/complete', {
+  const { data } = await client.post<TachigoToken>('/api/v1/extension/t-point/complete', {
     extension_jwt: extensionJwt,
     transaction_receipt: transactionReceipt,
     sku,

--- a/tachimint/src/types/twitch-ext.d.ts
+++ b/tachimint/src/types/twitch-ext.d.ts
@@ -4,7 +4,7 @@
 interface TwitchExtBits {
   getProducts(): Promise<TwitchBitsProduct[]>
   useBits(sku: string): void
-  onTransactionComplete(callback: (transaction: import('./twitch').BitsTransaction) => void): void
+  onTransactionComplete(callback: (transaction: import('./twitch').TPointTransaction) => void): void
   onTransactionCancelled(callback: () => void): void
 }
 

--- a/tachimint/src/types/twitch.ts
+++ b/tachimint/src/types/twitch.ts
@@ -6,14 +6,16 @@ export interface TwitchContext {
   role: 'broadcaster' | 'moderator' | 'viewer' | 'external'
 }
 
-export interface BitsTransaction {
+// TPointTransaction is the payload received from Twitch when a viewer completes a T-point purchase.
+// Note: the `type` field value is "bits" — this is a Twitch SDK contract value and must not be changed.
+export interface TPointTransaction {
   transactionId: string
   product: {
     sku: string
     displayName: string
     cost: {
       amount: number
-      type: 'bits'
+      type: 'bits' // Twitch SDK contract — do not rename
     }
     inDevelopment: boolean
   }


### PR DESCRIPTION
## Summary

- `BitsTransaction` type → `TPointTransaction`（field value `type: 'bits'` 保留，Twitch SDK contract）
- `useBits.ts` → `useTPoint.ts`，hook export `useBits` → `useTPoint`，`buyWithBits` → `buyWithTPoint`
- `completeBitsTransaction` → `completeTPointTransaction`，API URL `/bits/complete` → `/t-point/complete`
- `bitsEnabled` → `tPointEnabled`（useTwitch.ts state + return）
- `TwitchBitsProduct` → `TwitchTPointProduct`，相關 comment 更新
- TwitchApp.tsx：import、destructure、JSX、文案一併更新
- CSS：`--bits` → `--tpoint`，`.ext-btn--bits` → `.ext-btn--tpoint`，`.ext-bits-icon` → `.ext-tpoint-icon`
- `tachimint/src/mock/twitch-ext.ts`：`BitsTransaction` → `TPointTransaction`（CI fix）
- `ext.bits.*` 所有 Twitch SDK 呼叫**不動**

## Scope 對齊

Source of truth: #316

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 本 PR 明確不做

- 不修改 backend 任何檔案
- 不修改 `ext.bits`、`ext.bits.useBits()`、`ext.bits.onTransactionComplete()` 等 Twitch SDK calls
- 不修改 `cost.type: 'bits'`、`type: 'bits'` 等 Twitch API contract field values
- 不更新 swagger docs
- 不修改 docs/plans（PR 4 處理）

## Test plan

- [ ] `npx tsc --noEmit` PASS（零 error）
- [ ] Frontend build PASS
- [ ] 確認 `ext.bits` 相關呼叫未被修改

## Related

refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 购买流程已从 Bits 系统迁移至 T-points，用户界面标签、按钮样式和相关图标均已相应更新。
  * T-points 交易处理已完全集成，后端端点已更新以支持新的交易完成流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->