### PR TITLE
[chore] conventions.md 補 merge 策略（--no-ff）說明

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -29,6 +29,13 @@ Co-Authored-By: Claude Sonnet 4.6 <claude[bot]@anthropic.com>
 
 Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 
+## Merge 策略
+
+本專案使用 **merge commit（--no-ff）**：feature branch 進 develop 時保留分支結構。
+
+- 日常 feature PR 目標分支：`develop`
+- `main` 不接受日常 feature PR；正式 release 由 `develop → main` 的 promotion PR 合入
+
 ## Scope 邊界
 
 禁止 scope pollution：不要把 issue 沒有明確要求的內容混進同一個 PR。


### PR DESCRIPTION
## Summary

- `.claude/rules/conventions.md` 新增 **Merge 策略** 段落，說明本專案使用 merge commit（--no-ff）及 feature PR 目標分支規則

Source of truth：Issue #382 / PR #369 Codex review (Majors)

Depends on PR: None

Backend contract already in develop:
- [x] yes
- [ ] no

## 本 PR 明確不做

- 不修改 CLAUDE.md（已有完整 Merge 策略說明）
- 不修改 GitHub repo merge 設定

closes #382