### PR TITLE
[backend] T-point 命名遷移 PR 2b：Swagger docs 重新產生

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -797,6 +797,494 @@ const docTemplate = `{
                 }
             }
         },
+        "/claim/{token}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "claim"
+                ],
+                "summary": "Get claim info by token",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Claim token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "claim"
+                ],
+                "summary": "Submit shipping info for a claim",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Claim token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Shipping info",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/services.ClaimInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "List my raffles",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Create a raffle",
+                "parameters": [
+                    {
+                        "description": "Raffle title",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Get raffle by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/complete": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Mark a raffle as completed",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/discord-webhook": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Set or clear the Discord webhook URL for a raffle",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Webhook URL (empty string to clear)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "discord_webhook_url": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/draws": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "List draws for a raffle",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Draw the next winner",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/entries/import-csv": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Import participants from CSV",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "CSV file (column 1: twitch_login, column 2: display_name)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/snapshot": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Sync raffle entries from Twitch subscriber list",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "source must be twitch_api",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "source": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/extension/auth/login": {
             "post": {
                 "consumes": [
@@ -861,6 +1349,7 @@ const docTemplate = `{
         },
         "/extension/bits/complete": {
             "post": {
+                "description": "Deprecated alias for /extension/t-point/complete. Use the new endpoint instead.",
                 "consumes": [
                     "application/json"
                 ],
@@ -870,10 +1359,114 @@ const docTemplate = `{
                 "tags": [
                     "extension"
                 ],
-                "summary": "Complete a Bits transaction",
+                "summary": "[Deprecated] Complete a Bits transaction",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Bits transaction payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "extension_jwt": {
+                                    "type": "string"
+                                },
+                                "sku": {
+                                    "type": "string"
+                                },
+                                "transaction_receipt": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/extension/raffles/{id}/result": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Get drawn winners for a raffle (Extension)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/extension/t-point/complete": {
+            "post": {
+                "description": "Verifies Twitch Extension JWT and transaction receipt, then awards T-points to the viewer.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "extension"
+                ],
+                "summary": "Complete a T-point transaction",
+                "parameters": [
+                    {
+                        "description": "T-point transaction payload",
                         "name": "body",
                         "in": "body",
                         "required": true,
@@ -1859,12 +2452,16 @@ const docTemplate = `{
         "handlers.redeemRequest": {
             "type": "object",
             "required": [
-                "amount"
+                "amount",
+                "coupon_id"
             ],
             "properties": {
                 "amount": {
                     "type": "integer",
                     "minimum": 1
+                },
+                "coupon_id": {
+                    "type": "string"
                 }
             }
         },
@@ -1873,6 +2470,9 @@ const docTemplate = `{
             "properties": {
                 "balance": {
                     "type": "integer"
+                },
+                "voucher_code": {
+                    "type": "string"
                 }
             }
         },
@@ -2053,6 +2653,37 @@ const docTemplate = `{
                 },
                 "is_default": {
                     "type": "boolean"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "postal_code": {
+                    "type": "string"
+                },
+                "recipient_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "services.ClaimInput": {
+            "type": "object",
+            "required": [
+                "address_line1",
+                "city",
+                "recipient_name"
+            ],
+            "properties": {
+                "address_line1": {
+                    "type": "string"
+                },
+                "address_line2": {
+                    "type": "string"
+                },
+                "city": {
+                    "type": "string"
+                },
+                "country": {
+                    "type": "string"
                 },
                 "phone": {
                     "type": "string"

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -872,6 +872,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/handlers.Response"
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {

--- a/backend/docs/docs_test.go
+++ b/backend/docs/docs_test.go
@@ -129,3 +129,32 @@ func TestSwaggerDoc_NoGlobalSecurity_ProtectedOpsRequireBearerAuth(t *testing.T)
 		})
 	}
 }
+
+func TestSwaggerDoc_ClaimSubmitDocumentsBadRequest(t *testing.T) {
+	raw := SwaggerInfo.ReadDoc()
+
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal doc: %v", err)
+	}
+
+	paths, ok := doc["paths"].(map[string]any)
+	if !ok {
+		t.Fatalf("paths: got %#v", doc["paths"])
+	}
+	pathItem, ok := paths["/claim/{token}"].(map[string]any)
+	if !ok {
+		t.Fatalf("/claim/{token}: path item missing, got %#v", paths["/claim/{token}"])
+	}
+	op, ok := pathItem["post"].(map[string]any)
+	if !ok {
+		t.Fatalf("post /claim/{token}: operation missing, got %#v", pathItem["post"])
+	}
+	responses, ok := op["responses"].(map[string]any)
+	if !ok {
+		t.Fatalf("post /claim/{token}: responses invalid, got %#v", op["responses"])
+	}
+	if _, ok := responses["400"]; !ok {
+		t.Fatalf("post /claim/{token}: missing 400 response, got %#v", responses)
+	}
+}

--- a/backend/docs/docs_test.go
+++ b/backend/docs/docs_test.go
@@ -50,6 +50,7 @@ func TestSwaggerDoc_NoGlobalSecurity_ProtectedOpsRequireBearerAuth(t *testing.T)
 		{path: "/auth/reset-password", method: "post"},
 		{path: "/extension/auth/login", method: "post"},
 		{path: "/extension/bits/complete", method: "post"},
+		{path: "/extension/t-point/complete", method: "post"},
 	} {
 		tc := tc
 		t.Run(fmt.Sprintf("%s %s", tc.method, tc.path), func(t *testing.T) {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -866,6 +866,12 @@
                             "$ref": "#/definitions/handlers.Response"
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -791,6 +791,494 @@
                 }
             }
         },
+        "/claim/{token}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "claim"
+                ],
+                "summary": "Get claim info by token",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Claim token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "claim"
+                ],
+                "summary": "Submit shipping info for a claim",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Claim token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Shipping info",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/services.ClaimInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "List my raffles",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Create a raffle",
+                "parameters": [
+                    {
+                        "description": "Raffle title",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Get raffle by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/complete": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Mark a raffle as completed",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/discord-webhook": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Set or clear the Discord webhook URL for a raffle",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Webhook URL (empty string to clear)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "discord_webhook_url": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/draws": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "List draws for a raffle",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Draw the next winner",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/entries/import-csv": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Import participants from CSV",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "CSV file (column 1: twitch_login, column 2: display_name)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/snapshot": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Sync raffle entries from Twitch subscriber list",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "source must be twitch_api",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "source": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/extension/auth/login": {
             "post": {
                 "consumes": [
@@ -855,6 +1343,7 @@
         },
         "/extension/bits/complete": {
             "post": {
+                "description": "Deprecated alias for /extension/t-point/complete. Use the new endpoint instead.",
                 "consumes": [
                     "application/json"
                 ],
@@ -864,10 +1353,114 @@
                 "tags": [
                     "extension"
                 ],
-                "summary": "Complete a Bits transaction",
+                "summary": "[Deprecated] Complete a Bits transaction",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Bits transaction payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "extension_jwt": {
+                                    "type": "string"
+                                },
+                                "sku": {
+                                    "type": "string"
+                                },
+                                "transaction_receipt": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.AuthResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/extension/raffles/{id}/result": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Get drawn winners for a raffle (Extension)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/extension/t-point/complete": {
+            "post": {
+                "description": "Verifies Twitch Extension JWT and transaction receipt, then awards T-points to the viewer.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "extension"
+                ],
+                "summary": "Complete a T-point transaction",
+                "parameters": [
+                    {
+                        "description": "T-point transaction payload",
                         "name": "body",
                         "in": "body",
                         "required": true,
@@ -1853,12 +2446,16 @@
         "handlers.redeemRequest": {
             "type": "object",
             "required": [
-                "amount"
+                "amount",
+                "coupon_id"
             ],
             "properties": {
                 "amount": {
                     "type": "integer",
                     "minimum": 1
+                },
+                "coupon_id": {
+                    "type": "string"
                 }
             }
         },
@@ -1867,6 +2464,9 @@
             "properties": {
                 "balance": {
                     "type": "integer"
+                },
+                "voucher_code": {
+                    "type": "string"
                 }
             }
         },
@@ -2047,6 +2647,37 @@
                 },
                 "is_default": {
                     "type": "boolean"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "postal_code": {
+                    "type": "string"
+                },
+                "recipient_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "services.ClaimInput": {
+            "type": "object",
+            "required": [
+                "address_line1",
+                "city",
+                "recipient_name"
+            ],
+            "properties": {
+                "address_line1": {
+                    "type": "string"
+                },
+                "address_line2": {
+                    "type": "string"
+                },
+                "city": {
+                    "type": "string"
+                },
+                "country": {
+                    "type": "string"
                 },
                 "phone": {
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -856,6 +856,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
         "404":
           description: Not Found
           schema:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -103,13 +103,18 @@ definitions:
       amount:
         minimum: 1
         type: integer
+      coupon_id:
+        type: string
     required:
     - amount
+    - coupon_id
     type: object
   handlers.redeemResponse:
     properties:
       balance:
         type: integer
+      voucher_code:
+        type: string
     type: object
   handlers.tachiBalanceResponse:
     properties:
@@ -229,6 +234,27 @@ definitions:
         type: string
       is_default:
         type: boolean
+      phone:
+        type: string
+      postal_code:
+        type: string
+      recipient_name:
+        type: string
+    required:
+    - address_line1
+    - city
+    - recipient_name
+    type: object
+  services.ClaimInput:
+    properties:
+      address_line1:
+        type: string
+      address_line2:
+        type: string
+      city:
+        type: string
+      country:
+        type: string
       phone:
         type: string
       postal_code:
@@ -782,6 +808,312 @@ paths:
       summary: Verify wallet signature and authenticate
       tags:
       - auth
+  /claim/{token}:
+    get:
+      parameters:
+      - description: Claim token
+        in: path
+        name: token
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "410":
+          description: Gone
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      summary: Get claim info by token
+      tags:
+      - claim
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Claim token
+        in: path
+        name: token
+        required: true
+        type: string
+      - description: Shipping info
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/services.ClaimInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "410":
+          description: Gone
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      summary: Submit shipping info for a claim
+      tags:
+      - claim
+  /dashboard/raffles:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: List my raffles
+      tags:
+      - raffles
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Raffle title
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            title:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Create a raffle
+      tags:
+      - raffles
+  /dashboard/raffles/{id}:
+    get:
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Get raffle by ID
+      tags:
+      - raffles
+  /dashboard/raffles/{id}/complete:
+    post:
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Mark a raffle as completed
+      tags:
+      - raffles
+  /dashboard/raffles/{id}/discord-webhook:
+    patch:
+      consumes:
+      - application/json
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Webhook URL (empty string to clear)
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            discord_webhook_url:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Set or clear the Discord webhook URL for a raffle
+      tags:
+      - raffles
+  /dashboard/raffles/{id}/draws:
+    get:
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: List draws for a raffle
+      tags:
+      - raffles
+    post:
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Draw the next winner
+      tags:
+      - raffles
+  /dashboard/raffles/{id}/entries/import-csv:
+    post:
+      consumes:
+      - multipart/form-data
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 'CSV file (column 1: twitch_login, column 2: display_name)'
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Import participants from CSV
+      tags:
+      - raffles
+  /dashboard/raffles/{id}/snapshot:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: source must be twitch_api
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            source:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Sync raffle entries from Twitch subscriber list
+      tags:
+      - raffles
   /extension/auth/login:
     post:
       consumes:
@@ -823,6 +1155,9 @@ paths:
     post:
       consumes:
       - application/json
+      deprecated: true
+      description: Deprecated alias for /extension/t-point/complete. Use the new endpoint
+        instead.
       parameters:
       - description: Bits transaction payload
         in: body
@@ -857,7 +1192,72 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
-      summary: Complete a Bits transaction
+      summary: '[Deprecated] Complete a Bits transaction'
+      tags:
+      - extension
+  /extension/raffles/{id}/result:
+    get:
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      summary: Get drawn winners for a raffle (Extension)
+      tags:
+      - raffles
+  /extension/t-point/complete:
+    post:
+      consumes:
+      - application/json
+      description: Verifies Twitch Extension JWT and transaction receipt, then awards
+        T-points to the viewer.
+      parameters:
+      - description: T-point transaction payload
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            extension_jwt:
+              type: string
+            sku:
+              type: string
+            transaction_receipt:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/handlers.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.AuthResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      summary: Complete a T-point transaction
       tags:
       - extension
   /spend/redeem:

--- a/backend/internal/handlers/raffle_handler.go
+++ b/backend/internal/handlers/raffle_handler.go
@@ -389,6 +389,7 @@ func (h *RaffleHandler) GetClaim(c *gin.Context) {
 // @Param        token path   string true "Claim token"
 // @Param        body  body   services.ClaimInput true "Shipping info"
 // @Success      200   {object}  Response
+// @Failure      400   {object}  Response
 // @Failure      404   {object}  Response
 // @Failure      409   {object}  Response
 // @Failure      410   {object}  Response


### PR DESCRIPTION
## 背景

PR 2a (#373) 已 merge，新增 `/extension/t-point/complete` 路由與 deprecated alias `/extension/bits/complete`。
本 PR 重新產生 Swagger docs，讓文件與程式碼同步。

## 變更內容

- `backend/docs/docs.go` / `swagger.json` / `swagger.yaml`：執行 `swag init` 重新產生
- `backend/docs/docs_test.go`：補上 `/extension/t-point/complete` 公開路徑測試

## 為何使用 scope-exception

Generated code（Swagger 自動產物）必須整批更新，無法按功能拆細。

Source of truth: docs/superpowers/plans/2026-04-26-bits-to-tpoint-migration.md（PR 2b 任務）

本 PR 明確不做：
- 不修改任何非 docs 目錄的後端邏輯
- 不新增路由或 handler
- 不觸碰 tachimint / dashboard

Depends on PR: none
Backend contract already in develop:
- [x] yes
- [ ] no

Backend contract note: `/extension/t-point/complete` 與 `/extension/bits/complete` alias 已在 develop；`/claim/{token}` 400 行為也已在 develop

closes #316（PR 2b，最後一張 backend docs PR）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* **声明履行** - 新增了通过令牌检索和提交收货地址及收货人信息的功能
* **抽奖管理仪表盘** - 新增了认证的抽奖管理功能，包括创建、列表、完成抽奖、配置Discord webhook、管理获奖者抽奖、导入CSV参赛者和同步Twitch订阅者数据
* **新的扩展端点** - 增加了查看抽奖结果和T积分完成提交的功能

## 已弃用

* **bits完成端点** - `/extension/bits/complete` 已标记为已弃用

## 改进

* **优惠券兑换** - 优化了兑换流程，响应中现在包含代金券代码

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
