### PR TITLE
[chore] PR template 與 CLAUDE.md 補充 swagger docs 更新規則

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,7 +42,7 @@
   - [ ] migration / schema
   - [ ] backend domain service
   - [ ] API handler / router
-  - [ ] 若有新增/修改/刪除 handler annotation 或 router 路由，已執行 `swag init` 並將 `backend/docs/` 變更一起 commit
+    - [ ] 已執行 `swag init` 並將 `backend/docs/` 變更一起 commit
   - [ ] frontend integration
   - [ ] tests
   - [ ] docs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,6 +42,7 @@
   - [ ] migration / schema
   - [ ] backend domain service
   - [ ] API handler / router
+  - [ ] 若有新增/修改/刪除 handler annotation 或 router 路由，已執行 `swag init` 並將 `backend/docs/` 變更一起 commit
   - [ ] frontend integration
   - [ ] tests
   - [ ] docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ docker compose run --no-deps --rm app go test ./...
 
 ## Swagger Docs 更新規則
 
-任何 PR 若有以下改動，**必須**在同一個 PR 裡附帶 `swag init` 產出的 docs 變更（`backend/docs/` 下的三個檔案）：
+任何 PR 若有以下改動，**必須**在同一個 PR 裡附帶 `swag init` 產出的 docs 變更（`backend/docs/docs.go`、`backend/docs/swagger.json`、`backend/docs/swagger.yaml`）：
 
 - 新增、修改、刪除 handler function 的 swagger annotation（`// @Router`、`// @Param`、`// @Success` 等）
 - 在 `router.go` 新增或移除路由

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ docker compose run --no-deps --rm app go test ./...
 
 執行指令：
 ```bash
+go install github.com/swaggo/swag/cmd/swag@latest
 cd backend && $(go env GOPATH)/bin/swag init -g cmd/server/main.go -o docs
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,18 @@ make down   # 停止所有服務
 docker compose run --no-deps --rm app go test ./...
 ```
 
+## Swagger Docs 更新規則
+
+任何 PR 若有以下改動，**必須**在同一個 PR 裡附帶 `swag init` 產出的 docs 變更（`backend/docs/` 下的三個檔案）：
+
+- 新增、修改、刪除 handler function 的 swagger annotation（`// @Router`、`// @Param`、`// @Success` 等）
+- 在 `router.go` 新增或移除路由
+
+執行指令：
+```bash
+cd backend && $(go env GOPATH)/bin/swag init -g cmd/server/main.go -o docs
+```
+
 ## Claude Code 設定
 
 `.claude/settings.json` 是共享設定，已 commit 進 repo，**請勿直接修改**。


### PR DESCRIPTION
## 背景

每次改 handler annotation 或 router 路由後須重跑 `swag init`，但目前沒有任何提醒機制，
導致 swagger docs 持續 drift（詳見 #391）。

## 變更內容

- `.github/PULL_REQUEST_TEMPLATE.md`：新增 checklist 項目，提醒改 annotation/router 時需附帶 `swag init`
- `CLAUDE.md`：新增「Swagger Docs 更新規則」段落，明確觸發條件與執行指令

## Scope 對齊

Source of truth: Issue #391（選項 B：PR Checklist 規範）

本 PR 明確不做：
- 不改 CI workflow
- 不改任何 handler 或路由邏輯

Depends on PR: none
Backend contract already in develop: N/A

closes #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **文档**
  * 更新了拉取请求模板，添加了API文档同步检查要求
  * 补充了文档规范，明确API路由变更时必须包含最新的API文档文件

<!-- end of auto-generated comment: release notes by coderabbit.ai -->