### PR TITLE
[backend] fix: require winner identity for raffle claim submission

### DIFF
--- a/backend/internal/handlers/raffle_handler.go
+++ b/backend/internal/handlers/raffle_handler.go
@@ -384,12 +384,15 @@ func (h *RaffleHandler) GetClaim(c *gin.Context) {
 // SubmitClaim godoc
 // @Summary      Submit shipping info for a claim
 // @Tags         claim
+// @Security     BearerAuth
 // @Accept       json
 // @Produce      json
 // @Param        token path   string true "Claim token"
 // @Param        body  body   services.ClaimInput true "Shipping info"
 // @Success      200   {object}  Response
 // @Failure      400   {object}  Response
+// @Failure      401   {object}  Response
+// @Failure      403   {object}  Response
 // @Failure      404   {object}  Response
 // @Failure      409   {object}  Response
 // @Failure      410   {object}  Response
@@ -397,13 +400,20 @@ func (h *RaffleHandler) GetClaim(c *gin.Context) {
 func (h *RaffleHandler) SubmitClaim(c *gin.Context) {
 	token := c.Param("token")
 
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, Response{Success: false, Error: "invalid user identity"})
+		return
+	}
+
 	var input services.ClaimInput
 	if err := c.ShouldBindJSON(&input); err != nil {
 		badRequest(c, err.Error())
 		return
 	}
 
-	claim, err := h.raffleSvc.SubmitClaim(token, input)
+	claim, err := h.raffleSvc.SubmitClaim(token, userID, input)
 	if err != nil {
 		if errors.Is(err, services.ErrClaimNotFound) {
 			notFound(c, "claim not found")
@@ -411,6 +421,10 @@ func (h *RaffleHandler) SubmitClaim(c *gin.Context) {
 		}
 		if errors.Is(err, services.ErrClaimTokenExpired) {
 			c.JSON(http.StatusGone, Response{Success: false, Error: "claim token has expired"})
+			return
+		}
+		if errors.Is(err, services.ErrClaimForbidden) {
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
 			return
 		}
 		if errors.Is(err, services.ErrClaimAlreadyDone) {

--- a/backend/internal/handlers/raffle_handler_test.go
+++ b/backend/internal/handlers/raffle_handler_test.go
@@ -68,10 +68,11 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 
 	v1 := r.Group("/api/v1")
 
-	// Public claim routes
-	claim := v1.Group("/claim")
-	claim.GET("/:token", raffleH.GetClaim)
-	claim.POST("/:token", raffleH.SubmitClaim)
+	// Claim routes: GET is public, POST requires JWT
+	v1.GET("/claim/:token", raffleH.GetClaim)
+	claimAuth := v1.Group("/claim")
+	claimAuth.Use(middleware.JWTAuth(authSvc))
+	claimAuth.POST("/:token", raffleH.SubmitClaim)
 
 	// Extension result
 	v1.GET("/extension/raffles/:id/result", raffleH.GetResult)
@@ -137,6 +138,19 @@ func (e *raffleTestEnv) createTwitchLinkedUser(t *testing.T, twitchLogin string)
 }
 
 func bearer(token string) string { return "Bearer " + token }
+
+// loginUser logs in a user created by createTwitchLinkedUser (email = login+"@test.com", password = "pass1234").
+func (e *raffleTestEnv) loginUser(t *testing.T, twitchLogin string) string {
+	t.Helper()
+	_, tokens, err := e.authSvc.Login(services.LoginInput{
+		Email:    twitchLogin + "@test.com",
+		Password: "pass1234",
+	})
+	if err != nil {
+		t.Fatalf("loginUser %s: %v", twitchLogin, err)
+	}
+	return tokens.AccessToken
+}
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
@@ -432,6 +446,7 @@ func TestRaffle_ClaimFlow(t *testing.T) {
 	raffleID := resp["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
 
 	env.createTwitchLinkedUser(t, "winner1")
+	winnerJWT := env.loginUser(t, "winner1")
 
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
@@ -454,7 +469,7 @@ func TestRaffle_ClaimFlow(t *testing.T) {
 	drawResp := parseBody(t, w3.Body.Bytes())
 	claimToken := drawResp["data"].(map[string]interface{})["draw"].(map[string]interface{})["claim_token"].(string)
 
-	// GET /claim/:token
+	// GET /claim/:token — no auth required
 	w4 := httptest.NewRecorder()
 	req4, _ := http.NewRequest(http.MethodGet, "/api/v1/claim/"+claimToken, nil)
 	env.router.ServeHTTP(w4, req4)
@@ -462,7 +477,7 @@ func TestRaffle_ClaimFlow(t *testing.T) {
 		t.Fatalf("get claim: want 200, got %d: %s", w4.Code, w4.Body.String())
 	}
 
-	// POST /claim/:token — submit shipping info
+	// POST /claim/:token — winner submits with JWT
 	claimBody, _ := json.Marshal(map[string]string{
 		"recipient_name": "王大明",
 		"phone":          "0912345678",
@@ -474,16 +489,18 @@ func TestRaffle_ClaimFlow(t *testing.T) {
 	req5, _ := http.NewRequest(http.MethodPost, "/api/v1/claim/"+claimToken,
 		bytes.NewReader(claimBody))
 	req5.Header.Set("Content-Type", "application/json")
+	req5.Header.Set("Authorization", bearer(winnerJWT))
 	env.router.ServeHTTP(w5, req5)
 	if w5.Code != http.StatusOK {
 		t.Fatalf("submit claim: want 200, got %d: %s", w5.Code, w5.Body.String())
 	}
 
-	// POST again → 409
+	// POST again with winner JWT → 409 duplicate
 	w6 := httptest.NewRecorder()
 	req6, _ := http.NewRequest(http.MethodPost, "/api/v1/claim/"+claimToken,
 		bytes.NewReader(claimBody))
 	req6.Header.Set("Content-Type", "application/json")
+	req6.Header.Set("Authorization", bearer(winnerJWT))
 	env.router.ServeHTTP(w6, req6)
 	if w6.Code != http.StatusConflict {
 		t.Fatalf("duplicate claim: want 409, got %d", w6.Code)
@@ -514,6 +531,115 @@ func TestRaffle_ClaimExpired(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	if w.Code != http.StatusGone {
 		t.Fatalf("expired claim: want 410, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestRaffle_ClaimSubmit_Unauthorized verifies that POST /claim/:token without
+// an Authorization header returns 401.
+func TestRaffle_ClaimSubmit_Unauthorized(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	hostToken := env.registerStreamer(t, "auth_host", "auth_host@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "auth test raffle"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w, req)
+	resp := parseBody(t, w.Body.Bytes())
+	raffleID := resp["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	env.createTwitchLinkedUser(t, "auth_winner")
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("file", "entries.csv")
+	fmt.Fprintln(fw, "auth_winner")
+	mw.Close()
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest(http.MethodPost,
+		"/api/v1/dashboard/raffles/"+raffleID+"/entries/import-csv", &buf)
+	req2.Header.Set("Content-Type", mw.FormDataContentType())
+	req2.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w2, req2)
+
+	w3 := httptest.NewRecorder()
+	req3, _ := http.NewRequest(http.MethodPost,
+		"/api/v1/dashboard/raffles/"+raffleID+"/draws", nil)
+	req3.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w3, req3)
+	drawResp := parseBody(t, w3.Body.Bytes())
+	claimToken := drawResp["data"].(map[string]interface{})["draw"].(map[string]interface{})["claim_token"].(string)
+
+	// POST without Authorization → 401
+	claimBody, _ := json.Marshal(map[string]string{
+		"recipient_name": "無名氏",
+		"address_line1":  "某地址",
+		"city":           "某市",
+	})
+	w4 := httptest.NewRecorder()
+	req4, _ := http.NewRequest(http.MethodPost, "/api/v1/claim/"+claimToken,
+		bytes.NewReader(claimBody))
+	req4.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w4, req4)
+	if w4.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated submit: want 401, got %d: %s", w4.Code, w4.Body.String())
+	}
+}
+
+// TestRaffle_ClaimSubmit_Forbidden verifies that a logged-in user who is NOT
+// the draw winner receives 403 when attempting to POST /claim/:token.
+func TestRaffle_ClaimSubmit_Forbidden(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	hostToken := env.registerStreamer(t, "fbd_host", "fbd_host@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "forbidden test raffle"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w, req)
+	resp := parseBody(t, w.Body.Bytes())
+	raffleID := resp["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	env.createTwitchLinkedUser(t, "fbd_winner")
+	env.createTwitchLinkedUser(t, "fbd_other")
+	otherJWT := env.loginUser(t, "fbd_other")
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("file", "entries.csv")
+	fmt.Fprintln(fw, "fbd_winner")
+	mw.Close()
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest(http.MethodPost,
+		"/api/v1/dashboard/raffles/"+raffleID+"/entries/import-csv", &buf)
+	req2.Header.Set("Content-Type", mw.FormDataContentType())
+	req2.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w2, req2)
+
+	w3 := httptest.NewRecorder()
+	req3, _ := http.NewRequest(http.MethodPost,
+		"/api/v1/dashboard/raffles/"+raffleID+"/draws", nil)
+	req3.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w3, req3)
+	drawResp := parseBody(t, w3.Body.Bytes())
+	claimToken := drawResp["data"].(map[string]interface{})["draw"].(map[string]interface{})["claim_token"].(string)
+
+	// POST with non-winner JWT → 403
+	claimBody, _ := json.Marshal(map[string]string{
+		"recipient_name": "非得獎者",
+		"address_line1":  "某地址",
+		"city":           "某市",
+	})
+	w4 := httptest.NewRecorder()
+	req4, _ := http.NewRequest(http.MethodPost, "/api/v1/claim/"+claimToken,
+		bytes.NewReader(claimBody))
+	req4.Header.Set("Content-Type", "application/json")
+	req4.Header.Set("Authorization", bearer(otherJWT))
+	env.router.ServeHTTP(w4, req4)
+	if w4.Code != http.StatusForbidden {
+		t.Fatalf("non-winner submit: want 403, got %d: %s", w4.Code, w4.Body.String())
 	}
 }
 

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -95,11 +95,13 @@ func New(
 		auth.POST("/reset-password", emailH.ResetPassword)
 	}
 
-	// ── Public claim endpoints (no auth) ─────────────────────────────────
-	claim := v1.Group("/claim")
+	// ── Claim endpoints ───────────────────────────────────────────────────
+	// GET is public; POST requires the winner's JWT.
+	v1.GET("/claim/:token", raffleH.GetClaim)
+	claimAuth := v1.Group("/claim")
+	claimAuth.Use(middleware.JWTAuth(authSvc))
 	{
-		claim.GET("/:token", raffleH.GetClaim)
-		claim.POST("/:token", raffleH.SubmitClaim)
+		claimAuth.POST("/:token", raffleH.SubmitClaim)
 	}
 
 	// ── Twitch Extension endpoints ────────────────────────────────────────

--- a/backend/internal/services/raffle_service.go
+++ b/backend/internal/services/raffle_service.go
@@ -29,6 +29,7 @@ var (
 	ErrClaimTokenExpired        = errors.New("claim token has expired")
 	ErrClaimNotFound            = errors.New("claim token not found")
 	ErrClaimAlreadyDone         = errors.New("claim already submitted")
+	ErrClaimForbidden           = errors.New("claim forbidden: not the winner")
 	ErrTwitchTokenMissing       = errors.New("no twitch access token: streamer must log in via twitch")
 	ErrTwitchInsufficientScope  = errors.New("twitch token lacks channel:read:subscriptions scope")
 	ErrUnsupportedRaffleSource  = errors.New("raffle source does not support twitch sync")
@@ -385,10 +386,15 @@ type ClaimInput struct {
 
 // SubmitClaim records the winner's shipping information.
 // Duplicate submissions are caught by the unique constraint on draw_id.
-func (s *RaffleService) SubmitClaim(token string, input ClaimInput) (*models.RaffleClaim, error) {
+// userID must match the linked user on the winning entry; otherwise ErrClaimForbidden is returned.
+func (s *RaffleService) SubmitClaim(token string, userID uuid.UUID, input ClaimInput) (*models.RaffleClaim, error) {
 	draw, err := s.GetDrawByToken(token)
 	if err != nil {
 		return nil, err
+	}
+
+	if draw.Entry.UserID == nil || *draw.Entry.UserID != userID {
+		return nil, ErrClaimForbidden
 	}
 
 	country := input.Country

--- a/backend/internal/services/raffle_service_claim_identity_test.go
+++ b/backend/internal/services/raffle_service_claim_identity_test.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestSubmitClaim_WinnerCanSubmit verifies that the draw winner can submit
+// shipping info when their userID matches the entry's linked user.
+func TestSubmitClaim_WinnerCanSubmit(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "claim_owner1@example.com")
+	winnerID := seedUserWithEmail(t, db, "claim_winner1@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, &winnerID, "claim_winner1_twitch")
+
+	svc := &RaffleService{db: db}
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+
+	input := ClaimInput{
+		RecipientName: "得獎者本人",
+		AddressLine1:  "台北市信義區信義路一段1號",
+		City:          "台北市",
+	}
+	claim, err := svc.SubmitClaim(draw.ClaimToken, winnerID, input)
+	if err != nil {
+		t.Fatalf("SubmitClaim: expected success, got %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected non-nil claim")
+	}
+}
+
+// TestSubmitClaim_NonWinnerForbidden verifies that a user who is not the draw
+// winner receives ErrClaimForbidden when attempting to submit shipping info.
+func TestSubmitClaim_NonWinnerForbidden(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "claim_owner2@example.com")
+	winnerID := seedUserWithEmail(t, db, "claim_winner2@example.com")
+	otherID := seedUserWithEmail(t, db, "claim_other2@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, &winnerID, "claim_winner2_twitch")
+
+	svc := &RaffleService{db: db}
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+
+	input := ClaimInput{
+		RecipientName: "非得獎者",
+		AddressLine1:  "台北市中正區重慶南路一段122號",
+		City:          "台北市",
+	}
+	_, err = svc.SubmitClaim(draw.ClaimToken, otherID, input)
+	if !errors.Is(err, ErrClaimForbidden) {
+		t.Errorf("expected ErrClaimForbidden, got %v", err)
+	}
+}
+
+// TestSubmitClaim_NilUserIDForbidden verifies that an entry without a linked
+// user account (userID == nil) always returns ErrClaimForbidden.
+func TestSubmitClaim_NilUserIDForbidden(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "claim_owner3@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	seedEntry(t, db, raffleID, nil, "anonymous_winner") // no linked account
+
+	svc := &RaffleService{db: db}
+	draw, err := svc.DrawNext(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("DrawNext: %v", err)
+	}
+
+	someUserID := uuid.New()
+	_, err = svc.SubmitClaim(draw.ClaimToken, someUserID, ClaimInput{
+		RecipientName: "任何人",
+		AddressLine1:  "某地址",
+		City:          "某市",
+	})
+	if !errors.Is(err, ErrClaimForbidden) {
+		t.Errorf("expected ErrClaimForbidden for nil entry userID, got %v", err)
+	}
+}

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -289,7 +289,7 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE TABLE IF NOT EXISTS raffle_claims (
 			id TEXT PRIMARY KEY,
-			draw_id TEXT NOT NULL UNIQUE REFERENCES raffle_draws(id),
+			draw_id TEXT NOT NULL UNIQUE REFERENCES raffle_draws(id) ON UPDATE CASCADE ON DELETE CASCADE,
 			recipient_name TEXT NOT NULL,
 			phone TEXT,
 			address_line1 TEXT NOT NULL,

--- a/backend/internal/services/testutil_test.go
+++ b/backend/internal/services/testutil_test.go
@@ -287,6 +287,18 @@ func migrateTestDB(db *gorm.DB) error {
 			drawn_at DATETIME NOT NULL,
 			UNIQUE (raffle_id, entry_id)
 		)`,
+		`CREATE TABLE IF NOT EXISTS raffle_claims (
+			id TEXT PRIMARY KEY,
+			draw_id TEXT NOT NULL UNIQUE REFERENCES raffle_draws(id),
+			recipient_name TEXT NOT NULL,
+			phone TEXT,
+			address_line1 TEXT NOT NULL,
+			address_line2 TEXT,
+			city TEXT NOT NULL,
+			postal_code TEXT,
+			country TEXT NOT NULL DEFAULT 'TW',
+			submitted_at DATETIME NOT NULL
+		)`,
 	}
 	for _, s := range stmts {
 		if err := db.Exec(s).Error; err != nil {


### PR DESCRIPTION
## 摘要

1. `POST /claim/:token` 加入 JWT 驗證（無 Authorization header → 401）。
2. `SubmitClaim` 新增身份比對：JWT user 必須是抽到的那位得獎者（`draw.Entry.UserID`），否則回 403。
3. `GET /claim/:token` 維持 public（不需登入）。
4. 新增 `ErrClaimForbidden` sentinel error。
5. 服務層 test DB migration 補上 `raffle_claims` 資料表。

refs #303
closes #335

## 發布背景
- 發布類型：不適用

## Scope 對齊

- Source of truth: #303 / #335
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- PR 完全在規格範圍內？
  - [x] 是
  - [ ] 否
- 本 PR 明確不做：
  - 不修改 GET /claim/:token（維持 public）
  - 不實作 frontend 未登入導向 Twitch OAuth 流程（另開 frontend PR）
  - 不修改 dashboard/、tachimint/ 任何檔案
  - 不修改 claim token 產生邏輯

## 測試計畫
- [x] 3 個新 service unit tests（TestSubmitClaim_WinnerCanSubmit / NonWinnerForbidden / NilUserIDForbidden）
- [x] 2 個新 handler tests（TestRaffle_ClaimSubmit_Unauthorized / Forbidden）
- [x] 更新 TestRaffle_ClaimFlow：winner POST 附帶 JWT
- [x] go test ./... 通過
- [x] go vet ./... 乾淨

Estimated diff 187 行（遠低於 400 行軟限制）。