### PR TITLE
[chore] Prepare monorepo path rules

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -104,6 +104,44 @@ test('scope gate and scope police use rename-aware allFilePaths for touches', as
   assert.match(scopePolice, /isDocsTemplateOrMetadataOnly[\s\S]*?allFilePaths\.every/, 'pr-scope-police.yml isDocsTemplateOrMetadataOnly must use allFilePaths')
 })
 
+test('scope gate and scope police recognize legacy and monorepo frontend/backend paths', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const scopePolice = await readFile(scopePolicePath, 'utf8')
+
+  assert.match(
+    workflow,
+    /frontend: allFilePaths\.some\(\(name\) =>[\s\S]*name\.startsWith\('dashboard\/'\)[\s\S]*name\.startsWith\('tachimint\/'\)[\s\S]*name\.startsWith\('apps\/dashboard\/'\)[\s\S]*name\.startsWith\('apps\/extension\/'\)/,
+    'ci.yml must treat legacy and future frontend paths as one frontend surface',
+  )
+  assert.match(
+    scopePolice,
+    /frontend: allFilePaths\.some\(\(name\) =>[\s\S]*name\.startsWith\('dashboard\/'\)[\s\S]*name\.startsWith\('tachimint\/'\)[\s\S]*name\.startsWith\('apps\/dashboard\/'\)[\s\S]*name\.startsWith\('apps\/extension\/'\)/,
+    'pr-scope-police.yml must treat legacy and future frontend paths as one frontend surface',
+  )
+
+  assert.match(
+    workflow,
+    /backend: allFilePaths\.some\(\(name\) =>[\s\S]*name\.startsWith\('backend\/'\)[\s\S]*name\.startsWith\('services\/api\/'\)/,
+    'ci.yml must recognize legacy and future backend paths',
+  )
+  assert.match(
+    scopePolice,
+    /backend: allFilePaths\.some\(\(name\) =>[\s\S]*name\.startsWith\('backend\/'\)[\s\S]*name\.startsWith\('services\/api\/'\)/,
+    'pr-scope-police.yml must recognize legacy and future backend paths',
+  )
+
+  assert.match(
+    workflow,
+    /name\.startsWith\('packages\/'\)/,
+    'ci.yml must recognize future packages paths',
+  )
+  assert.match(
+    scopePolice,
+    /name\.startsWith\('packages\/'\)/,
+    'pr-scope-police.yml must recognize future packages paths',
+  )
+})
+
 test('PR size thresholds match CLAUDE.md', async () => {
   const claude = await readFile(claudePath, 'utf8')
   const workflow = await readFile(workflowPath, 'utf8')

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -160,6 +160,11 @@ test('docs/template-only PRs skip heavy product CI in scope gate', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
 
   assert.match(workflow, /const isDocsTemplateOrMetadataOnly =/)
+  assert.match(
+    workflow,
+    /const isDocsTemplateOrMetadataOnly =\n\s+allFilePaths\.length > 0 && allFilePaths\.every\(isNonProductMetadataPath\)/,
+    'ci.yml metadata-only detection must stay rename-aware via allFilePaths.every(...)',
+  )
   assert.match(workflow, /standardBodyValid &&\n\s+!isDocsTemplateOrMetadataOnly &&/)
   assert.match(
     workflow,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
               name === '.gitignore' ||
               name === '.gitattributes'
             const isDocsTemplateOrMetadataOnly =
-              filenames.length > 0 && filenames.every(isNonProductMetadataPath)
+              allFilePaths.length > 0 && allFilePaths.every(isNonProductMetadataPath)
             const body = pr.body || ''
             const title = pr.title || ''
             const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]', '[infra]', '[chore]']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,14 @@ jobs:
             const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
             const isDocsOrTemplatePath = (name) =>
               name.startsWith('docs/') ||
+              name.startsWith('docs/ai/') ||
               name.startsWith('plans/') ||
               name.startsWith('.github/ISSUE_TEMPLATE/') ||
               name === '.github/PULL_REQUEST_TEMPLATE.md' ||
               /^[^/]+\.md$/i.test(name)
             const isNonProductMetadataPath = (name) =>
               isDocsOrTemplatePath(name) ||
+              name.startsWith('infra/') ||
               name === '.gitignore' ||
               name === '.gitattributes'
             const isDocsTemplateOrMetadataOnly =
@@ -90,12 +92,19 @@ jobs:
             const allowedPrefixes = ['[backend]', '[frontend]', '[contract]', '[discussion]', '[release]', '[infra]', '[chore]']
             const titlePrefix = allowedPrefixes.find((prefix) => title.startsWith(prefix))
             const touches = {
-              backend: allFilePaths.some((name) => name.startsWith('backend/')),
-              dashboard: allFilePaths.some((name) => name.startsWith('dashboard/')),
-              tachimint: allFilePaths.some((name) => name.startsWith('tachimint/')),
+              backend: allFilePaths.some((name) =>
+                name.startsWith('backend/') || name.startsWith('services/api/'),
+              ),
+              frontend: allFilePaths.some((name) =>
+                name.startsWith('dashboard/') ||
+                name.startsWith('tachimint/') ||
+                name.startsWith('apps/dashboard/') ||
+                name.startsWith('apps/extension/'),
+              ),
               contracts: allFilePaths.some((name) => name.startsWith('contracts/')),
+              packages: allFilePaths.some((name) => name.startsWith('packages/')),
             }
-            const productSurfaces = Object.values(touches).filter(Boolean).length
+            const productSurfaces = ['backend', 'frontend', 'contracts'].filter((surface) => touches[surface]).length
 
             const dependsOnMatch = body.match(/Depends on PR[：:]\s*(.+)/i)
             const dependsOnRaw = dependsOnMatch?.[1]?.trim()
@@ -135,13 +144,14 @@ jobs:
               (isReleasePromotionPr || filenames.length <= hardMaxChangedFiles) &&
               (isReleasePromotionPr || diffLines <= hardMaxDiffLines) &&
               (isReleasePromotionPr || productSurfaces <= 1) &&
-              (isReleasePromotionPr || !(titlePrefix === '[backend]' && (touches.dashboard || touches.tachimint))) &&
+              (isReleasePromotionPr || !(titlePrefix === '[backend]' && touches.frontend)) &&
               (isReleasePromotionPr || !(titlePrefix === '[frontend]' && touches.backend)) &&
-              (isReleasePromotionPr || !(titlePrefix === '[contract]' && (touches.backend || touches.dashboard || touches.tachimint))) &&
+              (isReleasePromotionPr || !(titlePrefix === '[contract]' && (touches.backend || touches.frontend))) &&
               !dependencyBlocked
 
             const backendIntegrationPaths = [
               /^backend\//,
+              /^services\/api\//,
               /^contracts\//,
               /^docker-compose(?:\..+)?\.ya?ml$/,
               /^\.github\/workflows\/ci\.yml$/,

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -65,29 +65,37 @@ jobs:
             const diffLines = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
             const isDocsOrTemplatePath = (name) =>
               name.startsWith('docs/') ||
+              name.startsWith('docs/ai/') ||
               name.startsWith('plans/') ||
               name.startsWith('.github/ISSUE_TEMPLATE/') ||
               name === '.github/PULL_REQUEST_TEMPLATE.md' ||
               /^[^/]+\.md$/i.test(name)
             const isNonProductMetadataPath = (name) =>
               isDocsOrTemplatePath(name) ||
+              name.startsWith('infra/') ||
               name === '.gitignore' ||
               name === '.gitattributes'
             const isDocsTemplateOrMetadataOnly =
               allFilePaths.length > 0 && allFilePaths.every(isNonProductMetadataPath)
 
             const touches = {
-              backend: allFilePaths.some((name) => name.startsWith('backend/')),
-              dashboard: allFilePaths.some((name) => name.startsWith('dashboard/')),
-              tachimint: allFilePaths.some((name) => name.startsWith('tachimint/')),
+              backend: allFilePaths.some((name) =>
+                name.startsWith('backend/') || name.startsWith('services/api/'),
+              ),
+              frontend: allFilePaths.some((name) =>
+                name.startsWith('dashboard/') ||
+                name.startsWith('tachimint/') ||
+                name.startsWith('apps/dashboard/') ||
+                name.startsWith('apps/extension/'),
+              ),
               contracts: allFilePaths.some((name) => name.startsWith('contracts/')),
               docs: allFilePaths.some((name) => name.startsWith('docs/') || name.startsWith('plans/')),
+              packages: allFilePaths.some((name) => name.startsWith('packages/')),
             }
 
             const productSurfaces = Object.entries({
               backend: touches.backend,
-              dashboard: touches.dashboard,
-              tachimint: touches.tachimint,
+              frontend: touches.frontend,
               contracts: touches.contracts,
             })
               .filter(([, touched]) => touched)
@@ -222,8 +230,8 @@ jobs:
                 severeFailures.push(message)
               }
 
-              if (!isReleasePromotionPr && titlePrefix === '[backend]' && (touches.dashboard || touches.tachimint)) {
-                const message = '[backend] PR must not change dashboard/ or tachimint/.'
+              if (!isReleasePromotionPr && titlePrefix === '[backend]' && touches.frontend) {
+                const message = '[backend] PR must not change frontend surfaces such as dashboard/, tachimint/, apps/dashboard/, or apps/extension/.'
                 failures.push(message)
                 severeFailures.push(message)
               }
@@ -235,8 +243,8 @@ jobs:
                 severeFailures.push(message)
               }
 
-              if (!isReleasePromotionPr && titlePrefix === '[contract]' && (touches.backend || touches.dashboard || touches.tachimint)) {
-                const message = '[contract] PR must not change backend/, dashboard/, or tachimint/.'
+              if (!isReleasePromotionPr && titlePrefix === '[contract]' && (touches.backend || touches.frontend)) {
+                const message = '[contract] PR must not change backend/ or frontend surfaces.'
                 failures.push(message)
                 severeFailures.push(message)
               }

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -34,13 +34,15 @@ repo 目前有一個 GitHub Actions workflow：
 - PR 變更檔案數超過 `35` 個時 fail
 - PR diff 超過 `1500` 行時 fail
 - PR 不可同時改多個 product surface：
-  - `backend/`
-  - `dashboard/`
-  - `tachimint/`
-- `[backend]` PR 不可修改 `dashboard/` 或 `tachimint/`
-- `[frontend]` PR 不可修改 `backend/`
-- `[contract]` PR 不可修改 `backend/` / `dashboard/` / `tachimint/`
+  - backend surface：`backend/` 或未來的 `services/api/`
+  - frontend surface：`dashboard/`、`tachimint/` 或未來的 `apps/dashboard/`、`apps/extension/`
+  - contract surface：`contracts/`
+- `[backend]` PR 不可修改 frontend surface
+- `[frontend]` PR 不可修改 backend surface
+- `[contract]` PR 不可修改 backend / frontend surface
 - `[frontend]` PR 若依賴尚未 merge 的 backend contract，會被 dependency gate 擋下
+
+未來 monorepo 的共享套件路徑（例如 `packages/shared-types/`、`packages/api-client/`）會被 workflow 辨識，但目前不單獨視為 product surface。是否能與某個 surface 同 PR 出現，仍應以 issue scope 與 reviewer 判斷為準，避免把 shared package 變成順手混改的出口。
 
 ### Dependabot maintenance PR
 
@@ -69,7 +71,9 @@ Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的
 目前視為 docs / template / metadata-only 的路徑：
 
 - `docs/`
+- `docs/ai/`
 - `plans/`
+- `infra/`
 - `.github/ISSUE_TEMPLATE/`
 - `.github/PULL_REQUEST_TEMPLATE.md`
 - repo root 的 Markdown 文件，例如 `AGENTS.md`、`CLAUDE.md`、`README.md`
@@ -129,9 +133,9 @@ Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的
 - 檔案數超過 `35`
 - diff 超過 `1500` 行
 - 同時改多個 product surface
-- `[backend]` PR 去改前端
+- `[backend]` PR 去改 frontend surface
 - `[frontend]` PR 去改 backend
-- `[contract]` PR 去改 backend / dashboard / tachimint
+- `[contract]` PR 去改 backend / frontend surface
 
 ## 例外機制
 


### PR DESCRIPTION
refs #395

## Scope 對齊

- Source of truth: #395 chore: prepare CI and path rules for monorepo directory moves
- Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

If no, this PR is:
- [ ] stacked on dependency branch
- [ ] intentionally blocked until dependency merges

## 本 PR 明確不做

- 不搬移任何 app / service 目錄
- 不改 Go module path
- 不建立未來 service 空殼
- 不處理 env key normalization
- 不處理 shared types / codegen

## Summary

- 更新 scope gate 與 scope police，辨識舊路徑與未來 monorepo 路徑
- 將 `dashboard/` 與 `tachimint/` 收斂為單一 frontend surface，避免後續搬移 PR 被誤擋
- 補 workflow regression test 與 scope policy 文件

## Verification

- `node --test .github/workflows/ci.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 新增测试用例验证更新后的范围门控逻辑。

* **文档**
  * 更新PR范围政策文档，明确跨域变更限制规则。
  * 扩展了文档和元数据豁免路径范围。

* **工作流优化**
  * 优化CI/CD范围分类逻辑，增强跨域变更检测能力。
  * 更新PR验证规则以适应新的范围划分。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->