### PR TITLE
[infra] Accept full-width colon in backend contract CI gate

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -142,6 +142,32 @@ test('scope gate and scope police recognize legacy and monorepo frontend/backend
   )
 })
 
+test('scope gate backend contract regex accepts full-width and half-width colons', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const scopePolice = await readFile(scopePolicePath, 'utf8')
+  const backendContractYesPattern =
+    String.raw`Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] yes`
+  const backendContractNoPattern =
+    String.raw`Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] no`
+
+  assert.ok(
+    workflow.includes(backendContractYesPattern),
+    'ci.yml Backend contract regex must accept full-width and half-width colons',
+  )
+  assert.ok(
+    workflow.includes(backendContractNoPattern),
+    'ci.yml Backend contract regex must accept full-width and half-width colons',
+  )
+  assert.ok(
+    scopePolice.includes(backendContractYesPattern),
+    'pr-scope-police.yml Backend contract regex must accept full-width and half-width colons',
+  )
+  assert.ok(
+    scopePolice.includes(backendContractNoPattern),
+    'pr-scope-police.yml Backend contract regex must accept full-width and half-width colons',
+  )
+})
+
 test('PR size thresholds match CLAUDE.md', async () => {
   const claude = await readFile(claudePath, 'utf8')
   const workflow = await readFile(workflowPath, 'utf8')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,8 @@ jobs:
             const dependsOnRaw = dependsOnMatch?.[1]?.trim()
             const dependsOnNone = dependsOnRaw?.toLowerCase() === 'none'
             const dependsOnPrMatch = dependsOnRaw?.match(/^#(\d+)$/)
-            const backendContractYes = /Backend contract already in develop:[\s\S]*?- \[[xX]\] yes/i.test(body)
-            const backendContractNo = /Backend contract already in develop:[\s\S]*?- \[[xX]\] no/i.test(body)
+            const backendContractYes = /Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] yes/i.test(body)
+            const backendContractNo = /Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] no/i.test(body)
             const dependencyBlocked =
               titlePrefix === '[frontend]' &&
               Boolean(dependsOnPrMatch) &&


### PR DESCRIPTION
## 什麼改動
- 更新 `ci.yml` 的 Backend contract regex，讓 scope gate 同時接受全形與半形冒號。
- 新增 workflow regression test，確認 `ci.yml` 與 `pr-scope-police.yml` 的 Backend contract regex 行為一致。

## 為什麼
closes #361

`ci.yml` 原本只接受 `Backend contract already in develop:`，使用全形冒號 `：` 的 PR body 會讓 Backend CI gate 判斷失敗，造成 Backend CI 靜默 skip。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#361
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 backend / frontend runtime 行為
  - 不調整 PR template 或 pr-scope-police policy

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 修正 Backend contract CI gate，使其接受全形與半形冒號。
- Approx changed lines：~30
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `backend/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 使用全形冒號的 PR 不再靜默跳過 Backend CI
- [x] `pr-scope-police.yml` 與 `ci.yml` 的 `Backend contract` regex 行為一致

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
node --test .github/workflows/ci.test.mjs
tests 9, pass 9, fail 0
```

## 備註
無

## Notes for Claude Code Review
- 請特別確認 `ci.yml` 的 regex 是否與 `pr-scope-police.yml` 保持一致：`Backend contract already in develop\s*[：:]`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 后端合约状态检查现已支持全角冒号（：）和半角冒号（:）

* **测试**
  * 添加了验证后端合约状态识别的新测试用例

<!-- end of auto-generated comment: release notes by coderabbit.ai -->