### PR TITLE
[backend] fix: use ClaimTokenRaw in SubmitClaim test calls

### DIFF
--- a/backend/internal/services/raffle_service_claim_identity_test.go
+++ b/backend/internal/services/raffle_service_claim_identity_test.go
@@ -27,7 +27,7 @@ func TestSubmitClaim_WinnerCanSubmit(t *testing.T) {
 		AddressLine1:  "台北市信義區信義路一段1號",
 		City:          "台北市",
 	}
-	claim, err := svc.SubmitClaim(draw.ClaimToken, winnerID, input)
+	claim, err := svc.SubmitClaim(draw.ClaimTokenRaw, winnerID, input)
 	if err != nil {
 		t.Fatalf("SubmitClaim: expected success, got %v", err)
 	}
@@ -57,7 +57,7 @@ func TestSubmitClaim_NonWinnerForbidden(t *testing.T) {
 		AddressLine1:  "台北市中正區重慶南路一段122號",
 		City:          "台北市",
 	}
-	_, err = svc.SubmitClaim(draw.ClaimToken, otherID, input)
+	_, err = svc.SubmitClaim(draw.ClaimTokenRaw, otherID, input)
 	if !errors.Is(err, ErrClaimForbidden) {
 		t.Errorf("expected ErrClaimForbidden, got %v", err)
 	}
@@ -78,7 +78,7 @@ func TestSubmitClaim_NilUserIDForbidden(t *testing.T) {
 	}
 
 	someUserID := uuid.New()
-	_, err = svc.SubmitClaim(draw.ClaimToken, someUserID, ClaimInput{
+	_, err = svc.SubmitClaim(draw.ClaimTokenRaw, someUserID, ClaimInput{
 		RecipientName: "任何人",
 		AddressLine1:  "某地址",
 		City:          "某市",


### PR DESCRIPTION
## 什麼改動
`raffle_service_claim_identity_test.go` 三個測試函數中，`svc.SubmitClaim` 的第一個參數從 `draw.ClaimToken` 改為 `draw.ClaimTokenRaw`。

## 為什麼
`RaffleDraw.ClaimToken` 是 SHA-256 hash 後的值（存在 DB）；`SubmitClaim` 內部呼叫 `GetDrawByToken` 會再次 hash 傳入的 token，因此期待的是 raw token。傳 hash 值進去等同於 hash-of-hash，永遠找不到紀錄，導致三個測試失敗並輸出 `claim token not found`。

此 bug 由 PR #394 帶入，merge 後讓所有觸發 backend CI 的 PR 都失敗。

closes #415

refs #388

## Release Context
- Release type：n/a

## Workflow Type
- n/a

## Scope 對齊
- Source of truth：#388
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不修改 SubmitClaim 或 GetDrawByToken 的實作邏輯
  - 不改其他測試

## PR 拆分檢查
- 這個 PR 的單一句子目的：修正測試中傳入 hashed token 而非 raw token 的 bug
- Approx changed lines：~3
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [x] tests
- 若已拆分，相關 PR：#414（ci.yml Dependabot 豁免，獨立）

## Acceptance Criteria
- [x] `TestSubmitClaim_WinnerCanSubmit` 通過
- [x] `TestSubmitClaim_NonWinnerForbidden` 通過
- [x] `TestSubmitClaim_NilUserIDForbidden` 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過

**驗證結果**
```
grep -n "ClaimToken" raffle_service_claim_identity_test.go
30: claim, err := svc.SubmitClaim(draw.ClaimTokenRaw, winnerID, input)
60: _, err = svc.SubmitClaim(draw.ClaimTokenRaw, otherID, input)
81: _, err = svc.SubmitClaim(draw.ClaimTokenRaw, someUserID, ClaimInput{
```

## 備註
無

## Notes for Claude Code Review
- 改動只在第 30、60、81 行，`draw.ClaimToken` → `draw.ClaimTokenRaw`
- 無已知風險

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 更新测试场景以使用原始声明令牌，覆盖获胜者允许、非获胜者禁止及链接用户为空等情况。现有的成功和错误处理验证保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->