### PR TITLE
[chore] CLAUDE.md — 整理 PR 規則並補充工作流程指引

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 @.claude/rules/conventions.md
 
+## 動手前
+
+- 需求有歧義時，列出多種詮釋再問，不要默默選一個
+- 不確定的地方直接說出來，不要猜測後實作
+- 若有更簡單的解法，主動說出來並等確認
+
 ## GitHub Issue 慣例
 
 ### 標題前綴
@@ -121,6 +127,23 @@
 | 摘要大量檔案、生成樣板、審查 log、搜尋 pattern、草擬測試 | Gemini |
 | 架構規劃、issue 撰寫、技術決策、最終 PR 審查 | Claude Code |
 | 實作、debug、patch、跑測試、推 branch、開 PR | Codex |
+
+### Claude Code 接到任務時
+
+把模糊目標轉成可驗證目標再開始：
+
+| 模糊 | 可驗證 |
+|---|---|
+| 「加驗證」 | 先寫 invalid input 測試，再讓測試通過 |
+| 「修這個 bug」 | 先重現 bug 的測試，再讓測試通過 |
+| 「實作 X」 | 先列出 checklist，每步附驗證條件 |
+
+多步驟任務先說計畫再動手：
+
+```text
+1. [步驟] → 驗證：[如何確認]
+2. [步驟] → 驗證：[如何確認]
+```
 
 @.claude/rules/pr-review-workflow.md
 


### PR DESCRIPTION
## 什麼改動

1. 補充 `CLAUDE.md` 兩個段落：
   - **動手前**：需求有歧義時的處理方式
   - **Claude Code 接到任務時**：模糊目標轉可驗證目標的範例 table

2. 整理 PR 規則，集中至 `conventions.md`：
   - 新增 PR 標題前綴清單（Scope Police CI 強制執行的 7 種前綴）
   - 合併 Merge 策略細節（`closes/refs` 格式、PR title 精確）
   - 移除 `CLAUDE.md` 中重複的 Merge 策略與 PR Diff 限制段落（`conventions.md` 已 `@`-included）

## 為什麼

closes #432

PR 標題前綴規則原本只散落在 CI 腳本，且 `CLAUDE.md` 與 `conventions.md` 有重複段落，每次載入浪費 token。

## Release Context

- Release type：n/a

## Workflow Type

n/a

## Scope 對齊

- Source of truth：#432
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不改 runtime 或 API 相關設定
  - 不動其他 rules/ 檔案內容（僅 conventions.md）

## PR 拆分檢查

- 這個 PR 的單一句子目的：補充 Claude Code 工作流程指引並消除 CLAUDE.md 與 conventions.md 的重複
- Approx changed lines：~37
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [x] docs
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？n/a

## Acceptance Criteria

- [x] 新增「動手前」段落
- [x] 新增「Claude Code 接到任務時」段落
- [x] conventions.md 有完整 PR 標題前綴清單
- [x] CLAUDE.md 無重複的 Merge 策略與 PR Diff 限制

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過

**驗證結果**

n/a（純文件變更）

## 備註

無