### PR TITLE
[frontend] fix: dashboard TypeScript 6 tsconfig compatibility

### DIFF
--- a/apps/dashboard/tsconfig.app.json
+++ b/apps/dashboard/tsconfig.app.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## Summary

closes #388

Removes the deprecated `baseUrl` option from `apps/dashboard/tsconfig.app.json` so the dashboard TypeScript project can be built with TypeScript 6 without TS5101.

## Scope 對齊

- Source of truth：#388
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no

- 本 PR 明確不做：
  - 不升級 dashboard dependencies
  - 不修改 dashboard UI 或產品邏輯
  - 不修改其他 tooling 設定
  - 不修改 Dependabot PR #378

## PR 拆分檢查

- 這個 PR 的單一句子目的：移除 dashboard tsconfig 中 TypeScript 6 會報 TS5101 的 deprecated `baseUrl` 設定
- Approx changed lines：1
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若已拆分，相關 PR：n/a

## Acceptance Criteria

- [x] 調整 `apps/dashboard` 的 TypeScript 設定，消除 TS5101
- [x] `apps/dashboard` build 驗證通過
- [x] `apps/dashboard` lint 驗證通過
- [x] 變更只為 TypeScript 6 相容性，不混入其他 tooling 變更

## 超出範圍內容

無

## 測試方式

- [x] `pnpm --package=typescript@6.0.3 dlx tsc -b apps/dashboard/tsconfig.json --force`
- [x] `pnpm --filter ./apps/dashboard build`
- [x] `pnpm --filter ./apps/dashboard lint`

## Notes

The original TypeScript 6 failure was reproduced before the fix:

```text
apps/dashboard/tsconfig.app.json(20,5): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
```

Removing `baseUrl` keeps the existing `paths` alias and avoids relying on `ignoreDeprecations`, which is not accepted by the current locked TypeScript 5.9 build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂项**
  * 更新仪表板应用的编译器配置，调整模块解析设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->