### PR TITLE
[frontend] fix: MarioHUD — clear all animation timeouts on unmount

### DIFF
--- a/apps/extension/src/app/components/MarioHUD.tsx
+++ b/apps/extension/src/app/components/MarioHUD.tsx
@@ -339,6 +339,13 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
   const [bgMusicOn, setBgMusicOn]         = useState(false);
 
   const floatId = useRef(0);
+  const timeoutRefs = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  useEffect(() => {
+    return () => {
+      timeoutRefs.current.forEach(clearTimeout);
+    };
+  }, []);
 
   // ── Helpers ──────────────────────────────────────────────
   const formatPts = (n: number) =>
@@ -346,14 +353,16 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
 
   const triggerBalancePop = useCallback(() => {
     setBalanceBump(true);
-    setTimeout(() => setBalanceBump(false), 420);
+    const timeoutId = setTimeout(() => setBalanceBump(false), 420);
+    timeoutRefs.current.push(timeoutId);
   }, []);
 
   const spawnFloat = useCallback((amount: number) => {
     const id = ++floatId.current;
     const offsetX = (Math.random() - 0.5) * 40;
     setFloats(f => [...f, { id, amount, offsetX }]);
-    setTimeout(() => setFloats(f => f.filter(x => x.id !== id)), 1600);
+    const timeoutId = setTimeout(() => setFloats(f => f.filter(x => x.id !== id)), 1600);
+    timeoutRefs.current.push(timeoutId);
   }, []);
 
   const awardPoints = useCallback(
@@ -365,17 +374,20 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
 
       // Success animation
       setShowSuccess(true);
-      setTimeout(() => setShowSuccess(false), 600);
+      const successTimeoutId = setTimeout(() => setShowSuccess(false), 600);
+      timeoutRefs.current.push(successTimeoutId);
 
       // Trigger mining animation based on amount
       if (amount >= 100) {
         // Big mining for +100 points
         setCapyState('big-mining');
-        setTimeout(() => setCapyState('idle'), 500);
+        const capyTimeoutId = setTimeout(() => setCapyState('idle'), 500);
+        timeoutRefs.current.push(capyTimeoutId);
       } else {
         // Regular mining for +1 point
         setCapyState('mining');
-        setTimeout(() => setCapyState('idle'), 250);
+        const capyTimeoutId = setTimeout(() => setCapyState('idle'), 250);
+        timeoutRefs.current.push(capyTimeoutId);
       }
     },
     [triggerBalancePop, spawnFloat]

--- a/apps/extension/src/app/components/MarioHUD.tsx
+++ b/apps/extension/src/app/components/MarioHUD.tsx
@@ -353,16 +353,22 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
 
   const triggerBalancePop = useCallback(() => {
     setBalanceBump(true);
-    const timeoutId = setTimeout(() => setBalanceBump(false), 420);
-    timeoutRefs.current.push(timeoutId);
+    const id = setTimeout(() => {
+      setBalanceBump(false);
+      timeoutRefs.current = timeoutRefs.current.filter(t => t !== id);
+    }, 420);
+    timeoutRefs.current.push(id);
   }, []);
 
   const spawnFloat = useCallback((amount: number) => {
-    const id = ++floatId.current;
+    const floatItemId = ++floatId.current;
     const offsetX = (Math.random() - 0.5) * 40;
-    setFloats(f => [...f, { id, amount, offsetX }]);
-    const timeoutId = setTimeout(() => setFloats(f => f.filter(x => x.id !== id)), 1600);
-    timeoutRefs.current.push(timeoutId);
+    setFloats(f => [...f, { id: floatItemId, amount, offsetX }]);
+    const id = setTimeout(() => {
+      setFloats(f => f.filter(x => x.id !== floatItemId));
+      timeoutRefs.current = timeoutRefs.current.filter(t => t !== id);
+    }, 1600);
+    timeoutRefs.current.push(id);
   }, []);
 
   const awardPoints = useCallback(
@@ -374,20 +380,27 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
 
       // Success animation
       setShowSuccess(true);
-      const successTimeoutId = setTimeout(() => setShowSuccess(false), 600);
-      timeoutRefs.current.push(successTimeoutId);
+      const successId = setTimeout(() => {
+        setShowSuccess(false);
+        timeoutRefs.current = timeoutRefs.current.filter(t => t !== successId);
+      }, 600);
+      timeoutRefs.current.push(successId);
 
       // Trigger mining animation based on amount
       if (amount >= 100) {
-        // Big mining for +100 points
         setCapyState('big-mining');
-        const capyTimeoutId = setTimeout(() => setCapyState('idle'), 500);
-        timeoutRefs.current.push(capyTimeoutId);
+        const capyId = setTimeout(() => {
+          setCapyState('idle');
+          timeoutRefs.current = timeoutRefs.current.filter(t => t !== capyId);
+        }, 500);
+        timeoutRefs.current.push(capyId);
       } else {
-        // Regular mining for +1 point
         setCapyState('mining');
-        const capyTimeoutId = setTimeout(() => setCapyState('idle'), 250);
-        timeoutRefs.current.push(capyTimeoutId);
+        const capyId = setTimeout(() => {
+          setCapyState('idle');
+          timeoutRefs.current = timeoutRefs.current.filter(t => t !== capyId);
+        }, 250);
+        timeoutRefs.current.push(capyId);
       }
     },
     [triggerBalancePop, spawnFloat]


### PR DESCRIPTION
## Summary
- 新增 `timeoutRefs = useRef<ReturnType<typeof setTimeout>[]>([])` 追蹤所有 timeout ID
- `triggerBalancePop`、`spawnFloat`、`awardPoints` 內共 5 個 `setTimeout` 呼叫全部 push ID 進 ref
- 新增 `useEffect` cleanup，unmount 時對所有 ID 執行 `clearTimeout`
- 每個 callback 在 timeout 觸發後自行 filter 移除 ID，防止 array 無限增長

## Scope 對齊
- Source of truth: [#431](https://github.com/nurockplayer/tachigo/issues/431)

Backend contract already in develop:
- [x] yes

## 本 PR 明確不做
- 不修改 animation 邏輯或時間參數
- 不補 unit test（現有元件無測試框架，另開 issue 追蹤）

## Test plan
- [ ] TypeScript `npx tsc --noEmit` 無錯誤（已在本機驗證）
- [ ] 元件正常渲染，動畫效果未受影響
- [ ] 快速 mount/unmount 不產生 "Can't perform a React state update on an unmounted component" 警告

Depends on PR: none

closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)