### PR TITLE
[frontend] fix: CouponShopPanel — catch unhandled promise rejection in handleRedeem

### DIFF
--- a/apps/extension/src/app/components/CouponShopPanel.tsx
+++ b/apps/extension/src/app/components/CouponShopPanel.tsx
@@ -107,8 +107,6 @@ export function CouponShopPanel({
         onRedeem,
         setError,
       })
-    } catch (err) {
-      setError(err instanceof Error && err.message ? err.message : t('common.error'))
     } finally {
       setIsRedeeming(false)
     }

--- a/apps/extension/src/app/components/CouponShopPanel.tsx
+++ b/apps/extension/src/app/components/CouponShopPanel.tsx
@@ -5,6 +5,7 @@ import { demoCouponMetas, type DemoCouponMeta } from '../../extension/couponCata
 import type { CouponRedeemResult } from '../../extension/types'
 import { hudPanelBackground } from '../theme/backgrounds'
 import { renderCouponRedeemStatus } from './couponRedeemStatus'
+import { redeemCouponForPanel } from './redeemCouponForPanel'
 
 const couponMetas: DemoCouponMeta[] = demoCouponMetas
 
@@ -14,52 +15,6 @@ interface CouponShopPanelProps {
   redeemedCouponIds: string[]
   voucherCodes: Record<string, string>
   onRedeem: (couponId: string, cost: number) => Promise<CouponRedeemResult | 'error'>
-}
-
-interface RedeemPanelMessages {
-  alreadyRedeemed: string
-  insufficientBalance: string
-  genericError: string
-}
-
-export async function redeemCouponForPanel({
-  couponId,
-  cost,
-  isAlreadyRedeemed,
-  messages,
-  onRedeem,
-  setError,
-}: {
-  couponId: string
-  cost: number
-  isAlreadyRedeemed: boolean
-  messages: RedeemPanelMessages
-  onRedeem: (couponId: string, cost: number) => Promise<CouponRedeemResult | 'error'>
-  setError: (message: string) => void
-}): Promise<void> {
-  if (isAlreadyRedeemed) {
-    setError(messages.alreadyRedeemed)
-    return
-  }
-
-  try {
-    const result = await onRedeem(couponId, cost)
-    if (result === 'already_redeemed') {
-      setError(messages.alreadyRedeemed)
-      return
-    }
-    if (result === 'insufficient') {
-      setError(messages.insufficientBalance)
-      return
-    }
-    if (result === 'error') {
-      setError(messages.genericError)
-      return
-    }
-    setError('')
-  } catch (err) {
-    setError(err instanceof Error && err.message ? err.message : messages.genericError)
-  }
 }
 
 export function CouponShopPanel({
@@ -98,7 +53,6 @@ export function CouponShopPanel({
       await redeemCouponForPanel({
         couponId: selectedCoupon.id,
         cost: selectedCoupon.price,
-        isAlreadyRedeemed: false,
         messages: {
           alreadyRedeemed: t('coupon.alreadyRedeemed'),
           insufficientBalance: t('coupon.insufficientBalance'),

--- a/apps/extension/src/app/components/CouponShopPanel.tsx
+++ b/apps/extension/src/app/components/CouponShopPanel.tsx
@@ -16,6 +16,52 @@ interface CouponShopPanelProps {
   onRedeem: (couponId: string, cost: number) => Promise<CouponRedeemResult | 'error'>
 }
 
+interface RedeemPanelMessages {
+  alreadyRedeemed: string
+  insufficientBalance: string
+  genericError: string
+}
+
+export async function redeemCouponForPanel({
+  couponId,
+  cost,
+  isAlreadyRedeemed,
+  messages,
+  onRedeem,
+  setError,
+}: {
+  couponId: string
+  cost: number
+  isAlreadyRedeemed: boolean
+  messages: RedeemPanelMessages
+  onRedeem: (couponId: string, cost: number) => Promise<CouponRedeemResult | 'error'>
+  setError: (message: string) => void
+}): Promise<void> {
+  if (isAlreadyRedeemed) {
+    setError(messages.alreadyRedeemed)
+    return
+  }
+
+  try {
+    const result = await onRedeem(couponId, cost)
+    if (result === 'already_redeemed') {
+      setError(messages.alreadyRedeemed)
+      return
+    }
+    if (result === 'insufficient') {
+      setError(messages.insufficientBalance)
+      return
+    }
+    if (result === 'error') {
+      setError(messages.genericError)
+      return
+    }
+    setError('')
+  } catch (err) {
+    setError(err instanceof Error && err.message ? err.message : messages.genericError)
+  }
+}
+
 export function CouponShopPanel({
   onBack,
   tcgBalance,
@@ -49,20 +95,20 @@ export function CouponShopPanel({
 
     setIsRedeeming(true)
     try {
-      const result = await onRedeem(selectedCoupon.id, selectedCoupon.price)
-      if (result === 'already_redeemed') {
-        setError(t('coupon.alreadyRedeemed'))
-        return
-      }
-      if (result === 'insufficient') {
-        setError(t('coupon.insufficientBalance'))
-        return
-      }
-      if (result === 'error') {
-        setError(t('common.error'))
-        return
-      }
-      setError('')
+      await redeemCouponForPanel({
+        couponId: selectedCoupon.id,
+        cost: selectedCoupon.price,
+        isAlreadyRedeemed: false,
+        messages: {
+          alreadyRedeemed: t('coupon.alreadyRedeemed'),
+          insufficientBalance: t('coupon.insufficientBalance'),
+          genericError: t('common.error'),
+        },
+        onRedeem,
+        setError,
+      })
+    } catch (err) {
+      setError(err instanceof Error && err.message ? err.message : t('common.error'))
     } finally {
       setIsRedeeming(false)
     }

--- a/apps/extension/src/app/components/redeemCouponForPanel.ts
+++ b/apps/extension/src/app/components/redeemCouponForPanel.ts
@@ -1,0 +1,40 @@
+import type { CouponRedeemResult } from '../../extension/types'
+
+interface RedeemPanelMessages {
+  alreadyRedeemed: string
+  insufficientBalance: string
+  genericError: string
+}
+
+export async function redeemCouponForPanel({
+  couponId,
+  cost,
+  messages,
+  onRedeem,
+  setError,
+}: {
+  couponId: string
+  cost: number
+  messages: RedeemPanelMessages
+  onRedeem: (couponId: string, cost: number) => Promise<CouponRedeemResult | 'error'>
+  setError: (message: string) => void
+}): Promise<void> {
+  try {
+    const result = await onRedeem(couponId, cost)
+    if (result === 'already_redeemed') {
+      setError(messages.alreadyRedeemed)
+      return
+    }
+    if (result === 'insufficient') {
+      setError(messages.insufficientBalance)
+      return
+    }
+    if (result === 'error') {
+      setError(messages.genericError)
+      return
+    }
+    setError('')
+  } catch (err) {
+    setError(err instanceof Error && err.message ? err.message : messages.genericError)
+  }
+}


### PR DESCRIPTION
## Summary

closes #430

在 `CouponShopPanel` 的兌換流程中集中處理 `onRedeem` rejection，確保兌換 Promise reject 時會更新錯誤狀態並顯示錯誤訊息，不再產生 unhandled promise rejection。

本 PR 也將 `redeemCouponForPanel` 移到獨立 `.ts` helper，避免 component 檔 export 非 component 而觸發 `react-refresh/only-export-components`。

## Scope 對齊

- Source of truth：#430
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no

- 本 PR 明確不做：
  - 不調整 UI 樣式或錯誤訊息文案
  - 不修改 API 呼叫邏輯
  - 不新增新的兌換功能或後端行為

## PR 拆分檢查

- 這個 PR 的單一句子目的：修正 `CouponShopPanel` 的兌換 rejection handling，防止 unhandled promise rejection。
- Approx changed lines：66
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若已拆分，相關 PR：n/a

## Acceptance Criteria

- [x] `onRedeem` reject 時顯示錯誤訊息
- [x] 沒有 unhandled promise rejection
- [x] Frontend lint 通過
- [x] Frontend build 通過
- [x] Extension test 通過
- [x] GitHub CI 主要 checks 通過

## 測試方式

- [x] `pnpm --filter ./apps/extension lint`
- [x] `pnpm --filter ./apps/extension build`
- [x] `pnpm --filter ./apps/extension test`
- [ ] Manual：觸發 redeem 失敗，確認錯誤訊息顯示於 UI

## CI 狀態

- GitHub `Frontend build` 已通過
- GitHub 主要 CI checks 已通過
- `Notify Discord on failure` 為 `SKIPPED`，不是程式碼失敗
