### PR TITLE
[frontend] fix: guard setGain/setIsAnimating after unmount in useClickBoost

### DIFF
--- a/apps/extension/src/hooks/useClickBoost.ts
+++ b/apps/extension/src/hooks/useClickBoost.ts
@@ -17,6 +17,7 @@ export function useClickBoost(
   const onCooldownRef = useRef(false)
   const cooldownTimerRef = useRef<number | null>(null)
   const animTimerRef = useRef<number | null>(null)
+  const mountedRef = useRef(true)
 
   const stopCooldown = useCallback(() => {
     if (cooldownTimerRef.current !== null) {
@@ -53,6 +54,7 @@ export function useClickBoost(
 
     try {
       const result = await sendClick(channelId)
+      if (!mountedRef.current) return
       onBalanceUpdate(result.balance)
       setGain(result.delta)
       setIsAnimating(true)
@@ -62,6 +64,7 @@ export function useClickBoost(
         setGain(null)
       }, ANIM_DURATION_MS)
     } catch (err: unknown) {
+      if (!mountedRef.current) return
       // If the server returns a precise retry-after, honour it.
       const retryAfterMs = (
         err as { response?: { data?: { retry_after_ms?: number } } }
@@ -79,6 +82,7 @@ export function useClickBoost(
   // Cleanup on unmount.
   useEffect(() => {
     return () => {
+      mountedRef.current = false
       if (cooldownTimerRef.current !== null) clearInterval(cooldownTimerRef.current)
       if (animTimerRef.current !== null) clearTimeout(animTimerRef.current)
     }


### PR DESCRIPTION
## Scope 對齊

Source of truth: https://github.com/nurockplayer/tachigo/issues/429

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 這張 PR 做了什麼

加 `mountedRef` flag，在 `sendClick` resolve 後、catch 分支開頭各加 `if (!mountedRef.current) return`，cleanup `useEffect` 設 `mountedRef.current = false`，防止元件卸載後仍呼叫 `setGain` / `setIsAnimating`。

## 本 PR 明確不做

- 不取消 in-flight HTTP request（AbortController）
- 不修改 `sendClick` API 層

## Test plan
- [ ] 元件 unmount 後 sendClick resolve 不再觸發 state update（無 React warning）
- [ ] CI 通過

closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)