### PR TITLE
[frontend] fix: useTwitch — mounted guard + inFlight guard for retry login

### DIFF
--- a/apps/extension/src/hooks/useTwitch.ts
+++ b/apps/extension/src/hooks/useTwitch.ts
@@ -29,6 +29,8 @@ export function useTwitch() {
     if (!ext) return
 
     ext.onContext((ctx: TwitchExtContext) => {
+      if (!mounted) return
+
       const rawLocale = ctx.locale ?? ctx.language ?? 'en'
       const appLang = mapTwitchLocaleToAppLanguage(rawLocale)
       if (i18n.language !== appLang && i18n.resolvedLanguage !== appLang) {
@@ -49,30 +51,32 @@ export function useTwitch() {
     })
 
     ext.onAuthorized(async (auth: TwitchExtAuth) => {
-      if (mounted) setJwt(auth.token)
+      if (!mounted) return
+
+      setJwt(auth.token)
       setExtensionJwtForRecovery(auth.token)
-      if (mounted) setBackendReady(false)
+      setBackendReady(false)
 
       // Login to tachigo backend with the extension JWT
       try {
         const result = await loginWithTwitchExtension(auth.token)
+        if (!mounted) return
+
         // result.data.tokens.access_token
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const tokens = (result as any)?.data?.tokens ?? (result as any)?.tokens
         if (tokens?.access_token) {
           setAuthToken(tokens.access_token)
-          if (mounted) {
-            setBackendReady(true)
-            setAuthError(null)
-          }
+          setBackendReady(true)
+          setAuthError(null)
         }
       } catch {
+        if (!mounted) return
+
         // Non-fatal: t-point flow still works via extension JWT directly
         clearAuthToken()
-        if (mounted) {
-          setBackendReady(false)
-          setAuthError('Backend unavailable')
-        }
+        setBackendReady(false)
+        setAuthError('Backend unavailable')
       }
 
       // Fetch T-point products

--- a/apps/extension/src/hooks/useTwitch.ts
+++ b/apps/extension/src/hooks/useTwitch.ts
@@ -24,6 +24,7 @@ export function useTwitch() {
   const [backendReady, setBackendReady] = useState(false)
 
   useEffect(() => {
+    let mounted = true
     const ext = window.Twitch?.ext
     if (!ext) return
 
@@ -36,19 +37,21 @@ export function useTwitch() {
         })
       }
 
-      setContext({
-        channelId: ctx.channelId,
-        clientId: ctx.clientId,
-        userId: ctx.userId,
-        opaqueUserId: ctx.opaqueUserId,
-        role: ctx.role,
-      })
+      if (mounted) {
+        setContext({
+          channelId: ctx.channelId,
+          clientId: ctx.clientId,
+          userId: ctx.userId,
+          opaqueUserId: ctx.opaqueUserId,
+          role: ctx.role,
+        })
+      }
     })
 
     ext.onAuthorized(async (auth: TwitchExtAuth) => {
-      setJwt(auth.token)
+      if (mounted) setJwt(auth.token)
       setExtensionJwtForRecovery(auth.token)
-      setBackendReady(false)
+      if (mounted) setBackendReady(false)
 
       // Login to tachigo backend with the extension JWT
       try {
@@ -58,28 +61,37 @@ export function useTwitch() {
         const tokens = (result as any)?.data?.tokens ?? (result as any)?.tokens
         if (tokens?.access_token) {
           setAuthToken(tokens.access_token)
-          setBackendReady(true)
-          setAuthError(null)
+          if (mounted) {
+            setBackendReady(true)
+            setAuthError(null)
+          }
         }
       } catch {
         // Non-fatal: t-point flow still works via extension JWT directly
         clearAuthToken()
-        setBackendReady(false)
-        setAuthError('Backend unavailable')
+        if (mounted) {
+          setBackendReady(false)
+          setAuthError('Backend unavailable')
+        }
       }
 
       // Fetch T-point products
       if (ext.bits?.getProducts) {
         ext.bits.getProducts()
           .then((p) => {
-            setProducts(p as TwitchTPointProduct[])
-            setTPointEnabled(true)
+            if (mounted) {
+              setProducts(p as TwitchTPointProduct[])
+              setTPointEnabled(true)
+            }
           })
-          .catch(() => setTPointEnabled(false))
+          .catch(() => {
+            if (mounted) setTPointEnabled(false)
+          })
       }
     })
 
     return () => {
+      mounted = false
       setExtensionJwtForRecovery(null)
       clearAuthToken()
     }
@@ -91,7 +103,10 @@ export function useTwitch() {
     }
 
     let cancelled = false
+    let inFlight = false
     const retryTimer = window.setInterval(() => {
+      if (inFlight) return
+      inFlight = true
       void (async () => {
         try {
           const result = await loginWithTwitchExtension(jwt)
@@ -106,6 +121,8 @@ export function useTwitch() {
           if (!cancelled) {
             setBackendReady(false)
           }
+        } finally {
+          inFlight = false
         }
       })()
     }, 15_000)


### PR DESCRIPTION
## Summary

- Add `mounted` flag in first `useEffect`; all `setState` calls (`setContext`, `setJwt`, `setBackendReady`, `setAuthError`, `setProducts`, `setTPointEnabled`) are now guarded with `if (mounted)` before executing
- Add `mounted = false` in the `useEffect` cleanup
- Add `inFlight` flag in the retry `useEffect` interval to prevent overlapping login requests; reset via `finally` block on both success and error paths

## Scope 對齊

- Source of truth: #428
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是

## 本 PR 明確不做

- 不加 unit test（hook 依賴 `window.Twitch.ext`，需 mock，屬獨立 issue）
- 不重構 retry 邏輯或調整 interval 時間
- 不變更任何 API / backend contract

## Test plan

- [x] TypeScript: `npx tsc --noEmit` passes（已驗證）
- [ ] Manual: 確認 unmount 後無 React "state update on unmounted component" 警告
- [ ] Manual: 慢網路下 retry interval 不重疊觸發登入

closes #428