### PR TITLE
[chore] CLAUDE.md + AGENTS.md — 開 PR 必須使用 PULL_REQUEST_TEMPLATE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,10 +76,10 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - **開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點**，不得自由格式撰寫：
 
   ```bash
-  gh pr create --title "[type] ..." --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)"
+  gh pr create --title "[type] ..." --base develop --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)"
   ```
 
-  填入 template 所有必填欄位（`Source of truth`、`Depends on PR`、`Backend contract already in develop` checkbox、`本 PR 明確不做`）後再送出。
+  **先將 template 所有欄位填妥（不得留空或刪除 section）**，再將填妥內容作為 `--body` 傳入後送出。
 
 ### 操作權限邊界
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,10 +76,10 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - **開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點**，不得自由格式撰寫：
 
   ```bash
-  gh pr create --title "[type] ..." --base develop --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)"
+  cp .github/PULL_REQUEST_TEMPLATE.md /tmp/pr_body.md
+  # 填妥 /tmp/pr_body.md 所有欄位，不得留空或刪除 section
+  gh pr create --title "[type] ..." --base develop --body-file /tmp/pr_body.md
   ```
-
-  **先將 template 所有欄位填妥（不得留空或刪除 section）**，再將填妥內容作為 `--body` 傳入後送出。
 
 ### 操作權限邊界
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,13 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - **不要**直接推 `main`；日常 feature PR 目標分支是 `develop`
 - GitHub 相關的 `gh` 指令與必要的 `git` 指令可由你執行
 - 執行 `git` 時仍須遵守 branch / commit / scope 規範，不得繞過 PR 流程
+- **開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點**，不得自由格式撰寫：
+
+  ```bash
+  gh pr create --title "[type] ..." --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)"
+  ```
+
+  填入 template 所有必填欄位（`Source of truth`、`Depends on PR`、`Backend contract already in develop` checkbox、`本 PR 明確不做`）後再送出。
 
 ### 操作權限邊界
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,10 @@
    **開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點**，不得自由格式撰寫：
 
    ```bash
-   gh pr create --title "[type] ..." --base develop --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)"
+   cp .github/PULL_REQUEST_TEMPLATE.md /tmp/pr_body.md
+   # 填妥 /tmp/pr_body.md 所有欄位，不得留空或刪除 section
+   gh pr create --title "[type] ..." --base develop --body-file /tmp/pr_body.md
    ```
-
-   **先將 template 所有欄位填妥（不得留空或刪除 section）**，再將填妥內容作為 `--body` 傳入後送出。
 
 4. 正式 release 流程走 Git Flow：
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,10 @@
    **開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點**，不得自由格式撰寫：
 
    ```bash
-   gh pr create --title "[type] ..." --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)"
+   gh pr create --title "[type] ..." --base develop --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)"
    ```
 
-   填入 template 所有必填欄位（`Source of truth`、`Depends on PR`、`Backend contract already in develop` checkbox、`本 PR 明確不做`）後再送出。
+   **先將 template 所有欄位填妥（不得留空或刪除 section）**，再將填妥內容作為 `--body` 傳入後送出。
 
 4. 正式 release 流程走 Git Flow：
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,14 @@
 
 3. 在 GitHub 發 PR，日常 feature PR 目標分支：`develop`
 
+   **開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點**，不得自由格式撰寫：
+
+   ```bash
+   gh pr create --title "[type] ..." --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)"
+   ```
+
+   填入 template 所有必填欄位（`Source of truth`、`Depends on PR`、`Backend contract already in develop` checkbox、`本 PR 明確不做`）後再送出。
+
 4. 正式 release 流程走 Git Flow：
 
    - `main` 不接受日常 feature PR


### PR DESCRIPTION
## 什麼改動
在 CLAUDE.md（開發流程第 3 步）與 AGENTS.md（Git 規範注意事項）同步補充規則：開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點填寫，不得自由格式撰寫，並附上範例指令與必填欄位清單。

## 為什麼
連續多張 PR 觸犯 Scope Police，根本原因是 AI agent 沒有對照 template，導致 `Source of truth`、`本 PR 明確不做`、`Backend contract already in develop` checkbox 格式不符 regex 驗證。Claude Code 讀 CLAUDE.md、Codex 單獨使用時讀 AGENTS.md，兩份都需要補。

## Release Context
- Release type: n/a

## Workflow Type
- n/a

## Scope 對齊
- Source of truth: #444
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是

## 本 PR 明確不做
- 不修改 `.github/PULL_REQUEST_TEMPLATE.md` 本身內容
- 不改動任何程式碼、workflow 或其他文件

## PR 拆分檢查
- 這個 PR 的單一句子目的：在所有 agent 入口文件補充開 PR 使用 template 的規則
- Approx changed lines: ~15
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [x] docs
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？ n/a
- 若已拆分，相關 PR: n/a

## Acceptance Criteria
- [x] CLAUDE.md 包含明確指令與範例 `gh pr create` 指令
- [x] AGENTS.md 包含相同規則（Codex 單獨使用時也能看到）
- [x] CI 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過（文件變更，無需執行測試）

**驗證結果**
```
CLAUDE.md  | 8 ++++++++
AGENTS.md  | 7 +++++++
2 files changed, 15 insertions(+)
```

## 備註
無

## Notes for Claude Code Review
- 純文件變更，無 runtime 影響，兩份文件加入的規則措辭一致

closes #444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* 新增 PR 建立規範，要求在建立功能 PR 時必須使用標準模板，並確保所有欄位完整填妥，不得保留空白或刪除區段。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->