### PR TITLE
[backend] fix: migration 017 — explicit DROP CONSTRAINT IF EXISTS (#346)

### DIFF
--- a/services/api/migrations/017_claim_finalize_failed.sql
+++ b/services/api/migrations/017_claim_finalize_failed.sql
@@ -21,6 +21,9 @@ BEGIN
     END LOOP;
 END $$;
 
+ALTER TABLE claims DROP CONSTRAINT IF EXISTS claims_status_check;
+ALTER TABLE claims DROP CONSTRAINT IF EXISTS chk_claim_status;
+
 ALTER TABLE claims
     ADD CONSTRAINT chk_claim_status
     CHECK (status IN ('pending', 'broadcast', 'confirmed', 'failed', 'finalize_failed'));


### PR DESCRIPTION
## Summary
- 在 `017_claim_finalize_failed.sql` 的 `ADD CONSTRAINT chk_claim_status` 前補兩行顯式 DROP，確保不論上游 constraint 命名為何都能安全重跑

## Scope 對齊
- Source of truth：#346
- Depends on PR：none
- Backend contract already in develop：
  - [x] yes
  - [ ] no

## 本 PR 明確不做
- 不修改 migration 以外的任何檔案
- 不改動 model、service 或測試檔

## Acceptance Criteria
- [x] `017_claim_finalize_failed.sql` 在 `ADD CONSTRAINT` 前新增兩行 DROP
- [x] `go test ./...` 全過（10 packages）
- [x] Diff：1 檔，3 行（< 200 行限制）

closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)