### PR TITLE
[backend] fix: wrap address default-switch operations in transaction

### DIFF
--- a/services/api/internal/services/address_service.go
+++ b/services/api/internal/services/address_service.go
@@ -38,12 +38,6 @@ func (s *AddressService) List(userID uuid.UUID) ([]models.ShippingAddress, error
 }
 
 func (s *AddressService) Create(userID uuid.UUID, input AddressInput) (*models.ShippingAddress, error) {
-	if input.IsDefault {
-		s.db.Model(&models.ShippingAddress{}).
-			Where("user_id = ?", userID).
-			Update("is_default", false)
-	}
-
 	country := input.Country
 	if country == "" {
 		country = "TW"
@@ -62,7 +56,17 @@ func (s *AddressService) Create(userID uuid.UUID, input AddressInput) (*models.S
 		IsDefault:     input.IsDefault,
 	}
 
-	if err := s.db.Create(addr).Error; err != nil {
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		if input.IsDefault {
+			if err := tx.Model(&models.ShippingAddress{}).
+				Where("user_id = ?", userID).
+				Update("is_default", false).Error; err != nil {
+				return err
+			}
+		}
+
+		return tx.Create(addr).Error
+	}); err != nil {
 		return nil, err
 	}
 	return addr, nil
@@ -73,12 +77,7 @@ func (s *AddressService) Update(userID, addrID uuid.UUID, input AddressInput) (*
 	if err := s.db.Where("id = ? AND user_id = ?", addrID, userID).First(&addr).Error; err != nil {
 		return nil, ErrAddressNotFound
 	}
-
-	if input.IsDefault && !addr.IsDefault {
-		s.db.Model(&models.ShippingAddress{}).
-			Where("user_id = ? AND id != ?", userID, addrID).
-			Update("is_default", false)
-	}
+	wasDefault := addr.IsDefault
 
 	addr.RecipientName = input.RecipientName
 	addr.Phone = input.Phone
@@ -92,7 +91,17 @@ func (s *AddressService) Update(userID, addrID uuid.UUID, input AddressInput) (*
 	}
 	addr.IsDefault = input.IsDefault
 
-	if err := s.db.Save(&addr).Error; err != nil {
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		if input.IsDefault && !wasDefault {
+			if err := tx.Model(&models.ShippingAddress{}).
+				Where("user_id = ? AND id != ?", userID, addrID).
+				Update("is_default", false).Error; err != nil {
+				return err
+			}
+		}
+
+		return tx.Save(&addr).Error
+	}); err != nil {
 		return nil, err
 	}
 	return &addr, nil
@@ -100,10 +109,13 @@ func (s *AddressService) Update(userID, addrID uuid.UUID, input AddressInput) (*
 
 func (s *AddressService) Delete(userID, addrID uuid.UUID) error {
 	result := s.db.Where("id = ? AND user_id = ?", addrID, userID).Delete(&models.ShippingAddress{})
+	if result.Error != nil {
+		return result.Error
+	}
 	if result.RowsAffected == 0 {
 		return ErrAddressNotFound
 	}
-	return result.Error
+	return nil
 }
 
 func (s *AddressService) SetDefault(userID, addrID uuid.UUID) (*models.ShippingAddress, error) {
@@ -112,11 +124,17 @@ func (s *AddressService) SetDefault(userID, addrID uuid.UUID) (*models.ShippingA
 		return nil, ErrAddressNotFound
 	}
 
-	s.db.Model(&models.ShippingAddress{}).
-		Where("user_id = ? AND id != ?", userID, addrID).
-		Update("is_default", false)
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.ShippingAddress{}).
+			Where("user_id = ? AND id != ?", userID, addrID).
+			Update("is_default", false).Error; err != nil {
+			return err
+		}
 
-	addr.IsDefault = true
-	s.db.Save(&addr)
+		addr.IsDefault = true
+		return tx.Save(&addr).Error
+	}); err != nil {
+		return nil, err
+	}
 	return &addr, nil
 }

--- a/services/api/internal/services/address_service_test.go
+++ b/services/api/internal/services/address_service_test.go
@@ -1,9 +1,11 @@
 package services
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/models"
 )
@@ -21,6 +23,36 @@ func minimalInput() AddressInput {
 		RecipientName: "John Doe",
 		AddressLine1:  "123 Main St",
 		City:          "Taipei",
+	}
+}
+
+func failAddressBulkUpdate(t *testing.T, db *gorm.DB, name string, err error) {
+	t.Helper()
+	if callbackErr := db.Callback().Update().Before("gorm:update").Register(name, func(tx *gorm.DB) {
+		if tx.Statement.Table != "shipping_addresses" {
+			return
+		}
+		if _, ok := tx.Statement.Dest.(map[string]interface{}); !ok {
+			return
+		}
+		tx.AddError(err)
+	}); callbackErr != nil {
+		t.Fatalf("register update callback: %v", callbackErr)
+	}
+}
+
+func failAddressSave(t *testing.T, db *gorm.DB, name string, err error) {
+	t.Helper()
+	if callbackErr := db.Callback().Update().Before("gorm:update").Register(name, func(tx *gorm.DB) {
+		if tx.Statement.Table != "shipping_addresses" {
+			return
+		}
+		if _, ok := tx.Statement.Dest.(*models.ShippingAddress); !ok {
+			return
+		}
+		tx.AddError(err)
+	}); callbackErr != nil {
+		t.Fatalf("register update callback: %v", callbackErr)
 	}
 }
 
@@ -98,6 +130,34 @@ func TestCreate_SetDefaultUnsetsOthers(t *testing.T) {
 	}
 	if !second.IsDefault {
 		t.Error("second address should be default")
+	}
+}
+
+func TestCreate_DefaultClearFailureReturnsErrorAndDoesNotCreate(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAddressService(db)
+	userID := seedUser(t, svc)
+
+	input := minimalInput()
+	input.IsDefault = true
+	if _, err := svc.Create(userID, input); err != nil {
+		t.Fatalf("seed default address: %v", err)
+	}
+
+	clearErr := errors.New("clear default failed")
+	failAddressBulkUpdate(t, db, "fail_create_default_clear", clearErr)
+
+	_, err := svc.Create(userID, input)
+	if !errors.Is(err, clearErr) {
+		t.Fatalf("expected clear default error, got %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&models.ShippingAddress{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+		t.Fatalf("count addresses: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected failed create to roll back, got %d addresses", count)
 	}
 }
 
@@ -201,6 +261,51 @@ func TestUpdate_WrongUser(t *testing.T) {
 	}
 }
 
+func TestUpdate_DefaultClearFailureReturnsErrorAndRollsBack(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAddressService(db)
+	userID := seedUser(t, svc)
+
+	defaultInput := minimalInput()
+	defaultInput.IsDefault = true
+	currentDefault, err := svc.Create(userID, defaultInput)
+	if err != nil {
+		t.Fatalf("create default address: %v", err)
+	}
+	target, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create target address: %v", err)
+	}
+
+	clearErr := errors.New("clear other defaults failed")
+	failAddressBulkUpdate(t, db, "fail_update_default_clear", clearErr)
+
+	_, err = svc.Update(userID, target.ID, AddressInput{
+		RecipientName: "Target",
+		AddressLine1:  "456 Other St",
+		City:          "Taipei",
+		IsDefault:     true,
+	})
+	if !errors.Is(err, clearErr) {
+		t.Fatalf("expected clear default error, got %v", err)
+	}
+
+	var reloadedCurrent models.ShippingAddress
+	if err := db.First(&reloadedCurrent, "id = ?", currentDefault.ID).Error; err != nil {
+		t.Fatalf("load current default: %v", err)
+	}
+	if !reloadedCurrent.IsDefault {
+		t.Fatal("existing default should remain default after rollback")
+	}
+	var reloadedTarget models.ShippingAddress
+	if err := db.First(&reloadedTarget, "id = ?", target.ID).Error; err != nil {
+		t.Fatalf("load target address: %v", err)
+	}
+	if reloadedTarget.IsDefault || reloadedTarget.RecipientName == "Target" {
+		t.Fatal("target address should not be saved after clear failure")
+	}
+}
+
 // ─── Delete ──────────────────────────────────────────────────────────────────
 
 func TestDelete_Success(t *testing.T) {
@@ -242,6 +347,32 @@ func TestDelete_WrongUser(t *testing.T) {
 	}
 }
 
+func TestDelete_ReturnsDBErrorBeforeNotFound(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAddressService(db)
+	userID := seedUser(t, svc)
+	addr, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create address: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db.DB(): %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	err = svc.Delete(userID, addr.ID)
+	if err == nil {
+		t.Fatal("expected DB error, got nil")
+	}
+	if errors.Is(err, ErrAddressNotFound) {
+		t.Fatalf("expected DB error before ErrAddressNotFound, got %v", err)
+	}
+}
+
 // ─── SetDefault ──────────────────────────────────────────────────────────────
 
 func TestSetDefault_Success(t *testing.T) {
@@ -275,5 +406,64 @@ func TestSetDefault_NotFound(t *testing.T) {
 	_, err := svc.SetDefault(userID, uuid.New())
 	if err != ErrAddressNotFound {
 		t.Errorf("want ErrAddressNotFound, got %v", err)
+	}
+}
+
+func TestSetDefault_ClearFailureReturnsErrorAndRollsBack(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAddressService(db)
+	userID := seedUser(t, svc)
+
+	defaultInput := minimalInput()
+	defaultInput.IsDefault = true
+	currentDefault, err := svc.Create(userID, defaultInput)
+	if err != nil {
+		t.Fatalf("create default address: %v", err)
+	}
+	target, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create target address: %v", err)
+	}
+
+	clearErr := errors.New("clear other defaults failed")
+	failAddressBulkUpdate(t, db, "fail_set_default_clear", clearErr)
+
+	_, err = svc.SetDefault(userID, target.ID)
+	if !errors.Is(err, clearErr) {
+		t.Fatalf("expected clear default error, got %v", err)
+	}
+
+	var reloadedCurrent models.ShippingAddress
+	if err := db.First(&reloadedCurrent, "id = ?", currentDefault.ID).Error; err != nil {
+		t.Fatalf("load current default: %v", err)
+	}
+	if !reloadedCurrent.IsDefault {
+		t.Fatal("existing default should remain default after rollback")
+	}
+	var reloadedTarget models.ShippingAddress
+	if err := db.First(&reloadedTarget, "id = ?", target.ID).Error; err != nil {
+		t.Fatalf("load target address: %v", err)
+	}
+	if reloadedTarget.IsDefault {
+		t.Fatal("target address should not become default after clear failure")
+	}
+}
+
+func TestSetDefault_SaveFailureReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAddressService(db)
+	userID := seedUser(t, svc)
+
+	addr, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create address: %v", err)
+	}
+
+	saveErr := errors.New("save default failed")
+	failAddressSave(t, db, "fail_set_default_save", saveErr)
+
+	_, err = svc.SetDefault(userID, addr.ID)
+	if !errors.Is(err, saveErr) {
+		t.Fatalf("expected save error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Scope 對齊

Source of truth: https://github.com/nurockplayer/tachigo/issues/426

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 這張 PR 做了什麼

- `Create` / `Update` / `SetDefault` 三個 default 切換路徑統一包 `db.Transaction`，確保 clear-default 與寫入為原子操作
- 補齊所有 DB write 的 error check（原本 SetDefault 的 Save error 被忽略、Update/SetDefault 的 clear error 未 return）
- `Delete` 修正 error 判斷順序：先檢查 `result.Error`，再判斷 `RowsAffected`，避免 DB error 被誤報為 `ErrAddressNotFound`

## 本 PR 明確不做

- 不修改其他 service 的 transaction 問題（如 `user_service.go` 的 LinkWallet，另開 issue 追蹤）
- 不新增或修改 API endpoint
- 不異動 DB schema / migration

## Test plan

- [ ] `TestCreate_DefaultClearFailureReturnsErrorAndDoesNotCreate` — transaction rollback 驗證
- [ ] `TestUpdate_DefaultClearFailureReturnsErrorAndRollsBack` — rollback 且原 default 不被清
- [ ] `TestSetDefault_ClearFailureReturnsErrorAndRollsBack` — rollback 驗證
- [ ] `TestSetDefault_SaveFailureReturnsError` — Save error 正確 return
- [ ] `TestDelete_ReturnsDBErrorBeforeNotFound` — DB error 優先於 ErrAddressNotFound
- [ ] 30 個 address service 測試全過

closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)