### PR TITLE
[backend] fix: wrap nonce consume inside LinkWallet db.Transaction

### DIFF
--- a/services/api/internal/services/user_service.go
+++ b/services/api/internal/services/user_service.go
@@ -103,16 +103,16 @@ func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (strin
 		return "", ErrInvalidSignature
 	}
 
-	result := s.db.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
-		Delete(&models.Web3Nonce{})
-	if result.Error != nil {
-		return "", result.Error
-	}
-	if result.RowsAffected != 1 {
-		return "", ErrInvalidNonce
-	}
-
 	err := s.db.Transaction(func(tx *gorm.DB) error {
+		result := tx.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
+			Delete(&models.Web3Nonce{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return ErrInvalidNonce
+		}
+
 		var count int64
 		if err := tx.Model(&models.AuthProvider{}).
 			Where("provider = ? AND provider_id = ? AND deleted_at IS NULL AND user_id != ?",

--- a/services/api/internal/services/user_service_test.go
+++ b/services/api/internal/services/user_service_test.go
@@ -261,6 +261,39 @@ func TestLinkWallet_AddressAlreadyLinkedToOtherUser(t *testing.T) {
 	}
 }
 
+func TestLinkWallet_CreateFailureKeepsNonce(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonce := "create-failure-keeps-nonce"
+	nr := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+
+	db.Callback().Create().Before("gorm:create").Register("test:fail_auth_provider_create", func(tx *gorm.DB) {
+		if tx.Statement.Table == "auth_providers" {
+			tx.AddError(gorm.ErrDuplicatedKey)
+		}
+	})
+
+	_, err := svc.LinkWallet(userID, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: signSIWE(t, msg, key),
+	})
+	if err != ErrProviderLinked {
+		t.Errorf("want ErrProviderLinked, got %v", err)
+	}
+
+	var nonceCount int64
+	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
+	if nonceCount != 1 {
+		t.Errorf("nonce should remain after auth provider create failure, got %d rows", nonceCount)
+	}
+}
+
 func TestLinkWallet_ReplacesUsersExistingPrimaryWallet(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewUserService(db)

--- a/services/api/internal/services/user_service_test.go
+++ b/services/api/internal/services/user_service_test.go
@@ -253,6 +253,12 @@ func TestLinkWallet_AddressAlreadyLinkedToOtherUser(t *testing.T) {
 	if err != ErrProviderLinked {
 		t.Errorf("want ErrProviderLinked, got %v", err)
 	}
+
+	var nonceCount int64
+	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonceB).Count(&nonceCount)
+	if nonceCount != 1 {
+		t.Errorf("nonce should remain after failed wallet link, got %d rows", nonceCount)
+	}
 }
 
 func TestLinkWallet_ReplacesUsersExistingPrimaryWallet(t *testing.T) {


### PR DESCRIPTION
## Summary

- `LinkWallet` 原本先刪 nonce、再進入 `auth_provider` transaction；provider link 失敗時 nonce 已不可逆地消耗
- 將 nonce delete 移入同一個 `s.db.Transaction` closure，確保失敗時 nonce 隨 transaction rollback
- 補 `TestLinkWallet_AddressAlreadyLinkedToOtherUser` 的 nonce 保留斷言（紅燈轉綠燈驗證修正有效）

## Scope 對齊

Source of truth: https://github.com/nurockplayer/tachigo/issues/427

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## 本 PR 明確不做

- 不修改 handler / router / API contract
- 不處理 address_service 或其他 service 的 transaction 問題
- 不調整 nonce 過期邏輯

## Test plan

- [x] `TestLinkWallet_Success` — nonce 成功後被消耗
- [x] `TestLinkWallet_AddressAlreadyLinkedToOtherUser` — `ErrProviderLinked` 後 nonce 保留（新斷言）
- [x] 既有 invalid signature 路徑 — nonce 保留

closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 优化钱包链接流程的数据库事务处理，确保操作的一致性。

## Tests
- 新增钱包链接失败场景的测试用例，验证数据在异常情况下的完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->