### PR TITLE
[chore] Normalize frontend API base URL env key

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8080
+VITE_TACHIGO_API_URL=http://localhost:8080

--- a/apps/dashboard/src/services/__tests__/api.env.test.ts
+++ b/apps/dashboard/src/services/__tests__/api.env.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadApiClient() {
+  vi.resetModules()
+  const module = await import('@/services/api')
+  return module.default
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('api client base URL env', () => {
+  it('uses VITE_TACHIGO_API_URL as the canonical API base URL', async () => {
+    vi.stubEnv('VITE_TACHIGO_API_URL', 'https://canonical.example.test')
+    vi.stubEnv('VITE_API_URL', 'https://legacy.example.test')
+
+    const client = await loadApiClient()
+
+    expect(client.defaults.baseURL).toBe('https://canonical.example.test')
+  })
+
+  it('falls back to VITE_API_URL during the env key migration', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://legacy.example.test')
+
+    const client = await loadApiClient()
+
+    expect(client.defaults.baseURL).toBe('https://legacy.example.test')
+  })
+})

--- a/apps/dashboard/src/services/api.ts
+++ b/apps/dashboard/src/services/api.ts
@@ -1,6 +1,10 @@
 import axios, { type AxiosRequestConfig } from 'axios'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8080'
+const BASE_URL =
+  import.meta.env.VITE_TACHIGO_API_URL ??
+  // Temporary fallback for existing local env files during the key migration.
+  import.meta.env.VITE_API_URL ??
+  'http://localhost:8080'
 
 const client = axios.create({
   baseURL: BASE_URL,


### PR DESCRIPTION
## 什麼改動
統一 dashboard 的 frontend API base URL env key，改以 `VITE_TACHIGO_API_URL` 作為 canonical key，並保留 `VITE_API_URL` 作為暫時 fallback。

## 為什麼
closes #400

extension 已使用 `VITE_TACHIGO_API_URL`，dashboard 原本使用 `VITE_API_URL`，兩個 Vite frontend app 的 API base URL env 命名不一致。這個 PR 只處理命名一致化，不改 API 行為。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#400
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 Next.js migration
  - 不改 backend API 行為
  - 不移動目錄
  - 不處理 shared types / codegen

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 統一 dashboard frontend API base URL env key，與 extension 使用同一個 canonical key。
- Approx changed lines：~38
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接鎖住 dashboard API client 的 env key 優先序與 legacy fallback，屬於同一個 env 命名行為變更。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] canonical env key is documented
- [x] both frontend apps use the canonical key
- [x] backward compatibility strategy is explicit if old keys remain temporarily supported
- [x] `.env.example` files and relevant tests are updated

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
PATH="/tmp/tachigo-node-shim:$PATH" pnpm --dir apps/dashboard test
Test Files  8 passed (8)
Tests  60 passed (60)

PATH="/tmp/tachigo-node-shim:$PATH" pnpm --dir apps/dashboard lint
passed

PATH="/tmp/tachigo-node-shim:$PATH" pnpm --dir apps/dashboard build
vite v8.0.10 building client environment for production...
✓ built in 586ms
```

## 備註
本機 shell 沒有 `node` binary；dashboard 驗證使用臨時 `/tmp/tachigo-node-shim/node -> bun` shim 執行。extension 的 Node test runner 不適合用 Bun shim 驗證，因此本 PR 只回報 dashboard 驗證。

## Notes for Claude Code Review
- 請確認暫時保留 `VITE_API_URL` fallback 是否符合 #400 的相容性策略。
- 本 PR 沒有處理 Next.js；dashboard 目前仍是 Vite app。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 新增 API 客户端环境变量配置的测试覆盖。

* **维护**
  * 更新 API 配置环境变量名称，并保持向后兼容性。旧的环境变量名称仍可作为备用选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->