### PR TITLE
[backend] stabilize broadcast stats date fixtures

### DIFF
--- a/services/api/internal/services/points_service_test.go
+++ b/services/api/internal/services/points_service_test.go
@@ -518,13 +518,16 @@ func TestPointsService_GetBroadcastStats_TimeWindows(t *testing.T) {
 
 	// Insert log entries directly with controlled recorded_at timestamps
 	now := time.Now()
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfYear := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
 	entries := []struct {
 		seconds    int64
 		recordedAt time.Time
 	}{
-		{60, now.Add(-10 * time.Minute)}, // today
-		{120, now.Add(-25 * time.Hour)},  // yesterday (outside daily, inside monthly)
-		{180, now.AddDate(0, -1, -1)},    // last month (outside monthly, inside yearly)
+		{60, now.Add(-10 * time.Minute)},    // today
+		{120, startOfDay.Add(-time.Hour)},   // previous day; outside daily, in monthly unless today is the 1st
+		{180, startOfMonth.Add(-time.Hour)}, // previous month; outside monthly, in yearly unless this is January
 	}
 	for _, e := range entries {
 		svc.db.Exec(
@@ -533,18 +536,31 @@ func TestPointsService_GetBroadcastStats_TimeWindows(t *testing.T) {
 		)
 	}
 
+	var wantDaily, wantMonthly, wantYearly int64
+	for _, e := range entries {
+		if !e.recordedAt.Before(startOfDay) {
+			wantDaily += e.seconds
+		}
+		if !e.recordedAt.Before(startOfMonth) {
+			wantMonthly += e.seconds
+		}
+		if !e.recordedAt.Before(startOfYear) {
+			wantYearly += e.seconds
+		}
+	}
+
 	stats, err := svc.GetBroadcastStats(streamerID, channelID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if stats.DailySeconds != 60 {
-		t.Errorf("daily: want 60, got %d", stats.DailySeconds)
+	if stats.DailySeconds != wantDaily {
+		t.Errorf("daily: want %d, got %d", wantDaily, stats.DailySeconds)
 	}
-	if stats.MonthlySeconds != 60+120 {
-		t.Errorf("monthly: want 180, got %d", stats.MonthlySeconds)
+	if stats.MonthlySeconds != wantMonthly {
+		t.Errorf("monthly: want %d, got %d", wantMonthly, stats.MonthlySeconds)
 	}
-	if stats.YearlySeconds != 60+120+180 {
-		t.Errorf("yearly: want 360, got %d", stats.YearlySeconds)
+	if stats.YearlySeconds != wantYearly {
+		t.Errorf("yearly: want %d, got %d", wantYearly, stats.YearlySeconds)
 	}
 }
 

--- a/services/api/internal/services/points_service_test.go
+++ b/services/api/internal/services/points_service_test.go
@@ -525,7 +525,7 @@ func TestPointsService_GetBroadcastStats_TimeWindows(t *testing.T) {
 		seconds    int64
 		recordedAt time.Time
 	}{
-		{60, now.Add(-10 * time.Minute)},    // today
+		{60, now},                           // today
 		{120, startOfDay.Add(-time.Hour)},   // previous day; outside daily, in monthly unless today is the 1st
 		{180, startOfMonth.Add(-time.Hour)}, // previous month; outside monthly, in yearly unless this is January
 	}

--- a/services/api/internal/services/streamer_service_test.go
+++ b/services/api/internal/services/streamer_service_test.go
@@ -146,7 +146,7 @@ func TestGetChannelStats_OK(t *testing.T) {
 	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
 	startOfYear := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
 	entries := []time.Time{
-		now.Add(-10 * time.Minute),
+		now,
 		startOfDay.Add(-time.Hour),
 		startOfMonth.Add(-time.Hour),
 	}

--- a/services/api/internal/services/streamer_service_test.go
+++ b/services/api/internal/services/streamer_service_test.go
@@ -142,11 +142,25 @@ func TestGetChannelStats_OK(t *testing.T) {
 	}
 
 	now := time.Now()
-	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 1, 0, 0, 0, now.Location())
-	startOfMonth := time.Date(now.Year(), now.Month(), 2, 0, 0, 0, 0, now.Location())
-	startOfYear := time.Date(now.Year(), 2, 1, 0, 0, 0, 0, now.Location())
-
-	for _, recordedAt := range []time.Time{startOfDay, startOfMonth, startOfYear} {
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfYear := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location())
+	entries := []time.Time{
+		now.Add(-10 * time.Minute),
+		startOfDay.Add(-time.Hour),
+		startOfMonth.Add(-time.Hour),
+	}
+	var wantDaily, wantMonthly, wantYearly int64
+	for _, recordedAt := range entries {
+		if !recordedAt.Before(startOfDay) {
+			wantDaily += 30
+		}
+		if !recordedAt.Before(startOfMonth) {
+			wantMonthly += 30
+		}
+		if !recordedAt.Before(startOfYear) {
+			wantYearly += 30
+		}
 		if err := db.Create(&models.BroadcastTimeLog{
 			StreamerID: userID,
 			ChannelID:  "ch_stats",
@@ -174,13 +188,13 @@ func TestGetChannelStats_OK(t *testing.T) {
 	if stats.CurrentSessionSeconds != 45 {
 		t.Fatalf("current_session_seconds: want 45, got %d", stats.CurrentSessionSeconds)
 	}
-	if stats.DailySeconds != 30 {
-		t.Fatalf("daily_seconds: want 30, got %d", stats.DailySeconds)
+	if stats.DailySeconds != wantDaily {
+		t.Fatalf("daily_seconds: want %d, got %d", wantDaily, stats.DailySeconds)
 	}
-	if stats.MonthlySeconds != 60 {
-		t.Fatalf("monthly_seconds: want 60, got %d", stats.MonthlySeconds)
+	if stats.MonthlySeconds != wantMonthly {
+		t.Fatalf("monthly_seconds: want %d, got %d", wantMonthly, stats.MonthlySeconds)
 	}
-	if stats.YearlySeconds != 90 {
-		t.Fatalf("yearly_seconds: want 90, got %d", stats.YearlySeconds)
+	if stats.YearlySeconds != wantYearly {
+		t.Fatalf("yearly_seconds: want %d, got %d", wantYearly, stats.YearlySeconds)
 	}
 }


### PR DESCRIPTION
## 什麼改動
修正 broadcast stats 相關測試的日期 fixture，避免在每月 1 號或年初跨 boundary 時錯誤失敗。

## 為什麼
closes #453

CI 在 2026-05-01 失敗，原因是測試資料假設「昨天仍在本月」以及「本月 2 號不是未來日期」。這些假設在每月 1 號不成立，導致 unrelated PR 的 backend test gate 被擋。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#453
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 production code
  - 不改 broadcast stats 查詢邏輯
  - 不處理其他 flaky tests

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 穩定 broadcast stats 測試，避免在月初日期邊界誤判失敗。
- Approx changed lines：~70
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 在 `develop` 可重現的兩個失敗測試改為通過
- [x] 測試 fixture 不再依賴「今天不是每月 1 號」
- [x] 不修改 production code

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
docker compose run --no-deps --rm app go test ./internal/services -run "TestPointsService_GetBroadcastStats_TimeWindows|TestGetChannelStats_OK" -count=1 -v
FAIL: both tests fail on 2026-05-01 boundary

GREEN:
docker compose run --no-deps --rm app go test ./internal/services -run "TestPointsService_GetBroadcastStats_TimeWindows|TestGetChannelStats_OK" -count=1 -v
PASS

docker compose run --no-deps --rm app go test ./...
PASS

git diff --check
PASS
```

## 備註
這是 test-only 修正，用來解除 backend CI 在日期 boundary 的 unrelated failure。

## Notes for Claude Code Review
- 請確認這個 PR 只調整測試 fixture 與 expected value 計算，沒有改 production behavior。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发行说明

* **测试**
  * 改进了时间窗口相关测试的可靠性，通过基于当前时间动态计算日/月/年时间范围和预期结果，替代之前的硬编码值，使测试在不同时间运行时都能正确执行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->