### PR TITLE
[frontend] Dashboard：遷移到 Refine.dev v5

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,73 +1,52 @@
-# React + TypeScript + Vite
+# Tachigo Dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Tachigo Dashboard 是 Vite + React + TypeScript 應用，管理介面以 Refine.dev 作為資料、認證與路由整合層，畫面仍使用專案既有 Tailwind / shadcn-style 元件。
 
-Currently, two official plugins are available:
+## 啟動方式
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+pnpm install
+pnpm dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+預設 Vite dev server 使用 `5174`。API base URL 依序讀取：
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+1. `VITE_TACHIGO_API_URL`
+2. `VITE_API_URL`
+3. `http://localhost:8080`
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+所有 API request 會再加上 `/api/v1` prefix。
+
+## Refine 架構
+
+`src/App.tsx` 以 `<Refine>` 包住 React Router v7 `createBrowserRouter`，並傳入：
+
+- `src/providers/authProvider.ts`：橋接既有 `services/auth.ts`，登入、登出、啟動時 session restore、JWT role / identity 解析都集中在這裡。
+- `src/providers/dataProvider.ts`：以 `@refinedev/simple-rest` 為 base，實際 request 使用既有 axios client，因此會沿用 in-memory access token、httpOnly refresh cookie 與 401 refresh interceptor。
+- Refine resources：`streamers`、`raffles`、`transactions`、`settings`。首頁 `DashboardPage` 保持自寫頁面，不走 resource。
+
+受保護路由使用 Refine `<Authenticated>`，未登入會導向 `/login`。`authProvider.check()` 是 async，會呼叫 `restoreSession()` 讓 app 啟動時可以用 refresh cookie 換回 access token。
+
+## API response envelope
+
+後端 response 不是標準 simple-rest 格式，常見格式如下：
+
+```json
+{ "data": { "raffles": [] } }
+```
+
+或：
+
+```json
+{ "data": { "raffle": {} } }
+```
+
+`dataProvider` 會把 envelope 轉成 Refine hooks 需要的 `{ data, total }` 或 `{ data }`，讓 `useList` / `useOne` 可直接在頁面使用。
+
+## 常用指令
+
+```bash
+pnpm test
+pnpm lint
+pnpm build
 ```

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -14,6 +14,11 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
+    "@hookform/resolvers": "^5.2.1",
+    "@refinedev/core": "^5.0.0",
+    "@refinedev/react-hook-form": "^5.0.0",
+    "@refinedev/react-router": "^2.0.0",
+    "@refinedev/simple-rest": "^6.0.0",
     "@tailwindcss/postcss": "^4.2.4",
     "axios": "^1.15.2",
     "class-variance-authority": "^0.7.1",
@@ -22,7 +27,9 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router": "^7.14.2",
-    "tailwind-merge": "^3.3.0"
+    "react-hook-form": "^7.62.0",
+    "tailwind-merge": "^3.3.0",
+    "zod": "^4.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,6 +1,7 @@
-import { createBrowserRouter, RouterProvider, Navigate } from 'react-router'
+import { Authenticated, Refine } from '@refinedev/core'
+import routerProvider from '@refinedev/react-router'
+import { createBrowserRouter, Navigate, Outlet, RouterProvider, useParams } from 'react-router'
 import Layout from '@/components/Layout'
-import ProtectedRoute from '@/components/ProtectedRoute'
 import LoginPage from '@/pages/LoginPage'
 import DashboardPage from '@/pages/DashboardPage'
 import StreamersPage from '@/pages/StreamersPage'
@@ -9,34 +10,68 @@ import TransactionsPage from '@/pages/TransactionsPage'
 import SettingsPage from '@/pages/SettingsPage'
 import RafflesPage from '@/pages/RafflesPage'
 import RaffleDetailPage from '@/pages/RaffleDetailPage'
+import { authProvider } from '@/providers/authProvider'
+import { dataProvider } from '@/providers/dataProvider'
 
 const router = createBrowserRouter([
   {
-    path: '/login',
-    element: <LoginPage />,
-  },
-  {
-    element: <ProtectedRoute />,
+    Component: RefineRoot,
     children: [
+      {
+        path: '/login',
+        element: <LoginPage />,
+      },
       {
         element: <Layout />,
         children: [
-          { index: true, element: <DashboardPage /> },
-          { path: 'streamers', element: <StreamersPage /> },
-          { path: 'streamers/:streamerId', element: <StreamerDetailPage /> },
-          { path: 'raffles', element: <RafflesPage /> },
-          { path: 'raffles/:raffleId', element: <RaffleDetailPage /> },
-          { path: 'transactions', element: <TransactionsPage /> },
-          { path: 'settings', element: <SettingsPage /> },
+          {
+            element: (
+              <Authenticated key="authenticated-routes" redirectOnFail="/login">
+                <Outlet />
+              </Authenticated>
+            ),
+            children: [
+              { index: true, element: <DashboardPage /> },
+              { path: 'streamers', element: <StreamersPage /> },
+              { path: 'streamers/:streamerId', element: <StreamerDetailRoute /> },
+              { path: 'raffles', element: <RafflesPage /> },
+              { path: 'raffles/:raffleId', element: <RaffleDetailPage /> },
+              { path: 'transactions', element: <TransactionsPage /> },
+              { path: 'settings', element: <SettingsPage /> },
+            ],
+          },
         ],
+      },
+      {
+        path: '*',
+        element: <Navigate to="/" replace />,
       },
     ],
   },
-  {
-    path: '*',
-    element: <Navigate to="/" replace />,
-  },
 ])
+
+function StreamerDetailRoute() {
+  const { streamerId } = useParams()
+  return <StreamerDetailPage key={streamerId} />
+}
+
+function RefineRoot() {
+  return (
+    <Refine
+      authProvider={authProvider}
+      dataProvider={dataProvider}
+      routerProvider={routerProvider}
+      resources={[
+        { name: 'streamers', list: '/streamers', show: '/streamers/:streamerId' },
+        { name: 'raffles', list: '/raffles', show: '/raffles/:raffleId' },
+        { name: 'transactions', list: '/transactions' },
+        { name: 'settings', list: '/settings' },
+      ]}
+    >
+      <Outlet />
+    </Refine>
+  )
+}
 
 export default function App() {
   return <RouterProvider router={router} />

--- a/apps/dashboard/src/pages/LoginPage.tsx
+++ b/apps/dashboard/src/pages/LoginPage.tsx
@@ -1,7 +1,6 @@
+import { useLogin } from '@refinedev/core'
 import { useState } from 'react'
-import { useNavigate } from 'react-router'
 import { isAxiosError } from 'axios'
-import { login } from '@/services/auth'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -95,7 +94,7 @@ function getMessages() {
 }
 
 export default function LoginPage() {
-  const navigate = useNavigate()
+  const { mutateAsync: refineLogin } = useLogin<{ email: string; password: string }>()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -108,8 +107,7 @@ export default function LoginPage() {
     setError('')
 
     try {
-      await login(email, password)
-      navigate('/')
+      await refineLogin({ email, password })
     } catch (err) {
       if (isAxiosError(err) && err.response?.status === 401) {
         setError(t.errorInvalidCredentials)

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -1,3 +1,59 @@
+import { useOne } from '@refinedev/core'
+import { useParams } from 'react-router'
+import { Skeleton } from '@/components/ui/skeleton'
+import type { Raffle } from '@/services/raffles'
+
+const statusLabel: Record<string, string> = {
+  draft: '草稿',
+  active: '進行中',
+  completed: '已結束',
+}
+
 export default function RaffleDetailPage() {
-  return <div>抽獎控制頁（開發中）</div>
+  const { raffleId } = useParams()
+  const { query: { data, isLoading, isError } } = useOne<Raffle>({
+    resource: 'raffles',
+    id: raffleId,
+    queryOptions: { enabled: Boolean(raffleId), retry: false },
+  })
+  const raffle = data?.data
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-foreground">抽獎控制頁</h1>
+
+      {isLoading ? (
+        <Skeleton className="h-32 w-full" />
+      ) : isError || !raffle ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          無法載入抽獎活動。
+        </div>
+      ) : (
+        <section className="space-y-3 rounded-lg border border-border bg-secondary/30 p-6">
+          <div>
+            <p className="text-sm text-muted-foreground">活動名稱</p>
+            <p className="text-xl font-semibold text-foreground">{raffle.title}</p>
+          </div>
+          <div className="grid gap-3 md:grid-cols-3">
+            <div>
+              <p className="text-sm text-muted-foreground">狀態</p>
+              <p className="font-medium text-foreground">{statusLabel[raffle.status] ?? raffle.status}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">建立時間</p>
+              <p className="font-medium text-foreground">
+                {new Date(raffle.created_at).toLocaleString('zh-TW')}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">更新時間</p>
+              <p className="font-medium text-foreground">
+                {new Date(raffle.updated_at).toLocaleString('zh-TW')}
+              </p>
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  )
 }

--- a/apps/dashboard/src/pages/RafflesPage.tsx
+++ b/apps/dashboard/src/pages/RafflesPage.tsx
@@ -1,10 +1,11 @@
+import { useCreate, useList } from '@refinedev/core'
 import { isAxiosError } from 'axios'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
-import { listRaffles, createRaffle, type Raffle, type RaffleStatus } from '@/services/raffles'
+import type { Raffle, RaffleStatus } from '@/services/raffles'
 
 const statusLabel: Record<RaffleStatus, string> = {
   draft: '草稿',
@@ -20,20 +21,17 @@ const statusClass: Record<RaffleStatus, string> = {
 
 export default function RafflesPage() {
   const navigate = useNavigate()
-  const [raffles, setRaffles] = useState<Raffle[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
+  const { query: { data, isLoading: loading, isError, refetch } } = useList<Raffle>({
+    resource: 'raffles',
+    queryOptions: { retry: false },
+  })
+  const { mutateAsync: createRaffle } = useCreate<Raffle>()
+  const [createdRaffles, setCreatedRaffles] = useState<Raffle[]>([])
   const [title, setTitle] = useState('')
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
-  useEffect(() => {
-    let mounted = true
-    listRaffles()
-      .then((data) => { if (mounted) setRaffles(data) })
-      .catch(() => { if (mounted) setError(true) })
-      .finally(() => { if (mounted) setLoading(false) })
-    return () => { mounted = false }
-  }, [])
+  const raffles: Raffle[] = [...createdRaffles, ...(data?.data ?? [])]
+  const error = isError && raffles.length === 0
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault()
@@ -41,9 +39,12 @@ export default function RafflesPage() {
     setCreating(true)
     setCreateError(null)
     try {
-      const raffle = await createRaffle(title.trim())
-      setRaffles((prev) => [raffle, ...prev])
-      setError(false)
+      const { data: raffle } = await createRaffle({
+        resource: 'raffles',
+        values: { title: title.trim() },
+      })
+      setCreatedRaffles((prev) => [raffle, ...prev])
+      void refetch()
       setTitle('')
     } catch (err) {
       const apiError = isAxiosError(err) ? err.response?.data?.error : undefined

--- a/apps/dashboard/src/pages/SettingsPage.tsx
+++ b/apps/dashboard/src/pages/SettingsPage.tsx
@@ -1,3 +1,10 @@
 export default function SettingsPage() {
-  return <h1 className="text-2xl font-bold text-foreground">設定</h1>
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-foreground">設定</h1>
+      <div className="rounded-lg border border-border bg-secondary/20 px-4 py-8 text-sm text-muted-foreground">
+        設定頁面建置中。
+      </div>
+    </div>
+  )
 }

--- a/apps/dashboard/src/pages/StreamerDetailPage.tsx
+++ b/apps/dashboard/src/pages/StreamerDetailPage.tsx
@@ -1,13 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useOne } from '@refinedev/core'
 import { useNavigate, useParams } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
-import {
-  getChannelConfig,
-  getStreamerStats,
-  type ChannelConfig,
-  type StreamerStats,
-} from '@/services/channels'
+import type { ChannelConfig, StreamerStats } from '@/services/channels'
 import { getUserRole } from '@/services/auth'
 
 function formatHours(seconds?: number) {
@@ -51,64 +46,26 @@ function MetricCard({ label, value }: { label: string; value: string }) {
 export default function StreamerDetailPage() {
   const { streamerId } = useParams()
   const navigate = useNavigate()
-  const [stats, setStats] = useState<StreamerStats | null>(null)
-  const [config, setConfig] = useState<ChannelConfig | null>(null)
-  const [resolvedStreamerId, setResolvedStreamerId] = useState<string | null>(null)
-  const [failedStreamerId, setFailedStreamerId] = useState<string | null>(null)
-  const [resolvedConfigStreamerId, setResolvedConfigStreamerId] = useState<string | null>(null)
-  const [failedConfigStreamerId, setFailedConfigStreamerId] = useState<string | null>(null)
+  const statsResult = useOne<StreamerStats & { channel_id?: string }>({
+    resource: 'streamer-stats',
+    id: streamerId,
+    queryOptions: { enabled: Boolean(streamerId), retry: false },
+  })
+  const statsQuery = statsResult.query
+  const stats = statsQuery.data?.data ?? null
+  const configResult = useOne<ChannelConfig>({
+    resource: 'channel-configs',
+    id: stats?.channel_id,
+    queryOptions: { enabled: Boolean(stats?.channel_id), retry: false },
+  })
+  const configQuery = configResult.query
 
   const role = getUserRole()
   const canGoBack = role !== 'streamer'
-
-  useEffect(() => {
-    if (!streamerId) return
-
-    let mounted = true
-
-    getStreamerStats(streamerId)
-      .then(({ stats, channelId }) => {
-        if (!mounted) return
-        setStats(stats)
-        setFailedStreamerId(null)
-        setResolvedStreamerId(streamerId)
-        setConfig(null)
-        setResolvedConfigStreamerId(null)
-        setFailedConfigStreamerId(null)
-
-        getChannelConfig(channelId)
-          .then((cfg) => {
-            if (!mounted) return
-            setConfig(cfg)
-            setResolvedConfigStreamerId(streamerId)
-            setFailedConfigStreamerId(null)
-          })
-          .catch(() => {
-            if (!mounted) return
-            setConfig(null)
-            setResolvedConfigStreamerId(null)
-            setFailedConfigStreamerId(streamerId)
-          })
-      })
-      .catch(() => {
-        if (!mounted) return
-        setFailedStreamerId(streamerId)
-      })
-
-    return () => {
-      mounted = false
-    }
-  }, [streamerId])
-
-  const loading = Boolean(streamerId) && resolvedStreamerId !== streamerId && failedStreamerId !== streamerId
-  const error = failedStreamerId === streamerId
-  const configLoading =
-    Boolean(streamerId) &&
-    resolvedStreamerId === streamerId &&
-    failedStreamerId !== streamerId &&
-    resolvedConfigStreamerId !== streamerId &&
-    failedConfigStreamerId !== streamerId
-  const displayConfig = resolvedConfigStreamerId === streamerId ? config : null
+  const loading = statsQuery.isLoading
+  const error = statsQuery.isError
+  const configLoading = statsQuery.isSuccess && configQuery.isLoading
+  const displayConfig = configQuery.data?.data ?? null
 
   const timeCards = [
     { label: '本次', value: formatHours(stats?.current_session_seconds) },

--- a/apps/dashboard/src/pages/StreamersPage.tsx
+++ b/apps/dashboard/src/pages/StreamersPage.tsx
@@ -1,8 +1,9 @@
+import { useList } from '@refinedev/core'
 import { isAxiosError } from 'axios'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { getMyChannels, getStreamers, type Streamer } from '@/services/channels'
+import type { Streamer } from '@/services/channels'
 
 function shouldFallbackToGetStreamers(error: unknown) {
   if (!isAxiosError(error)) return false
@@ -11,49 +12,36 @@ function shouldFallbackToGetStreamers(error: unknown) {
 
 export default function StreamersPage() {
   const navigate = useNavigate()
-  const [streamers, setStreamers] = useState<Streamer[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
   const [shouldAutoRedirect, setShouldAutoRedirect] = useState(false)
+  const myChannelsResult = useList<Streamer>({
+    resource: 'streamer-channels',
+    queryOptions: { retry: false },
+  })
+  const myChannelsQuery = myChannelsResult.query
+  const shouldFallback = shouldFallbackToGetStreamers(myChannelsQuery.error)
+  const streamersResult = useList<Streamer>({
+    resource: 'streamers',
+    queryOptions: { enabled: shouldFallback, retry: false },
+  })
+  const streamersQuery = streamersResult.query
+  const streamers: Streamer[] =
+    myChannelsQuery.data?.data
+    ?? (shouldFallback ? streamersQuery.data?.data : undefined)
+    ?? []
+  const loading = myChannelsQuery.isLoading || (shouldFallback && streamersQuery.isLoading)
+  const error = Boolean(
+    (myChannelsQuery.error && !shouldFallback) || (shouldFallback && streamersQuery.error),
+  )
 
   function openStreamer(streamerId: string) {
     navigate(`/streamers/${streamerId}`)
   }
 
   useEffect(() => {
-    let mounted = true
-
-    getMyChannels()
-      .then((data) => {
-        if (!mounted) return
-        setStreamers(data)
-        setShouldAutoRedirect(true)
-      })
-      .catch(async (error: unknown) => {
-        if (!shouldFallbackToGetStreamers(error)) {
-          if (!mounted) return
-          setError(true)
-          return
-        }
-
-        try {
-          const data = await getStreamers()
-          if (!mounted) return
-          setStreamers(data)
-        } catch {
-          if (!mounted) return
-          setError(true)
-        }
-      })
-      .finally(() => {
-        if (!mounted) return
-        setLoading(false)
-      })
-
-    return () => {
-      mounted = false
+    if (myChannelsQuery.isSuccess) {
+      setShouldAutoRedirect(true)
     }
-  }, [])
+  }, [myChannelsQuery.isSuccess])
 
   useEffect(() => {
     if (loading || error || !shouldAutoRedirect) return

--- a/apps/dashboard/src/pages/TransactionsPage.tsx
+++ b/apps/dashboard/src/pages/TransactionsPage.tsx
@@ -1,3 +1,77 @@
+import { useList } from '@refinedev/core'
+import { Skeleton } from '@/components/ui/skeleton'
+
+type Transaction = {
+  id?: string
+  type?: string
+  source?: string
+  amount?: number
+  delta?: number
+  balance_after?: number
+  note?: string
+  created_at?: string
+}
+
 export default function TransactionsPage() {
-  return <h1 className="text-2xl font-bold text-foreground">交易紀錄</h1>
+  const { query: { data, isLoading, isError } } = useList<Transaction>({
+    resource: 'transactions',
+    queryOptions: { retry: false },
+  })
+  const transactions: Transaction[] = data?.data ?? []
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-foreground">交易紀錄</h1>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-11 w-full" />
+          ))}
+        </div>
+      ) : isError ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          無法載入交易紀錄。
+        </div>
+      ) : transactions.length === 0 ? (
+        <div className="rounded-lg border border-border bg-secondary/20 px-4 py-8 text-center text-sm text-muted-foreground">
+          尚無交易紀錄。
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-secondary/50">
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">類型</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">數量</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">備註</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">時間</th>
+              </tr>
+            </thead>
+            <tbody>
+              {transactions.map((transaction, index) => (
+                <tr
+                  key={transaction.id ?? `${transaction.created_at}-${index}`}
+                  className={`border-b border-border last:border-0 ${index % 2 === 0 ? '' : 'bg-secondary/20'}`}
+                >
+                  <td className="px-4 py-3 font-medium text-foreground">
+                    {transaction.type ?? transaction.source ?? '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right text-muted-foreground">
+                    {(transaction.amount ?? transaction.delta ?? 0).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{transaction.note ?? '—'}</td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {transaction.created_at
+                      ? new Date(transaction.created_at).toLocaleString('zh-TW')
+                      : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
 }

--- a/apps/dashboard/src/pages/__tests__/RafflesPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RafflesPage.test.tsx
@@ -2,15 +2,9 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter, Route, Routes, useParams } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BaseRecord, DataProvider } from '@refinedev/core'
 import RafflesPage from '@/pages/RafflesPage'
-
-const listRafflesMock = vi.fn()
-const createRaffleMock = vi.fn()
-
-vi.mock('@/services/raffles', () => ({
-  listRaffles: (...a: unknown[]) => listRafflesMock(...a),
-  createRaffle: (...a: unknown[]) => createRaffleMock(...a),
-}))
+import { createMockDataProvider, RefineWrapper, waitFor } from '@/test/refine-wrapper'
 
 function DetailProbe() {
   const { raffleId } = useParams()
@@ -26,18 +20,22 @@ function RoutedApp() {
   )
 }
 
-async function renderAt(path: string) {
+async function renderAt(path: string, dataProvider: DataProvider) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
-  await act(async () => {
-    root.render(<MemoryRouter initialEntries={[path]}><RoutedApp /></MemoryRouter>)
-  })
-  return { container, root }
-}
 
-async function flush() {
-  await act(async () => { await Promise.resolve() })
+  await act(async () => {
+    root.render(
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter initialEntries={[path]}>
+          <RoutedApp />
+        </MemoryRouter>
+      </RefineWrapper>,
+    )
+  })
+
+  return { container, root }
 }
 
 function cleanupRoot(root: Root, container: HTMLDivElement) {
@@ -45,47 +43,62 @@ function cleanupRoot(root: Root, container: HTMLDivElement) {
   container.remove()
 }
 
-const mockRaffle = { id: 'r1', user_id: 'u1', title: '春季抽獎', status: 'draft' as const, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }
+const mockRaffle = {
+  id: 'r1',
+  user_id: 'u1',
+  title: '春季抽獎',
+  status: 'draft' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
 
 describe('RafflesPage', () => {
-  beforeEach(() => { listRafflesMock.mockReset(); createRaffleMock.mockReset() })
   afterEach(() => { document.body.innerHTML = '' })
 
   it('shows skeleton while loading', async () => {
-    listRafflesMock.mockReturnValue(new Promise(() => {}))
-    const { container, root } = await renderAt('/raffles')
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'raffles': vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
     expect(container.querySelector('[data-testid="skeleton"]')).toBeTruthy()
     cleanupRoot(root, container)
   })
 
   it('renders raffle list after load', async () => {
-    listRafflesMock.mockResolvedValue([mockRaffle])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
-    expect(container.textContent).toContain('春季抽獎')
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([mockRaffle as BaseRecord]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
     cleanupRoot(root, container)
   })
 
   it('shows empty state when no raffles', async () => {
-    listRafflesMock.mockResolvedValue([])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
-    expect(container.textContent).toContain('尚無')
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('尚無'))
     cleanupRoot(root, container)
   })
 
   it('shows error message when API fails', async () => {
-    listRafflesMock.mockRejectedValue(new Error('boom'))
-    const { container, root } = await renderAt('/raffles')
-    await flush()
-    expect(container.textContent).toContain('無法載入')
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockRejectedValue(new Error('boom')) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法載入'))
     cleanupRoot(root, container)
   })
 
   it('navigates to detail page on row click', async () => {
-    listRafflesMock.mockResolvedValue([mockRaffle])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([mockRaffle as BaseRecord]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('tbody tr')).toBeTruthy())
     const row = container.querySelector('tbody tr') as HTMLElement
     await act(async () => { row.click() })
     expect(container.querySelector('[data-testid="detail"]')?.textContent).toBe('r1')
@@ -94,10 +107,13 @@ describe('RafflesPage', () => {
 
   it('creates a raffle and adds it to the list', async () => {
     const newRaffle = { ...mockRaffle, id: 'r2', title: '夏季抽獎' }
-    listRafflesMock.mockResolvedValue([mockRaffle])
-    createRaffleMock.mockResolvedValue(newRaffle)
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const createMock = vi.fn().mockResolvedValue(newRaffle as BaseRecord)
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([mockRaffle as BaseRecord]) },
+      create: { 'raffles': createMock },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('input[name="title"]')).toBeTruthy())
 
     const input = container.querySelector('input[name="title"]') as HTMLInputElement
     await act(async () => {
@@ -107,21 +123,24 @@ describe('RafflesPage', () => {
     })
     const form = container.querySelector('form') as HTMLFormElement
     await act(async () => { form.dispatchEvent(new Event('submit', { bubbles: true })) })
-    await flush()
+    await waitFor(() => expect(container.textContent).toContain('夏季抽獎'))
 
-    expect(createRaffleMock).toHaveBeenCalledWith('夏季抽獎')
-    expect(container.textContent).toContain('夏季抽獎')
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ title: '夏季抽獎' }))
     cleanupRoot(root, container)
   })
 
   it('falls back to a string message when create API error is not a string', async () => {
-    listRafflesMock.mockResolvedValue([])
-    createRaffleMock.mockRejectedValue({
-      isAxiosError: true,
-      response: { data: { error: { message: 'invalid title' } } },
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([]) },
+      create: {
+        'raffles': vi.fn().mockRejectedValue({
+          isAxiosError: true,
+          response: { data: { error: { message: 'invalid title' } } },
+        }),
+      },
     })
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('input[name="title"]')).toBeTruthy())
 
     const input = container.querySelector('input[name="title"]') as HTMLInputElement
     await act(async () => {
@@ -131,37 +150,46 @@ describe('RafflesPage', () => {
     })
     const form = container.querySelector('form') as HTMLFormElement
     await act(async () => { form.dispatchEvent(new Event('submit', { bubbles: true })) })
-    await flush()
+    await waitFor(() => expect(container.textContent).toContain('建立失敗'))
 
-    expect(container.textContent).toContain('建立失敗')
     cleanupRoot(root, container)
   })
 
   it('shows the created raffle after the initial list request fails', async () => {
-    listRafflesMock.mockRejectedValue(new Error('boom')); createRaffleMock.mockResolvedValue({ ...mockRaffle, id: 'r2', title: 'manual raffle' })
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const newRaffle = { ...mockRaffle, id: 'r2', title: 'manual raffle' }
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockRejectedValue(new Error('boom')) },
+      create: { 'raffles': vi.fn().mockResolvedValue(newRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('input[name="title"]')).toBeTruthy())
+
     const input = container.querySelector('input[name="title"]') as HTMLInputElement
-    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, 'manual raffle'); await act(async () => { input.dispatchEvent(new Event('input', { bubbles: true })) })
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, 'manual raffle')
+    await act(async () => { input.dispatchEvent(new Event('input', { bubbles: true })) })
     await act(async () => { container.querySelector('form')?.dispatchEvent(new Event('submit', { bubbles: true })) })
-    await flush()
-    expect(container.textContent).toContain('manual raffle')
+    await waitFor(() => expect(container.textContent).toContain('manual raffle'))
+
     cleanupRoot(root, container)
   })
 
   it('disables submit button when title is empty', async () => {
-    listRafflesMock.mockResolvedValue([])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('button[type="submit"]')).toBeTruthy())
     const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement
     expect(btn.disabled).toBe(true)
     cleanupRoot(root, container)
   })
 
   it('navigates to detail page on Enter key press', async () => {
-    listRafflesMock.mockResolvedValue([mockRaffle])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([mockRaffle as BaseRecord]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('tbody tr')).toBeTruthy())
     const row = container.querySelector('tbody tr') as HTMLElement
     await act(async () => {
       row.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
@@ -169,4 +197,8 @@ describe('RafflesPage', () => {
     expect(container.querySelector('[data-testid="detail"]')?.textContent).toBe('r1')
     cleanupRoot(root, container)
   })
+})
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
 })

--- a/apps/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
@@ -1,17 +1,12 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { MemoryRouter, Route, Routes, useNavigate } from 'react-router'
+import { MemoryRouter, Route, Routes, useNavigate, useParams } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BaseRecord, DataProvider } from '@refinedev/core'
 import StreamerDetailPage from '@/pages/StreamerDetailPage'
+import { createMockDataProvider, RefineWrapper, waitFor } from '@/test/refine-wrapper'
 
-const getStreamerStatsMock = vi.fn()
-const getChannelConfigMock = vi.fn()
 const getUserRoleMock = vi.fn()
-
-vi.mock('@/services/channels', () => ({
-  getStreamerStats: (...args: unknown[]) => getStreamerStatsMock(...args),
-  getChannelConfig: (...args: unknown[]) => getChannelConfigMock(...args),
-}))
 
 vi.mock('@/services/auth', () => ({
   getUserRole: () => getUserRoleMock(),
@@ -28,11 +23,12 @@ function RoutedApp() {
 
 function DetailRouteWithNavigation() {
   const navigate = useNavigate()
+  const { streamerId } = useParams()
 
   return (
     <>
       <button onClick={() => navigate('/streamers/uuid-2')}>go-second</button>
-      <StreamerDetailPage />
+      <StreamerDetailPage key={streamerId} />
     </>
   )
 }
@@ -46,42 +42,40 @@ function NavigableRoutedApp() {
   )
 }
 
-async function renderAt(path: string) {
+async function renderAt(path: string, dataProvider: DataProvider) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
   await act(async () => {
     root.render(
-      <MemoryRouter initialEntries={[path]}>
-        <RoutedApp />
-      </MemoryRouter>,
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter initialEntries={[path]}>
+          <RoutedApp />
+        </MemoryRouter>
+      </RefineWrapper>,
     )
   })
 
   return { container, root }
 }
 
-async function renderNavigableAt(path: string) {
+async function renderNavigableAt(path: string, dataProvider: DataProvider) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
   await act(async () => {
     root.render(
-      <MemoryRouter initialEntries={[path]}>
-        <NavigableRoutedApp />
-      </MemoryRouter>,
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter initialEntries={[path]}>
+          <NavigableRoutedApp />
+        </MemoryRouter>
+      </RefineWrapper>,
     )
   })
 
   return { container, root }
-}
-
-async function flush() {
-  await act(async () => {
-    await Promise.resolve()
-  })
 }
 
 function cleanupRoot(root: Root, container: HTMLDivElement) {
@@ -108,17 +102,19 @@ const defaultConfig = {
   multiplier: 2,
 }
 
+function defaultDataProvider() {
+  return createMockDataProvider({
+    getOne: {
+      'streamer-stats': vi.fn().mockResolvedValue({ ...defaultStats, channel_id: 'channel-1' } as BaseRecord),
+      'channel-configs': vi.fn().mockResolvedValue(defaultConfig as BaseRecord),
+    },
+  })
+}
+
 describe('StreamerDetailPage', () => {
   beforeEach(() => {
-    getStreamerStatsMock.mockReset()
-    getChannelConfigMock.mockReset()
     getUserRoleMock.mockReset()
     getUserRoleMock.mockReturnValue('agency')
-    getStreamerStatsMock.mockResolvedValue({
-      stats: defaultStats,
-      channelId: 'channel-1',
-    })
-    getChannelConfigMock.mockResolvedValue(defaultConfig)
   })
 
   afterEach(() => {
@@ -126,11 +122,8 @@ describe('StreamerDetailPage', () => {
   })
 
   it('顯示秒數換算與倍率資訊，並顯示 action 按鈕', async () => {
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('1.5 小時')
+    const { container, root } = await renderAt('/streamers/uuid-1', defaultDataProvider())
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
     expect(container.textContent).toContain('10 分')
     expect(container.textContent).toContain('30 秒 / 點')
     expect(container.textContent).toContain('2x')
@@ -143,56 +136,53 @@ describe('StreamerDetailPage', () => {
 
   it('Agency 顯示返回列表按鈕', async () => {
     getUserRoleMock.mockReturnValue('agency')
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('返回列表')
+    const { container, root } = await renderAt('/streamers/uuid-1', defaultDataProvider())
+    await waitFor(() => expect(container.textContent).toContain('返回列表'))
 
     cleanupRoot(root, container)
   })
 
   it('Admin 顯示返回列表按鈕', async () => {
     getUserRoleMock.mockReturnValue('admin')
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('返回列表')
+    const { container, root } = await renderAt('/streamers/uuid-1', defaultDataProvider())
+    await waitFor(() => expect(container.textContent).toContain('返回列表'))
 
     cleanupRoot(root, container)
   })
 
   it('Streamer 不顯示返回列表按鈕', async () => {
     getUserRoleMock.mockReturnValue('streamer')
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
+    const { container, root } = await renderAt('/streamers/uuid-1', defaultDataProvider())
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
     expect(container.textContent).not.toContain('返回列表')
 
     cleanupRoot(root, container)
   })
 
   it('stats API 失敗時顯示整頁錯誤訊息', async () => {
-    getStreamerStatsMock.mockRejectedValue(new Error('boom'))
+    const dataProvider = createMockDataProvider({
+      getOne: {
+        'streamer-stats': vi.fn().mockRejectedValue(new Error('boom')),
+        'channel-configs': vi.fn().mockResolvedValue(defaultConfig as BaseRecord),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-
-    expect(container.textContent).toContain('無法載入頻道詳細資料')
+    const { container, root } = await renderAt('/streamers/uuid-1', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法載入頻道詳細資料'))
 
     cleanupRoot(root, container)
   })
 
   it('config API 失敗時仍顯示 stats，倍率區塊以破折號降級', async () => {
-    getChannelConfigMock.mockRejectedValue(new Error('config unavailable'))
+    const dataProvider = createMockDataProvider({
+      getOne: {
+        'streamer-stats': vi.fn().mockResolvedValue({ ...defaultStats, channel_id: 'channel-1' } as BaseRecord),
+        'channel-configs': vi.fn().mockRejectedValue(new Error('config unavailable')),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('1.5 小時')
+    const { container, root } = await renderAt('/streamers/uuid-1', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
     expect(container.textContent).toContain('挖礦倍率設定')
     expect(container.textContent).toContain('—')
 
@@ -200,49 +190,50 @@ describe('StreamerDetailPage', () => {
   })
 
   it('stats 成功後立即顯示主內容，不等 config', async () => {
-    let resolveConfig: ((value: typeof defaultConfig) => void) | null = null
-    getChannelConfigMock.mockImplementation(
-      () => new Promise((resolve) => { resolveConfig = resolve }),
-    )
+    let resolveConfig: ((value: BaseRecord) => void) | null = null
+    const dataProvider = createMockDataProvider({
+      getOne: {
+        'streamer-stats': vi.fn().mockResolvedValue({ ...defaultStats, channel_id: 'channel-1' } as BaseRecord),
+        'channel-configs': vi.fn().mockImplementation(
+          () => new Promise((resolve) => { resolveConfig = resolve }),
+        ),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-
-    // stats 已載入，主內容可見；config 尚未 resolve
-    expect(container.textContent).toContain('1.5 小時')
+    const { container, root } = await renderAt('/streamers/uuid-1', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
     expect(container.textContent).toContain('挖礦倍率設定')
 
     await act(async () => {
-      resolveConfig?.(defaultConfig)
+      resolveConfig?.(defaultConfig as BaseRecord)
     })
-    await flush()
-
-    expect(container.textContent).toContain('30 秒 / 點')
+    await waitFor(() => expect(container.textContent).toContain('30 秒 / 點'))
 
     cleanupRoot(root, container)
   })
 
   it('streamerId 變更時會先清掉舊資料並回到 loading 狀態', async () => {
-    let resolveSecond: ((value: { stats: typeof defaultStats; channelId: string }) => void) | null = null
+    let resolveSecond: ((value: BaseRecord) => void) | null = null
 
-    getStreamerStatsMock.mockImplementation((streamerId: string) => {
-      if (streamerId === 'uuid-1') {
-        return Promise.resolve({
-          stats: defaultStats,
-          channelId: 'channel-1',
-        })
+    const statsMock = vi.fn().mockImplementation((id: string | number) => {
+      if (id === 'uuid-1') {
+        return Promise.resolve({ ...defaultStats, channel_id: 'channel-1' } as BaseRecord)
       }
 
-      return new Promise((resolve) => {
+      return new Promise<BaseRecord>((resolve) => {
         resolveSecond = resolve
       })
     })
 
-    const { container, root } = await renderNavigableAt('/streamers/uuid-1')
-    await flush()
-    await flush()
+    const dataProvider = createMockDataProvider({
+      getOne: {
+        'streamer-stats': statsMock,
+        'channel-configs': vi.fn().mockResolvedValue(defaultConfig as BaseRecord),
+      },
+    })
 
-    expect(container.textContent).toContain('1.5 小時')
+    const { container, root } = await renderNavigableAt('/streamers/uuid-1', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
 
     const navigateButton = Array.from(container.querySelectorAll('button')).find(
       (button) => button.textContent === 'go-second',
@@ -257,19 +248,14 @@ describe('StreamerDetailPage', () => {
     expect(container.textContent).toContain('調整倍率')
 
     await act(async () => {
-      resolveSecond?.({
-        stats: {
-          ...defaultStats,
-          current_session_seconds: 7200,
-        },
-        channelId: 'channel-2',
-      })
+      resolveSecond?.({ ...defaultStats, current_session_seconds: 7200, channel_id: 'channel-2' } as BaseRecord)
     })
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('2.0 小時')
+    await waitFor(() => expect(container.textContent).toContain('2.0 小時'))
 
     cleanupRoot(root, container)
   })
+})
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
 })

--- a/apps/dashboard/src/pages/__tests__/StreamersPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/StreamersPage.test.tsx
@@ -2,19 +2,12 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter, Route, Routes, useParams } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DataProvider } from '@refinedev/core'
 import StreamersPage from '@/pages/StreamersPage'
-
-const getStreamersMock = vi.fn()
-const getMyChannelsMock = vi.fn()
-
-vi.mock('@/services/channels', () => ({
-  getStreamers: (...args: unknown[]) => getStreamersMock(...args),
-  getMyChannels: (...args: unknown[]) => getMyChannelsMock(...args),
-}))
+import { createMockDataProvider, flushAsync, RefineWrapper, waitFor } from '@/test/refine-wrapper'
 
 function DetailRouteProbe() {
   const { streamerId } = useParams()
-
   return <div data-testid="detail-page">{streamerId}</div>
 }
 
@@ -27,86 +20,73 @@ function RoutedApp() {
   )
 }
 
-async function renderAt(path: string) {
+async function renderAt(path: string, dataProvider: DataProvider) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
   await act(async () => {
     root.render(
-      <MemoryRouter initialEntries={[path]}>
-        <RoutedApp />
-      </MemoryRouter>,
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter initialEntries={[path]}>
+          <RoutedApp />
+        </MemoryRouter>
+      </RefineWrapper>,
     )
   })
 
   return { container, root }
 }
 
-async function flush() {
-  await act(async () => {
-    await Promise.resolve()
-  })
-}
-
 function cleanupRoot(root: Root, container: HTMLDivElement) {
-  act(() => {
-    root.unmount()
-  })
+  act(() => { root.unmount() })
   container.remove()
 }
 
 function axiosError(status: number) {
-  return {
-    isAxiosError: true,
-    response: { status },
-  }
+  return { isAxiosError: true, response: { status } }
 }
 
 describe('StreamersPage', () => {
-  beforeEach(() => {
-    getStreamersMock.mockReset()
-    getMyChannelsMock.mockReset()
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-  })
-
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
+  afterEach(() => { document.body.innerHTML = '' })
 
   it('renders streamers from the API response', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
-      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
-      { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
-    ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([
+          { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+          { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
+        ]),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-
-    expect(container.textContent).toContain('Alice')
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('Alice'))
     expect(container.textContent).toContain('Bob')
 
     cleanupRoot(root, container)
   })
 
   it('顯示 summary metrics 欄位（本日開台、挖礦觀眾、總產出點數）', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
-      {
-        id: 'uuid-1',
-        channel_id: 'channel-1',
-        display_name: 'Alice',
-        daily_seconds: 12600,
-        unique_miners: 1240,
-        total_token_minted: 3200,
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([
+          {
+            id: 'uuid-1',
+            channel_id: 'channel-1',
+            display_name: 'Alice',
+            daily_seconds: 12600,
+            unique_miners: 1240,
+            total_token_minted: 3200,
+          },
+        ]),
       },
-    ])
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-
-    expect(container.textContent).toContain('3.5 hr')
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('3.5 hr'))
     expect(container.textContent).toContain('1,240')
     expect(container.textContent).toContain('3,200')
 
@@ -114,15 +94,18 @@ describe('StreamersPage', () => {
   })
 
   it('summary metrics 為 undefined 時顯示破折號', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
-      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
-    ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([
+          { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+        ]),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('Alice'))
 
-    // 三欄都顯示破折號
     const dashes = (container.textContent?.match(/—/g) ?? []).length
     expect(dashes).toBeGreaterThanOrEqual(3)
 
@@ -130,22 +113,22 @@ describe('StreamersPage', () => {
   })
 
   it('opens the detail page when pressing Enter on a row', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
-      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
-      { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
-    ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([
+          { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+          { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
+        ]),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.querySelector('tbody tr')).toBeTruthy())
 
-    const firstRow = container.querySelector('tbody tr')
-    expect(firstRow).toBeTruthy()
-
+    const firstRow = container.querySelector('tbody tr')!
     act(() => {
-      firstRow?.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
-      )
+      firstRow.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
     })
 
     expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toBe('uuid-1')
@@ -154,114 +137,155 @@ describe('StreamersPage', () => {
   })
 
   it('redirects a streamer to the first available channel', async () => {
-    getMyChannelsMock.mockResolvedValue([
+    const channelsMock = vi.fn().mockResolvedValue([
       { id: 'uuid-1', user_id: 'user-1', channel_id: 'channel-1', display_name: 'Alice' },
       { id: 'uuid-2', user_id: 'user-2', channel_id: 'channel-2', display_name: 'Bob' },
     ])
+    const streamersMock = vi.fn()
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toBe('uuid-1'),
+    )
 
-    expect(getStreamersMock).not.toHaveBeenCalled()
-    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
-    expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toBe('uuid-1')
+    expect(streamersMock).not.toHaveBeenCalled()
+    expect(channelsMock).toHaveBeenCalledTimes(1)
 
     cleanupRoot(root, container)
   })
 
   it('keeps streamer on the listing page when no channel exists', async () => {
-    getMyChannelsMock.mockResolvedValue([])
+    const channelsMock = vi.fn().mockResolvedValue([])
+    const streamersMock = vi.fn()
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('尚無'))
 
-    expect(getStreamersMock).not.toHaveBeenCalled()
-    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
+    expect(streamersMock).not.toHaveBeenCalled()
+    expect(channelsMock).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-testid="detail-page"]')).toBeNull()
 
     cleanupRoot(root, container)
   })
 
   it('shows an error message when the API request fails', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockRejectedValue(new Error('boom'))
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockRejectedValue(new Error('boom')),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-
-    expect(container.textContent).toContain('無法')
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法'))
 
     cleanupRoot(root, container)
   })
 
   it('shows an empty state when the list is empty', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([]),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-
-    expect(container.textContent).toContain('尚無')
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('尚無'))
 
     cleanupRoot(root, container)
   })
 
   it('falls back to getStreamers only when getMyChannels returns 401', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
+    const channelsMock = vi.fn().mockRejectedValue(axiosError(401))
+    const streamersMock = vi.fn().mockResolvedValue([
       { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
     ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('Alice'))
 
-    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
-    expect(getStreamersMock).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('Alice')
+    expect(channelsMock).toHaveBeenCalledTimes(1)
+    expect(streamersMock).toHaveBeenCalledTimes(1)
 
     cleanupRoot(root, container)
   })
 
   it('falls back to getStreamers when getMyChannels returns 403', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(403))
-    getStreamersMock.mockResolvedValue([
+    const channelsMock = vi.fn().mockRejectedValue(axiosError(403))
+    const streamersMock = vi.fn().mockResolvedValue([
       { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
     ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('Alice'))
 
-    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
-    expect(getStreamersMock).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('Alice')
+    expect(channelsMock).toHaveBeenCalledTimes(1)
+    expect(streamersMock).toHaveBeenCalledTimes(1)
 
     cleanupRoot(root, container)
   })
 
   it('shows an error state when getMyChannels returns 500', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(500))
+    const channelsMock = vi.fn().mockRejectedValue(axiosError(500))
+    const streamersMock = vi.fn()
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法載入直播主資料'))
 
-    expect(getStreamersMock).not.toHaveBeenCalled()
-    expect(container.textContent).toContain('無法載入直播主資料')
+    expect(streamersMock).not.toHaveBeenCalled()
 
     cleanupRoot(root, container)
   })
 
   it('shows an error state when fallback getStreamers also fails after a 401', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockRejectedValue(new Error('fallback failed'))
+    const streamersMock = vi.fn().mockRejectedValue(new Error('fallback failed'))
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法載入直播主資料'))
 
-    expect(getStreamersMock).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('無法載入直播主資料')
+    expect(streamersMock).toHaveBeenCalledTimes(1)
 
     cleanupRoot(root, container)
   })
+})
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
 })

--- a/apps/dashboard/src/providers/authProvider.ts
+++ b/apps/dashboard/src/providers/authProvider.ts
@@ -1,0 +1,90 @@
+import type { AuthProvider } from '@refinedev/core'
+import { getAuthToken } from '@/services/api'
+import {
+  getUserRole,
+  isAuthenticated,
+  login,
+  logout,
+  restoreSession,
+} from '@/services/auth'
+
+type JwtPayload = {
+  sub?: string
+  user_id?: string
+  email?: string
+  name?: string
+  role?: string
+}
+
+function decodeAccessToken(): JwtPayload | null {
+  const accessToken = getAuthToken()
+  if (!accessToken) return null
+
+  try {
+    const b64 = accessToken.split('.')[1]
+    if (!b64) return null
+    const normalized = b64.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
+    return JSON.parse(atob(padded)) as JwtPayload
+  } catch {
+    return null
+  }
+}
+
+export const authProvider: AuthProvider = {
+  login: async ({ email, password }: { email: string; password: string }) => {
+    await login(String(email), String(password))
+
+    return {
+      success: true,
+      redirectTo: '/',
+    }
+  },
+
+  logout: async () => {
+    await logout()
+
+    return {
+      success: true,
+      redirectTo: '/login',
+    }
+  },
+
+  check: async () => {
+    await restoreSession()
+
+    if (isAuthenticated()) {
+      return { authenticated: true }
+    }
+
+    return {
+      authenticated: false,
+      redirectTo: '/login',
+    }
+  },
+
+  getPermissions: async () => getUserRole(),
+
+  getIdentity: async () => {
+    const payload = decodeAccessToken()
+    if (!payload) return null
+
+    return {
+      id: payload.user_id ?? payload.sub ?? '',
+      name: payload.name ?? payload.email ?? payload.sub ?? 'Dashboard user',
+      email: payload.email,
+      role: payload.role,
+    }
+  },
+
+  onError: async (error: unknown) => {
+    const status = (error as { status?: number; response?: { status?: number } }).status
+      ?? (error as { response?: { status?: number } }).response?.status
+
+    if (status === 401 || status === 403) {
+      return { logout: true }
+    }
+
+    return { error: error as Error }
+  },
+}

--- a/apps/dashboard/src/providers/dataProvider.ts
+++ b/apps/dashboard/src/providers/dataProvider.ts
@@ -1,0 +1,188 @@
+import type {
+  BaseRecord,
+  CreateResponse,
+  DataProvider,
+  DeleteOneResponse,
+  GetListResponse,
+  GetOneResponse,
+  UpdateResponse,
+  CreateParams,
+  DeleteOneParams,
+  GetListParams,
+  GetOneParams,
+  UpdateParams,
+} from '@refinedev/core'
+import simpleRestDataProvider from '@refinedev/simple-rest'
+import client from '@/services/api'
+
+const API_ORIGIN =
+  import.meta.env.VITE_TACHIGO_API_URL
+  ?? import.meta.env.VITE_API_URL
+  ?? 'http://localhost:8080'
+
+const API_URL = `${API_ORIGIN.replace(/\/$/, '')}/api/v1`
+
+const resourcePaths: Record<string, string> = {
+  streamers: '/dashboard/streamers',
+  'streamer-channels': '/dashboard/streamers/channels',
+  'streamer-stats': '/dashboard/streamers',
+  raffles: '/dashboard/raffles',
+  transactions: '/transactions',
+  settings: '/dashboard/settings',
+  'channel-configs': '/dashboard/channels',
+}
+
+function resourcePath(resource: string) {
+  return resourcePaths[resource] ?? `/${resource}`
+}
+
+function pathWithId(resource: string, id: string | number) {
+  const encodedId = encodeURIComponent(String(id))
+
+  if (resource === 'streamer-stats') {
+    return `${resourcePath(resource)}/${encodedId}/stats`
+  }
+
+  if (resource === 'channel-configs') {
+    return `${resourcePath(resource)}/${encodedId}/config`
+  }
+
+  return `${resourcePath(resource)}/${encodedId}`
+}
+
+function unwrapPayload<T>(payload: unknown): T {
+  if (payload && typeof payload === 'object' && 'data' in payload) {
+    return (payload as { data: T }).data
+  }
+
+  return payload as T
+}
+
+function unwrapList<T extends BaseRecord>(payload: unknown, resource: string): T[] {
+  const data = unwrapPayload<unknown>(payload)
+
+  if (Array.isArray(data)) return data as T[]
+  if (!data || typeof data !== 'object') return []
+
+  const keyed = data as Record<string, unknown>
+  const candidates = [
+    resource,
+    resource.replace(/^streamer-/, ''),
+    'channels',
+    'streamers',
+    'raffles',
+    'transactions',
+    'items',
+  ]
+
+  for (const key of candidates) {
+    const value = keyed[key]
+    if (Array.isArray(value)) return value as T[]
+  }
+
+  return []
+}
+
+function unwrapOne<T extends BaseRecord>(payload: unknown, resource: string): T {
+  const data = unwrapPayload<unknown>(payload)
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return data as T
+  }
+
+  const keyed = data as Record<string, unknown>
+  const candidates = [
+    resource.replace(/s$/, ''),
+    'raffle',
+    'streamer',
+    'stats',
+    'config',
+  ]
+
+  for (const key of candidates) {
+    const value = keyed[key]
+    if (value && typeof value === 'object') {
+      if (resource === 'streamer-stats' && key === 'stats') {
+        return { ...(value as object), channel_id: keyed.channel_id } as unknown as T
+      }
+
+      return value as T
+    }
+  }
+
+  return data as T
+}
+
+export const dataProvider: DataProvider = {
+  ...simpleRestDataProvider(API_URL, client),
+
+  getList: async <TData extends BaseRecord = BaseRecord>({
+    resource,
+    pagination,
+    sorters,
+    filters,
+    meta,
+  }: GetListParams): Promise<GetListResponse<TData>> => {
+    const { data } = await client.get(resourcePath(resource), {
+      params: {
+        ...(meta?.params as object | undefined),
+        pagination,
+        sorters,
+        filters,
+      },
+    })
+    const list = unwrapList<TData>(data, resource)
+
+    return {
+      data: list,
+      total: list.length,
+    }
+  },
+
+  getOne: async <TData extends BaseRecord = BaseRecord>({
+    resource,
+    id,
+  }: GetOneParams): Promise<GetOneResponse<TData>> => {
+    const { data } = await client.get(pathWithId(resource, id))
+
+    return {
+      data: unwrapOne<TData>(data, resource),
+    }
+  },
+
+  create: async <TData extends BaseRecord = BaseRecord, TVariables = {}>({
+    resource,
+    variables,
+  }: CreateParams<TVariables>): Promise<CreateResponse<TData>> => {
+    const { data } = await client.post(resourcePath(resource), variables)
+
+    return {
+      data: unwrapOne<TData>(data, resource),
+    }
+  },
+
+  update: async <TData extends BaseRecord = BaseRecord, TVariables = {}>({
+    resource,
+    id,
+    variables,
+  }: UpdateParams<TVariables>): Promise<UpdateResponse<TData>> => {
+    const { data } = await client.patch(pathWithId(resource, id), variables)
+
+    return {
+      data: unwrapOne<TData>(data, resource),
+    }
+  },
+
+  deleteOne: async <TData extends BaseRecord = BaseRecord, TVariables = {}>({
+    resource,
+    id,
+  }: DeleteOneParams<TVariables>): Promise<DeleteOneResponse<TData>> => {
+    const { data } = await client.delete(pathWithId(resource, id))
+
+    return {
+      data: unwrapOne<TData>(data, resource),
+    }
+  },
+
+  getApiUrl: () => API_URL,
+}

--- a/apps/dashboard/src/test/refine-wrapper.tsx
+++ b/apps/dashboard/src/test/refine-wrapper.tsx
@@ -1,0 +1,87 @@
+import { act } from 'react'
+import type { BaseRecord, DataProvider } from '@refinedev/core'
+import { Refine } from '@refinedev/core'
+import type { ReactNode } from 'react'
+
+export type MockGetListFn = () => Promise<BaseRecord[]>
+export type MockGetOneFn = (id: string | number) => Promise<BaseRecord>
+export type MockCreateFn = (variables: unknown) => Promise<BaseRecord>
+
+export interface MockDataConfig {
+  getList?: Record<string, MockGetListFn>
+  getOne?: Record<string, MockGetOneFn>
+  create?: Record<string, MockCreateFn>
+}
+
+export function createMockDataProvider(config: MockDataConfig): DataProvider {
+  return {
+    getList: async ({ resource }) => {
+      const handler = config.getList?.[resource]
+      if (!handler) return { data: [], total: 0 }
+      const data = await handler()
+      return { data, total: data.length }
+    },
+    getOne: async ({ resource, id }) => {
+      const handler = config.getOne?.[resource]
+      if (!handler) return { data: {} as BaseRecord }
+      const data = await handler(id)
+      return { data }
+    },
+    create: async ({ resource, variables }) => {
+      const handler = config.create?.[resource]
+      if (!handler) return { data: {} as BaseRecord }
+      const data = await handler(variables)
+      return { data }
+    },
+    update: async () => ({ data: {} as BaseRecord }),
+    deleteOne: async () => ({ data: {} as BaseRecord }),
+    getApiUrl: () => 'http://localhost:8080/api/v1',
+  }
+}
+
+export function RefineWrapper({
+  children,
+  dataProvider,
+}: {
+  children: ReactNode
+  dataProvider: DataProvider
+}) {
+  return (
+    <Refine dataProvider={dataProvider}>
+      {children}
+    </Refine>
+  )
+}
+
+/**
+ * Flush pending React state updates and TanStack Query async chains.
+ * Uses setTimeout(0) rather than Promise.resolve() so that macro-tasks
+ * scheduled by React 19 concurrent rendering also get a chance to run.
+ */
+export async function flushAsync() {
+  await act(async () => {
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+  })
+}
+
+/**
+ * Repeatedly flush until `assertion` passes or `maxMs` expires.
+ * Replaces bare flush() calls in tests that need data to appear.
+ */
+export async function waitFor(
+  assertion: () => void,
+  maxMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + maxMs
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    await flushAsync()
+    try {
+      assertion()
+      return
+    } catch (e) {
+      lastError = e
+    }
+  }
+  throw lastError
+}

--- a/docs/dashboard-stack-evaluation.md
+++ b/docs/dashboard-stack-evaluation.md
@@ -10,11 +10,9 @@
 - 手動放入的 `shadcn/ui` 基礎元件
 - 後端為 Go + Gin + GORM，提供 REST API
 
-本文件的目的是評估：
+本文件記錄 dashboard 的技術選型過程與最終決策。
 
-- 目前同事已經做的 dashboard 骨架是否適合延續
-- 針對 MVP 階段，是否適合導入 `Refine.dev`
-- 若導入，應採取什麼範圍與方式
+**決策（2026-05-01）：採用 `Refine.dev` 作為 dashboard 主框架。**
 
 ---
 
@@ -55,15 +53,16 @@
 
 ### 結論摘要
 
-在目前條件下：
+**已決定（2026-05-01）採用 `Refine.dev` 作為 dashboard framework，保留既有 React 專案與部分 UI 骨架。**
 
-- 不追求深度客製化
-- 目前還在 MVP
-- 希望盡可能有現成能力快速跑起來
+理由：dashboard 會持續成長；Refine 的 resource/provider convention 在頁面規模擴大時帶來一致性；access control、快取、分頁等功能免費獲得；複合頁面仍可在 Refine 專案內自寫，不受限制。
 
-建議採用：
+### 為什麼不是 Next.js
 
-**`Refine.dev` 作為 dashboard framework，保留既有 React 專案與部分 UI 骨架。**
+- 後端是 Go + Gin 的 API-first 架構，不需要 SSR 或 SSG
+- Dashboard 是純後台管理工具，沒有 SEO 需求，server render 的優勢無法轉化為價值
+- Next.js 帶來的複雜度（server actions、routing convention、需要 Node server 部署）在此場景沒有對應回報
+- 初始骨架已用 Vite 建立，重來成本高
 
 ### 為什麼不是 Go Admin
 
@@ -145,16 +144,16 @@
 
 ---
 
-## 推薦決策
+## 決策
 
-### 建議採納
+### 已確認採納
 
-1. 將 `Refine.dev` 視為 MVP 階段 dashboard 主框架
+1. `Refine.dev` 作為 MVP 階段 dashboard 主框架
 2. 保留既有 React 專案結構，不另起新專案
 3. 先用 `Refine` 解決 auth、resource、list/edit/create 的基本問題
 4. 自訂程度先控制在必要範圍
 
-### 不建議現在投入的方向
+### 不投入的方向
 
 - 大量手刻 table/form infra
 - 為了未來可能需求而過早最佳化 dashboard 架構
@@ -164,19 +163,6 @@
 
 ## 下一步
 
-建議接著執行：
-
-1. 建立 Refine MVP 導入計畫
-2. 決定第一波 resource：
-   - `streamers`
-   - `transactions`
-   - `settings`
-3. 重構 auth flow：
-   - token 持久化
-   - refresh 機制
-   - `authProvider`
-4. 再進行第一波頁面實作
-
-對應的實作規劃見：
+實作規劃見：
 
 - [`plans/refine-dashboard-mvp.md`](../plans/refine-dashboard-mvp.md)

--- a/plans/refine-dashboard-mvp.md
+++ b/plans/refine-dashboard-mvp.md
@@ -2,11 +2,11 @@
 
 ## 狀態
 
-提案中
+進行中
 
 ## 目標
 
-在不推翻既有 `dashboard/` 專案的前提下，導入 `Refine.dev` 作為 MVP 階段的 dashboard framework，快速完成：
+在不推翻既有 `apps/dashboard/` 專案的前提下，導入 `Refine.dev` 作為 MVP 階段的 dashboard framework，快速完成：
 
 - 登入後台基礎流程
 - 受保護路由
@@ -17,13 +17,13 @@
 
 ## 專案背景
 
-目前 repo 結構：
+目前 repo 結構（monorepo）：
 
-- `backend/`：Go + Gin + GORM
-- `tachimint/`：Twitch Extension 前端
-- `dashboard/`：React 後台骨架
+- `services/api/`：Go + Gin + GORM
+- `apps/extension/`：Twitch Extension 前端
+- `apps/dashboard/`：React 後台骨架
 
-目前 `dashboard/` 已經有：
+目前 `apps/dashboard/` 已經有：
 
 - React Router 路由骨架
 - 基本 Layout
@@ -80,7 +80,7 @@
 
 ### Phase 2: Auth 與 Session
 
-- 重構 [`dashboard/src/services/auth.ts`](/Users/tachikoma/Documents/Web3/tachigo/dashboard/src/services/auth.ts)
+- 重構 [`apps/dashboard/src/services/auth.ts`](../apps/dashboard/src/services/auth.ts)
 - 支援：
   - access token 持久化策略
   - refresh token 使用策略
@@ -103,13 +103,13 @@
 
 ### Phase 4: 保留式整合
 
-- 盡量保留現有 [`dashboard/src/components/Layout.tsx`](/Users/tachikoma/Documents/Web3/tachigo/dashboard/src/components/Layout.tsx)
+- 盡量保留現有 [`apps/dashboard/src/components/Layout.tsx`](../apps/dashboard/src/components/Layout.tsx)
 - 將現有 nav 與 Refine resource route 對齊
-- 保留 [`dashboard/src/pages/DashboardPage.tsx`](/Users/tachikoma/Documents/Web3/tachigo/dashboard/src/pages/DashboardPage.tsx) 作為自寫總覽頁
+- 保留 [`apps/dashboard/src/pages/DashboardPage.tsx`](../apps/dashboard/src/pages/DashboardPage.tsx) 作為自寫總覽頁
 
 ### Phase 5: 文件與驗證
 
-- 更新 `dashboard/README.md`
+- 更新 `apps/dashboard/README.md`
 - 補上 dashboard 啟動與架構說明
 - 驗證基本登入、跳轉、resource 頁面流程
 
@@ -118,7 +118,7 @@
 ## 建議檔案結構
 
 ```text
-dashboard/src/
+apps/dashboard/src/
 ├── main.tsx
 ├── App.tsx
 ├── components/
@@ -181,7 +181,7 @@ dashboard/src/
 
 目前有些 dashboard / admin / agency 路由仍回傳 `501 not implemented`：
 
-- [`backend/internal/router/router.go`](/Users/tachikoma/Documents/Web3/tachigo/backend/internal/router/router.go)
+- [`services/api/internal/router/router.go`](../services/api/internal/router/router.go)
 
 影響：
 
@@ -204,14 +204,14 @@ dashboard/src/
 
 ## 驗收標準
 
-- [ ] `dashboard/` 可正常啟動
+- [ ] `apps/dashboard/` 可正常啟動
 - [ ] 登入後可進入受保護頁面
 - [ ] 重新整理後登入狀態不會立即失效
 - [ ] `streamers` resource 可顯示 list 頁
 - [ ] `transactions` resource 可顯示 list 頁
 - [ ] `settings` 頁可作為 Refine route 或整合式頁面進入
 - [ ] Layout 與側邊欄仍正常運作
-- [ ] `dashboard/README.md` 已更新
+- [ ] `apps/dashboard/README.md` 已更新
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,24 @@ importers:
 
   apps/dashboard:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.2(react-hook-form@7.74.0(react@19.2.5))
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
+      '@refinedev/core':
+        specifier: ^5.0.0
+        version: 5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@refinedev/react-hook-form':
+        specifier: ^5.0.0
+        version: 5.0.4(@refinedev/core@5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.74.0(react@19.2.5))(react@19.2.5)
+      '@refinedev/react-router':
+        specifier: ^2.0.0
+        version: 2.0.4(@refinedev/core@5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@refinedev/simple-rest':
+        specifier: ^6.0.0
+        version: 6.0.1(@refinedev/core@5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
@@ -34,12 +49,18 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-hook-form:
+        specifier: ^7.62.0
+        version: 7.74.0(react@19.2.5)
       react-router:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.5.0
+      zod:
+        specifier: ^4.1.5
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -346,6 +367,11 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -408,6 +434,62 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@refinedev/core@5.0.12':
+    resolution: {integrity: sha512-9y5Bi9Lb7XyJmM55b8rCeBTDRCBU41p47OymJldasLfrtpUm2EwI+27DjjNpHTOugymiZsIbLlPtHCPQIXBHcg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@tanstack/react-query': ^5.81.5
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@refinedev/devtools-internal@2.0.2':
+    resolution: {integrity: sha512-1YYizOW1lyy9ep8eQ7TcUPBooKXIlvzTLjLdDArsQwx7P33cn2uXdqM7So5VhlNFXhjOjAKFgrH5c1jleRF8Jg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@refinedev/devtools-shared@2.0.2':
+    resolution: {integrity: sha512-3cTjR1mEWn0tHFZBfPD5aVpBGLUhpAkfjqYCwKrijIicr1Utp/j0BqiPRnNqTf+W71HTng3znBpUhnR83u+tuA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@refinedev/react-hook-form@5.0.4':
+    resolution: {integrity: sha512-JT4Wsr9ovVt0t06TYqUT/VeevfRRTLv6cr3zAsDE2e4IoDnZfG+Rz4YGzSIbn/WxBpveY6oSPd9UfXaOfffvXg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@refinedev/core': ^5.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      react-hook-form: ^7.57.0
+
+  '@refinedev/react-router@2.0.4':
+    resolution: {integrity: sha512-5s31Ao2BE0f1XMBnF1bSX1eVOAmU8eelD9EYYeTHGkcPJKZTX+gA8zdtG0GBbLXgpE4l/llfrkMoIc820ruPvQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@refinedev/core': ^5.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      react-router: ^7.0.2
+
+  '@refinedev/simple-rest@6.0.1':
+    resolution: {integrity: sha512-/xx/SiZ2aaA3KJO7PWFxWXvgG5n8roEay6BBdRHhwCMYFuHIOob82pl5KBGbRi+KLuFLUj+nSt9Q76D0uyIOlg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@refinedev/core': ^5.0.0
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -513,6 +595,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
 
@@ -604,6 +689,14 @@ packages:
 
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
+
+  '@tanstack/query-core@5.100.6':
+    resolution: {integrity: sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==}
+
+  '@tanstack/react-query@5.100.6':
+    resolution: {integrity: sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -810,6 +903,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
@@ -862,6 +959,10 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -887,6 +988,9 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
+
+  error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -996,6 +1100,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  filter-obj@1.1.0:
+    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
+    engines: {node: '>=0.10.0'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -1242,6 +1350,12 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -1290,6 +1404,10 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -1304,6 +1422,9 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  papaparse@5.5.3:
+    resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -1326,6 +1447,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -1345,10 +1470,24 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
+    engines: {node: '>=6'}
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-hook-form@7.74.0:
+    resolution: {integrity: sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-i18next@17.0.6:
     resolution: {integrity: sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw==}
@@ -1416,6 +1555,22 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1423,11 +1578,22 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  split-on-first@1.1.0:
+    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
+    engines: {node: '>=6'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  strict-uri-encode@2.0.0:
+    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
+    engines: {node: '>=4'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -1614,6 +1780,9 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  warn-once@0.1.1:
+    resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -1870,6 +2039,11 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.74.0(react@19.2.5))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.74.0(react@19.2.5)
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1927,6 +2101,70 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@refinedev/core@5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@refinedev/devtools-internal': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-query': 5.100.6(react@19.2.5)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      papaparse: 5.5.3
+      pluralize: 8.0.0
+      qs: 6.15.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+      warn-once: 0.1.1
+
+  '@refinedev/devtools-internal@2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@refinedev/devtools-shared': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-query': 5.100.6(react@19.2.5)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      error-stack-parser: 2.1.4
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@refinedev/devtools-shared@2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/react-query': 5.100.6(react@19.2.5)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      error-stack-parser: 2.1.4
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@refinedev/react-hook-form@5.0.4(@refinedev/core@5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.74.0(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@refinedev/core': 5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-hook-form: 7.74.0(react@19.2.5)
+
+  '@refinedev/react-router@2.0.4(@refinedev/core@5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@refinedev/core': 5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      qs: 6.15.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  '@refinedev/simple-rest@6.0.1(@refinedev/core@5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
+      '@refinedev/core': 5.0.12(@tanstack/react-query@5.100.6(react@19.2.5))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      axios: 1.15.2
+      query-string: 7.1.3
+    transitivePeerDependencies:
+      - debug
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
@@ -1981,6 +2219,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.2.4':
     dependencies:
@@ -2050,6 +2290,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       postcss: 8.5.12
       tailwindcss: 4.2.4
+
+  '@tanstack/query-core@5.100.6': {}
+
+  '@tanstack/react-query@5.100.6(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.6
+      react: 19.2.5
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -2377,6 +2624,11 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001791: {}
 
   chai@6.2.2: {}
@@ -2421,6 +2673,8 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-uri-component@0.2.2: {}
+
   deep-is@0.1.4: {}
 
   delayed-stream@1.0.0: {}
@@ -2441,6 +2695,10 @@ snapshots:
       tapable: 2.3.3
 
   entities@8.0.0: {}
+
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
 
   es-define-property@1.0.1: {}
 
@@ -2563,6 +2821,8 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  filter-obj@1.1.0: {}
 
   find-up@5.0.0:
     dependencies:
@@ -2773,6 +3033,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
+  lodash@4.18.1: {}
+
   lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
@@ -2809,6 +3073,8 @@ snapshots:
 
   node-releases@2.0.38: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
 
   optionator@0.9.4:
@@ -2828,6 +3094,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  papaparse@5.5.3: {}
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -2841,6 +3109,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pluralize@8.0.0: {}
 
   postcss-value-parser@4.2.0: {}
 
@@ -2856,10 +3126,25 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  query-string@7.1.3:
+    dependencies:
+      decode-uri-component: 0.2.2
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-hook-form@7.74.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   react-i18next@17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
     dependencies:
@@ -2923,13 +3208,47 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
 
+  split-on-first@1.1.0: {}
+
   stackback@0.0.2: {}
 
+  stackframe@1.3.4: {}
+
   std-env@4.1.0: {}
+
+  strict-uri-encode@2.0.0: {}
 
   symbol-tree@3.2.4: {}
 
@@ -2972,8 +3291,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -3068,6 +3386,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  warn-once@0.1.1: {}
 
   webidl-conversions@8.0.1: {}
 


### PR DESCRIPTION
## 什麼改動

將 `apps/dashboard/` 從純 Vite + React 遷移到 Refine.dev v5：
- 新增 `authProvider`（包裝現有 auth.ts）和 `dataProvider`（包裝現有 axios client，處理 `{ data: [...] }` envelope）
- 改寫 App.tsx：`<Refine>` + `<Authenticated>` + resources 定義
- StreamersPage、StreamerDetailPage、RafflesPage 改用 `useList` / `useOne` hooks
- TransactionsPage、RaffleDetailPage：基本 useList / useOne 實作
- 測試套件：新增 `refine-wrapper.tsx`（RefineWrapper + createMockDataProvider + waitFor）並重寫三個頁面測試

## 為什麼

架構評估後決定遷移 Refine（見 docs/dashboard-stack-evaluation.md）：
- Go API-first 後端，不需要 SSR/SEO，Next.js 不適合
- Refine 提供 DataProvider / AuthProvider / CRUD hooks，減少大量 boilerplate
- 姊妹專案 Tachiya 也採用相同 Refine 架構

closes #456

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## Scope 對齊

- Source of truth：#456
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 UI design system / component library
  - 不做 Admin panel UI（table filters、pagination、form builder）
  - 不做 Tachiya Dashboard 遷移（另開 issue）

## PR 拆分檢查

- 這個 PR 的單一句子目的：將 dashboard 從 Vite + React 的手動 fetch 遷移至 Refine.dev v5 的資料層框架
- Approx changed lines：~1,000 行（架構遷移 + 測試重寫，整合度高無法拆分）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Refine 架構遷移是 frontend-only 改動，providers / pages / tests 三部分高度耦合，拆分會造成中間狀態無法通過測試

## Acceptance Criteria

- [x] TypeScript compile 無 error（`tsc --noEmit`）
- [x] 58 個測試全數通過
- [x] authProvider.check 是 async（呼叫 restoreSession）
- [x] dataProvider 包裝現有 axios client，不建新 instance
- [x] StreamersPage 正確處理 401/403 fallback 邏輯
- [x] StreamerDetailPage 導覽到新 streamerId 時清除舊資料（key remount）

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**

```
Test Files  7 passed (7)
      Tests  58 passed (58)
   Duration  1.65s

TypeScript compilation completed
```

## 備註

- `refine-wrapper.tsx` 中的 `waitFor` 採用 `setTimeout(0)` polling 而非 `Promise.resolve`，以確保 React 19 concurrent rendering + TanStack Query 的非同步狀態更新都被 flush
- `StreamerDetailRoute` wrapper 用 `key={streamerId}` 強制 remount，這是 TanStack Query 跨 route 清除舊資料的 React-idiomatic 做法

## Notes for Claude Code Review

- dataProvider 的 `unwrapList` / `unwrapOne` 函數覆蓋多種 key candidates（'streamers'、'channels' 等），是否需要收緊？
- authProvider.check 目前 await restoreSession() 後再呼叫 isAuthenticated()，失敗時 return `{ authenticated: false }`，是否還需要處理 redirect loop？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 發行說明

* **新功能**
  * 整合 Refine.dev 框架至儀表板，提供完整的資料管理與驗證流程
  * 抽獎頁面現支援詳細檢視與建立功能
  * 實況主頁面新增頻道設定與統計資訊檢視
  * 交易紀錄頁面新增表格顯示與篩選功能
  * 設定頁面 UI 版面最佳化

* **文件**
  * 更新儀表板 README，記錄啟動步驟與架構說明
  * 更新技術決策文檔，確認採用 Refine.dev 作為開發框架

<!-- end of auto-generated comment: release notes by coderabbit.ai -->