### PR TITLE
[chore] Dashboard：Refine.dev 決策記錄與遷移計畫更新

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -24,7 +24,7 @@ pnpm dev
 - `src/providers/authProvider.ts`：為 Refine `<Authenticated>` 提供 `check()` 介面；`check()` 內部同樣呼叫 `restoreSession()`，`main.tsx` 的啟動呼叫不變
 - `src/providers/dataProvider.ts`：以 `@refinedev/simple-rest` 為 base，實際 request 使用既有 axios client；`/api/v1` prefix 作為 base URL 的一部分（非中介層自動注入）
 - `src/App.tsx`：改以 `<Refine>` 包住 React Router，resources 定義 `streamers`、`raffles`、`transactions`、`settings`
-- API base URL 優先讀 `VITE_TACHIGO_API_URL`，其次 `VITE_API_URL`，最後回退到 `http://localhost:8080`
+- dataProvider base URL 使用 `VITE_API_URL`，未設定時回退到 `http://localhost:8080`，並加上 `/api/v1` 作為路徑前綴
 
 ## API response envelope
 

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,73 +1,52 @@
-# React + TypeScript + Vite
+# Tachigo Dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Tachigo Dashboard 是 Vite + React + TypeScript 應用，管理介面以 Refine.dev 作為資料、認證與路由整合層，畫面仍使用專案既有 Tailwind / shadcn-style 元件。
 
-Currently, two official plugins are available:
+## 啟動方式
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+pnpm install
+pnpm dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+預設 Vite dev server 使用 `5174`。API base URL 依序讀取：
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+1. `VITE_TACHIGO_API_URL`
+2. `VITE_API_URL`
+3. `http://localhost:8080`
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+所有 API request 會再加上 `/api/v1` prefix。
+
+## Refine 架構
+
+`src/App.tsx` 以 `<Refine>` 包住 React Router v7 `createBrowserRouter`，並傳入：
+
+- `src/providers/authProvider.ts`：橋接既有 `services/auth.ts`，登入、登出、啟動時 session restore、JWT role / identity 解析都集中在這裡。
+- `src/providers/dataProvider.ts`：以 `@refinedev/simple-rest` 為 base，實際 request 使用既有 axios client，因此會沿用 in-memory access token、httpOnly refresh cookie 與 401 refresh interceptor。
+- Refine resources：`streamers`、`raffles`、`transactions`、`settings`。首頁 `DashboardPage` 保持自寫頁面，不走 resource。
+
+受保護路由使用 Refine `<Authenticated>`，未登入會導向 `/login`。`authProvider.check()` 是 async，會呼叫 `restoreSession()` 讓 app 啟動時可以用 refresh cookie 換回 access token。
+
+## API response envelope
+
+後端 response 不是標準 simple-rest 格式，常見格式如下：
+
+```json
+{ "data": { "raffles": [] } }
+```
+
+或：
+
+```json
+{ "data": { "raffle": {} } }
+```
+
+`dataProvider` 會把 envelope 轉成 Refine hooks 需要的 `{ data, total }` 或 `{ data }`，讓 `useList` / `useOne` 可直接在頁面使用。
+
+## 常用指令
+
+```bash
+pnpm test
+pnpm lint
+pnpm build
 ```

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,6 +1,6 @@
 # Tachigo Dashboard
 
-Tachigo Dashboard 是 Vite + React + TypeScript 應用，管理介面以 Refine.dev 作為資料、認證與路由整合層，畫面仍使用專案既有 Tailwind / shadcn-style 元件。
+Tachigo Dashboard 是 Vite + React + TypeScript 應用，管理介面。
 
 ## 啟動方式
 
@@ -9,27 +9,26 @@ pnpm install
 pnpm dev
 ```
 
-預設 Vite dev server 使用 `5174`。API base URL 依序讀取：
+預設 Vite dev server 使用 `5174`。API base URL 使用 `VITE_API_URL`，未設定時回退到 `http://localhost:8080`。
 
-1. `VITE_TACHIGO_API_URL`
-2. `VITE_API_URL`
-3. `http://localhost:8080`
+## 目前架構
 
-所有 API request 會再加上 `/api/v1` prefix。
+`src/App.tsx` 使用 React Router v7 `createBrowserRouter`，並以 `ProtectedRoute`（驗證 `isAuthenticated()`）保護需要登入的路由。
 
-## Refine 架構
+認證邏輯集中在 `src/services/auth.ts`，使用 in-memory access token + httpOnly refresh cookie。`src/main.tsx` 在 app 啟動時呼叫 `restoreSession()` 取回 access token；各頁面的 API request path 由各 service 函式自行帶入 `/api/v1` prefix。
 
-`src/App.tsx` 以 `<Refine>` 包住 React Router v7 `createBrowserRouter`，並傳入：
+## 規劃中：Refine.dev 架構遷移
 
-- `src/providers/authProvider.ts`：橋接既有 `services/auth.ts`，登入、登出、啟動時 session restore、JWT role / identity 解析都集中在這裡。
-- `src/providers/dataProvider.ts`：以 `@refinedev/simple-rest` 為 base，實際 request 使用既有 axios client，因此會沿用 in-memory access token、httpOnly refresh cookie 與 401 refresh interceptor。
-- Refine resources：`streamers`、`raffles`、`transactions`、`settings`。首頁 `DashboardPage` 保持自寫頁面，不走 resource。
+以下異動正在進行，尚未合併到 develop（追蹤 #456）：
 
-受保護路由使用 Refine `<Authenticated>`，未登入會導向 `/login`。`authProvider.check()` 是 async，會呼叫 `restoreSession()` 讓 app 啟動時可以用 refresh cookie 換回 access token。
+- `src/providers/authProvider.ts`：為 Refine `<Authenticated>` 提供 `check()` 介面；`check()` 內部同樣呼叫 `restoreSession()`，`main.tsx` 的啟動呼叫不變
+- `src/providers/dataProvider.ts`：以 `@refinedev/simple-rest` 為 base，實際 request 使用既有 axios client；`/api/v1` prefix 作為 base URL 的一部分（非中介層自動注入）
+- `src/App.tsx`：改以 `<Refine>` 包住 React Router，resources 定義 `streamers`、`raffles`、`transactions`、`settings`
+- API base URL 優先讀 `VITE_TACHIGO_API_URL`，其次 `VITE_API_URL`，最後回退到 `http://localhost:8080`
 
 ## API response envelope
 
-後端 response 不是標準 simple-rest 格式，常見格式如下：
+後端 response 格式如下（非標準 simple-rest）：
 
 ```json
 { "data": { "raffles": [] } }
@@ -40,8 +39,6 @@ pnpm dev
 ```json
 { "data": { "raffle": {} } }
 ```
-
-`dataProvider` 會把 envelope 轉成 Refine hooks 需要的 `{ data, total }` 或 `{ data }`，讓 `useList` / `useOne` 可直接在頁面使用。
 
 ## 常用指令
 

--- a/docs/dashboard-stack-evaluation.md
+++ b/docs/dashboard-stack-evaluation.md
@@ -10,11 +10,9 @@
 - 手動放入的 `shadcn/ui` 基礎元件
 - 後端為 Go + Gin + GORM，提供 REST API
 
-本文件的目的是評估：
+本文件記錄 dashboard 的技術選型過程與最終決策。
 
-- 目前同事已經做的 dashboard 骨架是否適合延續
-- 針對 MVP 階段，是否適合導入 `Refine.dev`
-- 若導入，應採取什麼範圍與方式
+**決策（2026-05-01）：採用 `Refine.dev` 作為 dashboard 主框架。**
 
 ---
 
@@ -55,15 +53,16 @@
 
 ### 結論摘要
 
-在目前條件下：
+**已決定（2026-05-01）採用 `Refine.dev` 作為 dashboard framework，保留既有 React 專案與部分 UI 骨架。**
 
-- 不追求深度客製化
-- 目前還在 MVP
-- 希望盡可能有現成能力快速跑起來
+理由：dashboard 會持續成長；Refine 的 resource/provider convention 在頁面規模擴大時帶來一致性；access control、快取、分頁等功能免費獲得；複合頁面仍可在 Refine 專案內自寫，不受限制。
 
-建議採用：
+### 為什麼不是 Next.js
 
-**`Refine.dev` 作為 dashboard framework，保留既有 React 專案與部分 UI 骨架。**
+- 後端是 Go + Gin 的 API-first 架構，不需要 SSR 或 SSG
+- Dashboard 是純後台管理工具，沒有 SEO 需求，server render 的優勢無法轉化為價值
+- Next.js 帶來的複雜度（server actions、routing convention、需要 Node server 部署）在此場景沒有對應回報
+- 初始骨架已用 Vite 建立，重來成本高
 
 ### 為什麼不是 Go Admin
 
@@ -145,16 +144,16 @@
 
 ---
 
-## 推薦決策
+## 決策
 
-### 建議採納
+### 已確認採納
 
-1. 將 `Refine.dev` 視為 MVP 階段 dashboard 主框架
+1. `Refine.dev` 作為 MVP 階段 dashboard 主框架
 2. 保留既有 React 專案結構，不另起新專案
 3. 先用 `Refine` 解決 auth、resource、list/edit/create 的基本問題
 4. 自訂程度先控制在必要範圍
 
-### 不建議現在投入的方向
+### 不投入的方向
 
 - 大量手刻 table/form infra
 - 為了未來可能需求而過早最佳化 dashboard 架構
@@ -164,19 +163,6 @@
 
 ## 下一步
 
-建議接著執行：
-
-1. 建立 Refine MVP 導入計畫
-2. 決定第一波 resource：
-   - `streamers`
-   - `transactions`
-   - `settings`
-3. 重構 auth flow：
-   - token 持久化
-   - refresh 機制
-   - `authProvider`
-4. 再進行第一波頁面實作
-
-對應的實作規劃見：
+實作規劃見：
 
 - [`plans/refine-dashboard-mvp.md`](../plans/refine-dashboard-mvp.md)

--- a/docs/dashboard-stack-evaluation.md
+++ b/docs/dashboard-stack-evaluation.md
@@ -40,8 +40,8 @@
 ### 目前技術風險
 
 - [`apps/dashboard/src/services/auth.ts`](../apps/dashboard/src/services/auth.ts)
-  - `accessToken` 僅保存在記憶體
-  - 重新整理頁面後，`isAuthenticated()` 會回傳 false
+  - `accessToken` 僅保存在記憶體；但 `main.tsx` 啟動時會 `await restoreSession()`，透過 httpOnly refresh cookie 還原 token，頁面重整不會立即掉登入
+  - Refine `authProvider` 尚未整合，目前 route guard 仍由 `ProtectedRoute` 處理
 - [`apps/dashboard/src/components/ProtectedRoute.tsx`](../apps/dashboard/src/components/ProtectedRoute.tsx)
   - 現在的 route guard 只適合非常早期原型
 - [`apps/dashboard/README.md`](../apps/dashboard/README.md)

--- a/plans/refine-dashboard-mvp.md
+++ b/plans/refine-dashboard-mvp.md
@@ -2,11 +2,11 @@
 
 ## 狀態
 
-提案中
+進行中
 
 ## 目標
 
-在不推翻既有 `dashboard/` 專案的前提下，導入 `Refine.dev` 作為 MVP 階段的 dashboard framework，快速完成：
+在不推翻既有 `apps/dashboard/` 專案的前提下，導入 `Refine.dev` 作為 MVP 階段的 dashboard framework，快速完成：
 
 - 登入後台基礎流程
 - 受保護路由
@@ -17,13 +17,13 @@
 
 ## 專案背景
 
-目前 repo 結構：
+目前 repo 結構（monorepo）：
 
-- `backend/`：Go + Gin + GORM
-- `tachimint/`：Twitch Extension 前端
-- `dashboard/`：React 後台骨架
+- `services/api/`：Go + Gin + GORM
+- `apps/extension/`：Twitch Extension 前端
+- `apps/dashboard/`：React 後台骨架
 
-目前 `dashboard/` 已經有：
+目前 `apps/dashboard/` 已經有：
 
 - React Router 路由骨架
 - 基本 Layout
@@ -80,7 +80,7 @@
 
 ### Phase 2: Auth 與 Session
 
-- 重構 [`dashboard/src/services/auth.ts`](/Users/tachikoma/Documents/Web3/tachigo/dashboard/src/services/auth.ts)
+- 重構 [`apps/dashboard/src/services/auth.ts`](../apps/dashboard/src/services/auth.ts)
 - 支援：
   - access token 持久化策略
   - refresh token 使用策略
@@ -103,13 +103,13 @@
 
 ### Phase 4: 保留式整合
 
-- 盡量保留現有 [`dashboard/src/components/Layout.tsx`](/Users/tachikoma/Documents/Web3/tachigo/dashboard/src/components/Layout.tsx)
+- 盡量保留現有 [`apps/dashboard/src/components/Layout.tsx`](../apps/dashboard/src/components/Layout.tsx)
 - 將現有 nav 與 Refine resource route 對齊
-- 保留 [`dashboard/src/pages/DashboardPage.tsx`](/Users/tachikoma/Documents/Web3/tachigo/dashboard/src/pages/DashboardPage.tsx) 作為自寫總覽頁
+- 保留 [`apps/dashboard/src/pages/DashboardPage.tsx`](../apps/dashboard/src/pages/DashboardPage.tsx) 作為自寫總覽頁
 
 ### Phase 5: 文件與驗證
 
-- 更新 `dashboard/README.md`
+- 更新 `apps/dashboard/README.md`
 - 補上 dashboard 啟動與架構說明
 - 驗證基本登入、跳轉、resource 頁面流程
 
@@ -118,7 +118,7 @@
 ## 建議檔案結構
 
 ```text
-dashboard/src/
+apps/dashboard/src/
 ├── main.tsx
 ├── App.tsx
 ├── components/
@@ -181,7 +181,7 @@ dashboard/src/
 
 目前有些 dashboard / admin / agency 路由仍回傳 `501 not implemented`：
 
-- [`backend/internal/router/router.go`](/Users/tachikoma/Documents/Web3/tachigo/backend/internal/router/router.go)
+- [`services/api/internal/router/router.go`](../services/api/internal/router/router.go)
 
 影響：
 
@@ -204,14 +204,14 @@ dashboard/src/
 
 ## 驗收標準
 
-- [ ] `dashboard/` 可正常啟動
+- [ ] `apps/dashboard/` 可正常啟動
 - [ ] 登入後可進入受保護頁面
 - [ ] 重新整理後登入狀態不會立即失效
 - [ ] `streamers` resource 可顯示 list 頁
 - [ ] `transactions` resource 可顯示 list 頁
 - [ ] `settings` 頁可作為 Refine route 或整合式頁面進入
 - [ ] Layout 與側邊欄仍正常運作
-- [ ] `dashboard/README.md` 已更新
+- [ ] `apps/dashboard/README.md` 已更新
 
 ---
 

--- a/plans/refine-dashboard-mvp.md
+++ b/plans/refine-dashboard-mvp.md
@@ -190,11 +190,11 @@ apps/dashboard/src/
 
 ### 2. 現有 auth 設計不足以支援穩定 dashboard 體驗
 
-目前 token 僅存在記憶體，重新整理會掉登入狀態。
+access token 仍是 in-memory，但 `main.tsx` 已在啟動時 `await restoreSession()`，透過 httpOnly refresh cookie 還原 token，頁面重整不會立即掉登入狀態。
 
 影響：
 
-- 在導入 Refine 前，應先一起整理 auth flow
+- Refine `authProvider.check()` 需同樣整合 `restoreSession()`，確保 Refine auth flow 與現有 restore 機制一致
 
 ### 3. Settings 頁不一定是典型 CRUD
 
@@ -206,7 +206,7 @@ apps/dashboard/src/
 
 - [ ] `apps/dashboard/` 可正常啟動
 - [ ] 登入後可進入受保護頁面
-- [ ] 重新整理後登入狀態不會立即失效
+- [x] 重新整理後登入狀態不會立即失效（`restoreSession()` 已在 `main.tsx` 實作）
 - [ ] `streamers` resource 可顯示 list 頁
 - [ ] `transactions` resource 可顯示 list 頁
 - [ ] `settings` 頁可作為 Refine route 或整合式頁面進入
@@ -219,7 +219,7 @@ apps/dashboard/src/
 
 1. 安裝 Refine 相關套件
 2. 建立 `authProvider` / `dataProvider`
-3. 修正 token 持久化與 refresh flow
+3. ~~修正 token 持久化與 refresh flow~~（已由 `restoreSession()` + refresh cookie 處理，無需額外修正）
 4. 將路由接入 Refine
 5. 實作 `streamers`
 6. 實作 `transactions`


### PR DESCRIPTION
## 什麼改動

- `docs/dashboard-stack-evaluation.md`：從評估文件改為決策記錄（決策日期 2026-05-01，已確認採用 Refine.dev）；補充「為什麼不是 Next.js」段落
- `plans/refine-dashboard-mvp.md`：狀態從提案中改為進行中；修正絕對路徑為 monorepo 相對路徑
- `apps/dashboard/README.md`：更新說明 Refine 架構、providers 說明、測試工具

## 為什麼

對應 #456 前置文件更新。Docs 不依賴任何 code 變更，獨立先進。

refs #456

## Release Context

- Release type：n/a

## Workflow Type

- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊

- Source of truth：#456
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否
- 本 PR 明確不做：
  - 不含任何 code 變更

## PR 拆分檢查

- 這個 PR 的單一句子目的：將 Dashboard Refine 決策記錄進 docs/ 並更新遷移計畫狀態
- Approx changed lines：~171 行（純文件）
- 本 PR 是否可獨立 review？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？n/a

## Acceptance Criteria

- [x] stack evaluation 標記決策日期與確認採用
- [x] migration plan 狀態改為進行中
- [x] 路徑全部改為 monorepo 相對路徑

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [ ] 有寫 / 更新測試（純文件，無需測試）

**驗證結果**

n/a

## 備註

後續 code PR 依序為：
1. feat/refine-dashboard-foundation（providers + App.tsx + deps）
2. feat/refine-dashboard-pages（7 個頁面遷移）
3. test/refine-dashboard-tests（測試套件更新）

## Notes for Claude Code Review

- 無高風險內容，純文件更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 發行說明

* **文檔**
  * 更新儀表板設置指南，包含啟動指令和 API 配置說明
  * 完成技術棧評估文檔，記錄 Refine.dev 的採納決策及其優勢
  * 更新專案計畫文檔以反映新的代碼庫結構

<!-- end of auto-generated comment: release notes by coderabbit.ai -->