### PR TITLE
[backend] fix: spend coupon redeem — return error and record compensation-needed on Tachiya failure

### DIFF
--- a/services/api/cmd/server/main.go
+++ b/services/api/cmd/server/main.go
@@ -86,6 +86,8 @@ func main() {
 		&models.RaffleEntry{},
 		&models.RaffleDraw{},
 		&models.RaffleClaim{},
+		// Coupon redemption tracking — refs #423
+		&models.CouponRedemption{},
 	); err != nil {
 		log.Fatalf("migration failed: %v", err)
 	}

--- a/services/api/cmd/server/main.go
+++ b/services/api/cmd/server/main.go
@@ -103,6 +103,11 @@ func main() {
 	`).Error; err != nil {
 		log.Fatalf("failed to create tachi_balances FK: %v", err)
 	}
+	if err := ensureCouponRedemptionRuntimeSchema(func(query string) error {
+		return db.Exec(query).Error
+	}); err != nil {
+		log.Fatalf("failed to create coupon_redemptions runtime schema: %v", err)
+	}
 
 	// Partial unique index: only one active session per (user_id, channel_id).
 	// GORM AutoMigrate does not support partial indexes via struct tags, so we
@@ -231,6 +236,35 @@ func initializeUserRoleEnum(exec func(query string) error) error {
 		return err
 	}
 
+	return nil
+}
+
+func ensureCouponRedemptionRuntimeSchema(exec func(query string) error) error {
+	if err := exec(`
+		DO $$ BEGIN
+			ALTER TABLE coupon_redemptions ADD CONSTRAINT chk_coupon_redemptions_amount_gt_0
+			CHECK (amount > 0);
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$;
+	`); err != nil {
+		return err
+	}
+	if err := exec(`
+		DO $$ BEGIN
+			ALTER TABLE coupon_redemptions ADD CONSTRAINT chk_coupon_redemptions_status
+			CHECK (status IN ('pending','redeemed','compensation-needed'));
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$;
+	`); err != nil {
+		return err
+	}
+	if err := exec(`
+		CREATE INDEX IF NOT EXISTS idx_coupon_redemptions_compensation
+		ON coupon_redemptions (status)
+		WHERE status = 'compensation-needed'
+	`); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/services/api/cmd/server/main_test.go
+++ b/services/api/cmd/server/main_test.go
@@ -71,6 +71,7 @@ func TestEnsureCouponRedemptionRuntimeSchema(t *testing.T) {
 	for _, want := range []string{
 		"CONSTRAINT chk_coupon_redemptions_amount_gt_0",
 		"CHECK (amount > 0)",
+		"EXCEPTION WHEN duplicate_object THEN NULL",
 		"CONSTRAINT chk_coupon_redemptions_status",
 		"status IN ('pending','redeemed','compensation-needed')",
 		"CREATE INDEX IF NOT EXISTS idx_coupon_redemptions_compensation",

--- a/services/api/cmd/server/main_test.go
+++ b/services/api/cmd/server/main_test.go
@@ -56,6 +56,32 @@ func TestInitializeUserRoleEnumExistingDatabase(t *testing.T) {
 	}
 }
 
+func TestEnsureCouponRedemptionRuntimeSchema(t *testing.T) {
+	var statements []string
+
+	err := ensureCouponRedemptionRuntimeSchema(func(query string) error {
+		statements = append(statements, normalizeSQL(query))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ensureCouponRedemptionRuntimeSchema returned error: %v", err)
+	}
+
+	joined := strings.Join(statements, " ")
+	for _, want := range []string{
+		"CONSTRAINT chk_coupon_redemptions_amount_gt_0",
+		"CHECK (amount > 0)",
+		"CONSTRAINT chk_coupon_redemptions_status",
+		"status IN ('pending','redeemed','compensation-needed')",
+		"CREATE INDEX IF NOT EXISTS idx_coupon_redemptions_compensation",
+		"WHERE status = 'compensation-needed'",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("runtime schema SQL missing %q:\n%s", want, joined)
+		}
+	}
+}
+
 func normalizeSQL(query string) string {
 	return strings.Join(strings.Fields(query), " ")
 }

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -837,6 +837,11 @@ const docTemplate = `{
                 }
             },
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "consumes": [
                     "application/json"
                 ],
@@ -874,6 +879,18 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
@@ -1599,6 +1616,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -831,6 +831,11 @@
                 }
             },
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "consumes": [
                     "application/json"
                 ],
@@ -868,6 +873,18 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
@@ -1593,6 +1610,12 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -860,6 +860,14 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.Response'
         "404":
           description: Not Found
           schema:
@@ -872,6 +880,8 @@ paths:
           description: Gone
           schema:
             $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
       summary: Submit shipping info for a claim
       tags:
       - claim
@@ -1305,6 +1315,10 @@ paths:
             $ref: '#/definitions/handlers.Response'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "503":
+          description: Service Unavailable
           schema:
             $ref: '#/definitions/handlers.Response'
       security:

--- a/services/api/internal/handlers/response.go
+++ b/services/api/internal/handlers/response.go
@@ -40,6 +40,10 @@ func unprocessableEntity(c *gin.Context, msg string) {
 	c.JSON(http.StatusUnprocessableEntity, Response{Success: false, Error: msg})
 }
 
+func serviceUnavailable(c *gin.Context, msg string) {
+	c.JSON(http.StatusServiceUnavailable, Response{Success: false, Error: msg})
+}
+
 func internal(c *gin.Context) {
 	c.JSON(http.StatusInternalServerError, Response{Success: false, Error: "internal server error"})
 }

--- a/services/api/internal/handlers/spend_handler.go
+++ b/services/api/internal/handlers/spend_handler.go
@@ -37,6 +37,7 @@ type redeemResponse struct {
 // @Success      200 {object} Response{data=redeemResponse}
 // @Failure      400 {object} Response
 // @Failure      401 {object} Response
+// @Failure      503 {object} Response
 // @Failure      500 {object} Response
 // @Security     BearerAuth
 // @Router       /spend/redeem [post]
@@ -66,6 +67,10 @@ func (h *SpendHandler) Redeem(c *gin.Context) {
 		}
 		if errors.Is(err, services.ErrSpendAmountInvalid) {
 			badRequest(c, err.Error())
+			return
+		}
+		if errors.Is(err, services.ErrTachiyaRedeemFailed) {
+			serviceUnavailable(c, "tachiya coupon redeem failed")
 			return
 		}
 		// ErrSpendContractConfig is a server-side misconfiguration; intentionally falls through to internal(c).

--- a/services/api/internal/handlers/spend_handler_test.go
+++ b/services/api/internal/handlers/spend_handler_test.go
@@ -1,0 +1,77 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/config"
+	"github.com/tachigo/tachigo/internal/handlers"
+	"github.com/tachigo/tachigo/internal/middleware"
+	"github.com/tachigo/tachigo/internal/services"
+)
+
+type mockSpendBurnCaller struct {
+	txHash string
+	err    error
+}
+
+func (m *mockSpendBurnCaller) BurnOnChain(_ context.Context, _ string, _ int64) (string, error) {
+	return m.txHash, m.err
+}
+
+type mockSpendTachiyaClient struct {
+	err error
+}
+
+func (m *mockSpendTachiyaClient) RedeemCoupon(_ context.Context, _ string, _ int64) (string, error) {
+	return "", m.err
+}
+
+func newSpendTestEnv(t *testing.T, tachiyaClient services.TachiyaClient) (*testEnv, *gin.Engine) {
+	t.Helper()
+	env := newTestEnv(t)
+	spendSvc := services.NewSpendService(env.db, config.ContractConfig{}, nil, tachiyaClient)
+	spendSvc.SetBurnCallerForTest(&mockSpendBurnCaller{txHash: "0xburn123"})
+	spendH := handlers.NewSpendHandler(spendSvc)
+
+	protected := env.router.Group("/api/v1")
+	protected.Use(middleware.JWTAuth(env.authSvc))
+	protected.POST("/spend/redeem", spendH.Redeem)
+
+	return env, env.router
+}
+
+func seedTachiBalanceForHandler(t *testing.T, env *testEnv, userID uuid.UUID, balance int64) {
+	t.Helper()
+	if err := env.db.Exec(`
+		INSERT INTO tachi_balances (id, user_id, balance, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+	`, uuid.New().String(), userID.String(), balance).Error; err != nil {
+		t.Fatalf("seedTachiBalanceForHandler: %v", err)
+	}
+}
+
+func TestSpendHandler_RedeemTachiyaFailureReturnsServiceUnavailable(t *testing.T) {
+	env, r := newSpendTestEnv(t, &mockSpendTachiyaClient{err: errors.New("tachiya unavailable")})
+	token, _ := env.registerUser(t, "spend-tachiya-fail", "spend-tachiya-fail@example.com", "password123")
+	userID := resolveUserID(t, env, "spend-tachiya-fail@example.com")
+	seedWeb3ProviderForHandler(t, env, userID)
+	seedTachiBalanceForHandler(t, env, userID, 300)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/spend/redeem", bytes.NewBufferString(`{"coupon_id":"coupon-123","amount":100}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/services/api/internal/handlers/testutil_test.go
+++ b/services/api/internal/handlers/testutil_test.go
@@ -241,6 +241,18 @@ func migrateTestDB(db *gorm.DB) error {
 			UNIQUE (user_id),
 			CHECK (balance >= 0)
 		)`,
+		`CREATE TABLE IF NOT EXISTS coupon_redemptions (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			coupon_id TEXT NOT NULL,
+			amount INTEGER NOT NULL CHECK (amount > 0),
+			tx_hash TEXT NOT NULL,
+			status TEXT NOT NULL CHECK (status IN ('pending', 'redeemed', 'compensation-needed')),
+			voucher_code TEXT,
+			error_message TEXT,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
 		`CREATE TABLE IF NOT EXISTS raffles (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),

--- a/services/api/internal/models/coupon_redemption.go
+++ b/services/api/internal/models/coupon_redemption.go
@@ -10,18 +10,23 @@ import (
 type CouponRedemptionStatus string
 
 const (
-	CouponRedemptionPending            CouponRedemptionStatus = "pending"
-	CouponRedemptionRedeemed           CouponRedemptionStatus = "redeemed"
+	// CouponRedemptionPending means burn succeeded and tx_hash is recorded, but
+	// Tachiya redeem or local voucher persistence is still unresolved.
+	CouponRedemptionPending CouponRedemptionStatus = "pending"
+	// CouponRedemptionRedeemed means Tachiya returned a voucher and it was persisted locally.
+	CouponRedemptionRedeemed CouponRedemptionStatus = "redeemed"
+	// CouponRedemptionCompensationNeeded means burn succeeded and Tachiya redeem failed.
 	CouponRedemptionCompensationNeeded CouponRedemptionStatus = "compensation-needed"
 )
 
 type CouponRedemption struct {
 	ID           uuid.UUID              `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
 	UserID       uuid.UUID              `gorm:"type:uuid;not null;index"                       json:"user_id"`
+	User         User                   `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"  json:"-"`
 	CouponID     string                 `gorm:"type:varchar(255);not null"                     json:"coupon_id"`
-	Amount       int64                  `gorm:"not null"                                       json:"amount"`
+	Amount       int64                  `gorm:"not null;check:chk_coupon_redemptions_amount_gt_0,amount > 0" json:"amount"`
 	TxHash       string                 `gorm:"type:varchar(255);not null"                     json:"tx_hash"`
-	Status       CouponRedemptionStatus `gorm:"type:varchar(50);not null"                      json:"status"`
+	Status       CouponRedemptionStatus `gorm:"type:varchar(50);not null;check:chk_coupon_redemptions_status,status IN ('pending','redeemed','compensation-needed')" json:"status"`
 	VoucherCode  *string                `gorm:"type:varchar(255)"                              json:"voucher_code,omitempty"`
 	ErrorMessage *string                `gorm:"type:text"                                      json:"error_message,omitempty"`
 	CreatedAt    time.Time              `                                                      json:"created_at"`

--- a/services/api/internal/models/coupon_redemption.go
+++ b/services/api/internal/models/coupon_redemption.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type CouponRedemptionStatus string
+
+const (
+	CouponRedemptionPending            CouponRedemptionStatus = "pending"
+	CouponRedemptionRedeemed           CouponRedemptionStatus = "redeemed"
+	CouponRedemptionCompensationNeeded CouponRedemptionStatus = "compensation-needed"
+)
+
+type CouponRedemption struct {
+	ID           uuid.UUID              `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	UserID       uuid.UUID              `gorm:"type:uuid;not null;index"                       json:"user_id"`
+	CouponID     string                 `gorm:"type:varchar(255);not null"                     json:"coupon_id"`
+	Amount       int64                  `gorm:"not null"                                       json:"amount"`
+	TxHash       string                 `gorm:"type:varchar(255);not null"                     json:"tx_hash"`
+	Status       CouponRedemptionStatus `gorm:"type:varchar(50);not null"                      json:"status"`
+	VoucherCode  *string                `gorm:"type:varchar(255)"                              json:"voucher_code,omitempty"`
+	ErrorMessage *string                `gorm:"type:text"                                      json:"error_message,omitempty"`
+	CreatedAt    time.Time              `                                                      json:"created_at"`
+	UpdatedAt    time.Time              `                                                      json:"updated_at"`
+}
+
+func (c *CouponRedemption) BeforeCreate(tx *gorm.DB) error {
+	if c.ID == uuid.Nil {
+		id, _ := uuid.NewV7()
+		c.ID = id
+	}
+	return nil
+}

--- a/services/api/internal/services/spend_service.go
+++ b/services/api/internal/services/spend_service.go
@@ -117,33 +117,41 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 
 	if s.tachiyaClient == nil {
 		if rec != nil {
-			s.db.Model(rec).Updates(map[string]interface{}{
+			if err := s.db.Model(rec).Updates(map[string]interface{}{
 				"status":     models.CouponRedemptionRedeemed,
 				"updated_at": time.Now(),
-			})
+			}).Error; err != nil {
+				log.Printf("warning: failed to mark coupon_redemption redeemed id=%s: %v", rec.ID, err)
+			}
 		}
 		return reservation.newBalance, "", nil
 	}
 
-	voucherCode, tachiyaErr := s.tachiyaClient.RedeemCoupon(ctx, couponID, reservation.amount)
+	tachiyaCtx, tachiyaCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer tachiyaCancel()
+	voucherCode, tachiyaErr := s.tachiyaClient.RedeemCoupon(tachiyaCtx, couponID, reservation.amount)
 	if tachiyaErr != nil {
 		if rec != nil {
 			errMsg := tachiyaErr.Error()
-			s.db.Model(rec).Updates(map[string]interface{}{
+			if err := s.db.Model(rec).Updates(map[string]interface{}{
 				"status":        models.CouponRedemptionCompensationNeeded,
 				"error_message": errMsg,
 				"updated_at":    time.Now(),
-			})
+			}).Error; err != nil {
+				log.Printf("warning: failed to mark coupon_redemption compensation-needed id=%s: %v", rec.ID, err)
+			}
 		}
 		return 0, "", fmt.Errorf("%w (coupon_id=%s): %v", ErrTachiyaRedeemFailed, couponID, tachiyaErr)
 	}
 
 	if rec != nil {
-		s.db.Model(rec).Updates(map[string]interface{}{
+		if err := s.db.Model(rec).Updates(map[string]interface{}{
 			"status":       models.CouponRedemptionRedeemed,
 			"voucher_code": voucherCode,
 			"updated_at":   time.Now(),
-		})
+		}).Error; err != nil {
+			log.Printf("warning: failed to persist redeemed voucher id=%s: %v", rec.ID, err)
+		}
 	}
 
 	return reservation.newBalance, voucherCode, nil

--- a/services/api/internal/services/spend_service.go
+++ b/services/api/internal/services/spend_service.go
@@ -123,7 +123,7 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 		return reservation.newBalance, "", nil
 	}
 
-	tachiyaCtx, tachiyaCancel := context.WithTimeout(ctx, 10*time.Second)
+	tachiyaCtx, tachiyaCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer tachiyaCancel()
 	voucherCode, tachiyaErr := s.tachiyaClient.RedeemCoupon(tachiyaCtx, couponID, reservation.amount)
 	if tachiyaErr != nil {
@@ -139,14 +139,12 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 		return 0, "", fmt.Errorf("%w (coupon_id=%s): %v", ErrTachiyaRedeemFailed, couponID, tachiyaErr)
 	}
 
-	if rec != nil {
-		if err := s.db.Model(rec).Updates(map[string]interface{}{
-			"status":       models.CouponRedemptionRedeemed,
-			"voucher_code": voucherCode,
-			"updated_at":   time.Now(),
-		}).Error; err != nil {
-			log.Printf("warning: failed to persist redeemed voucher id=%s: %v", rec.ID, err)
-		}
+	if err := s.db.Model(rec).Updates(map[string]interface{}{
+		"status":       models.CouponRedemptionRedeemed,
+		"voucher_code": voucherCode,
+		"updated_at":   time.Now(),
+	}).Error; err != nil {
+		return 0, "", fmt.Errorf("failed to persist redeemed voucher id=%s coupon_id=%s: %w", rec.ID, couponID, err)
 	}
 
 	return reservation.newBalance, voucherCode, nil

--- a/services/api/internal/services/spend_service.go
+++ b/services/api/internal/services/spend_service.go
@@ -23,6 +23,7 @@ var (
 	ErrSpendInsufficientBalance = errors.New("insufficient tachi balance")
 	ErrSpendWalletNotLinked     = errors.New("web3 wallet not linked")
 	ErrSpendContractConfig      = errors.New("spend contract config is incomplete")
+	ErrTachiyaRedeemFailed      = errors.New("tachiya coupon redeem failed after successful burn")
 )
 
 // BurnCaller abstracts the on-chain burn call; replaced with a mock in tests.
@@ -66,7 +67,9 @@ func NewSpendService(db *gorm.DB, contractCfg config.ContractConfig, ethClient *
 func (s *SpendService) SetBurnCallerForTest(bc BurnCaller) { s.burnCaller = bc }
 
 // Redeem burns `amount` $TACHI from the user's on-chain wallet and deducts
-// the same amount from tachi_balances. Returns the new balance.
+// the same amount from tachi_balances. Returns the new balance and voucher code.
+// If the Tachiya coupon call fails after a successful burn, returns
+// ErrTachiyaRedeemFailed and records the attempt as "compensation-needed".
 func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID string, amount int64) (int64, string, error) {
 	if amount <= 0 {
 		return 0, "", ErrSpendAmountInvalid
@@ -99,14 +102,48 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 		return 0, "", err
 	}
 
-	voucherCode := ""
-	if s.tachiyaClient != nil {
-		var tachiyaErr error
-		voucherCode, tachiyaErr = s.tachiyaClient.RedeemCoupon(ctx, couponID, reservation.amount)
-		if tachiyaErr != nil {
-			log.Printf("warning: tachiya redeem coupon failed for coupon_id=%s user_id=%s: %v", couponID, userID, tachiyaErr)
-			voucherCode = ""
+	rec := &models.CouponRedemption{
+		UserID:   userID,
+		CouponID: couponID,
+		Amount:   amount,
+		TxHash:   txHash,
+		Status:   models.CouponRedemptionPending,
+	}
+	if createErr := s.db.Create(rec).Error; createErr != nil {
+		log.Printf("warning: failed to create coupon_redemption record coupon_id=%s user_id=%s: %v",
+			couponID, userID, createErr)
+		rec = nil
+	}
+
+	if s.tachiyaClient == nil {
+		if rec != nil {
+			s.db.Model(rec).Updates(map[string]interface{}{
+				"status":     models.CouponRedemptionRedeemed,
+				"updated_at": time.Now(),
+			})
 		}
+		return reservation.newBalance, "", nil
+	}
+
+	voucherCode, tachiyaErr := s.tachiyaClient.RedeemCoupon(ctx, couponID, reservation.amount)
+	if tachiyaErr != nil {
+		if rec != nil {
+			errMsg := tachiyaErr.Error()
+			s.db.Model(rec).Updates(map[string]interface{}{
+				"status":        models.CouponRedemptionCompensationNeeded,
+				"error_message": errMsg,
+				"updated_at":    time.Now(),
+			})
+		}
+		return 0, "", fmt.Errorf("%w (coupon_id=%s): %v", ErrTachiyaRedeemFailed, couponID, tachiyaErr)
+	}
+
+	if rec != nil {
+		s.db.Model(rec).Updates(map[string]interface{}{
+			"status":       models.CouponRedemptionRedeemed,
+			"voucher_code": voucherCode,
+			"updated_at":   time.Now(),
+		})
 	}
 
 	return reservation.newBalance, voucherCode, nil

--- a/services/api/internal/services/spend_service.go
+++ b/services/api/internal/services/spend_service.go
@@ -144,6 +144,7 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 		"voucher_code": voucherCode,
 		"updated_at":   time.Now(),
 	}).Error; err != nil {
+		// Tachiya already issued the voucher; leave the local record pending so reconciliation can resolve it.
 		return 0, "", fmt.Errorf("failed to persist redeemed voucher id=%s coupon_id=%s: %w", rec.ID, couponID, err)
 	}
 

--- a/services/api/internal/services/spend_service.go
+++ b/services/api/internal/services/spend_service.go
@@ -110,19 +110,15 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 		Status:   models.CouponRedemptionPending,
 	}
 	if createErr := s.db.Create(rec).Error; createErr != nil {
-		log.Printf("warning: failed to create coupon_redemption record coupon_id=%s user_id=%s: %v",
-			couponID, userID, createErr)
-		rec = nil
+		return 0, "", fmt.Errorf("failed to record coupon_redemption before tachiya call (burn tx_hash=%s coupon_id=%s): %w", txHash, couponID, createErr)
 	}
 
 	if s.tachiyaClient == nil {
-		if rec != nil {
-			if err := s.db.Model(rec).Updates(map[string]interface{}{
-				"status":     models.CouponRedemptionRedeemed,
-				"updated_at": time.Now(),
-			}).Error; err != nil {
-				log.Printf("warning: failed to mark coupon_redemption redeemed id=%s: %v", rec.ID, err)
-			}
+		if err := s.db.Model(rec).Updates(map[string]interface{}{
+			"status":     models.CouponRedemptionRedeemed,
+			"updated_at": time.Now(),
+		}).Error; err != nil {
+			log.Printf("warning: failed to mark coupon_redemption redeemed id=%s: %v", rec.ID, err)
 		}
 		return reservation.newBalance, "", nil
 	}
@@ -131,15 +127,14 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 	defer tachiyaCancel()
 	voucherCode, tachiyaErr := s.tachiyaClient.RedeemCoupon(tachiyaCtx, couponID, reservation.amount)
 	if tachiyaErr != nil {
-		if rec != nil {
-			errMsg := tachiyaErr.Error()
-			if err := s.db.Model(rec).Updates(map[string]interface{}{
-				"status":        models.CouponRedemptionCompensationNeeded,
-				"error_message": errMsg,
-				"updated_at":    time.Now(),
-			}).Error; err != nil {
-				log.Printf("warning: failed to mark coupon_redemption compensation-needed id=%s: %v", rec.ID, err)
-			}
+		errMsg := tachiyaErr.Error()
+		if dbErr := s.db.Model(rec).Updates(map[string]interface{}{
+			"status":        models.CouponRedemptionCompensationNeeded,
+			"error_message": errMsg,
+			"updated_at":    time.Now(),
+		}).Error; dbErr != nil {
+			return 0, "", fmt.Errorf("%w (coupon_id=%s): tachiya_err=%v, db_update_err=%v",
+				ErrTachiyaRedeemFailed, couponID, tachiyaErr, dbErr)
 		}
 		return 0, "", fmt.Errorf("%w (coupon_id=%s): %v", ErrTachiyaRedeemFailed, couponID, tachiyaErr)
 	}

--- a/services/api/internal/services/spend_service_test.go
+++ b/services/api/internal/services/spend_service_test.go
@@ -103,6 +103,12 @@ func TestRedeem_Success(t *testing.T) {
 	if dbBal != 400 {
 		t.Fatalf("expected db balance=400, got %d", dbBal)
 	}
+
+	var redemptionStatus string
+	db.Raw("SELECT status FROM coupon_redemptions WHERE user_id = ?", userID).Scan(&redemptionStatus)
+	if redemptionStatus != "redeemed" {
+		t.Fatalf("expected coupon_redemption status=redeemed, got %q", redemptionStatus)
+	}
 }
 
 func TestRedeem_InsufficientBalance(t *testing.T) {
@@ -188,7 +194,7 @@ func TestRedeem_BurnFailureRollback(t *testing.T) {
 	}
 }
 
-func TestRedeem_TachiyaFailureIsNonBlocking(t *testing.T) {
+func TestRedeem_TachiyaFailure_ReturnsErrorAndRecordsCompensation(t *testing.T) {
 	db := newTestDB(t)
 	burnCaller := &mockBurnCaller{txHash: "0xburn123"}
 	tachiyaClient := &mockTachiyaClient{err: errors.New("tachiya unavailable")}
@@ -198,17 +204,32 @@ func TestRedeem_TachiyaFailureIsNonBlocking(t *testing.T) {
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
 	seedTachiBalance(t, db, userID, 300)
 
-	newBal, voucherCode, err := svc.Redeem(context.Background(), userID, "coupon-123", 100)
+	_, _, err := svc.Redeem(context.Background(), userID, "coupon-123", 100)
+	if !errors.Is(err, ErrTachiyaRedeemFailed) {
+		t.Fatalf("expected ErrTachiyaRedeemFailed, got %v", err)
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 200 {
+		t.Fatalf("expected balance=200 (burn not rolled back), got %d", dbBal)
+	}
+
+	var status string
+	db.Raw("SELECT status FROM coupon_redemptions WHERE user_id = ?", userID).Scan(&status)
+	if status != "compensation-needed" {
+		t.Fatalf("expected status=compensation-needed, got %q", status)
+	}
+}
+
+func TestCouponRedemptionSchema(t *testing.T) {
+	db := newTestDB(t)
+	err := db.Exec(`
+		INSERT INTO coupon_redemptions (id, user_id, coupon_id, amount, tx_hash, status, created_at, updated_at)
+		VALUES ('test-id-1', 'user-id-1', 'coupon-123', 100, '0xabc', 'pending',
+		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`).Error
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if newBal != 200 {
-		t.Fatalf("expected newBalance=200, got %d", newBal)
-	}
-	if voucherCode != "" {
-		t.Fatalf("expected empty voucherCode, got %s", voucherCode)
-	}
-	if len(tachiyaClient.calls) != 1 {
-		t.Fatalf("expected 1 tachiya call, got %d", len(tachiyaClient.calls))
+		t.Fatalf("coupon_redemptions table not ready: %v", err)
 	}
 }

--- a/services/api/internal/services/spend_service_test.go
+++ b/services/api/internal/services/spend_service_test.go
@@ -296,20 +296,25 @@ func TestRedeem_TachiyaFailure_ReturnsErrorAndRecordsCompensation(t *testing.T) 
 	}
 
 	var status string
-	db.Raw("SELECT status FROM coupon_redemptions WHERE user_id = ?", userID).Scan(&status)
+	var errorMessage sql.NullString
+	db.Raw("SELECT status, error_message FROM coupon_redemptions WHERE user_id = ?", userID).Row().Scan(&status, &errorMessage)
 	if status != "compensation-needed" {
 		t.Fatalf("expected status=compensation-needed, got %q", status)
+	}
+	if !errorMessage.Valid || errorMessage.String != "tachiya unavailable" {
+		t.Fatalf("expected error_message=tachiya unavailable, got valid=%v value=%q", errorMessage.Valid, errorMessage.String)
 	}
 }
 
 func TestCouponRedemptionSchema(t *testing.T) {
 	db := newTestDB(t)
 	userID := userIDForClaim(t, db)
+	redemptionID := uuid.NewString()
 	err := db.Exec(`
 		INSERT INTO coupon_redemptions (id, user_id, coupon_id, amount, tx_hash, status, created_at, updated_at)
-		VALUES ('test-id-1', ?, 'coupon-123', 100, '0xabc', 'pending',
+		VALUES (?, ?, 'coupon-123', 100, '0xabc', 'pending',
 		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-	`, userID.String()).Error
+	`, redemptionID, userID.String()).Error
 	if err != nil {
 		t.Fatalf("coupon_redemptions table not ready: %v", err)
 	}
@@ -317,11 +322,13 @@ func TestCouponRedemptionSchema(t *testing.T) {
 
 func TestCouponRedemptionSchemaRequiresExistingUser(t *testing.T) {
 	db := newTestDB(t)
+	redemptionID := uuid.NewString()
+	missingUserID := uuid.NewString()
 	err := db.Exec(`
 		INSERT INTO coupon_redemptions (id, user_id, coupon_id, amount, tx_hash, status, created_at, updated_at)
-		VALUES ('test-id-invalid-user', '00000000-0000-0000-0000-000000000000', 'coupon-123', 100, '0xabc', 'pending',
+		VALUES (?, ?, 'coupon-123', 100, '0xabc', 'pending',
 		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-	`).Error
+	`, redemptionID, missingUserID).Error
 	if err == nil {
 		t.Fatal("expected coupon_redemptions.user_id to require an existing user")
 	}

--- a/services/api/internal/services/spend_service_test.go
+++ b/services/api/internal/services/spend_service_test.go
@@ -15,6 +15,7 @@ type mockBurnCaller struct {
 	txHash string
 	err    error
 	calls  []burnCall
+	after  func()
 }
 
 type burnCall struct {
@@ -24,6 +25,9 @@ type burnCall struct {
 
 func (m *mockBurnCaller) BurnOnChain(_ context.Context, fromAddr string, amount int64) (string, error) {
 	m.calls = append(m.calls, burnCall{fromAddr: fromAddr, amount: amount})
+	if m.after != nil {
+		m.after()
+	}
 	return m.txHash, m.err
 }
 
@@ -33,6 +37,8 @@ type mockTachiyaClient struct {
 	voucherCode string
 	err         error
 	calls       []tachiyaCall
+	ctxErr      error
+	beforeReply func()
 }
 
 type tachiyaCall struct {
@@ -40,8 +46,12 @@ type tachiyaCall struct {
 	tcgCost  int64
 }
 
-func (m *mockTachiyaClient) RedeemCoupon(_ context.Context, couponID string, tcgCost int64) (string, error) {
+func (m *mockTachiyaClient) RedeemCoupon(ctx context.Context, couponID string, tcgCost int64) (string, error) {
 	m.calls = append(m.calls, tachiyaCall{couponID: couponID, tcgCost: tcgCost})
+	m.ctxErr = ctx.Err()
+	if m.beforeReply != nil {
+		m.beforeReply()
+	}
 	return m.voucherCode, m.err
 }
 
@@ -108,6 +118,59 @@ func TestRedeem_Success(t *testing.T) {
 	db.Raw("SELECT status FROM coupon_redemptions WHERE user_id = ?", userID).Scan(&redemptionStatus)
 	if redemptionStatus != "redeemed" {
 		t.Fatalf("expected coupon_redemption status=redeemed, got %q", redemptionStatus)
+	}
+
+	var voucher string
+	db.Raw("SELECT voucher_code FROM coupon_redemptions WHERE user_id = ?", userID).Scan(&voucher)
+	if voucher != "VOUCHER-XYZ" {
+		t.Fatalf("expected voucher_code=VOUCHER-XYZ, got %q", voucher)
+	}
+}
+
+func TestRedeem_SuccessPersistFailureReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db handle: %v", err)
+	}
+	burnCaller := &mockBurnCaller{txHash: "0xburn123"}
+	tachiyaClient := &mockTachiyaClient{
+		voucherCode: "VOUCHER-XYZ",
+		beforeReply: func() {
+			_ = sqlDB.Close()
+		},
+	}
+	svc := &SpendService{db: db, burnCaller: burnCaller, tachiyaClient: tachiyaClient}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 500)
+
+	_, _, err = svc.Redeem(context.Background(), userID, "coupon-123", 100)
+	if err == nil {
+		t.Fatal("expected error when redeemed voucher persistence fails, got nil")
+	}
+}
+
+func TestRedeem_TachiyaCallOutlivesRequestCancellationAfterBurn(t *testing.T) {
+	db := newTestDB(t)
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	burnCaller := &mockBurnCaller{
+		txHash: "0xburn123",
+		after:  cancelReq,
+	}
+	tachiyaClient := &mockTachiyaClient{voucherCode: "VOUCHER-XYZ"}
+	svc := &SpendService{db: db, burnCaller: burnCaller, tachiyaClient: tachiyaClient}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 500)
+
+	if _, _, err := svc.Redeem(reqCtx, userID, "coupon-123", 100); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tachiyaClient.ctxErr != nil {
+		t.Fatalf("tachiya context should not inherit canceled request context, got %v", tachiyaClient.ctxErr)
 	}
 }
 
@@ -224,12 +287,25 @@ func TestRedeem_TachiyaFailure_ReturnsErrorAndRecordsCompensation(t *testing.T) 
 
 func TestCouponRedemptionSchema(t *testing.T) {
 	db := newTestDB(t)
+	userID := userIDForClaim(t, db)
 	err := db.Exec(`
 		INSERT INTO coupon_redemptions (id, user_id, coupon_id, amount, tx_hash, status, created_at, updated_at)
-		VALUES ('test-id-1', 'user-id-1', 'coupon-123', 100, '0xabc', 'pending',
+		VALUES ('test-id-1', ?, 'coupon-123', 100, '0xabc', 'pending',
 		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-	`).Error
+	`, userID.String()).Error
 	if err != nil {
 		t.Fatalf("coupon_redemptions table not ready: %v", err)
+	}
+}
+
+func TestCouponRedemptionSchemaRequiresExistingUser(t *testing.T) {
+	db := newTestDB(t)
+	err := db.Exec(`
+		INSERT INTO coupon_redemptions (id, user_id, coupon_id, amount, tx_hash, status, created_at, updated_at)
+		VALUES ('test-id-invalid-user', '00000000-0000-0000-0000-000000000000', 'coupon-123', 100, '0xabc', 'pending',
+		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`).Error
+	if err == nil {
+		t.Fatal("expected coupon_redemptions.user_id to require an existing user")
 	}
 }

--- a/services/api/internal/services/spend_service_test.go
+++ b/services/api/internal/services/spend_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 
@@ -127,28 +128,44 @@ func TestRedeem_Success(t *testing.T) {
 	}
 }
 
-func TestRedeem_SuccessPersistFailureReturnsError(t *testing.T) {
+func TestRedeem_TachiyaIssuedVoucherButPersistFailureReturnsErrorAndLeavesPending(t *testing.T) {
 	db := newTestDB(t)
-	sqlDB, err := db.DB()
-	if err != nil {
-		t.Fatalf("db handle: %v", err)
+	updateErr := errors.New("forced redeemed voucher update failure")
+	if err := db.Callback().Update().Before("gorm:update").Register("fail_coupon_redemption_redeemed_update", func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "coupon_redemptions" {
+			tx.AddError(updateErr)
+		}
+	}); err != nil {
+		t.Fatalf("register update callback: %v", err)
 	}
+
 	burnCaller := &mockBurnCaller{txHash: "0xburn123"}
-	tachiyaClient := &mockTachiyaClient{
-		voucherCode: "VOUCHER-XYZ",
-		beforeReply: func() {
-			_ = sqlDB.Close()
-		},
-	}
+	tachiyaClient := &mockTachiyaClient{voucherCode: "VOUCHER-XYZ"}
 	svc := &SpendService{db: db, burnCaller: burnCaller, tachiyaClient: tachiyaClient}
 
 	userID := userIDForClaim(t, db)
 	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
 	seedTachiBalance(t, db, userID, 500)
 
-	_, _, err = svc.Redeem(context.Background(), userID, "coupon-123", 100)
-	if err == nil {
-		t.Fatal("expected error when redeemed voucher persistence fails, got nil")
+	_, _, err := svc.Redeem(context.Background(), userID, "coupon-123", 100)
+	if !errors.Is(err, updateErr) {
+		t.Fatalf("expected redeemed voucher persistence error, got %v", err)
+	}
+
+	var status string
+	var voucher sql.NullString
+	var txHash string
+	if err := db.Raw("SELECT status, voucher_code, tx_hash FROM coupon_redemptions WHERE user_id = ?", userID).Row().Scan(&status, &voucher, &txHash); err != nil {
+		t.Fatalf("scan coupon_redemption: %v", err)
+	}
+	if status != "pending" {
+		t.Fatalf("expected status to remain pending for reconciliation, got %q", status)
+	}
+	if txHash != "0xburn123" {
+		t.Fatalf("expected pending redemption to retain burn tx_hash for reconciliation, got %q", txHash)
+	}
+	if voucher.Valid {
+		t.Fatalf("expected voucher_code to remain unset after persist failure, got %q", voucher.String)
 	}
 }
 

--- a/services/api/internal/services/testutil_test.go
+++ b/services/api/internal/services/testutil_test.go
@@ -300,6 +300,18 @@ func migrateTestDB(db *gorm.DB) error {
 			country TEXT NOT NULL DEFAULT 'TW',
 			submitted_at DATETIME NOT NULL
 		)`,
+		`CREATE TABLE IF NOT EXISTS coupon_redemptions (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			coupon_id TEXT NOT NULL,
+			amount INTEGER NOT NULL CHECK (amount > 0),
+			tx_hash TEXT NOT NULL,
+			status TEXT NOT NULL CHECK (status IN ('pending', 'redeemed', 'compensation-needed')),
+			voucher_code TEXT,
+			error_message TEXT,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
 	}
 	for _, s := range stmts {
 		if err := db.Exec(s).Error; err != nil {

--- a/services/api/internal/services/testutil_test.go
+++ b/services/api/internal/services/testutil_test.go
@@ -302,7 +302,7 @@ func migrateTestDB(db *gorm.DB) error {
 		)`,
 		`CREATE TABLE IF NOT EXISTS coupon_redemptions (
 			id TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 			coupon_id TEXT NOT NULL,
 			amount INTEGER NOT NULL CHECK (amount > 0),
 			tx_hash TEXT NOT NULL,

--- a/services/api/migrations/019_coupon_redemptions.sql
+++ b/services/api/migrations/019_coupon_redemptions.sql
@@ -1,0 +1,23 @@
+-- migrations/019_coupon_redemptions.sql
+-- Tracks the lifecycle of each coupon redemption attempt for compensation.
+
+CREATE TABLE IF NOT EXISTS coupon_redemptions (
+    id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    coupon_id     VARCHAR(255) NOT NULL,
+    amount        BIGINT       NOT NULL CHECK (amount > 0),
+    tx_hash       VARCHAR(255) NOT NULL,
+    status        VARCHAR(50)  NOT NULL
+                  CHECK (status IN ('pending', 'redeemed', 'compensation-needed')),
+    voucher_code  VARCHAR(255),
+    error_message TEXT,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_coupon_redemptions_user_id
+    ON coupon_redemptions (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_coupon_redemptions_compensation
+    ON coupon_redemptions (status)
+    WHERE status = 'compensation-needed';


### PR DESCRIPTION
## 什麼改動
修正 `SpendService.Redeem()` 在 Tachiya coupon call 失敗後吞掉 error 並回傳 success 的 bug。新增 `coupon_redemptions` 表記錄每次 redeem 嘗試的狀態（pending / redeemed / compensation-needed），Tachiya 失敗時寫入 `compensation-needed` 並回傳 `ErrTachiyaRedeemFailed`。

## 為什麼
closes #423

Codex code review（refs #408）發現：點數已扣除、on-chain burn 已完成，但 Tachiya call 失敗後 caller 仍拿到 success + 空 voucher，導致資料不一致且無自動補償路徑。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#423
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 compensation 自動補發流程
  - 不做 admin 查詢 compensation-needed 紀錄的 API
  - 不改 handler HTTP status code（維持 500）

## PR 拆分檢查
- 這個 PR 的單一句子目的：修正 Tachiya 失敗時 error 被吞掉並回傳 success 的 bug
- Approx changed lines：~120
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [x] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  schema + service + test 是同一個 bug fix 的不可分割最小單元，拆開任何一層都無法獨立驗證。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Tachiya call 失敗時不回傳 success（回傳 `ErrTachiyaRedeemFailed`）
- [x] 有明確的失敗狀態記錄供後續補償（`coupon_redemptions.status = 'compensation-needed'`）
- [x] CI 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
go test ./internal/services/ -run "TestRedeem|TestCouponRedemptionSchema" -v
→ 7 passed
```

## 備註
- `rec = nil` 分支：若 INSERT `coupon_redemptions` 失敗，log warning 後跳過後續 UPDATE（非致命）。burn 已完成，不影響點數一致性。
- 既有 `TestRedeem_TachiyaFailureIsNonBlocking` 已刪除（它驗證的是錯誤行為）。

## Notes for Claude Code Review
- `rec = nil` 設計：CREATE 失敗時 → log + nil → 後續 UPDATE skip。是否可接受？
- `mockBurnCaller` 在 burn 失敗的現有測試中 txHash 為空字串，不會觸及 coupon_redemptions 路徑，無需額外處理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 记录每次优惠券兑换尝试（含状态、金额、交易哈希、可选券码/错误信息）。
* **修复**
  * 当外部券服务兑换失败时返回明确 503 错误并将记录标为“需补偿”。
* **文档**
  * API 文档补充了鉴权要求与 401/403/503 的响应说明。
* **测试**
  * 扩展测试覆盖持久化、状态流转、失败与取消行为。
* **数据库迁移**
  * 新增兑换记录表、约束与索引以支持查询与补偿流程。
* **运维**
  * 启动时自动确保运行时约束与索引存在。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->