### PR TITLE
[chore] tachimint i18n CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,9 @@ jobs:
       - name: Build
         run: docker compose run --no-deps --rm frontend pnpm build
 
+      - name: i18n check
+        run: docker compose run --no-deps --rm frontend pnpm check:i18n
+
   dashboard:
     timeout-minutes: 15
     name: Dashboard build


### PR DESCRIPTION
## 什麼改動
在 frontend CI job 新增 `pnpm check:i18n` step。

## 為什麼
closes #224

`tachimint/package.json` 已有 `check:i18n` script，但未接入 CI，i18n key 完整性只能本地手動驗證。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#224
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 check:i18n script 本身
  - 不擴展 i18n 涵蓋範圍
  - 不實作 path-aware 觸發（#209 追蹤）

## PR 拆分檢查
- 這個 PR 的單一句子目的：將現有 `pnpm check:i18n` script 接入 frontend CI job
- Approx changed lines：~3
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] CI 加入 `pnpm check:i18n` job
- [x] i18n key 不完整時 CI fail

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
diff: +3 行，僅新增 i18n check step
```

## 備註
無

## Notes for Claude Code Review
- 唯一改動是在 frontend job 的 Build step 後加一個 step，reviewer 直接確認指令正確即可