### PR TITLE
[chore] Harden pr-metadata-check section parsing and add fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,18 @@ jobs:
       - name: Verify commit message hook assertions
         run: bash infra/scripts/commit-message-check.test.sh
 
+  pr-metadata-regression:
+    timeout-minutes: 5
+    name: PR metadata check regression tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify PR metadata check assertions
+        run: bash infra/scripts/pr-metadata-check.test.sh
+
   pr-commit-messages:
     timeout-minutes: 5
     name: PR commit messages
@@ -378,7 +390,7 @@ jobs:
   notify-discord:
     timeout-minutes: 5
     name: Notify Discord on failure
-    needs: [workflow-regression, commit-message-regression, check-cache-wiring, backend-ci, frontend, dashboard, contracts]
+    needs: [workflow-regression, commit-message-regression, pr-metadata-regression, check-cache-wiring, backend-ci, frontend, dashboard, contracts]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure git identity for test commits
+        run: |
+          git config user.email "ci@test.local"
+          git config user.name "CI Test"
+
       - name: Verify PR metadata check assertions
         run: bash infra/scripts/pr-metadata-check.test.sh
 

--- a/infra/scripts/pr-metadata-check.sh
+++ b/infra/scripts/pr-metadata-check.sh
@@ -63,7 +63,6 @@ checked_item() {
       next
     }
     in_section && $0 ~ /^##[[:space:]]/ { exit }
-    in_section && $0 ~ /^[[:space:]]*$/ { exit }
     in_section && $0 ~ pattern {
       found = 1
       exit

--- a/infra/scripts/pr-metadata-check.test.sh
+++ b/infra/scripts/pr-metadata-check.test.sh
@@ -198,12 +198,9 @@ run_case_body "similar_section_no_false_positive" "[backend] similar section nam
 - Backend contract already in develop:
   - [ ] yes
   - [x] no
-- If no, this PR is:
-  - [x] stacked on dependency branch
-  - [ ] intentionally blocked until dependency merges
 - 本 PR 明確不做：
   - no-op
-'
+' 1
 
 # Both yes and no checked at the same time is a conflict — must be rejected.
 run_case_body "yes_no_conflict" "[backend] yes no conflict fixture" \

--- a/infra/scripts/pr-metadata-check.test.sh
+++ b/infra/scripts/pr-metadata-check.test.sh
@@ -120,4 +120,104 @@ git worktree remove -f "$_frontend_wt"
 run_case frontend_apps_single_surface "[frontend] update both frontend apps" "Depends on PR：none"
 git branch -f "$head_branch" "$base_ref" >/dev/null 2>&1
 
+# ── checked_item robustness fixtures ─────────────────────────────────────────
+
+run_case_body() {
+  local name="$1" title="$2" body="$3" expected_exit="${4:-0}"
+  local body_file="$tmpdir/$name.md"
+  local fakebin="$tmpdir/$name-bin"
+  mkdir -p "$fakebin"
+  cat > "$fakebin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "auth" ] && [ "${2:-}" = "status" ]; then exit 0; fi
+exit 1
+GHEOF
+  chmod +x "$fakebin/gh"
+  printf '%s' "$body" > "$body_file"
+  set +e
+  PATH="$fakebin:$PATH" "$root_dir/infra/scripts/pr-metadata-check.sh" \
+    --title "$title" --body-file "$body_file" --base develop --head "$head_branch" \
+    >/dev/null 2>"$tmpdir/$name.stderr"
+  local exit_code=$?
+  set -e
+  if [ "$exit_code" -ne "$expected_exit" ]; then
+    echo "expected exit $expected_exit for case $name but got $exit_code" >&2
+    cat "$tmpdir/$name.stderr" >&2
+    exit 1
+  fi
+}
+
+# Blank line after section header must not prevent finding the checkbox.
+run_case_body "blank_after_section_header" "[backend] blank after header fixture" \
+'refs #123
+
+## Scope 對齊
+
+- Source of truth：test
+- Depends on PR：none
+- Backend contract already in develop:
+
+  - [x] yes
+  - [ ] no
+- 本 PR 明確不做：
+  - no-op
+'
+
+# Blank lines between checkboxes must not cause early exit.
+run_case_body "blank_between_checkboxes" "[frontend] blank between checkboxes fixture" \
+'refs #123
+
+## Scope 對齊
+
+- Source of truth：test
+- Depends on PR：none
+- Backend contract already in develop:
+  - [ ] yes
+
+  - [x] no
+- If no, this PR is:
+  - [x] stacked on dependency branch
+  - [ ] intentionally blocked until dependency merges
+- 本 PR 明確不做：
+  - no-op
+'
+
+# Section with extra text in name must not false-positive match.
+# "Backend contract already in develop (notes):" should NOT count as the section.
+run_case_body "similar_section_no_false_positive" "[backend] similar section name fixture" \
+'refs #123
+
+## Scope 對齊
+
+- Source of truth：test
+- Depends on PR：none
+- Backend contract already in develop (notes):
+  - [x] yes
+  - [ ] no
+- Backend contract already in develop:
+  - [ ] yes
+  - [x] no
+- If no, this PR is:
+  - [x] stacked on dependency branch
+  - [ ] intentionally blocked until dependency merges
+- 本 PR 明確不做：
+  - no-op
+'
+
+# Both yes and no checked at the same time is a conflict — must be rejected.
+run_case_body "yes_no_conflict" "[backend] yes no conflict fixture" \
+'refs #123
+
+## Scope 對齊
+
+- Source of truth：test
+- Depends on PR：none
+- Backend contract already in develop:
+  - [x] yes
+  - [x] no
+- 本 PR 明確不做：
+  - no-op
+' 1
+
 echo "pr-metadata-check regression tests passed"

--- a/infra/scripts/pr-metadata-check.test.sh
+++ b/infra/scripts/pr-metadata-check.test.sh
@@ -121,6 +121,16 @@ run_case frontend_apps_single_surface "[frontend] update both frontend apps" "De
 git branch -f "$head_branch" "$base_ref" >/dev/null 2>&1
 
 # ── checked_item robustness fixtures ─────────────────────────────────────────
+# Add one non-docs commit to head_branch so docs_only=0 when run_case_body runs.
+# Using infra/ path: not a product surface, so no [frontend]/[backend] surface
+# violation fires, but docs_only=0 causes the backend contract block to execute.
+_item_wt="$tmpdir/item-wt"
+git worktree add -q "$_item_wt" "$head_branch"
+mkdir -p "$_item_wt/infra/scripts"
+printf '# checked_item surface marker\n' > "$_item_wt/infra/scripts/_checked_item_surface.sh"
+git -C "$_item_wt" add infra/scripts/_checked_item_surface.sh
+git -C "$_item_wt" commit -q -m "test: surface marker for checked_item fixtures"
+git worktree remove -f "$_item_wt"
 
 run_case_body() {
   local name="$1" title="$2" body="$3" expected_exit="${4:-0}"
@@ -184,7 +194,10 @@ run_case_body "blank_between_checkboxes" "[frontend] blank between checkboxes fi
 '
 
 # Section with extra text in name must not false-positive match.
-# "Backend contract already in develop (notes):" should NOT count as the section.
+# Only the "(notes):" variant is present — no exact section.
+# A correct parser finds nothing → "必須標記" failure → exit 1.
+# A buggy parser that matches "(notes):" would see [x] yes → no failure → exit 0,
+# which would cause this case to fail and reveal the bug.
 run_case_body "similar_section_no_false_positive" "[backend] similar section name fixture" \
 'refs #123
 
@@ -195,9 +208,6 @@ run_case_body "similar_section_no_false_positive" "[backend] similar section nam
 - Backend contract already in develop (notes):
   - [x] yes
   - [ ] no
-- Backend contract already in develop:
-  - [ ] yes
-  - [x] no
 - 本 PR 明確不做：
   - no-op
 ' 1
@@ -216,5 +226,7 @@ run_case_body "yes_no_conflict" "[backend] yes no conflict fixture" \
 - 本 PR 明確不做：
   - no-op
 ' 1
+
+git branch -f "$head_branch" "$base_ref" >/dev/null 2>&1
 
 echo "pr-metadata-check regression tests passed"


### PR DESCRIPTION
## 什麼改動
- `checked_item` 移除「遇到空行立即停止」的行為，改為只在下一個 `##` heading 才停止掃描
- 補充 4 個 fixture 測試：空行後的 section header、checkbox 之間有空行、相似 section 名稱不誤判、yes/no 同時勾選應拒絕

## 為什麼
closes #332

`checked_item` 在 section 掃描時遇到單一空行就提前停止，若有人在 section header 與 checkbox 之間插空行，或在 checkbox 之間留空行分組，會產生 false negative。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#332
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 GitHub Actions PR Scope Police
  - 不擴張到整套 PR parser 重寫
  - 不修改產品 runtime code

## PR 拆分檢查
- 這個 PR 的單一句子目的：放寬 `checked_item` 的空行終止條件並補 fixture 測試
- Approx changed lines：~101
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] `checked_item` 在 section header 後有空行時仍能正確找到 checkbox
- [x] `checked_item` 在 checkbox 之間有空行時仍能正確找到目標 checkbox
- [x] 相似 section 名稱不誤判（`(notes):` suffix 不算同一 section）
- [x] yes/no 同時勾選回傳 1（拒絕）

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過（修改前後邏輯手動驗證）
- [x] 有寫 / 更新測試（補 4 個 fixture cases）

**驗證結果**
```
pr-metadata-check.sh 移除 1 行（blank-line exit），加 4 個 fixture cases
CI 上的 Linux runner 可正確執行（本地 Windows 有預先存在的 encoding 問題，與本修改無關）
```

## 備註
本地 Windows 環境跑 `pr-metadata-check.test.sh` 有 fullwidth colon `：` encoding 問題，這是預先存在的問題（在本 PR 修改前即存在），CI Linux runner 不受影響。

## Notes for Claude Code Review
- 核心修改只有 1 行刪除（`checked_item` 中的空行退出條件）
- `run_case_body` helper 為新增的 fixture runner，行為與既有 `run_case` 類似但接受完整 body string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进元数据检查的选项扫描逻辑，能跨越空行继续识别预期的复选项状态，避免漏判或误判。

* **Tests**
  * 新增四个回归测试用例，覆盖空行容忍、项间空行、相似节误报及冲突状态检测。

* **Chores**
  * 在持续集成中新增针对 PR 元数据回归的检查任务，并将其纳入失败通知流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->