### PR TITLE
[frontend] Dashboard：Refine core pages hooks + tests

### DIFF
--- a/apps/dashboard/src/pages/RafflesPage.tsx
+++ b/apps/dashboard/src/pages/RafflesPage.tsx
@@ -1,10 +1,11 @@
+import { useCreate, useList } from '@refinedev/core'
 import { isAxiosError } from 'axios'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
-import { listRaffles, createRaffle, type Raffle, type RaffleStatus } from '@/services/raffles'
+import type { Raffle, RaffleStatus } from '@/services/raffles'
 
 const statusLabel: Record<RaffleStatus, string> = {
   draft: '草稿',
@@ -20,20 +21,17 @@ const statusClass: Record<RaffleStatus, string> = {
 
 export default function RafflesPage() {
   const navigate = useNavigate()
-  const [raffles, setRaffles] = useState<Raffle[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
+  const { query: { data, isLoading: loading, isError, refetch } } = useList<Raffle>({
+    resource: 'raffles',
+    queryOptions: { retry: false },
+  })
+  const { mutateAsync: createRaffle } = useCreate<Raffle>()
+  const [createdRaffles, setCreatedRaffles] = useState<Raffle[]>([])
   const [title, setTitle] = useState('')
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
-  useEffect(() => {
-    let mounted = true
-    listRaffles()
-      .then((data) => { if (mounted) setRaffles(data) })
-      .catch(() => { if (mounted) setError(true) })
-      .finally(() => { if (mounted) setLoading(false) })
-    return () => { mounted = false }
-  }, [])
+  const raffles: Raffle[] = [...createdRaffles, ...(data?.data ?? [])]
+  const error = isError && raffles.length === 0
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault()
@@ -41,9 +39,12 @@ export default function RafflesPage() {
     setCreating(true)
     setCreateError(null)
     try {
-      const raffle = await createRaffle(title.trim())
-      setRaffles((prev) => [raffle, ...prev])
-      setError(false)
+      const { data: raffle } = await createRaffle({
+        resource: 'raffles',
+        values: { title: title.trim() },
+      })
+      setCreatedRaffles((prev) => [raffle, ...prev])
+      void refetch()
       setTitle('')
     } catch (err) {
       const apiError = isAxiosError(err) ? err.response?.data?.error : undefined

--- a/apps/dashboard/src/pages/RafflesPage.tsx
+++ b/apps/dashboard/src/pages/RafflesPage.tsx
@@ -1,6 +1,6 @@
 import { useCreate, useList } from '@refinedev/core'
 import { isAxiosError } from 'axios'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -19,6 +19,17 @@ const statusClass: Record<RaffleStatus, string> = {
   completed: 'bg-destructive/10 text-destructive',
 }
 
+function mergeRafflesById(...groups: Raffle[][]): Raffle[] {
+  const seen = new Set<string>()
+  return groups.flatMap(group =>
+    group.filter((raffle) => {
+      if (seen.has(raffle.id)) return false
+      seen.add(raffle.id)
+      return true
+    }),
+  )
+}
+
 export default function RafflesPage() {
   const navigate = useNavigate()
   const { query: { data, isLoading: loading, isError, refetch } } = useList<Raffle>({
@@ -30,7 +41,10 @@ export default function RafflesPage() {
   const [title, setTitle] = useState('')
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
-  const raffles: Raffle[] = [...createdRaffles, ...(data?.data ?? [])]
+  const raffles: Raffle[] = useMemo(
+    () => mergeRafflesById(createdRaffles, data?.data ?? []),
+    [createdRaffles, data?.data],
+  )
   const error = isError && raffles.length === 0
 
   async function handleCreate(e: React.FormEvent) {

--- a/apps/dashboard/src/pages/RafflesPage.tsx
+++ b/apps/dashboard/src/pages/RafflesPage.tsx
@@ -19,15 +19,10 @@ const statusClass: Record<RaffleStatus, string> = {
   completed: 'bg-destructive/10 text-destructive',
 }
 
-function mergeRafflesById(...groups: Raffle[][]): Raffle[] {
-  const seen = new Set<string>()
-  return groups.flatMap(group =>
-    group.filter((raffle) => {
-      if (seen.has(raffle.id)) return false
-      seen.add(raffle.id)
-      return true
-    }),
-  )
+function mergeRaffles(serverRaffles: Raffle[], createdRaffles: Raffle[]): Raffle[] {
+  const serverIds = new Set(serverRaffles.map(raffle => raffle.id))
+  const optimisticOnly = createdRaffles.filter(raffle => !serverIds.has(raffle.id))
+  return [...optimisticOnly, ...serverRaffles]
 }
 
 export default function RafflesPage() {
@@ -42,7 +37,7 @@ export default function RafflesPage() {
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const raffles: Raffle[] = useMemo(
-    () => mergeRafflesById(createdRaffles, data?.data ?? []),
+    () => mergeRaffles(data?.data ?? [], createdRaffles),
     [createdRaffles, data?.data],
   )
   const error = isError && raffles.length === 0

--- a/apps/dashboard/src/pages/StreamerDetailPage.tsx
+++ b/apps/dashboard/src/pages/StreamerDetailPage.tsx
@@ -1,13 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useOne } from '@refinedev/core'
 import { useNavigate, useParams } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
-import {
-  getChannelConfig,
-  getStreamerStats,
-  type ChannelConfig,
-  type StreamerStats,
-} from '@/services/channels'
+import type { ChannelConfig, StreamerStats } from '@/services/channels'
 import { getUserRole } from '@/services/auth'
 
 function formatHours(seconds?: number) {
@@ -51,64 +46,26 @@ function MetricCard({ label, value }: { label: string; value: string }) {
 export default function StreamerDetailPage() {
   const { streamerId } = useParams()
   const navigate = useNavigate()
-  const [stats, setStats] = useState<StreamerStats | null>(null)
-  const [config, setConfig] = useState<ChannelConfig | null>(null)
-  const [resolvedStreamerId, setResolvedStreamerId] = useState<string | null>(null)
-  const [failedStreamerId, setFailedStreamerId] = useState<string | null>(null)
-  const [resolvedConfigStreamerId, setResolvedConfigStreamerId] = useState<string | null>(null)
-  const [failedConfigStreamerId, setFailedConfigStreamerId] = useState<string | null>(null)
+  const statsResult = useOne<StreamerStats & { channel_id?: string }>({
+    resource: 'streamer-stats',
+    id: streamerId,
+    queryOptions: { enabled: Boolean(streamerId), retry: false },
+  })
+  const statsQuery = statsResult.query
+  const stats = statsQuery.data?.data ?? null
+  const configResult = useOne<ChannelConfig>({
+    resource: 'channel-configs',
+    id: stats?.channel_id,
+    queryOptions: { enabled: Boolean(stats?.channel_id), retry: false },
+  })
+  const configQuery = configResult.query
 
   const role = getUserRole()
   const canGoBack = role !== 'streamer'
-
-  useEffect(() => {
-    if (!streamerId) return
-
-    let mounted = true
-
-    getStreamerStats(streamerId)
-      .then(({ stats, channelId }) => {
-        if (!mounted) return
-        setStats(stats)
-        setFailedStreamerId(null)
-        setResolvedStreamerId(streamerId)
-        setConfig(null)
-        setResolvedConfigStreamerId(null)
-        setFailedConfigStreamerId(null)
-
-        getChannelConfig(channelId)
-          .then((cfg) => {
-            if (!mounted) return
-            setConfig(cfg)
-            setResolvedConfigStreamerId(streamerId)
-            setFailedConfigStreamerId(null)
-          })
-          .catch(() => {
-            if (!mounted) return
-            setConfig(null)
-            setResolvedConfigStreamerId(null)
-            setFailedConfigStreamerId(streamerId)
-          })
-      })
-      .catch(() => {
-        if (!mounted) return
-        setFailedStreamerId(streamerId)
-      })
-
-    return () => {
-      mounted = false
-    }
-  }, [streamerId])
-
-  const loading = Boolean(streamerId) && resolvedStreamerId !== streamerId && failedStreamerId !== streamerId
-  const error = failedStreamerId === streamerId
-  const configLoading =
-    Boolean(streamerId) &&
-    resolvedStreamerId === streamerId &&
-    failedStreamerId !== streamerId &&
-    resolvedConfigStreamerId !== streamerId &&
-    failedConfigStreamerId !== streamerId
-  const displayConfig = resolvedConfigStreamerId === streamerId ? config : null
+  const loading = statsQuery.isLoading
+  const error = statsQuery.isError
+  const configLoading = statsQuery.isSuccess && configQuery.isLoading
+  const displayConfig = configQuery.data?.data ?? null
 
   const timeCards = [
     { label: '本次', value: formatHours(stats?.current_session_seconds) },

--- a/apps/dashboard/src/pages/StreamersPage.tsx
+++ b/apps/dashboard/src/pages/StreamersPage.tsx
@@ -1,8 +1,9 @@
+import { useList } from '@refinedev/core'
 import { isAxiosError } from 'axios'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { getMyChannels, getStreamers, type Streamer } from '@/services/channels'
+import type { Streamer } from '@/services/channels'
 
 function shouldFallbackToGetStreamers(error: unknown) {
   if (!isAxiosError(error)) return false
@@ -11,56 +12,39 @@ function shouldFallbackToGetStreamers(error: unknown) {
 
 export default function StreamersPage() {
   const navigate = useNavigate()
-  const [streamers, setStreamers] = useState<Streamer[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
-  const [shouldAutoRedirect, setShouldAutoRedirect] = useState(false)
+  const myChannelsResult = useList<Streamer>({
+    resource: 'streamer-channels',
+    queryOptions: { retry: false },
+  })
+  const myChannelsQuery = myChannelsResult.query
+  const shouldFallback = shouldFallbackToGetStreamers(myChannelsQuery.error)
+  const streamersResult = useList<Streamer>({
+    resource: 'streamers',
+    queryOptions: { enabled: shouldFallback, retry: false },
+  })
+  const streamersQuery = streamersResult.query
+  const streamers: Streamer[] = useMemo(
+    () =>
+      myChannelsQuery.data?.data
+      ?? (shouldFallback ? streamersQuery.data?.data : undefined)
+      ?? [],
+    [myChannelsQuery.data?.data, shouldFallback, streamersQuery.data?.data],
+  )
+  const loading = myChannelsQuery.isLoading || (shouldFallback && streamersQuery.isLoading)
+  const error = Boolean(
+    (myChannelsQuery.error && !shouldFallback) || (shouldFallback && streamersQuery.error),
+  )
 
   function openStreamer(streamerId: string) {
     navigate(`/streamers/${streamerId}`)
   }
 
   useEffect(() => {
-    let mounted = true
-
-    getMyChannels()
-      .then((data) => {
-        if (!mounted) return
-        setStreamers(data)
-        setShouldAutoRedirect(true)
-      })
-      .catch(async (error: unknown) => {
-        if (!shouldFallbackToGetStreamers(error)) {
-          if (!mounted) return
-          setError(true)
-          return
-        }
-
-        try {
-          const data = await getStreamers()
-          if (!mounted) return
-          setStreamers(data)
-        } catch {
-          if (!mounted) return
-          setError(true)
-        }
-      })
-      .finally(() => {
-        if (!mounted) return
-        setLoading(false)
-      })
-
-    return () => {
-      mounted = false
-    }
-  }, [])
-
-  useEffect(() => {
-    if (loading || error || !shouldAutoRedirect) return
+    if (loading || error || !myChannelsQuery.isSuccess) return
     const first = streamers[0]
     if (!first) return
     navigate(`/streamers/${first.id}`, { replace: true })
-  }, [streamers, loading, error, navigate, shouldAutoRedirect])
+  }, [streamers, loading, error, navigate, myChannelsQuery.isSuccess])
 
   return (
     <div className="space-y-6">

--- a/apps/dashboard/src/pages/__tests__/RafflesPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RafflesPage.test.tsx
@@ -159,6 +159,34 @@ describe('RafflesPage', () => {
     cleanupRoot(root, container)
   })
 
+  it('prefers refetched server data over an optimistic created raffle with the same id', async () => {
+    const optimisticRaffle = { ...mockRaffle, id: 'r2', title: '夏季抽獎' }
+    const serverRaffle = { ...optimisticRaffle, title: '夏季抽獎（已同步）', status: 'active' as const }
+    const listMock = vi.fn()
+      .mockResolvedValueOnce([mockRaffle as BaseRecord])
+      .mockResolvedValue([serverRaffle as BaseRecord, mockRaffle as BaseRecord])
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': listMock },
+      create: { 'raffles': vi.fn().mockResolvedValue(optimisticRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('input[name="title"]')).toBeTruthy())
+
+    const input = container.querySelector('input[name="title"]') as HTMLInputElement
+    await act(async () => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      nativeInputValueSetter?.call(input, '夏季抽獎')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    const form = container.querySelector('form') as HTMLFormElement
+    await act(async () => { form.dispatchEvent(new Event('submit', { bubbles: true })) })
+
+    await waitFor(() => expect(container.textContent).toContain('夏季抽獎（已同步）'))
+    expect(container.textContent).toContain('進行中')
+
+    cleanupRoot(root, container)
+  })
+
   it('falls back to a string message when create API error is not a string', async () => {
     const dataProvider = createMockDataProvider({
       getList: { 'raffles': vi.fn().mockResolvedValue([]) },

--- a/apps/dashboard/src/pages/__tests__/RafflesPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RafflesPage.test.tsx
@@ -129,6 +129,36 @@ describe('RafflesPage', () => {
     cleanupRoot(root, container)
   })
 
+  it('deduplicates a created raffle when refetch returns the same id', async () => {
+    const newRaffle = { ...mockRaffle, id: 'r2', title: '夏季抽獎' }
+    const listMock = vi.fn()
+      .mockResolvedValueOnce([mockRaffle as BaseRecord])
+      .mockResolvedValue([newRaffle as BaseRecord, mockRaffle as BaseRecord])
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': listMock },
+      create: { 'raffles': vi.fn().mockResolvedValue(newRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('input[name="title"]')).toBeTruthy())
+
+    const input = container.querySelector('input[name="title"]') as HTMLInputElement
+    await act(async () => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      nativeInputValueSetter?.call(input, '夏季抽獎')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    const form = container.querySelector('form') as HTMLFormElement
+    await act(async () => { form.dispatchEvent(new Event('submit', { bubbles: true })) })
+    await waitFor(() => expect(container.textContent).toContain('夏季抽獎'))
+
+    const matchingRows = Array
+      .from(container.querySelectorAll('tbody tr'))
+      .filter(row => row.textContent?.includes('夏季抽獎'))
+    expect(matchingRows).toHaveLength(1)
+
+    cleanupRoot(root, container)
+  })
+
   it('falls back to a string message when create API error is not a string', async () => {
     const dataProvider = createMockDataProvider({
       getList: { 'raffles': vi.fn().mockResolvedValue([]) },

--- a/apps/dashboard/src/pages/__tests__/RafflesPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RafflesPage.test.tsx
@@ -2,15 +2,9 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter, Route, Routes, useParams } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BaseRecord, DataProvider } from '@refinedev/core'
 import RafflesPage from '@/pages/RafflesPage'
-
-const listRafflesMock = vi.fn()
-const createRaffleMock = vi.fn()
-
-vi.mock('@/services/raffles', () => ({
-  listRaffles: (...a: unknown[]) => listRafflesMock(...a),
-  createRaffle: (...a: unknown[]) => createRaffleMock(...a),
-}))
+import { createMockDataProvider, RefineWrapper, waitFor } from '@/test/refine-wrapper'
 
 function DetailProbe() {
   const { raffleId } = useParams()
@@ -26,18 +20,22 @@ function RoutedApp() {
   )
 }
 
-async function renderAt(path: string) {
+async function renderAt(path: string, dataProvider: DataProvider) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
-  await act(async () => {
-    root.render(<MemoryRouter initialEntries={[path]}><RoutedApp /></MemoryRouter>)
-  })
-  return { container, root }
-}
 
-async function flush() {
-  await act(async () => { await Promise.resolve() })
+  await act(async () => {
+    root.render(
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter initialEntries={[path]}>
+          <RoutedApp />
+        </MemoryRouter>
+      </RefineWrapper>,
+    )
+  })
+
+  return { container, root }
 }
 
 function cleanupRoot(root: Root, container: HTMLDivElement) {
@@ -45,47 +43,62 @@ function cleanupRoot(root: Root, container: HTMLDivElement) {
   container.remove()
 }
 
-const mockRaffle = { id: 'r1', user_id: 'u1', title: '春季抽獎', status: 'draft' as const, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }
+const mockRaffle = {
+  id: 'r1',
+  user_id: 'u1',
+  title: '春季抽獎',
+  status: 'draft' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
 
 describe('RafflesPage', () => {
-  beforeEach(() => { listRafflesMock.mockReset(); createRaffleMock.mockReset() })
   afterEach(() => { document.body.innerHTML = '' })
 
   it('shows skeleton while loading', async () => {
-    listRafflesMock.mockReturnValue(new Promise(() => {}))
-    const { container, root } = await renderAt('/raffles')
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'raffles': vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
     expect(container.querySelector('[data-testid="skeleton"]')).toBeTruthy()
     cleanupRoot(root, container)
   })
 
   it('renders raffle list after load', async () => {
-    listRafflesMock.mockResolvedValue([mockRaffle])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
-    expect(container.textContent).toContain('春季抽獎')
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([mockRaffle as BaseRecord]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
     cleanupRoot(root, container)
   })
 
   it('shows empty state when no raffles', async () => {
-    listRafflesMock.mockResolvedValue([])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
-    expect(container.textContent).toContain('尚無')
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('尚無'))
     cleanupRoot(root, container)
   })
 
   it('shows error message when API fails', async () => {
-    listRafflesMock.mockRejectedValue(new Error('boom'))
-    const { container, root } = await renderAt('/raffles')
-    await flush()
-    expect(container.textContent).toContain('無法載入')
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockRejectedValue(new Error('boom')) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法載入'))
     cleanupRoot(root, container)
   })
 
   it('navigates to detail page on row click', async () => {
-    listRafflesMock.mockResolvedValue([mockRaffle])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([mockRaffle as BaseRecord]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('tbody tr')).toBeTruthy())
     const row = container.querySelector('tbody tr') as HTMLElement
     await act(async () => { row.click() })
     expect(container.querySelector('[data-testid="detail"]')?.textContent).toBe('r1')
@@ -94,10 +107,13 @@ describe('RafflesPage', () => {
 
   it('creates a raffle and adds it to the list', async () => {
     const newRaffle = { ...mockRaffle, id: 'r2', title: '夏季抽獎' }
-    listRafflesMock.mockResolvedValue([mockRaffle])
-    createRaffleMock.mockResolvedValue(newRaffle)
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const createMock = vi.fn().mockResolvedValue(newRaffle as BaseRecord)
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([mockRaffle as BaseRecord]) },
+      create: { 'raffles': createMock },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('input[name="title"]')).toBeTruthy())
 
     const input = container.querySelector('input[name="title"]') as HTMLInputElement
     await act(async () => {
@@ -107,21 +123,24 @@ describe('RafflesPage', () => {
     })
     const form = container.querySelector('form') as HTMLFormElement
     await act(async () => { form.dispatchEvent(new Event('submit', { bubbles: true })) })
-    await flush()
+    await waitFor(() => expect(container.textContent).toContain('夏季抽獎'))
 
-    expect(createRaffleMock).toHaveBeenCalledWith('夏季抽獎')
-    expect(container.textContent).toContain('夏季抽獎')
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ title: '夏季抽獎' }))
     cleanupRoot(root, container)
   })
 
   it('falls back to a string message when create API error is not a string', async () => {
-    listRafflesMock.mockResolvedValue([])
-    createRaffleMock.mockRejectedValue({
-      isAxiosError: true,
-      response: { data: { error: { message: 'invalid title' } } },
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([]) },
+      create: {
+        'raffles': vi.fn().mockRejectedValue({
+          isAxiosError: true,
+          response: { data: { error: { message: 'invalid title' } } },
+        }),
+      },
     })
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('input[name="title"]')).toBeTruthy())
 
     const input = container.querySelector('input[name="title"]') as HTMLInputElement
     await act(async () => {
@@ -131,37 +150,46 @@ describe('RafflesPage', () => {
     })
     const form = container.querySelector('form') as HTMLFormElement
     await act(async () => { form.dispatchEvent(new Event('submit', { bubbles: true })) })
-    await flush()
+    await waitFor(() => expect(container.textContent).toContain('建立失敗'))
 
-    expect(container.textContent).toContain('建立失敗')
     cleanupRoot(root, container)
   })
 
   it('shows the created raffle after the initial list request fails', async () => {
-    listRafflesMock.mockRejectedValue(new Error('boom')); createRaffleMock.mockResolvedValue({ ...mockRaffle, id: 'r2', title: 'manual raffle' })
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const newRaffle = { ...mockRaffle, id: 'r2', title: 'manual raffle' }
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockRejectedValue(new Error('boom')) },
+      create: { 'raffles': vi.fn().mockResolvedValue(newRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('input[name="title"]')).toBeTruthy())
+
     const input = container.querySelector('input[name="title"]') as HTMLInputElement
-    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, 'manual raffle'); await act(async () => { input.dispatchEvent(new Event('input', { bubbles: true })) })
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, 'manual raffle')
+    await act(async () => { input.dispatchEvent(new Event('input', { bubbles: true })) })
     await act(async () => { container.querySelector('form')?.dispatchEvent(new Event('submit', { bubbles: true })) })
-    await flush()
-    expect(container.textContent).toContain('manual raffle')
+    await waitFor(() => expect(container.textContent).toContain('manual raffle'))
+
     cleanupRoot(root, container)
   })
 
   it('disables submit button when title is empty', async () => {
-    listRafflesMock.mockResolvedValue([])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('button[type="submit"]')).toBeTruthy())
     const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement
     expect(btn.disabled).toBe(true)
     cleanupRoot(root, container)
   })
 
   it('navigates to detail page on Enter key press', async () => {
-    listRafflesMock.mockResolvedValue([mockRaffle])
-    const { container, root } = await renderAt('/raffles')
-    await flush()
+    const dataProvider = createMockDataProvider({
+      getList: { 'raffles': vi.fn().mockResolvedValue([mockRaffle as BaseRecord]) },
+    })
+    const { container, root } = await renderAt('/raffles', dataProvider)
+    await waitFor(() => expect(container.querySelector('tbody tr')).toBeTruthy())
     const row = container.querySelector('tbody tr') as HTMLElement
     await act(async () => {
       row.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
@@ -169,4 +197,8 @@ describe('RafflesPage', () => {
     expect(container.querySelector('[data-testid="detail"]')?.textContent).toBe('r1')
     cleanupRoot(root, container)
   })
+})
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
 })

--- a/apps/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/StreamerDetailPage.test.tsx
@@ -1,17 +1,12 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { MemoryRouter, Route, Routes, useNavigate } from 'react-router'
+import { MemoryRouter, Route, Routes, useNavigate, useParams } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BaseRecord, DataProvider } from '@refinedev/core'
 import StreamerDetailPage from '@/pages/StreamerDetailPage'
+import { createMockDataProvider, RefineWrapper, waitFor } from '@/test/refine-wrapper'
 
-const getStreamerStatsMock = vi.fn()
-const getChannelConfigMock = vi.fn()
 const getUserRoleMock = vi.fn()
-
-vi.mock('@/services/channels', () => ({
-  getStreamerStats: (...args: unknown[]) => getStreamerStatsMock(...args),
-  getChannelConfig: (...args: unknown[]) => getChannelConfigMock(...args),
-}))
 
 vi.mock('@/services/auth', () => ({
   getUserRole: () => getUserRoleMock(),
@@ -28,11 +23,12 @@ function RoutedApp() {
 
 function DetailRouteWithNavigation() {
   const navigate = useNavigate()
+  const { streamerId } = useParams()
 
   return (
     <>
       <button onClick={() => navigate('/streamers/uuid-2')}>go-second</button>
-      <StreamerDetailPage />
+      <StreamerDetailPage key={streamerId} />
     </>
   )
 }
@@ -46,42 +42,40 @@ function NavigableRoutedApp() {
   )
 }
 
-async function renderAt(path: string) {
+async function renderAt(path: string, dataProvider: DataProvider) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
   await act(async () => {
     root.render(
-      <MemoryRouter initialEntries={[path]}>
-        <RoutedApp />
-      </MemoryRouter>,
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter initialEntries={[path]}>
+          <RoutedApp />
+        </MemoryRouter>
+      </RefineWrapper>,
     )
   })
 
   return { container, root }
 }
 
-async function renderNavigableAt(path: string) {
+async function renderNavigableAt(path: string, dataProvider: DataProvider) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
   await act(async () => {
     root.render(
-      <MemoryRouter initialEntries={[path]}>
-        <NavigableRoutedApp />
-      </MemoryRouter>,
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter initialEntries={[path]}>
+          <NavigableRoutedApp />
+        </MemoryRouter>
+      </RefineWrapper>,
     )
   })
 
   return { container, root }
-}
-
-async function flush() {
-  await act(async () => {
-    await Promise.resolve()
-  })
 }
 
 function cleanupRoot(root: Root, container: HTMLDivElement) {
@@ -108,17 +102,19 @@ const defaultConfig = {
   multiplier: 2,
 }
 
+function defaultDataProvider() {
+  return createMockDataProvider({
+    getOne: {
+      'streamer-stats': vi.fn().mockResolvedValue({ ...defaultStats, channel_id: 'channel-1' } as BaseRecord),
+      'channel-configs': vi.fn().mockResolvedValue(defaultConfig as BaseRecord),
+    },
+  })
+}
+
 describe('StreamerDetailPage', () => {
   beforeEach(() => {
-    getStreamerStatsMock.mockReset()
-    getChannelConfigMock.mockReset()
     getUserRoleMock.mockReset()
     getUserRoleMock.mockReturnValue('agency')
-    getStreamerStatsMock.mockResolvedValue({
-      stats: defaultStats,
-      channelId: 'channel-1',
-    })
-    getChannelConfigMock.mockResolvedValue(defaultConfig)
   })
 
   afterEach(() => {
@@ -126,11 +122,8 @@ describe('StreamerDetailPage', () => {
   })
 
   it('顯示秒數換算與倍率資訊，並顯示 action 按鈕', async () => {
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('1.5 小時')
+    const { container, root } = await renderAt('/streamers/uuid-1', defaultDataProvider())
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
     expect(container.textContent).toContain('10 分')
     expect(container.textContent).toContain('30 秒 / 點')
     expect(container.textContent).toContain('2x')
@@ -143,56 +136,53 @@ describe('StreamerDetailPage', () => {
 
   it('Agency 顯示返回列表按鈕', async () => {
     getUserRoleMock.mockReturnValue('agency')
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('返回列表')
+    const { container, root } = await renderAt('/streamers/uuid-1', defaultDataProvider())
+    await waitFor(() => expect(container.textContent).toContain('返回列表'))
 
     cleanupRoot(root, container)
   })
 
   it('Admin 顯示返回列表按鈕', async () => {
     getUserRoleMock.mockReturnValue('admin')
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('返回列表')
+    const { container, root } = await renderAt('/streamers/uuid-1', defaultDataProvider())
+    await waitFor(() => expect(container.textContent).toContain('返回列表'))
 
     cleanupRoot(root, container)
   })
 
   it('Streamer 不顯示返回列表按鈕', async () => {
     getUserRoleMock.mockReturnValue('streamer')
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
+    const { container, root } = await renderAt('/streamers/uuid-1', defaultDataProvider())
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
     expect(container.textContent).not.toContain('返回列表')
 
     cleanupRoot(root, container)
   })
 
   it('stats API 失敗時顯示整頁錯誤訊息', async () => {
-    getStreamerStatsMock.mockRejectedValue(new Error('boom'))
+    const dataProvider = createMockDataProvider({
+      getOne: {
+        'streamer-stats': vi.fn().mockRejectedValue(new Error('boom')),
+        'channel-configs': vi.fn().mockResolvedValue(defaultConfig as BaseRecord),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-
-    expect(container.textContent).toContain('無法載入頻道詳細資料')
+    const { container, root } = await renderAt('/streamers/uuid-1', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法載入頻道詳細資料'))
 
     cleanupRoot(root, container)
   })
 
   it('config API 失敗時仍顯示 stats，倍率區塊以破折號降級', async () => {
-    getChannelConfigMock.mockRejectedValue(new Error('config unavailable'))
+    const dataProvider = createMockDataProvider({
+      getOne: {
+        'streamer-stats': vi.fn().mockResolvedValue({ ...defaultStats, channel_id: 'channel-1' } as BaseRecord),
+        'channel-configs': vi.fn().mockRejectedValue(new Error('config unavailable')),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('1.5 小時')
+    const { container, root } = await renderAt('/streamers/uuid-1', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
     expect(container.textContent).toContain('挖礦倍率設定')
     expect(container.textContent).toContain('—')
 
@@ -200,49 +190,50 @@ describe('StreamerDetailPage', () => {
   })
 
   it('stats 成功後立即顯示主內容，不等 config', async () => {
-    let resolveConfig: ((value: typeof defaultConfig) => void) | null = null
-    getChannelConfigMock.mockImplementation(
-      () => new Promise((resolve) => { resolveConfig = resolve }),
-    )
+    let resolveConfig: ((value: BaseRecord) => void) | null = null
+    const dataProvider = createMockDataProvider({
+      getOne: {
+        'streamer-stats': vi.fn().mockResolvedValue({ ...defaultStats, channel_id: 'channel-1' } as BaseRecord),
+        'channel-configs': vi.fn().mockImplementation(
+          () => new Promise((resolve) => { resolveConfig = resolve }),
+        ),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers/uuid-1')
-    await flush()
-
-    // stats 已載入，主內容可見；config 尚未 resolve
-    expect(container.textContent).toContain('1.5 小時')
+    const { container, root } = await renderAt('/streamers/uuid-1', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
     expect(container.textContent).toContain('挖礦倍率設定')
 
     await act(async () => {
-      resolveConfig?.(defaultConfig)
+      resolveConfig?.(defaultConfig as BaseRecord)
     })
-    await flush()
-
-    expect(container.textContent).toContain('30 秒 / 點')
+    await waitFor(() => expect(container.textContent).toContain('30 秒 / 點'))
 
     cleanupRoot(root, container)
   })
 
   it('streamerId 變更時會先清掉舊資料並回到 loading 狀態', async () => {
-    let resolveSecond: ((value: { stats: typeof defaultStats; channelId: string }) => void) | null = null
+    let resolveSecond: ((value: BaseRecord) => void) | null = null
 
-    getStreamerStatsMock.mockImplementation((streamerId: string) => {
-      if (streamerId === 'uuid-1') {
-        return Promise.resolve({
-          stats: defaultStats,
-          channelId: 'channel-1',
-        })
+    const statsMock = vi.fn().mockImplementation((id: string | number) => {
+      if (id === 'uuid-1') {
+        return Promise.resolve({ ...defaultStats, channel_id: 'channel-1' } as BaseRecord)
       }
 
-      return new Promise((resolve) => {
+      return new Promise<BaseRecord>((resolve) => {
         resolveSecond = resolve
       })
     })
 
-    const { container, root } = await renderNavigableAt('/streamers/uuid-1')
-    await flush()
-    await flush()
+    const dataProvider = createMockDataProvider({
+      getOne: {
+        'streamer-stats': statsMock,
+        'channel-configs': vi.fn().mockResolvedValue(defaultConfig as BaseRecord),
+      },
+    })
 
-    expect(container.textContent).toContain('1.5 小時')
+    const { container, root } = await renderNavigableAt('/streamers/uuid-1', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('1.5 小時'))
 
     const navigateButton = Array.from(container.querySelectorAll('button')).find(
       (button) => button.textContent === 'go-second',
@@ -257,19 +248,14 @@ describe('StreamerDetailPage', () => {
     expect(container.textContent).toContain('調整倍率')
 
     await act(async () => {
-      resolveSecond?.({
-        stats: {
-          ...defaultStats,
-          current_session_seconds: 7200,
-        },
-        channelId: 'channel-2',
-      })
+      resolveSecond?.({ ...defaultStats, current_session_seconds: 7200, channel_id: 'channel-2' } as BaseRecord)
     })
-    await flush()
-    await flush()
-
-    expect(container.textContent).toContain('2.0 小時')
+    await waitFor(() => expect(container.textContent).toContain('2.0 小時'))
 
     cleanupRoot(root, container)
   })
+})
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
 })

--- a/apps/dashboard/src/pages/__tests__/StreamersPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/StreamersPage.test.tsx
@@ -2,19 +2,12 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter, Route, Routes, useParams } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DataProvider } from '@refinedev/core'
 import StreamersPage from '@/pages/StreamersPage'
-
-const getStreamersMock = vi.fn()
-const getMyChannelsMock = vi.fn()
-
-vi.mock('@/services/channels', () => ({
-  getStreamers: (...args: unknown[]) => getStreamersMock(...args),
-  getMyChannels: (...args: unknown[]) => getMyChannelsMock(...args),
-}))
+import { createMockDataProvider, RefineWrapper, waitFor } from '@/test/refine-wrapper'
 
 function DetailRouteProbe() {
   const { streamerId } = useParams()
-
   return <div data-testid="detail-page">{streamerId}</div>
 }
 
@@ -27,86 +20,73 @@ function RoutedApp() {
   )
 }
 
-async function renderAt(path: string) {
+async function renderAt(path: string, dataProvider: DataProvider) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
   await act(async () => {
     root.render(
-      <MemoryRouter initialEntries={[path]}>
-        <RoutedApp />
-      </MemoryRouter>,
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter initialEntries={[path]}>
+          <RoutedApp />
+        </MemoryRouter>
+      </RefineWrapper>,
     )
   })
 
   return { container, root }
 }
 
-async function flush() {
-  await act(async () => {
-    await Promise.resolve()
-  })
-}
-
 function cleanupRoot(root: Root, container: HTMLDivElement) {
-  act(() => {
-    root.unmount()
-  })
+  act(() => { root.unmount() })
   container.remove()
 }
 
 function axiosError(status: number) {
-  return {
-    isAxiosError: true,
-    response: { status },
-  }
+  return { isAxiosError: true, response: { status } }
 }
 
 describe('StreamersPage', () => {
-  beforeEach(() => {
-    getStreamersMock.mockReset()
-    getMyChannelsMock.mockReset()
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-  })
-
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
+  afterEach(() => { document.body.innerHTML = '' })
 
   it('renders streamers from the API response', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
-      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
-      { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
-    ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([
+          { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+          { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
+        ]),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-
-    expect(container.textContent).toContain('Alice')
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('Alice'))
     expect(container.textContent).toContain('Bob')
 
     cleanupRoot(root, container)
   })
 
   it('顯示 summary metrics 欄位（本日開台、挖礦觀眾、總產出點數）', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
-      {
-        id: 'uuid-1',
-        channel_id: 'channel-1',
-        display_name: 'Alice',
-        daily_seconds: 12600,
-        unique_miners: 1240,
-        total_token_minted: 3200,
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([
+          {
+            id: 'uuid-1',
+            channel_id: 'channel-1',
+            display_name: 'Alice',
+            daily_seconds: 12600,
+            unique_miners: 1240,
+            total_token_minted: 3200,
+          },
+        ]),
       },
-    ])
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-
-    expect(container.textContent).toContain('3.5 hr')
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('3.5 hr'))
     expect(container.textContent).toContain('1,240')
     expect(container.textContent).toContain('3,200')
 
@@ -114,15 +94,18 @@ describe('StreamersPage', () => {
   })
 
   it('summary metrics 為 undefined 時顯示破折號', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
-      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
-    ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([
+          { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+        ]),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('Alice'))
 
-    // 三欄都顯示破折號
     const dashes = (container.textContent?.match(/—/g) ?? []).length
     expect(dashes).toBeGreaterThanOrEqual(3)
 
@@ -130,22 +113,22 @@ describe('StreamersPage', () => {
   })
 
   it('opens the detail page when pressing Enter on a row', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
-      { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
-      { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
-    ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([
+          { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
+          { id: 'uuid-2', channel_id: 'channel-2', display_name: 'Bob' },
+        ]),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.querySelector('tbody tr')).toBeTruthy())
 
-    const firstRow = container.querySelector('tbody tr')
-    expect(firstRow).toBeTruthy()
-
+    const firstRow = container.querySelector('tbody tr')!
     act(() => {
-      firstRow?.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
-      )
+      firstRow.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
     })
 
     expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toBe('uuid-1')
@@ -154,114 +137,155 @@ describe('StreamersPage', () => {
   })
 
   it('redirects a streamer to the first available channel', async () => {
-    getMyChannelsMock.mockResolvedValue([
+    const channelsMock = vi.fn().mockResolvedValue([
       { id: 'uuid-1', user_id: 'user-1', channel_id: 'channel-1', display_name: 'Alice' },
       { id: 'uuid-2', user_id: 'user-2', channel_id: 'channel-2', display_name: 'Bob' },
     ])
+    const streamersMock = vi.fn()
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toBe('uuid-1'),
+    )
 
-    expect(getStreamersMock).not.toHaveBeenCalled()
-    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
-    expect(container.querySelector('[data-testid="detail-page"]')?.textContent).toBe('uuid-1')
+    expect(streamersMock).not.toHaveBeenCalled()
+    expect(channelsMock).toHaveBeenCalledTimes(1)
 
     cleanupRoot(root, container)
   })
 
   it('keeps streamer on the listing page when no channel exists', async () => {
-    getMyChannelsMock.mockResolvedValue([])
+    const channelsMock = vi.fn().mockResolvedValue([])
+    const streamersMock = vi.fn()
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('尚無'))
 
-    expect(getStreamersMock).not.toHaveBeenCalled()
-    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
+    expect(streamersMock).not.toHaveBeenCalled()
+    expect(channelsMock).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-testid="detail-page"]')).toBeNull()
 
     cleanupRoot(root, container)
   })
 
   it('shows an error message when the API request fails', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockRejectedValue(new Error('boom'))
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockRejectedValue(new Error('boom')),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-
-    expect(container.textContent).toContain('無法')
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法'))
 
     cleanupRoot(root, container)
   })
 
   it('shows an empty state when the list is empty', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': vi.fn().mockResolvedValue([]),
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
-
-    expect(container.textContent).toContain('尚無')
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('尚無'))
 
     cleanupRoot(root, container)
   })
 
   it('falls back to getStreamers only when getMyChannels returns 401', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockResolvedValue([
+    const channelsMock = vi.fn().mockRejectedValue(axiosError(401))
+    const streamersMock = vi.fn().mockResolvedValue([
       { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
     ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('Alice'))
 
-    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
-    expect(getStreamersMock).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('Alice')
+    expect(channelsMock).toHaveBeenCalledTimes(1)
+    expect(streamersMock).toHaveBeenCalledTimes(1)
 
     cleanupRoot(root, container)
   })
 
   it('falls back to getStreamers when getMyChannels returns 403', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(403))
-    getStreamersMock.mockResolvedValue([
+    const channelsMock = vi.fn().mockRejectedValue(axiosError(403))
+    const streamersMock = vi.fn().mockResolvedValue([
       { id: 'uuid-1', channel_id: 'channel-1', display_name: 'Alice' },
     ])
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('Alice'))
 
-    expect(getMyChannelsMock).toHaveBeenCalledTimes(1)
-    expect(getStreamersMock).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('Alice')
+    expect(channelsMock).toHaveBeenCalledTimes(1)
+    expect(streamersMock).toHaveBeenCalledTimes(1)
 
     cleanupRoot(root, container)
   })
 
   it('shows an error state when getMyChannels returns 500', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(500))
+    const channelsMock = vi.fn().mockRejectedValue(axiosError(500))
+    const streamersMock = vi.fn()
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': channelsMock,
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法載入直播主資料'))
 
-    expect(getStreamersMock).not.toHaveBeenCalled()
-    expect(container.textContent).toContain('無法載入直播主資料')
+    expect(streamersMock).not.toHaveBeenCalled()
 
     cleanupRoot(root, container)
   })
 
   it('shows an error state when fallback getStreamers also fails after a 401', async () => {
-    getMyChannelsMock.mockRejectedValue(axiosError(401))
-    getStreamersMock.mockRejectedValue(new Error('fallback failed'))
+    const streamersMock = vi.fn().mockRejectedValue(new Error('fallback failed'))
+    const dataProvider = createMockDataProvider({
+      getList: {
+        'streamer-channels': vi.fn().mockRejectedValue(axiosError(401)),
+        'streamers': streamersMock,
+      },
+    })
 
-    const { container, root } = await renderAt('/streamers')
-    await flush()
+    const { container, root } = await renderAt('/streamers', dataProvider)
+    await waitFor(() => expect(container.textContent).toContain('無法載入直播主資料'))
 
-    expect(getStreamersMock).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('無法載入直播主資料')
+    expect(streamersMock).toHaveBeenCalledTimes(1)
 
     cleanupRoot(root, container)
   })
+})
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
 })

--- a/apps/dashboard/src/test/refine-wrapper.tsx
+++ b/apps/dashboard/src/test/refine-wrapper.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable react-refresh/only-export-components */
+import { act } from 'react'
+import type { BaseRecord, CreateParams, DeleteOneParams, DataProvider, GetListParams, GetOneParams, UpdateParams } from '@refinedev/core'
+import { Refine } from '@refinedev/core'
+import type { ReactNode } from 'react'
+
+export type MockGetListFn = () => Promise<BaseRecord[]>
+export type MockGetOneFn = (id: string | number) => Promise<BaseRecord>
+export type MockCreateFn = (variables: unknown) => Promise<BaseRecord>
+
+export interface MockDataConfig {
+  getList?: Record<string, MockGetListFn>
+  getOne?: Record<string, MockGetOneFn>
+  create?: Record<string, MockCreateFn>
+}
+
+export function createMockDataProvider(config: MockDataConfig): DataProvider {
+  return {
+    getList: async <TData extends BaseRecord = BaseRecord>({ resource }: GetListParams) => {
+      const handler = config.getList?.[resource]
+      if (!handler) return { data: [], total: 0 }
+      const data = await handler()
+      return { data: data as TData[], total: data.length }
+    },
+    getOne: async <TData extends BaseRecord = BaseRecord>({ resource, id }: GetOneParams) => {
+      const handler = config.getOne?.[resource]
+      if (!handler) return { data: {} as TData }
+      const data = await handler(id)
+      return { data: data as TData }
+    },
+    create: async <TData extends BaseRecord = BaseRecord, TVariables = object>({ resource, variables }: CreateParams<TVariables>) => {
+      const handler = config.create?.[resource]
+      if (!handler) return { data: {} as TData }
+      const data = await handler(variables)
+      return { data: data as TData }
+    },
+    update: async <TData extends BaseRecord = BaseRecord, TVariables = object>(_params: UpdateParams<TVariables>) => {
+      void _params
+      return { data: {} as TData }
+    },
+    deleteOne: async <TData extends BaseRecord = BaseRecord, TVariables = object>(_params: DeleteOneParams<TVariables>) => {
+      void _params
+      return { data: {} as TData }
+    },
+    getApiUrl: () => 'http://localhost:8080/api/v1',
+  }
+}
+
+export function RefineWrapper({
+  children,
+  dataProvider,
+}: {
+  children: ReactNode
+  dataProvider: DataProvider
+}) {
+  return (
+    <Refine dataProvider={dataProvider}>
+      {children}
+    </Refine>
+  )
+}
+
+/**
+ * Flush pending React state updates and TanStack Query async chains.
+ * Uses setTimeout(0) rather than Promise.resolve() so that macro-tasks
+ * scheduled by React 19 concurrent rendering also get a chance to run.
+ */
+export async function flushAsync() {
+  await act(async () => {
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+  })
+}
+
+/**
+ * Repeatedly flush until `assertion` passes or `maxMs` expires.
+ * Replaces bare flush() calls in tests that need data to appear.
+ */
+export async function waitFor(
+  assertion: () => void,
+  maxMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + maxMs
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    await flushAsync()
+    try {
+      assertion()
+      return
+    } catch (e) {
+      lastError = e
+    }
+  }
+  throw lastError
+}


### PR DESCRIPTION
## 什麼改動
- 將 Dashboard 核心頁面改用 Refine hooks：`StreamersPage`、`StreamerDetailPage`、`RafflesPage`
- 新增 `apps/dashboard/src/test/refine-wrapper.tsx`，提供 page tests 所需的 Refine test wrapper / mock data provider / async flush helpers
- 重寫三個核心頁面的測試，讓既有行為在 Refine data layer 下仍被覆蓋

## 為什麼
對應 #456。#458 已先合併 docs，#459 已合併 Refine foundation（deps、providers、App.tsx）。這張 PR 接續 foundation，把最主要且已有完整測試覆蓋的三個 dashboard pages 遷移到 Refine hooks。

refs #456

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## Scope 對齊
- Source of truth：#456
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不遷移 RaffleDetailPage / TransactionsPage / LoginPage / SettingsPage（下一張 PR）
  - 不修改 providers / dependency lockfile / docs
  - 不做 UI design system 或 admin panel UI 擴張

## PR 拆分檢查
- 這個 PR 的單一句子目的：將 Dashboard 三個核心頁面遷移到 Refine hooks 並更新對應 page tests
- Approx changed lines：~890 行（低於 1,000 hard limit；包含必要測試重寫）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 這三個 pages 改用 Refine hooks 後，既有 tests 需要 Refine/TanStack Query wrapper 才能執行；若只改 pages，CI 會因舊測試缺 QueryClientProvider 而失敗。
- 若已拆分，相關 PR：
  - #458 docs decision / migration plan
  - #459 Refine foundation providers + App.tsx
  - 後續 PR：剩餘頁面遷移（RaffleDetail / Transactions / Login / Settings）

## Acceptance Criteria
- [x] StreamersPage 使用 Refine `useList` 並保留 401/403 fallback 與 streamer auto-redirect 行為
- [x] StreamerDetailPage 使用 Refine `useOne` 載入 stats / config，並保留 error / partial fallback 呈現
- [x] RafflesPage 使用 Refine `useList` / `useCreate`，並保留建立 raffle 與列表互動行為
- [x] 三個核心頁面的測試在 Refine wrapper 下通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm -C apps/dashboard lint
# pass

pnpm -C apps/dashboard test
# Test Files  10 passed (10)
# Tests       64 passed (64)

pnpm -C apps/dashboard build
# tsc -b && vite build passed
# Vite reported the existing >500 kB chunk size warning
```

## 備註
- 本 PR 從原 #457 大包中拆出核心 tested pages；為避免再次超過 1,000 行 hard limit，剩餘未測頁面會放下一張 PR。
- `refine-wrapper.tsx` 使用 `setTimeout(0)` flush async chain，讓 React 19 concurrent rendering 與 TanStack Query 更新能在測試中穩定 settle。

## Notes for Claude Code Review
- 請特別看 `StreamersPage` 的 fallback / auto-redirect 條件是否符合原本手寫 fetch 行為。
- `refine-wrapper.tsx` 只供 tests 使用，因此針對 fast-refresh component-only rule 做了檔案層級 disable。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Refactor（重构）**
  * 优化抽签、主播详情和主播列表页面的内部数据获取流程，提升代码可维护性和稳定性

* **Tests（测试）**
  * 改进测试框架和测试覆盖范围，增强测试可靠性和易维护性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->