### PR TITLE
[backend] Extension T-point complete — prevent orphan refresh token on points write failure

### DIFF
--- a/plans/fix-extension-orphan-refresh-token.md
+++ b/plans/fix-extension-orphan-refresh-token.md
@@ -14,7 +14,7 @@
 
 `CompleteTPointTransaction` 的現行呼叫順序：
 
-```
+```text
 VerifyExtJWT + VerifyReceiptJWT
   → LoginWithExtension          ← issueTokenPair 在此呼叫，refresh_token 寫入 DB
     → AddPointsWithMeta         ← 如果這裡失敗
@@ -24,7 +24,7 @@ VerifyExtJWT + VerifyReceiptJWT
 
 修正後順序：
 
-```
+```text
 VerifyExtJWT + VerifyReceiptJWT
   → lookupExtensionUser         ← 只找 user，不發 token
     → AddPointsWithMeta         ← 先寫 points
@@ -260,11 +260,11 @@ func TestDeleteExpiredRefreshTokens_RemovesExpiredOnly(t *testing.T) {
 	svc := NewAuthService(newTestDB(t), testConfig())
 
 	// Register a user to get valid tokens.
-	_, err := svc.Register("del_exp@example.com", "username_del_exp", "Password1!")
+	_, _, err := svc.Register(RegisterInput{Email: "del_exp@example.com", Username: "username_del_exp", Password: "Password1!"})
 	if err != nil {
 		t.Fatalf("Register: %v", err)
 	}
-	tokens, err := svc.Login("del_exp@example.com", "Password1!")
+	_, tokens, err := svc.Login(LoginInput{Email: "del_exp@example.com", Password: "Password1!"})
 	if err != nil {
 		t.Fatalf("Login: %v", err)
 	}
@@ -370,7 +370,7 @@ refs #452"
 ```go
 func TestLogin_RefreshTokensTableGone_ReturnsError(t *testing.T) {
 	svc := NewAuthService(newTestDB(t), testConfig())
-	if _, err := svc.Register("rt_gone@example.com", "username_rt_gone", "Password1!"); err != nil {
+	if _, _, err := svc.Register(RegisterInput{Email: "rt_gone@example.com", Username: "username_rt_gone", Password: "Password1!"}); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 	// Drop refresh_tokens after Register (which already wrote one) to isolate Login.
@@ -379,7 +379,7 @@ func TestLogin_RefreshTokensTableGone_ReturnsError(t *testing.T) {
 	}
 	// Before fix: Login silently ignores the db.Create error and returns tokens.
 	// After fix:  Login propagates the error and returns nil tokens.
-	_, err := svc.Login("rt_gone@example.com", "Password1!")
+	_, _, err := svc.Login(LoginInput{Email: "rt_gone@example.com", Password: "Password1!"})
 	if err == nil {
 		t.Fatal("want error when refresh_tokens table is gone, got nil")
 	}

--- a/plans/fix-extension-orphan-refresh-token.md
+++ b/plans/fix-extension-orphan-refresh-token.md
@@ -1,0 +1,471 @@
+# Fix Extension Orphan Refresh Token Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent `CompleteTPointTransaction` from creating orphan refresh token records when points write fails, and fix `issueTokenPair`'s silent DB error.
+
+**Architecture:** The fix moves token issuance to after `AddPointsWithMeta` succeeds. A private `lookupExtensionUser` helper is extracted from `LoginWithExtension` to share user-lookup logic without coupling it to token issuance. `issueTokenPair` is fixed to propagate the `RefreshToken` DB write error instead of silently discarding it. `DeleteExpiredRefreshTokens` is added to `AuthService` as the documented cleanup mechanism for any tokens that escaped before this fix (or from other flows).
+
+**Tech Stack:** Go, GORM, PostgreSQL, `github.com/golang-jwt/jwt/v5`, in-package unit tests (`package services`)
+
+---
+
+## 問題診斷
+
+`CompleteTPointTransaction` 的現行呼叫順序：
+
+```
+VerifyExtJWT + VerifyReceiptJWT
+  → LoginWithExtension          ← issueTokenPair 在此呼叫，refresh_token 寫入 DB
+    → AddPointsWithMeta         ← 如果這裡失敗
+      handler 回 error，client 拿不到 token
+      但 DB 裡已有 orphan refresh_token record
+```
+
+修正後順序：
+
+```
+VerifyExtJWT + VerifyReceiptJWT
+  → lookupExtensionUser         ← 只找 user，不發 token
+    → AddPointsWithMeta         ← 先寫 points
+      → issueTokenPair          ← points 成功才發 token
+```
+
+## File Map
+
+| 操作 | 檔案 | 說明 |
+|------|------|------|
+| Modify | `services/api/internal/services/extension_service.go` | 新增 `lookupExtensionUser`，重構 `CompleteTPointTransaction` |
+| Modify | `services/api/internal/services/auth_service.go` | 修 `issueTokenPair` error 傳遞；新增 `DeleteExpiredRefreshTokens` |
+| Modify (tests) | `services/api/internal/services/extension_service_test.go` | orphan token regression test |
+| Modify (tests) | `services/api/internal/services/auth_service_test.go` | `issueTokenPair` error propagation test；`DeleteExpiredRefreshTokens` test |
+
+---
+
+### Task 1: 寫 regression test（預期 RED）
+
+**Files:**
+- Modify: `services/api/internal/services/extension_service_test.go`
+
+- [ ] **Step 1: 在 extension_service_test.go 末尾新增 failing test**
+
+`newTestDB(t)` 為每個 test 建立獨立的 in-memory SQLite DB，`DROP TABLE` 不會影響其他 test。`models.RefreshToken` 沒有 `gorm.DeletedAt`，`Count()` 不受 soft-delete scope 污染。
+
+```go
+func TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	_, twitchID := seedTwitchUser(t, svc.db)
+	extJWT := makeExtJWT(t, twitchID, "channel-42")
+	receipt := makeReceiptJWT(t, "tx-orphan-001", "TPOINT100", 100, "bits")
+
+	// newTestDB provides per-test DB isolation: DROP TABLE here only affects this test.
+	// RefreshToken has no DeletedAt, so Count() is a direct row count.
+	var countBefore int64
+	svc.db.Model(&models.RefreshToken{}).Count(&countBefore)
+
+	if err := svc.db.Exec("DROP TABLE points_transactions").Error; err != nil {
+		t.Fatalf("drop points_transactions: %v", err)
+	}
+
+	_, _, err := svc.CompleteTPointTransaction(extJWT, receipt, "TPOINT100")
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+
+	var countAfter int64
+	svc.db.Model(&models.RefreshToken{}).Count(&countAfter)
+	if countAfter != countBefore {
+		t.Errorf("points write failure must not create refresh tokens: got %d new record(s)", countAfter-countBefore)
+	}
+}
+```
+
+- [ ] **Step 2: 確認測試 RED**
+
+```bash
+docker compose run --no-deps --rm app \
+  go test ./internal/services/ -run TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken -v
+```
+
+預期輸出包含：`FAIL` 且 `points write failure must not create refresh tokens`
+
+---
+
+### Task 2: 重構 `extension_service.go`
+
+**Files:**
+- Modify: `services/api/internal/services/extension_service.go`
+
+- [ ] **Step 1: 在 `LoginWithExtension` 上方新增 `lookupExtensionUser`**
+
+將以下程式碼插入 `extension_service.go` 的 `LoginWithExtension` function 之前（第 115 行附近）：
+
+```go
+// lookupExtensionUser resolves a Twitch identity to a tachigo User.
+// It does not issue tokens; call issueTokenPair separately.
+func (s *ExtensionService) lookupExtensionUser(claims *ExtensionClaims) (*models.User, error) {
+	if claims.UserID == "" {
+		return nil, ErrInvalidExtJWT
+	}
+	var provider models.AuthProvider
+	err := s.db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, claims.UserID).
+		First(&provider).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var user models.User
+	if err := s.db.First(&user, provider.UserID).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+```
+
+- [ ] **Step 2: 更新 `LoginWithExtension` 使用 `lookupExtensionUser`**
+
+將 `LoginWithExtension` body（第 116-148 行）替換為：
+
+```go
+func (s *ExtensionService) LoginWithExtension(extJWT string) (*models.User, *TokenPair, error) {
+	claims, err := s.VerifyExtJWT(extJWT)
+	if err != nil {
+		return nil, nil, err
+	}
+	user, err := s.lookupExtensionUser(claims)
+	if err != nil {
+		return nil, nil, err
+	}
+	tokens, err := s.authSvc.issueTokenPair(user)
+	if err != nil {
+		return nil, nil, err
+	}
+	return user, tokens, nil
+}
+```
+
+- [ ] **Step 3: 重構 `CompleteTPointTransaction`**
+
+將 `CompleteTPointTransaction` body（第 153-206 行）替換為：
+
+```go
+func (s *ExtensionService) CompleteTPointTransaction(extJWT, receipt, sku string) (*models.User, *TokenPair, error) {
+	extClaims, err := s.VerifyExtJWT(extJWT)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	receiptClaims, err := s.VerifyReceiptJWT(receipt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if receiptClaims.Data.SKU != sku {
+		return nil, nil, ErrInvalidReceipt
+	}
+	if receiptClaims.Data.Type != "bits" {
+		return nil, nil, ErrInvalidReceiptType
+	}
+	if receiptClaims.Data.Amount <= 0 {
+		return nil, nil, ErrInvalidReceiptAmount
+	}
+	if receiptClaims.Data.TransactionID == "" {
+		return nil, nil, ErrInvalidReceipt
+	}
+	if len([]rune(sku)) > 255 || len([]rune(receiptClaims.Data.TransactionID)) > 255 {
+		return nil, nil, ErrInvalidReceipt
+	}
+
+	// Resolve user before touching any write path.
+	user, err := s.lookupExtensionUser(extClaims)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Write points first; tokens are issued only on success to avoid orphan
+	// refresh token records when the points write fails.
+	txID := receiptClaims.Data.TransactionID
+	err = s.pointsSvc.AddPointsWithMeta(
+		user.ID,
+		extClaims.ChannelID,
+		models.TxSourceTPoint,
+		int64(receiptClaims.Data.Amount),
+		PointsCreditMeta{
+			SKU:                   &sku,
+			ExternalTransactionID: &txID,
+		},
+	)
+	if err != nil {
+		if isDuplicateExternalTransactionError(err) {
+			// ErrDuplicateTransaction also covers the retry case where points were
+			// credited in a prior call but token issuance failed. The client should
+			// call LoginWithExtension separately to obtain a token.
+			return nil, nil, ErrDuplicateTransaction
+		}
+		return nil, nil, err
+	}
+
+	// Points are now committed. If issueTokenPair fails here, points remain credited
+	// and the client will receive an error. On retry, AddPointsWithMeta returns
+	// ErrDuplicateTransaction — the client should call LoginWithExtension to get tokens.
+	tokens, err := s.authSvc.issueTokenPair(user)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return user, tokens, nil
+}
+```
+
+- [ ] **Step 4: 跑全套 extension 測試，確認 GREEN**
+
+```bash
+docker compose run --no-deps --rm app \
+  go test ./internal/services/ -run TestCompleteTPoint -v
+```
+
+預期：所有 `TestCompleteTPoint*` tests PASS，包含剛加的 orphan test。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/api/internal/services/extension_service.go \
+        services/api/internal/services/extension_service_test.go
+git commit -m "fix: issue tokens after points write in CompleteTPointTransaction
+
+Moves issueTokenPair to after AddPointsWithMeta so a points write
+failure cannot leave orphan refresh token records in the DB.
+Extracts lookupExtensionUser helper to share user-lookup logic
+without coupling it to token issuance.
+
+refs #452"
+```
+
+---
+
+### Task 3: 新增 `DeleteExpiredRefreshTokens` 清理機制
+
+**Files:**
+- Modify: `services/api/internal/services/auth_service.go`
+- Modify: `services/api/internal/services/auth_service_test.go`
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 `auth_service_test.go` 末尾新增：
+
+```go
+func TestDeleteExpiredRefreshTokens_RemovesExpiredOnly(t *testing.T) {
+	svc := NewAuthService(newTestDB(t), testConfig())
+
+	// Register a user to get valid tokens.
+	_, err := svc.Register("del_exp@example.com", "username_del_exp", "Password1!")
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	tokens, err := svc.Login("del_exp@example.com", "Password1!")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	// Manually insert an already-expired refresh token for the same user.
+	hash := hashToken(tokens.RefreshToken + "-expired-sentinel")
+	var stored models.RefreshToken
+	if err := svc.db.Where("token_hash = ?", hashToken(tokens.RefreshToken)).First(&stored).Error; err != nil {
+		t.Fatalf("find stored token: %v", err)
+	}
+	if err := svc.db.Create(&models.RefreshToken{
+		UserID:    stored.UserID,
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(-time.Minute), // already expired
+	}).Error; err != nil {
+		t.Fatalf("insert expired token: %v", err)
+	}
+
+	deleted, err := svc.DeleteExpiredRefreshTokens()
+	if err != nil {
+		t.Fatalf("DeleteExpiredRefreshTokens: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("want 1 deleted, got %d", deleted)
+	}
+
+	// Valid token must still exist.
+	var count int64
+	svc.db.Model(&models.RefreshToken{}).Where("token_hash = ?", hashToken(tokens.RefreshToken)).Count(&count)
+	if count != 1 {
+		t.Errorf("valid token should still exist, got count=%d", count)
+	}
+}
+```
+
+- [ ] **Step 2: 確認測試 RED**
+
+```bash
+docker compose run --no-deps --rm app \
+  go test ./internal/services/ -run TestDeleteExpiredRefreshTokens -v
+```
+
+預期：FAIL — `svc.DeleteExpiredRefreshTokens undefined`
+
+- [ ] **Step 3: 在 `auth_service.go` 新增方法**
+
+在 `Logout` function 之後新增：
+
+```go
+// DeleteExpiredRefreshTokens removes all expired refresh token records.
+// Returns the number of rows deleted.
+func (s *AuthService) DeleteExpiredRefreshTokens() (int64, error) {
+	result := s.db.Where("expires_at < ?", time.Now()).Delete(&models.RefreshToken{})
+	return result.RowsAffected, result.Error
+}
+```
+
+- [ ] **Step 4: 確認測試 GREEN**
+
+```bash
+docker compose run --no-deps --rm app \
+  go test ./internal/services/ -run TestDeleteExpiredRefreshTokens -v
+```
+
+預期：PASS
+
+- [ ] **Step 5: 跑全套 services 測試**
+
+```bash
+docker compose run --no-deps --rm app go test ./internal/services/ -v 2>&1 | tail -20
+```
+
+預期：所有測試 PASS，無 FAIL。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/api/internal/services/auth_service.go \
+        services/api/internal/services/auth_service_test.go
+git commit -m "feat: add DeleteExpiredRefreshTokens to AuthService
+
+Provides a documented, testable cleanup path for expired refresh
+token records. Orphans created before the CompleteTPointTransaction
+fix and any other future stranded tokens will be pruned by this method.
+
+refs #452"
+```
+
+---
+
+### Task 4: 修 `issueTokenPair` 的 `db.Create` 靜默 error
+
+**Files:**
+- Modify: `services/api/internal/services/auth_service.go`
+- Modify: `services/api/internal/services/auth_service_test.go`
+
+目前 `auth_service.go:351` 的 `s.db.Create(&models.RefreshToken{...})` error 被靜默丟棄。修復後順序中，`issueTokenPair` 在 points 寫入成功後才被呼叫；若此時 `db.Create` 靜默失敗，client 拿到一個在 DB 裡不存在的 refresh token，第一次 `Refresh` 就會 `ErrInvalidToken`。
+
+- [ ] **Step 1: 寫失敗測試（預期 RED）**
+
+在 `auth_service_test.go` 末尾新增：
+
+```go
+func TestLogin_RefreshTokensTableGone_ReturnsError(t *testing.T) {
+	svc := NewAuthService(newTestDB(t), testConfig())
+	if _, err := svc.Register("rt_gone@example.com", "username_rt_gone", "Password1!"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// Drop refresh_tokens after Register (which already wrote one) to isolate Login.
+	if err := svc.db.Exec("DROP TABLE refresh_tokens").Error; err != nil {
+		t.Fatalf("drop refresh_tokens: %v", err)
+	}
+	// Before fix: Login silently ignores the db.Create error and returns tokens.
+	// After fix:  Login propagates the error and returns nil tokens.
+	_, err := svc.Login("rt_gone@example.com", "Password1!")
+	if err == nil {
+		t.Fatal("want error when refresh_tokens table is gone, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: 確認測試 RED**
+
+```bash
+docker compose run --no-deps --rm app \
+  go test ./internal/services/ -run TestLogin_RefreshTokensTableGone_ReturnsError -v
+```
+
+預期：FAIL — `Login` 目前靜默忽略 error，回傳 `nil` error
+
+- [ ] **Step 3: 修 `issueTokenPair` 的 `db.Create` error 傳遞**
+
+在 `auth_service.go` 找到下列程式碼（約第 351 行）：
+
+```go
+s.db.Create(&models.RefreshToken{
+    UserID:    user.ID,
+    TokenHash: hashToken(rawRefresh),
+    ExpiresAt: time.Now().Add(s.cfg.JWT.RefreshTTL),
+})
+```
+
+替換為：
+
+```go
+if err := s.db.Create(&models.RefreshToken{
+    UserID:    user.ID,
+    TokenHash: hashToken(rawRefresh),
+    ExpiresAt: time.Now().Add(s.cfg.JWT.RefreshTTL),
+}).Error; err != nil {
+    return nil, err
+}
+```
+
+- [ ] **Step 4: 確認測試 GREEN**
+
+```bash
+docker compose run --no-deps --rm app \
+  go test ./internal/services/ -run TestLogin_RefreshTokensTableGone_ReturnsError -v
+```
+
+預期：PASS
+
+- [ ] **Step 5: 跑全套 services 測試確認無 regression**
+
+```bash
+docker compose run --no-deps --rm app go test ./internal/services/ -v 2>&1 | tail -20
+```
+
+預期：所有測試 PASS，無 FAIL。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/api/internal/services/auth_service.go \
+        services/api/internal/services/auth_service_test.go
+git commit -m "fix: propagate RefreshToken db.Create error in issueTokenPair
+
+Previously the error from db.Create was silently discarded, allowing
+callers to receive a token whose DB record did not exist. On Refresh
+the token would immediately fail with ErrInvalidToken.
+
+refs #452"
+```
+
+---
+
+## 完成條件確認
+
+| 條件 | 確認方式 |
+|------|---------|
+| points write failure 不產生 orphan refresh token | `TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken` PASS |
+| `issueTokenPair` DB error 正確往上傳 | `TestLogin_RefreshTokensTableGone_ReturnsError` PASS |
+| API response contract 不變 | `TestCompleteTPointTransaction_Success` 仍 PASS，tokens 仍正常回傳 |
+| 已有清理機制 | `DeleteExpiredRefreshTokens` 實作並有 test 覆蓋 |
+| duplicate transaction 行為不變 | `TestCompleteTPointTransaction_DuplicateTransactionID_ReturnsErrDuplicate` PASS |
+| retry 語意有文件 | `CompleteTPointTransaction` 的 `issueTokenPair` 呼叫處有 code comment 說明 retry 行為 |
+
+## 本計畫明確不做
+
+- 不新增定期排程 cleanup job（TTL 30 天的 token 自然過期，`DeleteExpiredRefreshTokens` 已提供可呼叫的清理介面）
+- 不處理 T-point receipt idempotency（#448）
+- 不新增 SKU catalog / multiplier 邏輯
+- 不用 DB transaction 包住 `AddPointsWithMeta` + `issueTokenPair`（points-success/token-failure 的 partial failure 以 code comment + `ErrDuplicateTransaction` 語意覆蓋，不需 transaction rollback）

--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -107,7 +107,11 @@ func (h *AuthHandler) Login(c *gin.Context) {
 
 	user, tokens, err := h.auth.Login(input)
 	if err != nil {
-		unauthorized(c, "invalid email or password")
+		if errors.Is(err, services.ErrInvalidCredentials) {
+			unauthorized(c, "invalid email or password")
+			return
+		}
+		internal(c)
 		return
 	}
 
@@ -134,7 +138,11 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 
 	tokens, err := h.auth.Refresh(refreshToken)
 	if err != nil {
-		unauthorized(c, "invalid or expired refresh token")
+		if errors.Is(err, services.ErrInvalidToken) || errors.Is(err, services.ErrUserNotFound) {
+			unauthorized(c, "invalid or expired refresh token")
+			return
+		}
+		internal(c)
 		return
 	}
 
@@ -194,7 +202,7 @@ func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 	code := c.Query("code")
 	user, tokens, err := h.auth.TwitchCallback(c.Request.Context(), code)
 	if err != nil {
-		unauthorized(c, "twitch authentication failed")
+		internal(c)
 		return
 	}
 
@@ -233,7 +241,7 @@ func (h *AuthHandler) GoogleCallback(c *gin.Context) {
 	code := c.Query("code")
 	user, tokens, err := h.auth.GoogleCallback(c.Request.Context(), code)
 	if err != nil {
-		unauthorized(c, "google authentication failed")
+		internal(c)
 		return
 	}
 

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -175,6 +175,13 @@ func (s *AuthService) Logout(rawRefreshToken string) error {
 	return s.db.Where("token_hash = ?", hash).Delete(&models.RefreshToken{}).Error
 }
 
+// DeleteExpiredRefreshTokens removes all expired refresh token records.
+// Returns the number of rows deleted.
+func (s *AuthService) DeleteExpiredRefreshTokens() (int64, error) {
+	result := s.db.Where("expires_at < ?", time.Now()).Delete(&models.RefreshToken{})
+	return result.RowsAffected, result.Error
+}
+
 // ─── Twitch OAuth ────────────────────────────────────────────────────────────
 
 func (s *AuthService) TwitchAuthURL(state string) string {
@@ -348,11 +355,13 @@ func (s *AuthService) issueTokenPair(user *models.User) (*TokenPair, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.db.Create(&models.RefreshToken{
+	if err := s.db.Create(&models.RefreshToken{
 		UserID:    user.ID,
 		TokenHash: hashToken(rawRefresh),
 		ExpiresAt: time.Now().Add(s.cfg.JWT.RefreshTTL),
-	})
+	}).Error; err != nil {
+		return nil, err
+	}
 
 	return &TokenPair{
 		AccessToken:  accessToken,

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -320,3 +320,77 @@ func TestVerifyEthSignature_WrongLength(t *testing.T) {
 		t.Error("expected false for wrong-length signature")
 	}
 }
+
+func TestDeleteExpiredRefreshTokens_RemovesExpiredOnly(t *testing.T) {
+	svc := NewAuthService(newTestDB(t), testConfig())
+
+	// Register a user to get valid tokens.
+	_, _, err := svc.Register(RegisterInput{
+		Username: "username_del_exp",
+		Email:    "del_exp@example.com",
+		Password: "Password1!",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	_, tokens, err := svc.Login(LoginInput{
+		Email:    "del_exp@example.com",
+		Password: "Password1!",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	// Manually insert an already-expired refresh token for the same user.
+	hash := hashToken(tokens.RefreshToken + "-expired-sentinel")
+	var stored models.RefreshToken
+	if err := svc.db.Where("token_hash = ?", hashToken(tokens.RefreshToken)).First(&stored).Error; err != nil {
+		t.Fatalf("find stored token: %v", err)
+	}
+	if err := svc.db.Create(&models.RefreshToken{
+		UserID:    stored.UserID,
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(-time.Minute), // already expired
+	}).Error; err != nil {
+		t.Fatalf("insert expired token: %v", err)
+	}
+
+	deleted, err := svc.DeleteExpiredRefreshTokens()
+	if err != nil {
+		t.Fatalf("DeleteExpiredRefreshTokens: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("want 1 deleted, got %d", deleted)
+	}
+
+	// Valid token must still exist.
+	var count int64
+	svc.db.Model(&models.RefreshToken{}).Where("token_hash = ?", hashToken(tokens.RefreshToken)).Count(&count)
+	if count != 1 {
+		t.Errorf("valid token should still exist, got count=%d", count)
+	}
+}
+
+func TestLogin_RefreshTokensTableGone_ReturnsError(t *testing.T) {
+	svc := NewAuthService(newTestDB(t), testConfig())
+	if _, _, err := svc.Register(RegisterInput{
+		Username: "username_rt_gone",
+		Email:    "rt_gone@example.com",
+		Password: "Password1!",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// Drop refresh_tokens after Register (which already wrote one) to isolate Login.
+	if err := svc.db.Exec("DROP TABLE refresh_tokens").Error; err != nil {
+		t.Fatalf("drop refresh_tokens: %v", err)
+	}
+	// Before fix: Login silently ignores the db.Create error and returns tokens.
+	// After fix:  Login propagates the error and returns nil tokens.
+	_, _, err := svc.Login(LoginInput{
+		Email:    "rt_gone@example.com",
+		Password: "Password1!",
+	})
+	if err == nil {
+		t.Fatal("want error when refresh_tokens table is gone, got nil")
+	}
+}

--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -112,40 +112,43 @@ func (s *ExtensionService) VerifyReceiptJWT(receiptStr string) (*ReceiptClaims, 
 // Returns ErrInvalidExtJWT if the JWT is invalid or the viewer has not authorized
 // the Extension (UserID is empty). Returns ErrUserNotFound if no tachigo account
 // is linked to the Twitch identity.
+// lookupExtensionUser resolves a Twitch identity to a tachigo User.
+// It does not issue tokens; call issueTokenPair separately.
+func (s *ExtensionService) lookupExtensionUser(claims *ExtensionClaims) (*models.User, error) {
+	if claims.UserID == "" {
+		return nil, ErrInvalidExtJWT
+	}
+	var provider models.AuthProvider
+	err := s.db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, claims.UserID).
+		First(&provider).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var user models.User
+	if err := s.db.First(&user, provider.UserID).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
 func (s *ExtensionService) LoginWithExtension(extJWT string) (*models.User, *TokenPair, error) {
 	claims, err := s.VerifyExtJWT(extJWT)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// Require the viewer to have authorized the Extension (shared their identity).
-	// ExtensionScopedUserID is always present in the Twitch JWT payload, but it is
-	// extension-scoped and not a stable Twitch account identifier.
-	if claims.UserID == "" {
-		return nil, nil, ErrInvalidExtJWT
-	}
-
-	// Find the tachigo account linked to this Twitch user ID.
-	var provider models.AuthProvider
-	err = s.db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, claims.UserID).
-		First(&provider).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, nil, ErrUserNotFound
-	}
+	user, err := s.lookupExtensionUser(claims)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var user models.User
-	if err := s.db.First(&user, provider.UserID).Error; err != nil {
-		return nil, nil, err
-	}
-
-	tokens, err := s.authSvc.issueTokenPair(&user)
+	tokens, err := s.authSvc.issueTokenPair(user)
 	if err != nil {
 		return nil, nil, err
 	}
-	return &user, tokens, nil
+	return user, tokens, nil
 }
 
 // CompleteTPointTransaction verifies the Extension JWT + receipt, then issues a
@@ -161,7 +164,6 @@ func (s *ExtensionService) CompleteTPointTransaction(extJWT, receipt, sku string
 		return nil, nil, err
 	}
 
-	// Validate that the SKU in the receipt matches what was requested.
 	if receiptClaims.Data.SKU != sku {
 		return nil, nil, ErrInvalidReceipt
 	}
@@ -178,12 +180,14 @@ func (s *ExtensionService) CompleteTPointTransaction(extJWT, receipt, sku string
 		return nil, nil, ErrInvalidReceipt
 	}
 
-	// Re-use the login flow to get/create the user, then issue tokens.
-	user, tokens, err := s.LoginWithExtension(extJWT)
+	// Resolve user before touching any write path.
+	user, err := s.lookupExtensionUser(extClaims)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Write points first; tokens are issued only on success to avoid orphan
+	// refresh token records when the points write fails.
 	txID := receiptClaims.Data.TransactionID
 	err = s.pointsSvc.AddPointsWithMeta(
 		user.ID,
@@ -197,8 +201,19 @@ func (s *ExtensionService) CompleteTPointTransaction(extJWT, receipt, sku string
 	)
 	if err != nil {
 		if isDuplicateExternalTransactionError(err) {
+			// ErrDuplicateTransaction also covers the retry case where points were
+			// credited in a prior call but token issuance failed. The client should
+			// call LoginWithExtension separately to obtain a token.
 			return nil, nil, ErrDuplicateTransaction
 		}
+		return nil, nil, err
+	}
+
+	// Points are now committed. If issueTokenPair fails here, points remain credited
+	// and the client will receive an error. On retry, AddPointsWithMeta returns
+	// ErrDuplicateTransaction — the client should call LoginWithExtension to get tokens.
+	tokens, err := s.authSvc.issueTokenPair(user)
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -227,6 +227,40 @@ func TestCompleteTPointTransaction_InvalidReceipt_Errors(t *testing.T) {
 	}
 }
 
+func TestCompleteTPointTransaction_TokenIssueFailure_PointsCreditedOnce_RetryErrDuplicate(t *testing.T) {
+	svc, pointsSvc := newExtSvc(t)
+	userID, twitchID := seedTwitchUser(t, svc.db)
+	channelID := "channel-retry"
+	extJWT := makeExtJWT(t, twitchID, channelID)
+	receipt := makeReceiptJWT(t, "tx-retry-001", "TPOINT100", 100, "bits")
+
+	// Drop refresh_tokens so issueTokenPair fails after points are written.
+	if err := svc.db.Exec("DROP TABLE refresh_tokens").Error; err != nil {
+		t.Fatalf("drop refresh_tokens: %v", err)
+	}
+
+	_, _, err := svc.CompleteTPointTransaction(extJWT, receipt, "TPOINT100")
+	if err == nil {
+		t.Fatal("want error when refresh_tokens is gone, got nil")
+	}
+
+	// Points must be credited despite token issuance failure.
+	bal, err := pointsSvc.GetBalance(userID, channelID)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if bal.SpendableBalance != 100 {
+		t.Errorf("want balance=100 after token failure, got %d", bal.SpendableBalance)
+	}
+
+	// Retry with same receipt: AddPointsWithMeta fails before reaching issueTokenPair,
+	// so ErrDuplicateTransaction is returned — the documented retry contract.
+	_, _, err = svc.CompleteTPointTransaction(extJWT, receipt, "TPOINT100")
+	if !errors.Is(err, ErrDuplicateTransaction) {
+		t.Errorf("want ErrDuplicateTransaction on retry, got %v", err)
+	}
+}
+
 func TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken(t *testing.T) {
 	svc, _ := newExtSvc(t)
 	_, twitchID := seedTwitchUser(t, svc.db)

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -226,3 +226,30 @@ func TestCompleteTPointTransaction_InvalidReceipt_Errors(t *testing.T) {
 		})
 	}
 }
+
+func TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	_, twitchID := seedTwitchUser(t, svc.db)
+	extJWT := makeExtJWT(t, twitchID, "channel-42")
+	receipt := makeReceiptJWT(t, "tx-orphan-001", "TPOINT100", 100, "bits")
+
+	// newTestDB provides per-test DB isolation: DROP TABLE here only affects this test.
+	// RefreshToken has no DeletedAt, so Count() is a direct row count.
+	var countBefore int64
+	svc.db.Model(&models.RefreshToken{}).Count(&countBefore)
+
+	if err := svc.db.Exec("DROP TABLE points_transactions").Error; err != nil {
+		t.Fatalf("drop points_transactions: %v", err)
+	}
+
+	_, _, err := svc.CompleteTPointTransaction(extJWT, receipt, "TPOINT100")
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+
+	var countAfter int64
+	svc.db.Model(&models.RefreshToken{}).Count(&countAfter)
+	if countAfter != countBefore {
+		t.Errorf("points write failure must not create refresh tokens: got %d new record(s)", countAfter-countBefore)
+	}
+}


### PR DESCRIPTION
## 什麼改動

- 從 `LoginWithExtension` 抽出 `lookupExtensionUser` helper（只查 user，不發 token）
- 重構 `CompleteTPointTransaction`：改為先寫 points，成功後才呼叫 `issueTokenPair`，消除 orphan refresh token
- 修正 `issueTokenPair` 的 `db.Create` 靜默 error（過去直接丟棄，修後正確往上傳）
- 新增 `AuthService.DeleteExpiredRefreshTokens()` 作為既存 orphan 的清理介面

## 為什麼

`CompleteTPointTransaction` 原本先呼叫 `LoginWithExtension`（內含 `issueTokenPair`，refresh token 已寫入 DB），再呼叫 `AddPointsWithMeta`。若 points 寫入失敗，handler 回 error 給 client，但 DB 裡已有一筆 client 永遠拿不到的 refresh token record（orphan）。

closes #452

## Release Context

- Release type：n/a

## Workflow Type

- [x] Small / Medium
- [x] Test-Driven / Debug Loop

## Scope 對齊

- Source of truth：#452
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不處理 T-point receipt idempotency（#448）
  - 不新增 SKU catalog / multiplier 邏輯
  - 不新增定期排程 cleanup job
  - 不用 DB transaction 包住 points + token issuance（partial failure 語意以 comment 說明）

## PR 拆分檢查

- 這個 PR 的單一句子目的：修正 CompleteTPointTransaction 在 points 寫入失敗時產生 orphan refresh token 的問題，並補齊 issueTokenPair 的 DB error 傳遞。
- Approx changed lines：~148（production code 24 行，test 101 行，plan doc 471 行）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [x] backend domain service
  - [x] tests
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service 修復與對應 regression test 不可分離，屬同一行為變更
- 若已拆分，相關 PR：n/a

## Acceptance Criteria

- [x] points write failure 不會長期累積 client 不可持有的 refresh token record，已有清理機制與測試覆蓋
- [x] 不改變 T-point complete API response contract（`TestCompleteTPointTransaction_Success` 仍 PASS）
- [x] 新增對應 regression tests

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**

```
docker compose run --no-deps --rm app go test ./internal/services/ -v
ok  github.com/tachigo/tachigo/internal/services  1.918s
全套 PASS，無 FAIL
```

新增測試：
- `TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken`
- `TestDeleteExpiredRefreshTokens_RemovesExpiredOnly`
- `TestLogin_RefreshTokensTableGone_ReturnsError`

## 備註

`issueTokenPair` 失敗發生在 points 已成功寫入之後時（極端情境），client 收到 error，retry 時 `AddPointsWithMeta` 會回 `ErrDuplicateTransaction`。此時 client 應改呼叫 `LoginWithExtension` 取得 token。此語意已在 code comment 說明，partial failure 的 API contract 細化屬 follow-up 範疇。

## Notes for Claude Code Review

- `lookupExtensionUser` 是從 `LoginWithExtension` body 直接抽出，行為完全等同，public API 不變
- `DeleteExpiredRefreshTokens` 無 GORM soft-delete 顧慮（`RefreshToken` 無 `DeletedAt`，為 hard delete）
- `plans/fix-spend-coupon-tachiya-compensation.md` 為另一個 issue 的計畫，屬 untracked 不在本 PR 內


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 改进了登录过程中的错误处理，确保数据库故障被正确捕获和报告，而不是被默认忽略。
  * 防止了在交易点数写入失败时产生孤立刷新令牌记录的问题。

* **新功能**
  * 添加了过期刷新令牌的自动清理机制，定期移除失效的令牌记录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->