### PR TITLE
[discussion] Atlas migration plan and schema reconciliation

### DIFF
--- a/docs/atlas-migration-plan.md
+++ b/docs/atlas-migration-plan.md
@@ -225,6 +225,6 @@ Co-Authored-By: Codex <codex[bot]@openai.com>
 - [ ] PR diff 沒超過專案 scope limit；若超過，PR body 有有效 scope exception 理由。
 - [ ] PR 沒混合 schema migration、service logic、handler/router、frontend changes。
 - [ ] Partial unique indexes 被保留，或有 issue-backed decision 說明為何移除。
-- [ ] Custom PostgreSQL enum definitions 與 server/model contract 使用相同 labels 與 ordering。
+- [ ] Custom PostgreSQL enum definitions 保留相同 label set，並依 `docs/atlas-schema-reconciliation.md` 的 enum ordering decision 處理；不得只因 runtime fresh-create order 與 production/migrated order 不同，就產生 enum rebuild 或 false-drift migration。
 - [ ] `go mod tidy` 不會移除 Atlas tooling dependencies。
 - [ ] CI lint 驗證 migration directory；本地驗證另行驗證 GORM loader path。

--- a/docs/atlas-migration-plan.md
+++ b/docs/atlas-migration-plan.md
@@ -1,0 +1,230 @@
+# Atlas Migration Implementation Plan
+
+> **給 agentic workers：** 執行本計劃時必須使用 `superpowers:subagent-driven-development` 或 `superpowers:executing-plans`，逐項完成 checkbox (`- [ ]`) 步驟。
+
+**目標：** 將 `services/api` 的 schema 管理由 GORM `AutoMigrate` 遷移到 Atlas，同時不削弱既有資料庫 invariant，也不送出不安全的 baseline。
+
+**架構：** Atlas 遷移必須拆成多個小型、可獨立 review 的 PR。先導入 tooling 與 CI validation，再盤點現有 schema source，接著決定並驗證 baseline 策略，最後在 staging 驗證後才移除 runtime `AutoMigrate` 與手寫 schema patches。
+
+**Tech Stack：** Go、GORM、PostgreSQL、Atlas、`atlas-provider-gorm`、GitHub Actions。
+
+---
+
+## Source Of Truth
+
+- GitHub issue：`#463` `[backend] Migration 工具遷移：GORM AutoMigrate → Atlas`
+- 前置討論：`#214`
+- Migration 目錄：`services/api/migrations/`
+- Atlas 設定檔：`services/api/atlas.hcl`
+- 目前 runtime schema 入口：`services/api/cmd/server/main.go`
+- 目前 GORM models：`services/api/internal/models/`
+
+本文件只是執行計劃，不代表 `#463` 已完成，也不得把文件本身當成 implementation source of truth。
+
+## Guardrails
+
+- 不得把 tooling、baseline SQL、`AutoMigrate` removal 合併在同一個 PR。
+- `docs/atlas-schema-reconciliation.md` review 前，不得產生大型 baseline migration。
+- 不得因為 `atlas migrate lint` 通過就宣稱 baseline 安全；lint 驗證 migration mechanics，不驗證 production data compatibility。
+- 不得移除 GORM model structs；`atlas-provider-gorm` 仍需要讀取它們。
+- 不得把 production deploy automation 或 rollback automation 混進 `#463`；issue 已明確排除。
+- 任何改變 runtime schema 行為的 PR，都必須在 PR body 補 staging 驗證說明。
+
+## PR 拆分順序
+
+### PR 1：Atlas Tooling Only
+
+**目的：** 加入最小 Atlas toolchain，讓開發者可以從 GORM schema source 產生 diff，CI 可以 lint migration 檔。
+
+**Files：**
+
+- Create：`services/api/atlas.hcl`
+- Create：`services/api/cmd/loader/main.go`
+- Create：`services/api/tools.go`
+- Modify：`services/api/go.mod`
+- Modify：`services/api/go.sum`
+- Modify：`.github/workflows/ci.yml`
+- Optional：`.gitattributes`，僅在這顆 PR 開始導入 Atlas checksum 檔時需要
+
+**明確不做：**
+
+- 不新增 `020_atlas_baseline.sql`
+- 不新增 `atlas.sum`，除非這顆 PR 明確開始讓 Atlas 管理 migration directory checksum
+- 不移除 `AutoMigrate`
+- 不清理 model tags，除非是 loader compilation 的必要前置
+
+**Implementation Steps：**
+
+- [ ] 新增 `services/api/tools.go`，使用 `//go:build tools`，並以 blank import 錨定 `ariga.io/atlas-provider-gorm/gormschema` 或所選 provider 版本需要的 package path。
+- [ ] 新增 `services/api/cmd/loader/main.go`，載入目前所有 GORM model structs。
+- [ ] 將 GORM 無法表達的 custom PostgreSQL schema objects 放進 loader output，或集中在清楚命名的 loader helper。
+- [ ] 新增 `services/api/atlas.hcl`，使用 `external_schema` program 執行 loader。
+- [ ] 新增 CI job，對 PR 變更的 migration files 執行 Atlas migration lint。
+- [ ] 確認 CI lint 是 non-destructive，不會對共用 database apply migration。
+
+**Verification：**
+
+```bash
+cd services/api
+go mod tidy
+go run ./cmd/loader/main.go > /tmp/tachigo-gorm-schema.sql
+atlas migrate diff smoke --env gorm
+```
+
+Expected：loader 可編譯、可輸出 PostgreSQL DDL，且 `atlas migrate diff` 可使用 GORM schema source。
+
+**Commit Message：**
+
+```text
+chore: add atlas migration tooling
+
+refs #463
+
+Co-Authored-By: Codex <codex[bot]@openai.com>
+```
+
+### PR 2：Schema Reconciliation
+
+**目的：** 在撰寫 baseline SQL 前，先把隱性的 schema history 變成可 review 的 reconciliation 文件。
+
+**Files：**
+
+- Modify：`docs/atlas-schema-reconciliation.md`
+
+**Implementation Steps：**
+
+- [ ] 將 `services/api/migrations/001-019` 依序 apply 到乾淨 PostgreSQL dev database。
+- [ ] 用另一個乾淨 PostgreSQL dev database 啟動目前 server，讓 `AutoMigrate` 與 runtime patches 跑完。
+- [ ] 用 `pg_dump --schema-only --no-owner --no-privileges` dump 兩邊 schema。
+- [ ] 用 Atlas 或文字 diff 比對兩個 schema state。
+- [ ] 將每個差異填進 reconciliation table，並寫出明確決策。
+- [ ] 每個差異都標成 `preserve`、`drop after review`、`model drift`、`runtime patch`、`data migration` 或 `out of scope`。
+
+**Verification：**
+
+```bash
+cd services/api
+docker compose run --no-deps --rm app go test ./...
+```
+
+Expected：文件 PR 不改 runtime，後端測試應通過；若本機 Docker 不可用，PR body 必須明確說明未跑原因。
+
+**Commit Message：**
+
+```text
+docs: reconcile atlas migration baseline inputs
+
+refs #463
+
+Co-Authored-By: Codex <codex[bot]@openai.com>
+```
+
+### PR 3：Baseline Strategy And Migration Directory Ownership
+
+**目的：** 建立第一個 Atlas-owned migration state，同時避免破壞既有環境。
+
+**Files：**
+
+- Create or modify：`services/api/migrations/020_atlas_baseline.sql`
+- Create or modify：`services/api/migrations/atlas.sum`
+- Modify：`docs/atlas-schema-reconciliation.md`
+
+**Baseline Decision Required Before Coding：**
+
+開始寫 SQL 前，必須在 PR body 選定且記錄其中一種策略：
+
+- **Import baseline：** 將 `001-019` 視為既有 history，避免把 create-table SQL 重套到已經有表的 database。
+- **Apply-safe baseline：** 產生可安全套用到已知 staging/current schema 的 SQL，必要時使用 `IF NOT EXISTS` 或 guarded `DO $$` blocks。
+
+**Implementation Steps：**
+
+- [ ] 根據已 review 的 reconciliation 文件產生候選 baseline。
+- [ ] 驗證 baseline 可套到 empty database。
+- [ ] 驗證 baseline 可套到已跑過目前 server `AutoMigrate` 的 database。
+- [ ] 驗證 baseline 保留 GORM tags 無法表達的 partial indexes 與 constraints。
+- [ ] 最終 SQL review 完成後，才重新產生 `atlas.sum`。
+
+**Verification：**
+
+```bash
+cd services/api
+atlas migrate lint --dev-url "postgres://postgres:postgres@localhost:5432/atlas_dev?sslmode=disable" --dir "file://migrations" --latest 1
+docker compose run --no-deps --rm app go test ./...
+```
+
+Expected：Atlas lint 通過、後端測試通過，且 PR body 明確寫出採用哪個 baseline strategy。
+
+**Commit Message：**
+
+```text
+chore: add atlas baseline migration
+
+refs #463
+
+Co-Authored-By: Codex <codex[bot]@openai.com>
+```
+
+### PR 4：Remove Runtime AutoMigrate After Staging Validation
+
+**目的：** 讓 Atlas 成為 runtime schema owner。
+
+**Files：**
+
+- Modify：`services/api/cmd/server/main.go`
+- Modify or add：`services/api/cmd/server` 相關測試，若現有 coverage 無法驗證 startup migration 行為
+- Modify：`docs/atlas-schema-reconciliation.md`
+
+**Preconditions：**
+
+- PR 1、PR 2、PR 3 已 merge。
+- Staging 已驗證 baseline strategy。
+- PR body 必須列出移除哪些 runtime patches，以及等價 Atlas migration 在哪裡。
+
+**Implementation Steps：**
+
+- [ ] 從 server startup 移除 `db.AutoMigrate(...)`。
+- [ ] 移除已由 Atlas migration 表達的 manual schema patches。
+- [ ] 只在仍有必要且有文件說明時，保留非 schema 的 runtime data repair code。
+- [ ] 新增 startup guard 或 log，明確表示 API process 不再執行 schema DDL。
+
+**Verification：**
+
+```bash
+cd services/api
+docker compose run --no-deps --rm app go test ./...
+```
+
+Expected：後端測試通過，且 server startup 不再執行 schema DDL。
+
+**Commit Message：**
+
+```text
+chore: remove gorm automigrate from server startup
+
+refs #463
+
+Co-Authored-By: Codex <codex[bot]@openai.com>
+```
+
+## Issue #463 Acceptance Checklist
+
+- [ ] `services/api/atlas.hcl` 存在，且 `atlas migrate diff` 可使用 GORM loader。
+- [ ] CI 有 Atlas migration lint，且 job pass。
+- [ ] `services/api/migrations/001-019` 與 GORM model drift 已記錄或修正。
+- [ ] Baseline strategy 明確，且已針對目標 schema state 驗證。
+- [ ] `AutoMigrate` 策略在移除前已明確化，且 removal 只在 baseline validation 後執行。
+
+## Atlas References
+
+- External schema loading：<https://atlasgo.io/atlas-schema/external>
+- Versioned migration diff：<https://atlasgo.io/versioned/diff>
+- Migration lint：<https://atlasgo.io/versioned/lint>
+
+## Review Checklist
+
+- [ ] PR diff 沒超過專案 scope limit；若超過，PR body 有有效 scope exception 理由。
+- [ ] PR 沒混合 schema migration、service logic、handler/router、frontend changes。
+- [ ] Partial unique indexes 被保留，或有 issue-backed decision 說明為何移除。
+- [ ] Custom PostgreSQL enum definitions 與 server/model contract 使用相同 labels 與 ordering。
+- [ ] `go mod tidy` 不會移除 Atlas tooling dependencies。
+- [ ] CI lint 驗證 migration directory；本地驗證另行驗證 GORM loader path。

--- a/docs/atlas-migration-plan.md
+++ b/docs/atlas-migration-plan.md
@@ -68,10 +68,10 @@
 cd services/api
 go mod tidy
 go run ./cmd/loader/main.go > /tmp/tachigo-gorm-schema.sql
-atlas migrate diff smoke --env gorm
+atlas schema inspect --env gorm --url env://src --format '{{ sql . }}' > /tmp/tachigo-atlas-inspect-schema.sql
 ```
 
-Expected：loader 可編譯、可輸出 PostgreSQL DDL，且 `atlas migrate diff` 可使用 GORM schema source。
+Expected：loader 可編譯、可輸出 PostgreSQL DDL，且 Atlas 可用 `env://src` 讀取 GORM schema source；這個 smoke test 不應寫入 migration file 或 `atlas.sum`。
 
 **Commit Message：**
 

--- a/docs/atlas-schema-reconciliation.md
+++ b/docs/atlas-schema-reconciliation.md
@@ -18,7 +18,7 @@
 
 | Runtime Behavior | Current Code | Reconciliation Decision |
 |---|---|---|
-| 建立 `user_role` enum | `initializeUserRoleEnum` 建立 `('viewer', 'streamer', 'agency', 'admin')`，並在缺少時補上 `agency`。 | 必須保留。Atlas loader 與 migrations 必須使用相同 label set 與 ordering。 |
+| 建立 `user_role` enum | `initializeUserRoleEnum` fresh-create 目前建立 `('viewer', 'streamer', 'agency', 'admin')`，但既有資料庫若由 `001_init.sql` 建立後再跑 `004_rbac_roles.sql`，實際 order 是 `('viewer', 'streamer', 'admin', 'agency')`；型別已存在時只會補 `agency`，不會重排。 | 必須保留 label set。Atlas reconciliation 不得把 enum order mismatch 視為必須重建 enum 的 drift；baseline 應以 production/migrated order 為準，或明確接受雙態。 |
 | 執行 GORM `AutoMigrate` | `db.AutoMigrate(...)` 套用所有 models。 | 只能在 Atlas baseline 已於 staging 驗證後移除。 |
 | 補 `tachi_balances.user_id` FK | 手寫 `ALTER TABLE tachi_balances ADD CONSTRAINT fk_tachi_balances_user_id`。 | 必須以 Atlas migration 或 model association 保留。 |
 | 補 coupon redemption checks | `ensureCouponRedemptionRuntimeSchema` 增加 amount/status constraints。 | 必須保留於 Atlas migration。 |
@@ -37,7 +37,7 @@
 | `001_init.sql` | `user_role`、`users`、`auth_providers`、`shipping_addresses`、`refresh_tokens`、`web3_nonces` | Enum 最初只有 `viewer`、`streamer`、`admin`；目前 runtime 另補 `agency`。 |
 | `002_email_auth.sql` | Email verification 與 password reset tables | 比對 unique constraints 與 token indexes 是否符合 GORM tags。 |
 | `003_watch_points.sql` | `watch_sessions`、`points_ledgers`、`points_transactions` | 包含 active-session partial unique index 與 ledger uniqueness，都是必須保留的 invariants。 |
-| `004_rbac_roles.sql` | Role 相關變更 | 確認它是否已由目前 enum handling 表達。 |
+| `004_rbac_roles.sql` | Role 相關變更 | 以 `ALTER TYPE ... ADD VALUE 'agency'` append 到既有 enum 後方；production/migrated order 會是 `viewer`、`streamer`、`admin`、`agency`。 |
 | `005_channel_config.sql` | `channel_configs` | 比對 numeric defaults 與 timestamp nullability。 |
 | `006_streamers.sql` | `streamers` | Runtime 也建立 `idx_streamers_user_channel`；需確認最終 desired uniqueness。 |
 | `007_click_boost.sql` | Watch session click boost fields | 與 `WatchSession` model 比對。 |
@@ -61,7 +61,7 @@
 | Raffle tables | Models 包含 `Raffle`、`RaffleEntry`、`RaffleDraw`、`RaffleClaim`；`001-019` 沒有建立 raffle tables。 | Baseline 若產生裸 `CREATE TABLE`，在 AutoMigrate 已建表的環境會失敗。 | 決定採 import baseline，或產生 apply-safe guarded SQL。 |
 | Watch and broadcast stats | Models 包含 `WatchTimeStat`、`BroadcastTimeStat`、`BroadcastTimeLog`；`001-019` 沒有 dedicated SQL migration。 | 與 raffle tables 有相同 table-exists risk。 | 產生 SQL 前先決定 baseline strategy。 |
 | Partial unique indexes | 多個 invariants 以 raw SQL 存在，因 GORM tags 無法完整表達。 | Atlas provider 若沒有看到 desired schema，可能產生 drop。 | 用 Atlas desired schema 或手寫 migration 明確保留。 |
-| Enum ordering | Historical SQL、runtime enum creation、Atlas loader 必須一致。 | PostgreSQL enum ordering 影響 comparison 與 drift detection。 | 使用 canonical order：`viewer`、`streamer`、`agency`、`admin`，對齊目前 runtime code。 |
+| Enum ordering | Historical SQL migration path 與 runtime fresh-create path 目前可能不同序。 | PostgreSQL enum ordering 影響 comparison 與 drift detection；若誤把 runtime fresh-create order 當唯一 canonical order，可能產生假性 drift，甚至導向高風險 enum 重建。 | 以 production/migrated order `viewer`、`streamer`、`admin`、`agency` 為準，或在 reconciliation 中明確記錄並接受雙態；不得只為重排 enum 建 migration。 |
 | Runtime data migration | Server 啟動時會 hash 36-char raffle claim tokens。 | Schema migration 工作可能讓不相關 data repair 永遠留在 runtime。 | 另行判斷 production 是否仍需要；不得藏在 Atlas tooling PR。 |
 | Dependency anchoring | Atlas provider 可能只被 loader command import。 | 若只存在 build-ignored loader，`go mod tidy` 可能移除 tool dependency。 | Tooling PR 新增 `services/api/tools.go`。 |
 

--- a/docs/atlas-schema-reconciliation.md
+++ b/docs/atlas-schema-reconciliation.md
@@ -1,0 +1,109 @@
+# Atlas Schema Reconciliation
+
+本文件追蹤 `services/api` 從 GORM `AutoMigrate` 遷移到 Atlas 前，必須先 reconcile 的 schema sources。
+
+這份文件刻意保守。標記為「必須保留」的項目，代表它已存在於目前程式碼或 migration 中；Atlas 接管後不得讓該 invariant 消失。
+
+## Inputs
+
+| Source | Path | Role | Current Status |
+|---|---|---|---|
+| Historical SQL migrations | `services/api/migrations/001_init.sql` through `019_coupon_redemptions.sql` | 手寫 schema history | 檔案存在於 repo，但 issue `#463` 已說明目前沒有 migration tool 執行它們。 |
+| GORM models | `services/api/internal/models/*.go` | Application schema model | 目前 `AutoMigrate` source。包含部分沒有完整出現在 `001-019` 的表。 |
+| Runtime schema patches | `services/api/cmd/server/main.go` | Startup-time DDL 與 data repair | API startup 仍會執行。這些 patch 必須遷移到 Atlas，或明確保留為非 schema runtime work。 |
+| Atlas config | `services/api/atlas.hcl` | 未來 schema diff entrypoint | 本文件建立時，`develop` 尚未有此檔案。 |
+| Closed attempt | PR `#476` | 前一次 implementation attempt | 已關閉，原因是 tooling、baseline、runtime migration strategy 被包在同一顆 PR，且 baseline 假設不安全。 |
+
+## Current Runtime DDL In `cmd/server/main.go`
+
+| Runtime Behavior | Current Code | Reconciliation Decision |
+|---|---|---|
+| 建立 `user_role` enum | `initializeUserRoleEnum` 建立 `('viewer', 'streamer', 'agency', 'admin')`，並在缺少時補上 `agency`。 | 必須保留。Atlas loader 與 migrations 必須使用相同 label set 與 ordering。 |
+| 執行 GORM `AutoMigrate` | `db.AutoMigrate(...)` 套用所有 models。 | 只能在 Atlas baseline 已於 staging 驗證後移除。 |
+| 補 `tachi_balances.user_id` FK | 手寫 `ALTER TABLE tachi_balances ADD CONSTRAINT fk_tachi_balances_user_id`。 | 必須以 Atlas migration 或 model association 保留。 |
+| 補 coupon redemption checks | `ensureCouponRedemptionRuntimeSchema` 增加 amount/status constraints。 | 必須保留於 Atlas migration。 |
+| 補 coupon compensation index | `coupon_redemptions(status)` 的 partial index，條件為 status = `compensation-needed`。 | 若 query behavior 仍依賴它，必須保留。 |
+| 補 active watch session uniqueness | Partial unique index `idx_watch_sessions_active_user_channel`。 | 必須保留。這是 concurrency invariant，不只是效能 index。 |
+| 補 points ledger uniqueness | Unique index `idx_points_ledgers_user_channel`。 | 必須保留。watch heartbeat upsert 依賴 `ON CONFLICT (user_id, channel_id)`。 |
+| 補 external transaction uniqueness | Partial unique index `idx_points_transactions_external_transaction_id`。 | 除非另開 issue 移除 idempotency guarantee，否則必須保留。 |
+| 補 streamer uniqueness | Unique index `idx_streamers_user_channel`。 | 必須保留，除非有等價 constraint 取代。 |
+| 執行 streamer agency migration | `applyStreamerAgencyMigration(db)`。 | 需與 migrations `010`、`011` 比對，缺漏部分要保留到 Atlas。 |
+| Hash raffle claim tokens | 將 36-char token 一次性轉成 SHA-256 hex。 | 與 schema migration 分開處理。只有 production data 仍需要此 repair 時才保留。 |
+
+## Historical Migration Inventory
+
+| Migration | Main Schema Surface | Notes For Atlas Baseline |
+|---|---|---|
+| `001_init.sql` | `user_role`、`users`、`auth_providers`、`shipping_addresses`、`refresh_tokens`、`web3_nonces` | Enum 最初只有 `viewer`、`streamer`、`admin`；目前 runtime 另補 `agency`。 |
+| `002_email_auth.sql` | Email verification 與 password reset tables | 比對 unique constraints 與 token indexes 是否符合 GORM tags。 |
+| `003_watch_points.sql` | `watch_sessions`、`points_ledgers`、`points_transactions` | 包含 active-session partial unique index 與 ledger uniqueness，都是必須保留的 invariants。 |
+| `004_rbac_roles.sql` | Role 相關變更 | 確認它是否已由目前 enum handling 表達。 |
+| `005_channel_config.sql` | `channel_configs` | 比對 numeric defaults 與 timestamp nullability。 |
+| `006_streamers.sql` | `streamers` | Runtime 也建立 `idx_streamers_user_channel`；需確認最終 desired uniqueness。 |
+| `007_click_boost.sql` | Watch session click boost fields | 與 `WatchSession` model 比對。 |
+| `008_points_transaction_sku.sql` | `points_transactions.sku` | 與 `PointsTransaction` 的 nullable/type 比對。 |
+| `009_channel_config_multiplier.sql` | `channel_configs.multiplier` | 與 model type/default 比對。 |
+| `010_agency_streamers.sql` | `agency_streamers` | 與 `AgencyStreamer` model 及 runtime agency migration 比對。 |
+| `011_streamers_agency.sql` | `streamers.agency_user_id` | 必須 reconcile FK names 與 delete behavior。 |
+| `012_tachi_balances.sql` | `tachi_balances` | Runtime 另補 FK；Atlas 接管前必須由 migration 擁有。 |
+| `013_airdrop.sql` | Channel config airdrop fields | 與 model defaults/limits 比對。 |
+| `014_auth_provider_partial_unique.sql` | Soft-delete-aware auth provider uniqueness | 必須保留 partial unique indexes。 |
+| `015_claims.sql` | `claims`、`claim_items` | 比對 checks、uniqueness、FK behavior、query indexes。 |
+| `016_claims_composite_fk.sql` | Composite claim/ledger/transaction FKs | 未經 service-level review 不得移除。 |
+| `017_claim_finalize_failed.sql` | Claim status check expansion | 確認 final status enum/check 符合 service behavior。 |
+| `018_points_transaction_external_id.sql` | External transaction ID idempotency | 必須保留 non-null external transaction ID 的 partial unique index。 |
+| `019_coupon_redemptions.sql` | Coupon redemption table、checks、compensation index | Runtime 有部分重複補強；Atlas 最終應成為單一 owner。 |
+
+## Known Gaps To Verify
+
+| Area | Evidence | Risk | Required Decision |
+|---|---|---|---|
+| Raffle tables | Models 包含 `Raffle`、`RaffleEntry`、`RaffleDraw`、`RaffleClaim`；`001-019` 沒有建立 raffle tables。 | Baseline 若產生裸 `CREATE TABLE`，在 AutoMigrate 已建表的環境會失敗。 | 決定採 import baseline，或產生 apply-safe guarded SQL。 |
+| Watch and broadcast stats | Models 包含 `WatchTimeStat`、`BroadcastTimeStat`、`BroadcastTimeLog`；`001-019` 沒有 dedicated SQL migration。 | 與 raffle tables 有相同 table-exists risk。 | 產生 SQL 前先決定 baseline strategy。 |
+| Partial unique indexes | 多個 invariants 以 raw SQL 存在，因 GORM tags 無法完整表達。 | Atlas provider 若沒有看到 desired schema，可能產生 drop。 | 用 Atlas desired schema 或手寫 migration 明確保留。 |
+| Enum ordering | Historical SQL、runtime enum creation、Atlas loader 必須一致。 | PostgreSQL enum ordering 影響 comparison 與 drift detection。 | 使用 canonical order：`viewer`、`streamer`、`agency`、`admin`，對齊目前 runtime code。 |
+| Runtime data migration | Server 啟動時會 hash 36-char raffle claim tokens。 | Schema migration 工作可能讓不相關 data repair 永遠留在 runtime。 | 另行判斷 production 是否仍需要；不得藏在 Atlas tooling PR。 |
+| Dependency anchoring | Atlas provider 可能只被 loader command import。 | 若只存在 build-ignored loader，`go mod tidy` 可能移除 tool dependency。 | Tooling PR 新增 `services/api/tools.go`。 |
+
+## Reconciliation Procedure
+
+產生任何 baseline migration 前，先完成以下程序：
+
+1. 建立乾淨 PostgreSQL database，依序套用 `services/api/migrations/001-019`。
+2. Dump migration-only schema：
+
+   ```bash
+   pg_dump --schema-only --no-owner --no-privileges "$MIGRATIONS_DATABASE_URL" > /tmp/tachigo-sql-migrations-schema.sql
+   ```
+
+3. 建立第二個乾淨 PostgreSQL database，啟動目前 API，讓 GORM `AutoMigrate` 與 runtime patches 執行完。
+4. Dump AutoMigrate/runtime schema：
+
+   ```bash
+   pg_dump --schema-only --no-owner --no-privileges "$AUTOMIGRATE_DATABASE_URL" > /tmp/tachigo-automigrate-schema.sql
+   ```
+
+5. 比對兩份 dump，並分類每個差異：
+
+   ```bash
+   diff -u /tmp/tachigo-sql-migrations-schema.sql /tmp/tachigo-automigrate-schema.sql
+   ```
+
+6. 在新增 `020_atlas_baseline.sql` 前，先把最終決策更新回本文件。
+
+## Baseline Strategy Decision Record
+
+Baseline PR commit SQL 前，必須先在 PR body 選定 baseline strategy。
+
+| Strategy | Use When | Required Proof |
+|---|---|---|
+| Import baseline | 既有環境已經透過 AutoMigrate 與 runtime patches 擁有目標 schema。 | Atlas history 可標記既有狀態，不會把 unsafe `CREATE TABLE` 重套到既有 DB。 |
+| Apply-safe baseline | 既有環境需要 SQL 從已知 current state reconcile。 | Migration 可同時套用到 clean migration DB 與已跑過目前 `AutoMigrate` 的 DB。 |
+
+## Completion Criteria
+
+- [ ] `001-019` 中每個 table/index 都已被保留、明確替代，或用 issue-backed rationale 明確移除。
+- [ ] `cmd/server/main.go` 中每個 runtime schema patch 都已進入 Atlas，或被記錄為刻意保留的非 schema runtime behavior。
+- [ ] Raffle/watch/broadcast tables 已有安全 baseline strategy，且有考慮 AutoMigrate 可能已建表。
+- [ ] Atlas loader output 包含或保留 GORM 無法表達的 invariants。
+- [ ] `AutoMigrate` removal 被 baseline staging validation 阻擋，不能提前執行。


### PR DESCRIPTION
## 什麼改動
新增兩份 Atlas migration 接手文件：

- `docs/atlas-migration-plan.md`：規劃 #463 的 PR 拆分順序、每顆 PR 的 scope、驗收指令與 review checklist。
- `docs/atlas-schema-reconciliation.md`：盤點目前 `001-019` migrations、GORM models、`cmd/server/main.go` runtime schema patches 之間需要 reconcile 的項目。
- 後續補正：PR 1 tooling smoke test 改用 non-mutating `atlas schema inspect --env gorm --url env://src`，避免在 tooling-only PR 寫入 migration file 或 `atlas.sum`。

## 為什麼
refs #463

PR #476 已關閉，主要問題是 tooling、baseline SQL、AutoMigrate removal strategy 混在同一顆 PR，且 baseline 對既有 AutoMigrate-created tables 有不安全假設。這顆 PR 先把重新接手 #463 的執行計劃與 reconciliation checklist 文件化，避免下一輪直接產生大型 baseline migration。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## Scope 對齊
- Source of truth：#463
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 `services/api/atlas.hcl`
  - 不新增 Atlas loader / tooling dependency
  - 不新增或修改 migration SQL
  - 不移除 `AutoMigrate`
  - 不修改 runtime code

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 文件化 #463 的安全拆分計劃與 schema reconciliation checklist，作為後續 Atlas tooling / baseline PR 的前置 review 材料。
- Approx changed lines：~339
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #476 closed attempt；後續預計拆成 tooling、reconciliation、baseline、AutoMigrate removal PR。

## Acceptance Criteria
- [x] AC 1：建立 #463 的拆分執行計劃，明確禁止 tooling / baseline / AutoMigrate removal 混在同一顆 PR。
- [x] AC 2：建立 schema reconciliation 文件，列出 `001-019` migrations、GORM models、runtime schema patches 的比對入口。
- [x] AC 3：文件明確列出 baseline strategy 必須在產生 SQL 前決定，並要求驗證既有 AutoMigrate-created DB。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rg -n "TBD|TODO|fill in|待補|待定|implement later|appropriate error handling|Similar to" docs/atlas-migration-plan.md docs/atlas-schema-reconciliation.md
# no matches

git diff --check
# pass

git diff --check HEAD^ HEAD
# pass

git show --stat --oneline HEAD
b9c2adb docs: clarify atlas tooling smoke test
docs/atlas-migration-plan.md | 4 ++--
1 file changed, 2 insertions(+), 2 deletions(-)

gh pr view 477 --repo nurockplayer/tachigo --json additions,deletions,changedFiles
{"additions":339,"changedFiles":2,"deletions":0}

Initial PR diff stat:
docs/atlas-migration-plan.md        | 230 ++++++++++++++++++++++++++++++++++++
docs/atlas-schema-reconciliation.md | 109 +++++++++++++++++
2 files changed, 339 insertions(+)
```

## 備註
這顆 PR 是 planning / documentation PR，不會 close #463。後續真正完成 #463 仍需依文件拆成多顆 implementation PR。

## Notes for Claude Code Review
- 請特別看 PR 拆分順序是否足以避免重演 #476 的 scope 問題。
- 請確認 `docs/atlas-schema-reconciliation.md` 是否漏列任何目前 runtime schema patch 或 must-preserve invariant。
- 文件中提到的 Atlas 指令會在後續 tooling PR 依實際 `atlas.hcl` 落地後再次驗證。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* 新增数据库迁移执行规划文档，详细说明实施策略、技术栈与验收清单
* 新增数据库架构协调文档，定义迁移前的基准线建立与验证步骤

<!-- end of auto-generated comment: release notes by coderabbit.ai -->