### PR TITLE
[chore] organize docs history records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# Tachigo Docs
+
+本目錄收納工程文件。文件分成兩種定位：
+
+- **現況 source of truth**：描述目前仍有效的架構、政策、規格。檔名不加日期，內容改變時直接更新。
+- **歷史紀錄**：像 SQL migration log 一樣，記錄某次遷移、盤點或決策當下的背景與結果。檔名使用日期開頭，完成後原則上只做狀態校正，不作為 active TODO。
+
+## 目錄分類
+
+| 位置 | 用途 | 命名 |
+|---|---|---|
+| `docs/` | 目前仍有效的架構、API、政策與設計文件 | `<topic>.md` |
+| `docs/ai/` | AI 協作指南與 agent-facing 文件 | `<topic>.md` |
+| `docs/history/` | 已完成的一次性遷移、盤點、整理紀錄 | `YYYY-MM-DD-<topic>.md` |
+| `plans/` | 實作前計畫與完成後的執行紀錄 | `<feature-slug>.md` |
+
+## 命名原則
+
+- 目前仍是 source of truth 的文件不加日期，例如 `architecture.md`、`tokenomics.md`。
+- 歷史紀錄與決策紀錄使用日期開頭，例如 `2026-04-30-monorepo-directory-refactor.md`。
+- 日期使用該事件完成、merge 或正式採納的日期；若只有月份，使用最接近的完成日期並在文件內說明。
+- 已完成但仍保留的歷史文件，文件頂端應標註狀態與最後校正日期。

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,9 @@
 | 位置 | 用途 | 命名 |
 |---|---|---|
 | `docs/` | 目前仍有效的架構、API、政策與設計文件 | `<topic>.md` |
-| `docs/ai/` | AI 協作指南與 agent-facing 文件 | `<topic>.md` |
 | `docs/history/` | 已完成的一次性遷移、盤點、整理紀錄 | `YYYY-MM-DD-<topic>.md` |
+| `docs/ai/` | 既有 AI 協作指南與 agent-facing 文件 | `<topic>.md` |
+| `docs/superpowers/` | 既有 Superpowers specs / plans 歷史文件 | 維持既有日期命名 |
 | `plans/` | 實作前計畫與完成後的執行紀錄 | `<feature-slug>.md` |
 
 ## 命名原則
@@ -20,3 +21,4 @@
 - 歷史紀錄與決策紀錄使用日期開頭，例如 `2026-04-30-monorepo-directory-refactor.md`。
 - 日期使用該事件完成、merge 或正式採納的日期；若只有月份，使用最接近的完成日期並在文件內說明。
 - 已完成但仍保留的歷史文件，文件頂端應標註狀態與最後校正日期。
+- 本規範先定義新增分類與命名原則，不要求批次搬移既有目錄；未列出的既有目錄應維持現況，待後續 PR 另行收斂。

--- a/docs/history/2026-04-30-monorepo-directory-refactor.md
+++ b/docs/history/2026-04-30-monorepo-directory-refactor.md
@@ -1,0 +1,70 @@
+# Monorepo 目錄重整紀錄（2026-04）
+
+> 狀態：已完成，保留作為歷史遷移紀錄
+> 最後校正：2026-05-03
+
+## 背景
+
+原始 repo 的頂層目錄隨著專案成長變得混亂：
+- 前端散落在 `tachimint/`、`dashboard/` 兩個分離目錄
+- 後端直接放在 `backend/`，與其他資料夾平行但缺乏語意分層
+
+這次重整的目標是讓目錄結構能反映「這個 repo 裡有哪些服務」，方便未來新增服務時有明確的放置位置。
+
+## 遷移前後對照
+
+```
+遷移前                          遷移後
+──────────────────────────────  ──────────────────────────────
+tachigo/                        tachigo/
+├── backend/                    ├── services/
+│   └── (Go API)                │   └── api/        ← 後端 Go 服務
+├── tachimint/                  ├── apps/
+│   └── (Chrome extension)      │   ├── extension/  ← Chrome extension 前端
+├── dashboard/                  │   └── dashboard/  ← 後台管理前端
+│   └── (React 後台)            ├── contracts/
+├── contracts/                  ├── docs/
+└── docs/                       └── ...
+```
+
+## 執行的 PR
+
+### PR #417 — 前端移入 apps workspace
+
+- `tachimint/` → `apps/extension/`
+- `dashboard/` → `apps/dashboard/`
+- 建立 pnpm workspace（`pnpm-workspace.yaml`）
+- 更新 Docker Compose、Dependabot、LFS 路徑、相關 docs/scripts
+- Issue：#396 | Merged：2026-04-30
+
+### PR #435 — 後端移入 services/api
+
+- `backend/` → `services/api/`
+- Go module path 不變（`github.com/nurockplayer/tachigo`）
+- 更新 Docker Compose、Makefile、CI、setup scripts
+- 屬於純路徑遷移，不改 API contract、migration、runtime behavior
+- Issue：#397 | Merged：2026-04-30
+
+### PR #438 — CI 優化：移除 artifact roundtrip
+
+- `backend-build` job 移除 artifact export/upload（只保留 Docker build 驗 cache）
+- `backend` job 改用 native `go test / go vet`（`actions/setup-go@v6`）
+- 兩個 job 改為平行執行，不再有 artifact 依賴
+- 實測節省約 2.5 分鐘（gzip 66s + upload 19s + download 16s + docker load 50s）
+- Issue：#437 | Merged：2026-04-30
+
+## 後續項目狀態
+
+| Issue | 內容 | 狀態 |
+|---|---|---|
+| #399 | 整合 monorepo 遷移後的 infra assets 與 AI instructions | 已關閉（2026-05-02） |
+| #400 | 統一前端 API base URL env 命名 | 已關閉（2026-05-02） |
+| #385 | check-backend-ci-cache.sh artifact pipeline 補強 | 仍 open；artifact roundtrip 已由 PR #438 移除，需另行判斷是否 close 或 retitle |
+
+## 不變的事項
+
+- Go module path：`github.com/nurockplayer/tachigo`
+- API contract 與 Swagger annotations
+- Database migration 內容
+- Runtime behavior
+- `contracts/`、`docs/`、`deployments/` 位置

--- a/docs/history/2026-04-30-monorepo-directory-refactor.md
+++ b/docs/history/2026-04-30-monorepo-directory-refactor.md
@@ -59,7 +59,7 @@ tachigo/                        tachigo/
 |---|---|---|
 | #399 | 整合 monorepo 遷移後的 infra assets 與 AI instructions | 已關閉（2026-05-02） |
 | #400 | 統一前端 API base URL env 命名 | 已關閉（2026-05-02） |
-| #385 | check-backend-ci-cache.sh artifact pipeline 補強 | 仍 open；artifact roundtrip 已由 PR #438 移除，需另行判斷是否 close 或 retitle |
+| #385 | check-backend-ci-cache.sh artifact pipeline 補強 | 2026-05-03 快照：仍 open；artifact roundtrip 已由 PR #438 移除 |
 
 ## 不變的事項
 


### PR DESCRIPTION
## 什麼改動
- 新增 `docs/README.md`，定義 docs 分類、source of truth 與 historical record 的命名規則。
- 新增 `docs/history/2026-04-30-monorepo-directory-refactor.md`，將 monorepo 目錄重整紀錄保存為日期開頭的歷史紀錄。

## 為什麼
`docs/` 目前同時放了現況文件與一次性歷史紀錄，容易讓已完成的遷移紀錄看起來像 active TODO。本 PR 先建立最小分類規則，並只搬一份 monorepo 歷史紀錄作為範例。

closes #478

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#478
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不批次搬移所有既有 `docs/` 文件
  - 不修改產品架構或開發流程
  - 不調整 CI / backend / frontend code

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 建立 docs 歷史紀錄分類規則，並加入 monorepo 目錄重整歷史紀錄。
- Approx changed lines：~92
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `docs/README.md` 清楚區分 source of truth 與 historical record
- [x] monorepo 重整紀錄位於 `docs/history/2026-04-30-monorepo-directory-refactor.md`
- [x] 歷史紀錄不再使用 `未開始`、`進行中`、`遷移後待辦` 這類 active TODO 字樣

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
git -C /private/tmp/tachigo-docs-history-index status --short --branch --untracked-files=all
## chore/docs-history-index...origin/develop [ahead 1]

test -f docs/README.md
PASS

test -f docs/history/2026-04-30-monorepo-directory-refactor.md
PASS

rg -n "未開始|進行中|遷移後待辦|可 close|待辦" docs/README.md docs/history/2026-04-30-monorepo-directory-refactor.md
PASS: no matches
```

## 備註
此 PR 使用獨立 worktree `/private/tmp/tachigo-docs-history-index` 建立，避免混入原工作區其他 unrelated workflow 變更。

## Notes for Claude Code Review
- 請確認 `docs/README.md` 的分類規則是否足夠清楚，且不會誤導為需要一次搬完所有既有 `docs/` 文件。
- 本 PR intentionally 只新增一份 history 範例，不處理其他歷史文件分類。
