### PR TITLE
[frontend] remove dead extension locale keys

### DIFF
--- a/apps/extension/src/i18n/locales/en/common.json
+++ b/apps/extension/src/i18n/locales/en/common.json
@@ -22,12 +22,6 @@
     "clicksLeft": "{{count}} / 30 CLICKS",
     "clicksExhausted": "LIMIT REACHED"
   },
-  "nonViewer": {
-    "titleLine1": "Your audience is on this channel",
-    "titleHighlight": "accumulating watch points",
-    "hintLine1": "Viewers just need to watch the stream",
-    "hintLine2": "to automatically earn mining points"
-  },
   "contextLoading": {
     "title": "Loading...",
     "subtitle": "Starting extension"
@@ -101,22 +95,5 @@
     "no_winners": "No winners yet.",
     "error_load_failed": "Failed to load results.",
     "back": "BACK"
-  },
-  "error": {
-    "account": {
-      "title": "Account Not Found",
-      "message": "Please create a tachigo account first",
-      "hint": "Visit tachigo.gg to create an account, then refresh to start mining"
-    },
-    "backend": {
-      "title": "Service Unavailable",
-      "message": "Service temporarily unavailable, please try again later",
-      "hint": "We are working on the issue, please refresh in a few minutes"
-    },
-    "session": {
-      "title": "Connection Failed",
-      "message": "Watch connection failed, please refresh",
-      "hint": "Please check your network connection and refresh the page"
-    }
   }
 }

--- a/apps/extension/src/i18n/locales/zh-CN/common.json
+++ b/apps/extension/src/i18n/locales/zh-CN/common.json
@@ -22,12 +22,6 @@
     "clicksLeft": "剩 {{count}} 次",
     "clicksExhausted": "本轮已达上限"
   },
-  "nonViewer": {
-    "titleLine1": "您的观众正在此频道",
-    "titleHighlight": "累积观看积分",
-    "hintLine1": "观众只要观看直播",
-    "hintLine2": "即可自动累积挖矿积分"
-  },
   "contextLoading": {
     "title": "加载中...",
     "subtitle": "正在启动 extension"
@@ -101,22 +95,5 @@
     "no_winners": "尚未抽出中奖者",
     "error_load_failed": "载入失败",
     "back": "返回"
-  },
-  "error": {
-    "account": {
-      "title": "尚未创建账号",
-      "message": "请先创建 tachigo 账号",
-      "hint": "前往 tachigo.gg 创建账号后，刷新即可开始挖矿"
-    },
-    "backend": {
-      "title": "服务暂时不可用",
-      "message": "服务暂时不可用，请稍后再试",
-      "hint": "我们正在处理问题，请等几分钟后刷新"
-    },
-    "session": {
-      "title": "连接建立失败",
-      "message": "观看连接建立失败，请刷新",
-      "hint": "请确认网络连接是否正常后刷新页面"
-    }
   }
 }

--- a/apps/extension/src/i18n/locales/zh-TW/common.json
+++ b/apps/extension/src/i18n/locales/zh-TW/common.json
@@ -22,12 +22,6 @@
     "clicksLeft": "剩 {{count}} 次",
     "clicksExhausted": "本輪已達上限"
   },
-  "nonViewer": {
-    "titleLine1": "您的觀眾正在此頻道",
-    "titleHighlight": "累積觀看點數",
-    "hintLine1": "觀眾只要觀看直播",
-    "hintLine2": "即可自動累積挖礦點數"
-  },
   "contextLoading": {
     "title": "載入中...",
     "subtitle": "正在啟動 extension"
@@ -101,22 +95,5 @@
     "no_winners": "尚未抽出中獎者",
     "error_load_failed": "載入失敗",
     "back": "返回"
-  },
-  "error": {
-    "account": {
-      "title": "尚未建立帳號",
-      "message": "請先建立 tachigo 帳號",
-      "hint": "前往 tachigo.gg 建立帳號後，重新整理即可開始挖礦"
-    },
-    "backend": {
-      "title": "服務暫時無法使用",
-      "message": "服務暫時無法使用，請稍後再試",
-      "hint": "我們正在處理問題，請稍等幾分鐘後重新整理"
-    },
-    "session": {
-      "title": "連線建立失敗",
-      "message": "觀看連線建立失敗，請重新整理",
-      "hint": "請確認網路連線是否正常後重新整理頁面"
-    }
   }
 }


### PR DESCRIPTION
## 什麼改動

- 移除 `apps/extension` 三個 locale 檔中未使用的 `nonViewer.*` 與 `error.*` 翻譯 key。
- 保留 `contextLoading.*`、`common.retry`、`common.initializing` 等 repo i18n 規則要求保留的 key。
- 補做 component / app / types / mock 掃描，確認這些區塊目前沒有可安全移除的 dead export。

## 為什麼

- 對齊 `#411` 的 extension dead code 掃描範圍，先清掉已確認無入口的 locale dead key，避免把仍被引用的 component / util / type / mock 誤刪。
- closes #411

## Release Context

- Release type：n/a

## Workflow Type

- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊

- Source of truth: #411
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不重構 `apps/extension` 其他邏輯。
  - 不修改 backend contract、dashboard、或其他 product surface。
  - 不移除仍有實際引用的 component / util / type / mock。
  - 不改 test 檔案。

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - 移除 extension locale bundles 中已確認未使用的 dead translation keys。
- Approx changed lines：~69
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [ ] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 這次 frontend 變更本質就是小型 dead code cleanup，沒有拆成額外 PR 的必要。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria

- [x] AC 1：掃描 `apps/extension/src/app/components/`、`src/app/`、`src/types/`、`src/mock/` 後，確認本輪沒有可安全移除的 dead export。
- [x] AC 2：移除 `src/i18n/` 中確認未使用、且不受 repo i18n 規則保留的 translation keys。
- [x] AC 3：PR diff < 400 行，且本地驗證通過。

## 超出範圍內容

- 無

## 測試方式

- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**

```text
$ rtk pnpm --dir apps/extension run check:i18n
i18n check passed: 21 locale mappings, 67 keys

$ rtk pnpm --dir apps/extension run build
vite build succeeded
```

## 備註

- 此 PR 只改三個 locale JSON 檔案。
- `mock/twitch-ext.ts` 仍由 `main.tsx` 的 `import.meta.env.DEV` 分支動態載入，未誤用於 production build。

## Notes for Claude Code Review

- 請特別確認 `nonViewer.*` 與 `error.*` 在 extension 目前程式入口中確實沒有使用。
- `contextLoading.*`、`common.retry`、`common.initializing` 已刻意保留，因為 `check:i18n` 會要求這些 key 存在。
