### PR TITLE
[frontend] remove dead exports in issue #410 scope

### DIFF
--- a/apps/extension/src/extension/couponCatalog.ts
+++ b/apps/extension/src/extension/couponCatalog.ts
@@ -1,4 +1,4 @@
-export type CouponItemKey = 'tachiya95' | 'freeShip' | 'bundle120'
+type CouponItemKey = 'tachiya95' | 'freeShip' | 'bundle120'
 
 export interface DemoCouponMeta {
   id: string
@@ -27,7 +27,3 @@ export const demoCouponMetas: DemoCouponMeta[] = [
     code: 'DROP120',
   },
 ]
-
-export function findCouponMetaById(couponId: string): DemoCouponMeta | undefined {
-  return demoCouponMetas.find((coupon) => coupon.id === couponId)
-}

--- a/apps/extension/src/extension/types.ts
+++ b/apps/extension/src/extension/types.ts
@@ -2,7 +2,7 @@ import type { AppLanguage } from '../i18n'
 
 export type DemoScreen = 'login' | 'loading' | 'hud' | 'claim' | 'coupon' | 'raffle'
 
-export interface RaffleResultEntry {
+interface RaffleResultEntry {
   id: string
   twitch_login: string
   display_name: string
@@ -49,7 +49,7 @@ export const defaultDemoState: DemoState = {
   redeemedCouponIds: [],
 }
 
-export function createDefaultHudDemoState(): HudDemoState {
+function createDefaultHudDemoState(): HudDemoState {
   return { ...defaultHudDemoState }
 }
 

--- a/apps/extension/src/hooks/useTwitch.ts
+++ b/apps/extension/src/hooks/useTwitch.ts
@@ -8,7 +8,7 @@ import {
 } from '../services/api'
 import i18n, { mapTwitchLocaleToAppLanguage } from '../i18n'
 
-export interface TwitchTPointProduct {
+interface TwitchTPointProduct {
   sku: string
   displayName: string
   cost: { amount: number; type: 'bits' }


### PR DESCRIPTION
## 什麼改動
- 移除 `apps/extension` 目標範圍內確認未被外部使用的 dead exports / helper
- 將只在檔內使用的型別或 helper 改為檔內宣告，避免不必要的公開 surface

## 為什麼
對應 `#410` 的前端 dead code 掃描子任務，先處理 hooks 與 extension helpers 中已確認可安全移除的 dead code。

closes #410

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#410
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 bug fix、不做 test 檔案修改、不做 issue 範圍外的額外清掃

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 移除 `apps/extension` 指定掃描範圍內已確認未使用的 dead exports / helper
- Approx changed lines：~12
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 移除確認未使用的 export / 函式 / 型別
- [x] PR diff < 400 行
- [ ] CI 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
rtk pnpm --dir apps/extension test
- pass: 33
- fail: 0

rtk pnpm --dir apps/extension build
- pass
```

## 備註
- `apps/extension/src/services/api.ts` 經掃描後，這輪沒有確認到可安全刪除的 exported function，因此未納入變更。

## Notes for Claude Code Review
- 這個 PR 只移除未被外部使用的 export / helper，沒有行為修改。
