### PR TITLE
[backend] 移除高信心未使用 helper（#406 第一批）

### DIFF
--- a/services/api/internal/contract/tachi_token.go
+++ b/services/api/internal/contract/tachi_token.go
@@ -75,19 +75,6 @@ func NewTachiToken(address common.Address, client *ethclient.Client) (*TachiToke
 	}, nil
 }
 
-func (t *TachiToken) Mint(ctx context.Context, toAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (string, error) {
-	txHash, err := t.MintBroadcast(ctx, toAddr, amount, signerKey)
-	if err != nil {
-		return "", err
-	}
-	if err := t.WaitMintReceipt(ctx, txHash); err != nil {
-		// Preserve backward-compatible wrapper behavior while exposing tx hash
-		// when receipt is unknown.
-		return txHash, err
-	}
-	return txHash, nil
-}
-
 // MintBroadcast signs and sends the mint tx without waiting for receipt.
 func (t *TachiToken) MintBroadcast(ctx context.Context, toAddr common.Address, amount *big.Int, signerKey *ecdsa.PrivateKey) (string, error) {
 	t.mu.Lock()

--- a/services/api/internal/services/airdrop_service.go
+++ b/services/api/internal/services/airdrop_service.go
@@ -211,10 +211,6 @@ func (s *AirdropService) activeViewersInTx(db *gorm.DB, channelID string) ([]air
 	return viewers, err
 }
 
-func (s *AirdropService) dailyLimit(channelID string) (int64, error) {
-	return s.dailyLimitInTx(s.db, channelID)
-}
-
 func (s *AirdropService) dailyLimitInTx(db *gorm.DB, channelID string) (int64, error) {
 	var cfg models.ChannelConfig
 	err := db.Where("channel_id = ?", channelID).First(&cfg).Error

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -278,20 +278,6 @@ func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPai
 	return s.upsertOAuthUser(context.Background(), models.ProviderWeb3, checksumAddr, "", "", nil, nil)
 }
 
-// ─── Provider Link (attach to existing account) ──────────────────────────────
-
-func (s *AuthService) LinkTwitch(ctx context.Context, userID uuid.UUID, code string) error {
-	token, err := s.twitchOAuth.Exchange(ctx, code)
-	if err != nil {
-		return err
-	}
-	info, err := fetchTwitchUser(ctx, s.twitchOAuth, token, s.cfg.OAuth.Twitch.ClientID)
-	if err != nil {
-		return err
-	}
-	return s.linkProvider(userID, models.ProviderTwitch, info.ID, token)
-}
-
 func (s *AuthService) UnlinkProvider(userID uuid.UUID, provider models.ProviderType) error {
 	// Ensure the user still has at least one other way to log in
 	var count int64
@@ -438,31 +424,6 @@ func (s *AuthService) upsertOAuthUser(
 
 	tokens, err := s.issueTokenPair(&user)
 	return &user, tokens, err
-}
-
-func (s *AuthService) linkProvider(userID uuid.UUID, provider models.ProviderType, providerID string, token *oauth2.Token) error {
-	// Check not already linked to someone else
-	var count int64
-	s.db.Model(&models.AuthProvider{}).
-		Where("provider = ? AND provider_id = ? AND user_id != ?", provider, providerID, userID).
-		Count(&count)
-	if count > 0 {
-		return ErrProviderLinked
-	}
-
-	ap := models.AuthProvider{
-		UserID:     userID,
-		Provider:   provider,
-		ProviderID: providerID,
-	}
-	if token != nil {
-		at := token.AccessToken
-		rt := token.RefreshToken
-		ap.AccessToken = &at
-		ap.RefreshToken = &rt
-		ap.TokenExpiresAt = &token.Expiry
-	}
-	return s.db.Save(&ap).Error
 }
 
 // ─── Utility ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 什麼改動
移除 4 個已確認未被 production 路徑使用的 backend dead code，範圍限於 auth / airdrop / contract 三個檔案。

## 為什麼
refs #406

issue #406 要求針對 backend models / services / config / contract / database 做 dead-code 掃描與移除。這個 PR 只先收掉高信心、低風險、且不需要改動 test 的第一批候選，避免把 dead-code cleanup 擴張成 test refactor 或其他邏輯變更。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#406
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不重構邏輯
  - 不混入 bug fix
  - 不動 test 檔案
  - 不移除目前只被測試使用的 test seam

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 移除 backend 中已確認未被 production 路徑使用的高信心 helper / wrapper。
- Approx changed lines：~56
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 掃描 `internal/services/` 中未被呼叫的函式 / method，並移除其中高信心且不需動 test 的候選
- [x] 掃描 `internal/contract/`、`internal/database/` 中未使用定義，並移除其中高信心候選
- [x] PR diff < 400 行
- [ ] 移除所有確認無用的 export / 函式 / 常數 / unused import
- [ ] CI 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
$ GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  github.com/tachigo/tachigo/cmd/server
ok  github.com/tachigo/tachigo/docs
ok  github.com/tachigo/tachigo/internal/config
ok  github.com/tachigo/tachigo/internal/contract
?   github.com/tachigo/tachigo/internal/database [no test files]
ok  github.com/tachigo/tachigo/internal/handlers
ok  github.com/tachigo/tachigo/internal/middleware
ok  github.com/tachigo/tachigo/internal/models
ok  github.com/tachigo/tachigo/internal/router
ok  github.com/tachigo/tachigo/internal/services
```

## 備註
本 PR 只處理高信心第一批。像 `SetMintCallerForTest`、`SetBurnCallerForTest`、`SetTwitchBaseURL`、`MintOnChain`、`EffectiveMultiplier` 這些雖然接近 dead code，但目前仍被測試依賴，因此刻意不在這一批處理。

## Notes for Claude Code Review
- 請特別確認這 4 個刪除點都沒有隱性 production 呼叫路徑。
- 請特別留意 `auth_service.go` 中移除的 `linkProvider` 是否真的沒有任何未來入口仍會依賴。
- 這個 PR 是 #406 的保守第一批，不主張已完整完成整張 issue。