### PR TITLE
[discussion] Reconcile Atlas schema baseline inputs

### DIFF
--- a/docs/atlas-schema-reconciliation.md
+++ b/docs/atlas-schema-reconciliation.md
@@ -11,8 +11,54 @@
 | Historical SQL migrations | `services/api/migrations/001_init.sql` through `019_coupon_redemptions.sql` | 手寫 schema history | 檔案存在於 repo，但 issue `#463` 已說明目前沒有 migration tool 執行它們。 |
 | GORM models | `services/api/internal/models/*.go` | Application schema model | 目前 `AutoMigrate` source。包含部分沒有完整出現在 `001-019` 的表。 |
 | Runtime schema patches | `services/api/cmd/server/main.go` | Startup-time DDL 與 data repair | API startup 仍會執行。這些 patch 必須遷移到 Atlas，或明確保留為非 schema runtime work。 |
-| Atlas config | `services/api/atlas.hcl` | 未來 schema diff entrypoint | 本文件建立時，`develop` 尚未有此檔案。 |
+| Atlas config | `services/api/atlas.hcl` | 未來 schema diff entrypoint | PR `#491` 已加入，使用 `external_schema` 執行 `go run -mod=mod ./cmd/loader`。 |
 | Closed attempt | PR `#476` | 前一次 implementation attempt | 已關閉，原因是 tooling、baseline、runtime migration strategy 被包在同一顆 PR，且 baseline 假設不安全。 |
+
+## Validation Run: 2026-05-04
+
+本次 reconciliation 以 `develop` 上 PR `#491` merge 後的狀態驗證，commit 為 `d5e9b9e`。
+
+### Schema States Built
+
+| State | How It Was Built | Dump |
+|---|---|---|
+| Historical migrations | PostgreSQL 16 clean DB，依序套用 `services/api/migrations/001-019`。 | `/tmp/tachigo-sql-migrations-schema.sql` |
+| Runtime AutoMigrate | PostgreSQL 16 clean DB，啟動目前 `cmd/server`，讓 enum init、`AutoMigrate`、manual runtime patches、data repair 跑完後停止 server。 | `/tmp/tachigo-automigrate-schema.sql` |
+| Atlas GORM loader | `go run ./cmd/loader/main.go` 輸出 SQL，套到 PostgreSQL 16 clean DB。 | `/tmp/tachigo-loader-schema.sql` |
+
+### Catalog Counts
+
+| State | Tables | Columns | Constraints | Indexes | Enum Labels |
+|---|---:|---:|---:|---:|---:|
+| Historical migrations | 17 | 135 | 52 | 58 | 4 |
+| Runtime AutoMigrate | 24 | 183 | 48 | 75 | 4 |
+| Atlas GORM loader | 24 | 183 | 47 | 77 | 4 |
+
+### High-Level Result
+
+| Comparison | Result | Decision |
+|---|---|---|
+| Runtime AutoMigrate vs Atlas loader tables | Exact match. | Loader is a usable table/column source for current models. |
+| Runtime AutoMigrate vs Atlas loader columns | Exact match. | Column-level runtime drift is not currently between runtime and loader; major column drift is between historical SQL and runtime/loader. |
+| Runtime AutoMigrate vs Atlas loader enum labels/order | Exact match: `viewer`, `streamer`, `agency`, `admin`. | This is current fresh-create runtime order, not proof that production/migrated enum order should be rebuilt. |
+| Runtime AutoMigrate vs Atlas loader constraints | Loader is missing runtime `fk_streamers_agency_user_id`. | Fix loader or add an explicit GORM association before generating baseline from loader. |
+| Runtime AutoMigrate vs Atlas loader indexes | Loader adds `idx_auth_providers_provider_provider_id_active` and `idx_auth_providers_web3_user_active`; runtime fresh-create does not. | Preserve these historical soft-delete invariants in Atlas; do not remove just because runtime fresh-create lacks them. |
+
+## Verified Reconciliation Gaps
+
+| Area | Evidence From Validation | Classification | Decision Before Baseline |
+|---|---|---|---|
+| Tables absent from `001-019` | Runtime/loader have `broadcast_time_logs`, `broadcast_time_stats`, `watch_time_stats`, `raffles`, `raffle_entries`, `raffle_draws`, `raffle_claims`; migration-only DB does not. | model drift | Baseline must account for these tables. For existing AutoMigrate-created environments, emitting bare `CREATE TABLE` without guards is unsafe. |
+| `user_role` enum order | Migration path produces `viewer`, `streamer`, `admin`, `agency`; runtime/loader fresh-create produces `viewer`, `streamer`, `agency`, `admin`. | false-drift risk | Preserve the label set. Do not create enum rebuild or reorder migration solely to normalize order. PR body for baseline must say whether it targets migrated order, fresh-create order, or explicitly accepts both. |
+| `streamers.agency_user_id` FK | Runtime has `fk_streamers_agency_user_id`; loader does not. Migration `011_streamers_agency.sql` and runtime `applyStreamerAgencyMigration` both create it. | runtime patch missing from loader | Must be added to Atlas desired schema before baseline generation, either in loader custom constraints or via an explicit model association. |
+| Auth provider soft-delete uniqueness | Migration `014_auth_provider_partial_unique.sql` and loader preserve `idx_auth_providers_provider_provider_id_active` and `idx_auth_providers_web3_user_active`; runtime fresh-create lacks them. | historical invariant not in runtime fresh-create | Keep these indexes in Atlas. They protect wallet/login rebinding semantics for soft-deleted auth providers. |
+| Claim composite consistency | Migration `016_claims_composite_fk.sql` adds `claim_user_id`, composite FKs `fk_claim_items_claim_user`, `fk_claim_items_ledger_user`, `fk_claim_items_tx_ledger`, and supporting unique indexes. Runtime/loader keep `claim_user_id` but do not recreate the composite FKs/supporting unique indexes. | historical invariant not in runtime/loader | Do not drop silently. Either port these invariants into Atlas desired schema or open an issue-backed service decision to remove them. |
+| Claim transaction hash uniqueness | Migration `015_claims.sql` creates partial unique `idx_claims_tx_hash_not_null`; runtime/loader do not. | historical invariant not in runtime/loader | Treat as preserve-by-default until claim service review confirms duplicate tx hashes are harmless. |
+| User-owned row delete behavior | Several historical FKs use `ON DELETE CASCADE` (`auth_providers`, `shipping_addresses`, `refresh_tokens`, `claims`, `streamers`); runtime/loader GORM FKs often omit cascade. | behavior drift | Baseline must not rewrite cascade behavior without an explicit data-retention decision. |
+| Timestamp nullability/defaults | Historical SQL frequently uses `NOT NULL DEFAULT now()` for `created_at` / `updated_at`; runtime/loader GORM schema leaves many timestamp columns nullable without defaults. | column drift | Baseline should avoid generating nullability/default churn until production/staging catalog confirms the actual deployed state and service-level expectations. |
+| Integer width drift | `channel_configs.multiplier` and `daily_airdrop_limit` are `integer` in historical migrations and `bigint` in runtime/loader. | column drift | Choose one canonical type in baseline PR and document compatibility. Do not narrow production data without proof. |
+| Constraint/index naming drift | Many semantically equivalent unique constraints/indexes have different names between historical SQL and GORM output, e.g. `users_email_key` vs `idx_users_email`, `streamers_user_id_channel_id_key` vs `idx_streamers_user_channel`, `tachi_balances_user_id_key` vs `idx_tachi_balances_user_id`. | name drift | Avoid rename-only churn unless Atlas requires it; prefer importing actual deployed names or using guarded SQL. |
+| `tachi_balances.user_id` FK duplication | Runtime/loader fresh-create have both GORM-generated `fk_tachi_balances_user` and manual `fk_tachi_balances_user_id`; historical migration has a single FK under a generated name. | runtime patch overlap | Baseline must pick a canonical target or explicitly tolerate duplicate equivalent FKs while AutoMigrate still runs. |
 
 ## Current Runtime DDL In `cmd/server/main.go`
 
@@ -54,16 +100,17 @@
 | `018_points_transaction_external_id.sql` | External transaction ID idempotency | 必須保留 non-null external transaction ID 的 partial unique index。 |
 | `019_coupon_redemptions.sql` | Coupon redemption table、checks、compensation index | Runtime 有部分重複補強；Atlas 最終應成為單一 owner。 |
 
-## Known Gaps To Verify
+## Remaining Baseline Decisions
+
+這些項目已由 2026-05-04 validation run 證實存在；baseline PR 不能再把它們當成待查假設。
 
 | Area | Evidence | Risk | Required Decision |
 |---|---|---|---|
-| Raffle tables | Models 包含 `Raffle`、`RaffleEntry`、`RaffleDraw`、`RaffleClaim`；`001-019` 沒有建立 raffle tables。 | Baseline 若產生裸 `CREATE TABLE`，在 AutoMigrate 已建表的環境會失敗。 | 決定採 import baseline，或產生 apply-safe guarded SQL。 |
-| Watch and broadcast stats | Models 包含 `WatchTimeStat`、`BroadcastTimeStat`、`BroadcastTimeLog`；`001-019` 沒有 dedicated SQL migration。 | 與 raffle tables 有相同 table-exists risk。 | 產生 SQL 前先決定 baseline strategy。 |
-| Partial unique indexes | 多個 invariants 以 raw SQL 存在，因 GORM tags 無法完整表達。 | Atlas provider 若沒有看到 desired schema，可能產生 drop。 | 用 Atlas desired schema 或手寫 migration 明確保留。 |
-| Enum ordering | Historical SQL migration path 與 runtime fresh-create path 目前可能不同序。 | PostgreSQL enum ordering 影響 comparison 與 drift detection；若誤把 runtime fresh-create order 當唯一 canonical order，可能產生假性 drift，甚至導向高風險 enum 重建。 | 以 production/migrated order `viewer`、`streamer`、`admin`、`agency` 為準，或在 reconciliation 中明確記錄並接受雙態；不得只為重排 enum 建 migration。 |
-| Runtime data migration | Server 啟動時會 hash 36-char raffle claim tokens。 | Schema migration 工作可能讓不相關 data repair 永遠留在 runtime。 | 另行判斷 production 是否仍需要；不得藏在 Atlas tooling PR。 |
-| Dependency anchoring | Atlas provider 可能只被 loader command import。 | 若只存在 build-ignored loader，`go mod tidy` 可能移除 tool dependency。 | Tooling PR 新增 `services/api/tools.go`。 |
+| Baseline strategy | Runtime/loader have 24 tables, historical migrations have 17. Some historical constraints are stricter than runtime/loader. | A single naive diff can either fail on existing tables or silently drop historical invariants. | PR body must choose `import baseline` or `apply-safe baseline`, and say which source state represents the deployed target. |
+| Production/staging catalog | This document only proves clean migration path, clean runtime path, and loader path. | The actual deployed database may match runtime, historical SQL, or a mixed state after years of AutoMigrate/runtime patches. | Before removing `AutoMigrate`, dump staging/current schema and compare it with the selected baseline target. |
+| Loader completeness | Loader currently misses `fk_streamers_agency_user_id`, while runtime creates it. | Atlas-generated baseline could omit a runtime FK that exists in server startup today. | Fix loader desired schema before using it for `atlas migrate diff`. |
+| Historical invariants | Claim composite FKs, claim tx hash uniqueness, cascade behavior, and auth soft-delete indexes are not all expressible from plain GORM tags. | Atlas may generate destructive drift if these are absent from desired schema. | Preserve by hand in loader/baseline, or document issue-backed removal decisions before PR3. |
+| Runtime data migration | Server startup hashes 36-char raffle claim tokens. | Schema migration work could leave unrelated data repair hidden in runtime forever. | Decide separately whether production still needs this repair; do not bury it in baseline SQL. |
 
 ## Reconciliation Procedure
 

--- a/docs/atlas-schema-reconciliation.md
+++ b/docs/atlas-schema-reconciliation.md
@@ -8,7 +8,7 @@
 
 | Source | Path | Role | Current Status |
 |---|---|---|---|
-| Historical SQL migrations | `services/api/migrations/001_init.sql` through `019_coupon_redemptions.sql` | 手寫 schema history | 檔案存在於 repo，但 issue `#463` 已說明目前沒有 migration tool 執行它們。 |
+| Historical SQL migrations | `services/api/migrations/001_init.sql` through `019_coupon_redemptions.sql` | 手寫 schema history | 檔案存在於 repo；issue `#463` 指的是正式 migration tool / 自動流程尚未建立。本文件的 validation run 以手動 sequential replay 方式把 `001-019` 套到 clean DB。 |
 | GORM models | `services/api/internal/models/*.go` | Application schema model | 目前 `AutoMigrate` source。包含部分沒有完整出現在 `001-019` 的表。 |
 | Runtime schema patches | `services/api/cmd/server/main.go` | Startup-time DDL 與 data repair | API startup 仍會執行。這些 patch 必須遷移到 Atlas，或明確保留為非 schema runtime work。 |
 | Atlas config | `services/api/atlas.hcl` | 未來 schema diff entrypoint | PR `#491` 已加入，使用 `external_schema` 執行 `go run -mod=mod ./cmd/loader`。 |
@@ -16,7 +16,7 @@
 
 ## Validation Run: 2026-05-04
 
-本次 reconciliation 以 `develop` 上 PR `#491` merge 後的狀態驗證，commit 為 `d5e9b9e`。
+本次 reconciliation 以 `develop` 上 PR `#491` merge 後的狀態驗證，commit 為 `d5e9b9e`。Historical migrations state 是用 `psql` 逐檔、依檔名順序手動套用 `services/api/migrations/001-019`；這不代表 repo 已有產品化 migration runner。
 
 ### Schema States Built
 
@@ -35,6 +35,8 @@
 | Atlas GORM loader | 24 | 183 | 47 | 77 | 4 |
 
 ### High-Level Result
+
+除 enum ordering 以外，本文件的 drift 分類以「目前 runtime AutoMigrate + runtime patches」作為暫定 comparison target；baseline PR 仍必須在 PR body 明確選擇 migrated order、fresh-create order，或接受雙態 enum ordering。
 
 | Comparison | Result | Decision |
 |---|---|---|
@@ -116,27 +118,75 @@
 
 產生任何 baseline migration 前，先完成以下程序：
 
-1. 建立乾淨 PostgreSQL database，依序套用 `services/api/migrations/001-019`。
-2. Dump migration-only schema：
+1. 準備三個乾淨 PostgreSQL database，並用相同 PostgreSQL major version、role、`search_path=public` 產生 dump：
+
+   - `MIGRATIONS_DATABASE_URL`：重播 `services/api/migrations/001-019`。
+   - `AUTOMIGRATE_DATABASE_URL`：啟動目前 server，讓 runtime `AutoMigrate` 與 patches 跑完。
+   - `LOADER_DATABASE_URL`：套用 Atlas GORM loader 輸出的 desired schema SQL。
+
+2. 建立 historical migrations state。repo 目前沒有正式 migration runner；此步驟是 reconciliation 專用的手動 sequential replay：
 
    ```bash
-   pg_dump --schema-only --no-owner --no-privileges "$MIGRATIONS_DATABASE_URL" > /tmp/tachigo-sql-migrations-schema.sql
+   cd services/api
+   for file in migrations/*.sql; do
+     psql "$MIGRATIONS_DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+   done
    ```
 
-3. 建立第二個乾淨 PostgreSQL database，啟動目前 API，讓 GORM `AutoMigrate` 與 runtime patches 執行完。
-4. Dump AutoMigrate/runtime schema：
+3. Dump migration-only schema：
 
    ```bash
-   pg_dump --schema-only --no-owner --no-privileges "$AUTOMIGRATE_DATABASE_URL" > /tmp/tachigo-automigrate-schema.sql
+   pg_dump --schema-only --no-owner --no-privileges --schema=public "$MIGRATIONS_DATABASE_URL" > /tmp/tachigo-sql-migrations-schema.sql
    ```
 
-5. 比對兩份 dump，並分類每個差異：
+4. 建立 runtime AutoMigrate state。用第二個乾淨 DB 啟動目前 API，等待 server startup 完成後停止 process；startup 會執行 enum init、`AutoMigrate`、manual schema patches 與 runtime data repair：
+
+   ```bash
+   cd services/api
+   APP_ENV=development DATABASE_URL="$AUTOMIGRATE_DATABASE_URL" go run ./cmd/server
+   ```
+
+5. Dump AutoMigrate/runtime schema：
+
+   ```bash
+   pg_dump --schema-only --no-owner --no-privileges --schema=public "$AUTOMIGRATE_DATABASE_URL" > /tmp/tachigo-automigrate-schema.sql
+   ```
+
+6. 建立 Atlas GORM loader state。先產生 loader SQL，再套到第三個乾淨 DB：
+
+   ```bash
+   cd services/api
+   go run ./cmd/loader/main.go > /tmp/tachigo-gorm-loader-schema.sql
+   psql "$LOADER_DATABASE_URL" -v ON_ERROR_STOP=1 -f /tmp/tachigo-gorm-loader-schema.sql
+   ```
+
+7. Dump Atlas loader schema：
+
+   ```bash
+   pg_dump --schema-only --no-owner --no-privileges --schema=public "$LOADER_DATABASE_URL" > /tmp/tachigo-loader-schema.sql
+   ```
+
+8. 比對三份 dump，並分類每個差異：
 
    ```bash
    diff -u /tmp/tachigo-sql-migrations-schema.sql /tmp/tachigo-automigrate-schema.sql
+   diff -u /tmp/tachigo-automigrate-schema.sql /tmp/tachigo-loader-schema.sql
+   diff -u /tmp/tachigo-sql-migrations-schema.sql /tmp/tachigo-loader-schema.sql
    ```
 
-6. 在新增 `020_atlas_baseline.sql` 前，先把最終決策更新回本文件。
+   Runtime vs loader diff 是必要步驟，因為 `fk_streamers_agency_user_id` 這類缺口只會在這組比較中浮現。
+
+9. 需要穩定分類 table、column、constraint、index、enum drift 時，從三個 DB 匯出 catalog lists，再比較 lists 而不是只看 raw `pg_dump`：
+
+   ```bash
+   psql "$DATABASE_URL" -At -F '|' -c "SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE' ORDER BY table_name"
+   psql "$DATABASE_URL" -At -F '|' -c "SELECT table_name, column_name, data_type, udt_name, COALESCE(character_maximum_length::text,''), COALESCE(numeric_precision::text,''), COALESCE(numeric_scale::text,''), is_nullable, COALESCE(column_default,'') FROM information_schema.columns WHERE table_schema='public' ORDER BY table_name, ordinal_position"
+   psql "$DATABASE_URL" -At -F '|' -c "SELECT conrelid::regclass::text, conname, contype, pg_get_constraintdef(oid) FROM pg_constraint WHERE connamespace = 'public'::regnamespace ORDER BY 1, 2"
+   psql "$DATABASE_URL" -At -F '|' -c "SELECT tablename, indexname, indexdef FROM pg_indexes WHERE schemaname='public' ORDER BY tablename, indexname"
+   psql "$DATABASE_URL" -At -F '|' -c "SELECT t.typname, e.enumsortorder, e.enumlabel FROM pg_type t JOIN pg_enum e ON t.oid=e.enumtypid JOIN pg_namespace n ON n.oid=t.typnamespace WHERE n.nspname='public' ORDER BY t.typname, e.enumsortorder"
+   ```
+
+10. 在新增 `020_atlas_baseline.sql` 前，先把最終決策更新回本文件。
 
 ## Baseline Strategy Decision Record
 


### PR DESCRIPTION
## 什麼改動
更新 Atlas schema reconciliation 文件，補上 PR #491 merge 後的實際驗證結果：

- 記錄三種 schema state：`001-019` historical migrations、目前 runtime `AutoMigrate` + patches、Atlas GORM loader。
- 新增 catalog counts 與 high-level comparison。
- 將已驗證 drift 分類成 model drift、false-drift risk、runtime patch missing from loader、historical invariant not in runtime/loader、column/name drift。
- 明確標出 baseline 前不能忽略的決策，包括 `fk_streamers_agency_user_id` 未進 loader、claim composite FK / tx hash uniqueness、enum ordering、auth soft-delete indexes、timestamp/default drift。

## 為什麼
refs #463

這是 Atlas migration 拆分計劃中的 PR 2：在新增 `020_atlas_baseline.sql` 或移除 `AutoMigrate` 前，先把 migration history、runtime schema、Atlas loader schema 的差異轉成可 review 的文件決策。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#463
- Depends on PR：#491
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 `020_atlas_baseline.sql`
  - 不新增或更新 `services/api/migrations/atlas.sum`
  - 不修改 Atlas loader、server runtime、GORM model 或 migration SQL
  - 不移除 `AutoMigrate`
  - 不做 production deploy / rollback automation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 記錄 PR #491 tooling 上跑出的 Atlas baseline input reconciliation 結果。
- Approx changed lines：~63
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #491 Atlas tooling；後續 PR 會處理 loader completeness / baseline migration / AutoMigrate removal。

## Acceptance Criteria
- [x] AC 1：`services/api/migrations/001-019` 與 runtime/loader schema drift 已記錄。
- [x] AC 2：baseline 前需保留或明確決策的 invariants 已列出。
- [x] AC 3：文件明確阻擋提前新增 baseline SQL 或移除 `AutoMigrate`。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
Docker/DB reconciliation:
- PostgreSQL 16 clean DB applied services/api/migrations/001-019
- Current cmd/server startup ran against a second clean DB
- go run ./cmd/loader/main.go SQL applied to a third clean DB
- Catalog counts recorded in docs/atlas-schema-reconciliation.md

cd services/api
go test ./...
# pass

go vet ./...
# pass

go run ./cmd/loader/main.go >/tmp/tachigo-recheck-loader.sql
# pass; generated 115 lines

git diff --check
# pass

docker compose run --no-deps --rm app go test ./...
# fail: Docker/OrbStack infrastructure dropped with "error waiting for container: unexpected EOF"
# follow-up diagnosis showed OrbStack stopped and local disk was full; this was not a Go test failure.
```

## 備註
這顆 PR 只提交 reconciliation 文件。驗證中發現 `fk_streamers_agency_user_id` 目前存在於 runtime，但不在 Atlas loader desired schema；這應該在 baseline 之前用後續 PR 修正，避免 Atlas baseline 漏掉 runtime FK。

## Notes for Claude Code Review
- 請特別確認本 PR 沒有越界修改 migration SQL、Atlas loader 或 server runtime。
- 請看 `Verified Reconciliation Gaps`：這些是已跑三路 schema state 後的結果，不是猜測。
- 後續 baseline PR 前至少要處理 loader completeness、claim composite invariants、enum ordering strategy、staging/current catalog dump。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 扩充并重塑架构协调报告，包含2026-05-04 验证运行记录与三种架构状态来源的比对摘要
  * 新增目录计数对比与明确的差异结果（包括缺失外键、需保留的索引差异等）
  * 增补运行时 DDL 列表、历史迁移清单与待定基线决策项
  * 提供完整的核对与和解步骤指南，包含目录差异提取与比对流程
<!-- end of auto-generated comment: release notes by coderabbit.ai -->