### PR TITLE
[infra] Support auto-ready PR wrapper

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -35,6 +35,9 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 
 - 日常 feature PR 目標分支：`develop`
 - `main` 不接受日常 feature PR；正式 release 由 `develop → main` 的 promotion PR 合入
+- Codex task PR 預設以 draft 建立並加上 `auto-ready` label；required
+  checks 通過後由 workflow 自動轉成 Ready for review。非 Codex task 或長期
+  WIP draft 不應加 `auto-ready`。
 
 ## Codex task PR auto-ready
 

--- a/.github/workflows/auto-ready-pr.yml
+++ b/.github/workflows/auto-ready-pr.yml
@@ -219,22 +219,6 @@ jobs:
               await github.graphql(mutation, { pullRequestId: pr.node_id })
             }
 
-            const enableAutoMerge = async (pr) => {
-              const mutation = `
-                mutation($pullRequestId: ID!) {
-                  enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: MERGE }) {
-                    pullRequest {
-                      number
-                      autoMergeRequest {
-                        enabledAt
-                      }
-                    }
-                  }
-                }
-              `
-              await github.graphql(mutation, { pullRequestId: pr.node_id })
-            }
-
             const prs = await listPrsForEvent()
             const seen = new Set()
 
@@ -306,6 +290,5 @@ jobs:
 
               await readyForReview(pr)
               await flagForCodexReview(pr)
-              await enableAutoMerge(pr)
-              core.notice(`PR #${pr.number} marked ready for review, flagged for Codex review, and queued for auto-merge.`)
+              core.notice(`PR #${pr.number} marked ready for review and flagged for Codex review.`)
             }

--- a/.github/workflows/auto-ready-pr.yml
+++ b/.github/workflows/auto-ready-pr.yml
@@ -219,6 +219,22 @@ jobs:
               await github.graphql(mutation, { pullRequestId: pr.node_id })
             }
 
+            const enableAutoMerge = async (pr) => {
+              const mutation = `
+                mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: MERGE }) {
+                    pullRequest {
+                      number
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }
+              `
+              await github.graphql(mutation, { pullRequestId: pr.node_id })
+            }
+
             const prs = await listPrsForEvent()
             const seen = new Set()
 
@@ -290,5 +306,6 @@ jobs:
 
               await readyForReview(pr)
               await flagForCodexReview(pr)
-              core.notice(`PR #${pr.number} marked ready for review and flagged for Codex review.`)
+              await enableAutoMerge(pr)
+              core.notice(`PR #${pr.number} marked ready for review, flagged for Codex review, and queued for auto-merge.`)
             }

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -218,6 +218,7 @@ test('CI workflow uses infra script entrypoints', async () => {
 
   assert.match(workflow, /run: bash infra\/scripts\/check-backend-ci-cache\.sh/)
   assert.match(workflow, /run: bash infra\/scripts\/commit-message-check\.test\.sh/)
+  assert.match(workflow, /run: bash infra\/scripts\/pr-open\.test\.sh/)
   assert.match(workflow, /run: bash infra\/scripts\/check-pr-commit-messages\.sh/)
   assert.doesNotMatch(workflow, /run: bash scripts\//)
 })

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -132,7 +132,6 @@ async function runAutoReadyWorkflow({
   const notices = []
   const warnings = []
   const mutations = []
-  const autoMergeMutations = []
   const labelsAdded = []
   const labelsRemoved = []
   const labelsCreated = []
@@ -181,11 +180,6 @@ async function runAutoReadyWorkflow({
         mutations.push(variables)
         return { markPullRequestReadyForReview: { pullRequest: { number: pr.number, isDraft: false } } }
       }
-      if (query.includes('enablePullRequestAutoMerge')) {
-        autoMergeMutations.push(variables)
-        return { enablePullRequestAutoMerge: { pullRequest: { number: pr.number, autoMergeRequest: {} } } }
-      }
-
       throw new Error('unexpected graphql query')
     },
   }
@@ -201,7 +195,7 @@ async function runAutoReadyWorkflow({
   }
 
   await AsyncFunction('context', 'github', 'core', script)(context, github, core)
-  return { autoMergeMutations, labelsAdded, labelsCreated, labelsRemoved, mutations, notices, warnings }
+  return { labelsAdded, labelsCreated, labelsRemoved, mutations, notices, warnings }
 }
 
 test('frontend CI job runs the frontend test command', async () => {
@@ -514,8 +508,8 @@ test('auto-ready workflow checks required contexts and excludes its own run', as
   assert.match(workflow, /try \{\s+const fetchedChecks = await Promise\.all\(\[/)
   assert.match(workflow, /core\.warning\(\s+`Skipping PR #\$\{pr\.number\} at \$\{headSha\}: failed to fetch checks\/statuses/)
   assert.match(workflow, /markPullRequestReadyForReview/)
-  assert.match(workflow, /enablePullRequestAutoMerge/)
-  assert.match(workflow, /mergeMethod: MERGE/)
+  assert.doesNotMatch(workflow, /enablePullRequestAutoMerge/)
+  assert.doesNotMatch(workflow, /mergeMethod: MERGE/)
   assert.doesNotMatch(workflow, /gh pr ready/)
 })
 
@@ -528,7 +522,7 @@ test('auto-ready workflow uses routine logs for skipped PRs', async () => {
   assert.doesNotMatch(workflow, /core\.notice\('At least one visible check or status is not successful yet\.'\)/)
   assert.doesNotMatch(workflow, /core\.notice\(`Skipping PR #/)
   assert.doesNotMatch(workflow, /core\.notice\(`PR #\$\{pr\.number\} remains draft until checks pass\.`\)/)
-  assert.match(workflow, /core\.notice\(`PR #\$\{pr\.number\} marked ready for review, flagged for Codex review, and queued for auto-merge\.`\)/)
+  assert.match(workflow, /core\.notice\(`PR #\$\{pr\.number\} marked ready for review and flagged for Codex review\.`\)/)
 })
 
 test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', async () => {
@@ -579,8 +573,8 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /listForRef/)
   assert.match(jobBlock, /getCombinedStatusForRef/)
   assert.match(jobBlock, /markPullRequestReadyForReview/)
-  assert.match(jobBlock, /enablePullRequestAutoMerge/)
-  assert.match(jobBlock, /mergeMethod: MERGE/)
+  assert.doesNotMatch(jobBlock, /enablePullRequestAutoMerge/)
+  assert.doesNotMatch(jobBlock, /mergeMethod: MERGE/)
 })
 
 test('auto-ready required-check snapshots stay aligned across workflows', () => {
@@ -624,9 +618,6 @@ test('auto-ready workflow flags ready PRs for Codex review', async () => {
   })
 
   assert.equal(result.mutations.length, 1)
-  assert.deepEqual(result.autoMergeMutations, [
-    { pullRequestId: 'PR_node_id' },
-  ])
   assert.deepEqual(result.labelsAdded, [
     { issue_number: 472, labels: ['needs-codex-review'] },
   ])
@@ -646,10 +637,8 @@ test('auto-ready workflow refreshes live PR state before marking ready', async (
   })
 
   assert.equal(staleHead.mutations.length, 0)
-  assert.equal(staleHead.autoMergeMutations.length, 0)
   assert.equal(staleHead.labelsAdded.length, 0)
   assert.equal(labelRemoved.mutations.length, 0)
-  assert.equal(labelRemoved.autoMergeMutations.length, 0)
   assert.equal(labelRemoved.labelsAdded.length, 0)
 })
 

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -132,6 +132,7 @@ async function runAutoReadyWorkflow({
   const notices = []
   const warnings = []
   const mutations = []
+  const autoMergeMutations = []
   const labelsAdded = []
   const labelsRemoved = []
   const labelsCreated = []
@@ -180,6 +181,10 @@ async function runAutoReadyWorkflow({
         mutations.push(variables)
         return { markPullRequestReadyForReview: { pullRequest: { number: pr.number, isDraft: false } } }
       }
+      if (query.includes('enablePullRequestAutoMerge')) {
+        autoMergeMutations.push(variables)
+        return { enablePullRequestAutoMerge: { pullRequest: { number: pr.number, autoMergeRequest: {} } } }
+      }
 
       throw new Error('unexpected graphql query')
     },
@@ -196,7 +201,7 @@ async function runAutoReadyWorkflow({
   }
 
   await AsyncFunction('context', 'github', 'core', script)(context, github, core)
-  return { labelsAdded, labelsCreated, labelsRemoved, mutations, notices, warnings }
+  return { autoMergeMutations, labelsAdded, labelsCreated, labelsRemoved, mutations, notices, warnings }
 }
 
 test('frontend CI job runs the frontend test command', async () => {
@@ -509,6 +514,8 @@ test('auto-ready workflow checks required contexts and excludes its own run', as
   assert.match(workflow, /try \{\s+const fetchedChecks = await Promise\.all\(\[/)
   assert.match(workflow, /core\.warning\(\s+`Skipping PR #\$\{pr\.number\} at \$\{headSha\}: failed to fetch checks\/statuses/)
   assert.match(workflow, /markPullRequestReadyForReview/)
+  assert.match(workflow, /enablePullRequestAutoMerge/)
+  assert.match(workflow, /mergeMethod: MERGE/)
   assert.doesNotMatch(workflow, /gh pr ready/)
 })
 
@@ -521,7 +528,7 @@ test('auto-ready workflow uses routine logs for skipped PRs', async () => {
   assert.doesNotMatch(workflow, /core\.notice\('At least one visible check or status is not successful yet\.'\)/)
   assert.doesNotMatch(workflow, /core\.notice\(`Skipping PR #/)
   assert.doesNotMatch(workflow, /core\.notice\(`PR #\$\{pr\.number\} remains draft until checks pass\.`\)/)
-  assert.match(workflow, /core\.notice\(`PR #\$\{pr\.number\} marked ready for review and flagged for Codex review\.`\)/)
+  assert.match(workflow, /core\.notice\(`PR #\$\{pr\.number\} marked ready for review, flagged for Codex review, and queued for auto-merge\.`\)/)
 })
 
 test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', async () => {
@@ -572,6 +579,8 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /listForRef/)
   assert.match(jobBlock, /getCombinedStatusForRef/)
   assert.match(jobBlock, /markPullRequestReadyForReview/)
+  assert.match(jobBlock, /enablePullRequestAutoMerge/)
+  assert.match(jobBlock, /mergeMethod: MERGE/)
 })
 
 test('auto-ready required-check snapshots stay aligned across workflows', () => {
@@ -615,6 +624,9 @@ test('auto-ready workflow flags ready PRs for Codex review', async () => {
   })
 
   assert.equal(result.mutations.length, 1)
+  assert.deepEqual(result.autoMergeMutations, [
+    { pullRequestId: 'PR_node_id' },
+  ])
   assert.deepEqual(result.labelsAdded, [
     { issue_number: 472, labels: ['needs-codex-review'] },
   ])
@@ -634,8 +646,10 @@ test('auto-ready workflow refreshes live PR state before marking ready', async (
   })
 
   assert.equal(staleHead.mutations.length, 0)
+  assert.equal(staleHead.autoMergeMutations.length, 0)
   assert.equal(staleHead.labelsAdded.length, 0)
   assert.equal(labelRemoved.mutations.length, 0)
+  assert.equal(labelRemoved.autoMergeMutations.length, 0)
   assert.equal(labelRemoved.labelsAdded.length, 0)
 })
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,24 +545,6 @@ jobs:
               await removeLabel(pr.number, changesLabel)
             }
 
-            const enableAutoMerge = async (pr) => {
-              await github.graphql(
-                `
-                  mutation($pullRequestId: ID!) {
-                    enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: MERGE }) {
-                      pullRequest {
-                        number
-                        autoMergeRequest {
-                          enabledAt
-                        }
-                      }
-                    }
-                  }
-                `,
-                { pullRequestId: pr.node_id },
-              )
-            }
-
             const isEligibleDraftPr = (pr) => {
               if (!targetBaseBranches.has(pr.base?.ref)) return false
               if (pr.draft !== true) return false
@@ -724,13 +706,12 @@ jobs:
                 { pullRequestId: pr.node_id },
               )
               await flagForCodexReview(pr)
-              await enableAutoMerge(pr)
             } catch (error) {
-              core.warning(`Failed to mark PR #${pr.number} ready for review, flag it for Codex review, or enable auto-merge (${error?.message || error}).`)
+              core.warning(`Failed to mark PR #${pr.number} ready for review or flag it for Codex review (${error?.message || error}).`)
               return
             }
 
-            core.notice(`PR #${pr.number} marked ready for review, flagged for Codex review, and queued for auto-merge.`)
+            core.notice(`PR #${pr.number} marked ready for review and flagged for Codex review.`)
 
   notify-discord:
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,9 @@ jobs:
       - name: Verify PR metadata check assertions
         run: bash infra/scripts/pr-metadata-check.test.sh
 
+      - name: Verify PR open assertions
+        run: bash infra/scripts/pr-open.test.sh
+
   pr-commit-messages:
     timeout-minutes: 5
     name: PR commit messages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,24 @@ jobs:
               await removeLabel(pr.number, changesLabel)
             }
 
+            const enableAutoMerge = async (pr) => {
+              await github.graphql(
+                `
+                  mutation($pullRequestId: ID!) {
+                    enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: MERGE }) {
+                      pullRequest {
+                        number
+                        autoMergeRequest {
+                          enabledAt
+                        }
+                      }
+                    }
+                  }
+                `,
+                { pullRequestId: pr.node_id },
+              )
+            }
+
             const isEligibleDraftPr = (pr) => {
               if (!targetBaseBranches.has(pr.base?.ref)) return false
               if (pr.draft !== true) return false
@@ -706,12 +724,13 @@ jobs:
                 { pullRequestId: pr.node_id },
               )
               await flagForCodexReview(pr)
+              await enableAutoMerge(pr)
             } catch (error) {
-              core.warning(`Failed to mark PR #${pr.number} ready for review or flag it for Codex review (${error?.message || error}).`)
+              core.warning(`Failed to mark PR #${pr.number} ready for review, flag it for Codex review, or enable auto-merge (${error?.message || error}).`)
               return
             }
 
-            core.notice(`PR #${pr.number} marked ready for review and flagged for Codex review.`)
+            core.notice(`PR #${pr.number} marked ready for review, flagged for Codex review, and queued for auto-merge.`)
 
   notify-discord:
     timeout-minutes: 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,18 +78,12 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
   ```bash
   cp .github/PULL_REQUEST_TEMPLATE.md /tmp/pr_body.md
   # 填妥 /tmp/pr_body.md 所有欄位，不得留空或刪除 section
-  gh pr create --title "[type] ..." --base develop --body-file /tmp/pr_body.md
+  make pr-open TITLE="[type] ..." BODY_FILE=/tmp/pr_body.md AUTO_READY=1
   ```
 
-  Codex task PR 在 auto-ready workflow 已進 `develop` 後，預設以 draft 開出並加上
-  `auto-ready` label，讓 required checks 全綠後自動轉為 ready for review：
-
-  ```bash
-  gh pr create --draft --label auto-ready --title "[type] ..." --base develop --body-file /tmp/pr_body.md
-  ```
-
-  非 Codex task、人工長期 WIP draft、或不想自動進 review queue 的 PR，不要加
-  `auto-ready` label。
+  Codex task PR 預設使用 `AUTO_READY=1`：PR 會以 draft 建立並加上
+  `auto-ready` label，等 required checks 通過後再由 workflow 自動轉成
+  Ready for review。非 Codex task 或長期 WIP draft 不應加 `auto-ready`。
 
 ### 操作權限邊界
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,18 +74,12 @@
    ```bash
    cp .github/PULL_REQUEST_TEMPLATE.md /tmp/pr_body.md
    # 填妥 /tmp/pr_body.md 所有欄位，不得留空或刪除 section
-   gh pr create --title "[type] ..." --base develop --body-file /tmp/pr_body.md
+   make pr-open TITLE="[type] ..." BODY_FILE=/tmp/pr_body.md AUTO_READY=1
    ```
 
-   Codex task PR 在 auto-ready workflow 已進 `develop` 後，預設以 draft 開出並加上
-   `auto-ready` label，讓 required checks 全綠後自動轉為 ready for review：
-
-   ```bash
-   gh pr create --draft --label auto-ready --title "[type] ..." --base develop --body-file /tmp/pr_body.md
-   ```
-
-   非 Codex task、人工長期 WIP draft、或不想自動進 review queue 的 PR，不要加
-   `auto-ready` label。
+   Codex task PR 預設使用 `AUTO_READY=1`：PR 會以 draft 建立並加上
+   `auto-ready` label，等 required checks 通過後再由 workflow 自動轉成
+   Ready for review。非 Codex task 或長期 WIP draft 不應加 `auto-ready`。
 
 4. 正式 release 流程走 Git Flow：
 

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ pr-meta-check:
 pr-open:
 	@test -n "$(TITLE)" || (echo "TITLE is required"; exit 2)
 	@test -n "$(BODY_FILE)" || (echo "BODY_FILE is required"; exit 2)
-	@./infra/scripts/pr-open.sh --title "$(TITLE)" --body-file "$(BODY_FILE)" --base "$(or $(BASE),develop)" $(if $(HEAD),--head "$(HEAD)",) $(if $(filter 1,$(DRAFT)),--draft,)
+	@./infra/scripts/pr-open.sh --title "$(TITLE)" --body-file "$(BODY_FILE)" --base "$(or $(BASE),develop)" $(if $(HEAD),--head "$(HEAD)",) $(if $(filter 1,$(DRAFT)),--draft,) $(if $(filter 1,$(AUTO_READY)),--auto-ready,)

--- a/docs/draft-pr-auto-ready.md
+++ b/docs/draft-pr-auto-ready.md
@@ -28,9 +28,6 @@ review, while auto-merge happens after approval.
 6. The same workflow adds `needs-codex-review` and removes `changes-requested`
    because events emitted by `GITHUB_TOKEN` do not trigger the separate
    `ready_for_review` label workflow.
-7. The same guarded path enables GitHub auto-merge because the
-   `ready_for_review` event emitted by `GITHUB_TOKEN` also does not trigger the
-   separate auto-merge workflow.
 
 ## Rollout state
 
@@ -149,11 +146,6 @@ The ready-for-review mutation is executed with `GITHUB_TOKEN`, so the resulting
 The auto-ready paths therefore also use `issues: write` to add
 `needs-codex-review` and remove stale `changes-requested` in the same guarded
 mutation path.
-
-For the same reason, auto-ready paths directly call
-`enablePullRequestAutoMerge` after marking the PR ready. They do not rely on the
-separate `Enable auto-merge` workflow waking up from a `ready_for_review` event
-emitted by `GITHUB_TOKEN`.
 
 ## PR creation default
 

--- a/docs/draft-pr-auto-ready.md
+++ b/docs/draft-pr-auto-ready.md
@@ -28,6 +28,9 @@ review, while auto-merge happens after approval.
 6. The same workflow adds `needs-codex-review` and removes `changes-requested`
    because events emitted by `GITHUB_TOKEN` do not trigger the separate
    `ready_for_review` label workflow.
+7. The same guarded path enables GitHub auto-merge because the
+   `ready_for_review` event emitted by `GITHUB_TOKEN` also does not trigger the
+   separate auto-merge workflow.
 
 ## Rollout state
 
@@ -146,6 +149,11 @@ The ready-for-review mutation is executed with `GITHUB_TOKEN`, so the resulting
 The auto-ready paths therefore also use `issues: write` to add
 `needs-codex-review` and remove stale `changes-requested` in the same guarded
 mutation path.
+
+For the same reason, auto-ready paths directly call
+`enablePullRequestAutoMerge` after marking the PR ready. They do not rely on the
+separate `Enable auto-merge` workflow waking up from a `ready_for_review` event
+emitted by `GITHUB_TOKEN`.
 
 ## PR creation default
 

--- a/docs/draft-pr-auto-ready.md
+++ b/docs/draft-pr-auto-ready.md
@@ -152,8 +152,10 @@ mutation path.
 Codex task PRs should now be opened as draft and labeled `auto-ready`:
 
 ```bash
-gh pr create --draft --label auto-ready --title "[type] ..." --base develop --body-file /tmp/pr_body.md
+make pr-open TITLE="[type] ..." BODY_FILE=/tmp/pr_body.md AUTO_READY=1
 ```
+
+If opening a PR directly with `gh pr create`, use `--draft --label auto-ready`.
 
 Non-Codex tasks, human WIP drafts, and PRs that should not enter the review queue
 automatically should not use the `auto-ready` label.

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -198,16 +198,23 @@ make pr-meta-check TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md
 make pr-open TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md
 ```
 
+Codex task PR 預設應使用 auto-ready 流程：
+
+```bash
+make pr-open TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md AUTO_READY=1
+```
+
 可選參數：
 
 - `BASE`：預設 `develop`
 - `HEAD`：預設目前 branch
 - `DRAFT=1`：建立 draft PR
+- `AUTO_READY=1`：建立 draft PR 並加上 `auto-ready` label，等 required
+  checks 通過後由 workflow 自動轉成 Ready for review
 
-Codex task PR 在 auto-ready workflow 已進 `develop` 後，應建立為 draft 並加上
-`auto-ready` label。若使用本地 `make pr-open`，先用 `DRAFT=1` 開出 PR，再用
-`gh pr edit <number> --add-label auto-ready` 加 label；若直接使用 `gh pr create`，
-則使用 `--draft --label auto-ready`。
+Codex task PR 應使用 `AUTO_READY=1`，讓 wrapper 一次建立 draft PR 並加上
+`auto-ready` label。若直接使用 `gh pr create`，則使用
+`--draft --label auto-ready`。
 
 底層腳本：
 

--- a/infra/scripts/pr-open.sh
+++ b/infra/scripts/pr-open.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  infra/scripts/pr-open.sh --title "<pr title>" --body-file <path> [--base develop] [--head <branch>] [--draft]
+  infra/scripts/pr-open.sh --title "<pr title>" --body-file <path> [--base develop] [--head <branch>] [--draft] [--auto-ready]
 
 Runs local PR metadata checks, then opens a PR with gh.
 EOF
@@ -17,6 +17,7 @@ main() {
   local base_branch="develop"
   local head_branch=""
   local draft=0
+  local auto_ready=0
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -38,6 +39,10 @@ main() {
         ;;
       --draft)
         draft=1
+        shift
+        ;;
+      --auto-ready)
+        auto_ready=1
         shift
         ;;
       -h|--help)
@@ -74,8 +79,11 @@ main() {
     --head "$head_branch"
 
   local cmd=(gh pr create --base "$base_branch" --head "$head_branch" --title "$title" --body-file "$body_file")
-  if [ "$draft" -eq 1 ]; then
+  if [ "$draft" -eq 1 ] || [ "$auto_ready" -eq 1 ]; then
     cmd+=(--draft)
+  fi
+  if [ "$auto_ready" -eq 1 ]; then
+    cmd+=(--label auto-ready)
   fi
 
   echo "Opening PR with gh..."

--- a/infra/scripts/pr-open.test.sh
+++ b/infra/scripts/pr-open.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "$0")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/infra/scripts" "$tmp_dir/fakebin"
+cp "$root_dir/infra/scripts/pr-open.sh" "$tmp_dir/infra/scripts/pr-open.sh"
+
+cat > "$tmp_dir/infra/scripts/pr-metadata-check.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$PR_METADATA_CHECK_LOG"
+STUB
+chmod +x "$tmp_dir/infra/scripts/pr-metadata-check.sh"
+
+cat > "$tmp_dir/fakebin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "auth" ] && [ "${2:-}" = "status" ]; then
+  exit 0
+fi
+
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then
+  printf '%s\n' "$*" > "$GH_PR_CREATE_LOG"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+STUB
+chmod +x "$tmp_dir/fakebin/gh"
+
+(
+  cd "$tmp_dir"
+  git init -q
+  git checkout -q -b test/pr-open
+  touch body.md
+
+  PATH="$tmp_dir/fakebin:$PATH" \
+    GH_PR_CREATE_LOG="$tmp_dir/gh-pr-create.log" \
+    PR_METADATA_CHECK_LOG="$tmp_dir/pr-metadata-check.log" \
+    "$tmp_dir/infra/scripts/pr-open.sh" \
+      --title "[chore] Test auto-ready PR" \
+      --body-file body.md \
+      --auto-ready
+)
+
+grep -q -- '--draft' "$tmp_dir/gh-pr-create.log"
+grep -q -- '--label auto-ready' "$tmp_dir/gh-pr-create.log"
+grep -q -- '--title \[chore\] Test auto-ready PR' "$tmp_dir/pr-metadata-check.log"
+
+echo "pr-open regression tests passed"

--- a/infra/scripts/pr-open.test.sh
+++ b/infra/scripts/pr-open.test.sh
@@ -53,4 +53,19 @@ grep -q -- '--draft' "$tmp_dir/gh-pr-create.log"
 grep -q -- '--label auto-ready' "$tmp_dir/gh-pr-create.log"
 grep -q -- '--title \[chore\] Test auto-ready PR' "$tmp_dir/pr-metadata-check.log"
 
+(
+  cd "$tmp_dir"
+
+  PATH="$tmp_dir/fakebin:$PATH" \
+    GH_PR_CREATE_LOG="$tmp_dir/gh-pr-create-default.log" \
+    PR_METADATA_CHECK_LOG="$tmp_dir/pr-metadata-check-default.log" \
+    "$tmp_dir/infra/scripts/pr-open.sh" \
+      --title "[chore] Test default PR" \
+      --body-file body.md
+)
+
+! grep -q -- '--draft' "$tmp_dir/gh-pr-create-default.log"
+! grep -q -- '--label auto-ready' "$tmp_dir/gh-pr-create-default.log"
+grep -q -- '--title \[chore\] Test default PR' "$tmp_dir/pr-metadata-check-default.log"
+
 echo "pr-open regression tests passed"


### PR DESCRIPTION
## 什麼改動
讓本地 PR wrapper 支援 `AUTO_READY=1` / `--auto-ready`，建立 Codex task PR 時一次開成 draft 並加上 `auto-ready` label。

## 為什麼
auto-ready workflow 已進 `develop`，但目前 `make pr-open` 只支援 `DRAFT=1`，還需要另外手動加 label。這會讓 AGENTS / CLAUDE 指引和實際 wrapper 行為不一致。

refs #470

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#470
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不調整 auto-ready workflow 的 readiness gate
  - 不變更 branch protection / required checks
  - 不變更 auto-merge policy
  - 不處理遠端 branch cleanup

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 `make pr-open ... AUTO_READY=1` 成為 Codex task PR 的一鍵 draft + auto-ready label 入口。
- Approx changed lines：~125
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - wrapper 行為、CI regression test、以及使用指引必須同步，避免文件要求的 `AUTO_READY=1` 在本地不可用。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `infra/scripts/pr-open.sh --auto-ready` 會建立 draft PR。
- [x] `infra/scripts/pr-open.sh --auto-ready` 會加上 `auto-ready` label。
- [x] `make pr-open ... AUTO_READY=1` 會傳遞 `--auto-ready` 到 wrapper。
- [x] CI 會跑 PR open wrapper regression test。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
bash infra/scripts/pr-open.test.sh
pr-open regression tests passed

node --test .github/workflows/ci.test.mjs
tests 26
pass 26
fail 0
```

## 備註
這支 PR 會用 `AUTO_READY=1` 開成 draft + `auto-ready`，也作為 #488/#489 merge 後的第一個真實 wrapper flow 驗證。

## Notes for Claude Code Review
- 請確認 `AUTO_READY=1` 是否比「先 DRAFT=1，再手動加 label」更符合目前 Codex task PR 指引。
- 這支 PR 沒有改 auto-ready workflow 的 required-check snapshot。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能與改進

* **新功能**
  * 新增 `AUTO_READY=1` 參數支援，可建立自動轉換狀態的草稿 PR。使用 `make pr-open` 搭配此參數後，系統將自動在 required checks 通過後將 PR 轉為「Ready for review」狀態。

* **文檔**
  * 更新 PR 建立指南，說明 Codex task PR 的推薦工作流程。

* **測試**
  * 新增 PR 建立流程的自動驗證測試。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->