### PR TITLE
[chore] Clamp Atlas historical replay glob

### DIFF
--- a/docs/atlas-schema-reconciliation.md
+++ b/docs/atlas-schema-reconciliation.md
@@ -124,11 +124,11 @@
    - `AUTOMIGRATE_DATABASE_URL`：啟動目前 server，讓 runtime `AutoMigrate` 與 patches 跑完。
    - `LOADER_DATABASE_URL`：套用 Atlas GORM loader 輸出的 desired schema SQL。
 
-2. 建立 historical migrations state。repo 目前沒有正式 migration runner；此步驟是 reconciliation 專用的手動 sequential replay：
+2. 建立 historical migrations state。repo 目前沒有正式 migration runner；此步驟是 reconciliation 專用的手動 sequential replay。此 loop 刻意只重播 `001-019`，避免未來新增 `020` 以後的 Atlas migration 污染 historical baseline：
 
    ```bash
    cd services/api
-   for file in migrations/*.sql; do
+   for file in migrations/00[1-9]_*.sql migrations/01[0-9]_*.sql; do
      psql "$MIGRATIONS_DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
    done
    ```


### PR DESCRIPTION
## 什麼改動
將 Atlas reconciliation procedure 的 historical migration replay loop 從 `migrations/*.sql` 改成只展開 `001-019` 的明確 glob。

## 為什麼
refs #463

PR #492 merge 後的 review follow-up 指出，原本 `migrations/*.sql` 會在未來新增 `020` 以後的 migration 時一併套入 historical migration state，污染 Atlas baseline reconciliation 的驗證基準。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#463；#492 follow-up comment https://github.com/nurockplayer/tachigo/pull/492#issuecomment-4371123095
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 migration
  - 不改 Atlas loader/tooling
  - 不重新跑 DB reconciliation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 固定 Atlas reconciliation procedure 的 historical replay 範圍為 `001-019`。
- Approx changed lines：~4
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Procedure 不再使用會包含未來 `020+` migration 的 `migrations/*.sql`。
- [x] Procedure 文字明確說明 historical replay 只應重播 `001-019`。
- [x] 新 glob 目前展開為 `001_init.sql` 到 `019_coupon_redemptions.sql`。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
bash -lc 'cd services/api
for file in migrations/00[1-9]_*.sql migrations/01[0-9]_*.sql; do printf "%s\n" "$file"; done'

展開結果為 001_init.sql 到 019_coupon_redemptions.sql，共 19 個檔案，未包含 020+。

git diff --check
pass
```

## 備註
這是 #492 merge 後 review comment 的小型 docs follow-up。

## Notes for Claude Code Review
- 請確認 glob 維持 shell sort 順序，且未來新增 `020_atlas_baseline.sql` 時不會被 historical state replay 吃進去。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新說明

* **文檔**
  * 更新資料庫調和程序文件，調整歷史遷移手動重播步驟中的遷移檔案指定方式，明確限制遷移檔案版本號範圍，提升遷移程序的明確性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->