### PR TITLE
[chore] Close issues when PRs merge into develop

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -12,6 +12,7 @@ const scopePolicePath = path.join(currentDir, 'pr-scope-police.yml')
 const autoMergeWorkflowPath = path.join(currentDir, 'auto-merge.yml')
 const autoReadyWorkflowPath = path.join(currentDir, 'auto-ready-pr.yml')
 const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rerequest.yml')
+const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-on-develop-merge.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 const developRequiredCheckRuns = [
@@ -285,6 +286,71 @@ async function runAutoReadyScript({
   return { autoMergeMutations, graphqlCalls, labelsAdded, labelsCreated, labelsRemoved, mutations, notices, warnings }
 }
 
+async function runCloseIssueOnDevelopMergeWorkflow({
+  body = '',
+  commits = [],
+  issueStateByNumber = {},
+} = {}) {
+  const parsedWorkflow = parseYaml(closeIssueOnDevelopMergeWorkflowPath)
+  const script = parsedWorkflow.jobs['close-linked-issues'].steps[0].with.script
+  const comments = []
+  const closed = []
+  const notices = []
+  const warnings = []
+  const requestedCommits = []
+  const errors = []
+  const failures = []
+  const context = {
+    repo: { owner: 'nurockplayer', repo: 'tachigo' },
+    payload: {
+      pull_request: {
+        number: 512,
+        body,
+      },
+    },
+  }
+  const github = {
+    rest: {
+      issues: {
+        get: async ({ issue_number }) => ({
+          data: {
+            number: issue_number,
+            state: issueStateByNumber[issue_number] || 'open',
+          },
+        }),
+        createComment: async (args) => {
+          comments.push(args)
+          return { data: { id: comments.length } }
+        },
+        update: async (args) => {
+          closed.push(args)
+          return { data: { number: args.issue_number, state: args.state } }
+        },
+      },
+      pulls: {
+        listCommits: async (args) => {
+          requestedCommits.push(args)
+          return { data: commits }
+        },
+      },
+    },
+    paginate: async (fn, args) => {
+      const result = await fn(args)
+      return result.data || result
+    },
+  }
+  const core = {
+    error: (message) => errors.push(message),
+    info: () => {},
+    notice: (message) => notices.push(message),
+    setFailed: (message) => failures.push(message),
+    warning: (message) => warnings.push(message),
+  }
+
+  await AsyncFunction('context', 'github', 'core', script)(context, github, core)
+  return { closed, comments, errors, failures, notices, requestedCommits, warnings }
+}
+
 test('frontend CI job runs the frontend test command', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
 
@@ -531,6 +597,67 @@ test('global auto-merge workflow excludes Dependabot PRs', async () => {
     "github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'",
   )
   assert.doesNotMatch(workflow, /if: github\.event\.pull_request\.draft == false\s*$/m)
+})
+
+test('develop merge issue closer only runs after merged PRs close into develop', async () => {
+  const parsedWorkflow = parseYaml(closeIssueOnDevelopMergeWorkflowPath)
+  const job = parsedWorkflow.jobs['close-linked-issues']
+
+  assert.deepEqual(parsedWorkflow.on.pull_request.types, ['closed'])
+  assert.deepEqual(parsedWorkflow.on.pull_request.branches, ['develop'])
+  assert.equal(parsedWorkflow.permissions.issues, 'write')
+  assert.equal(parsedWorkflow.permissions['pull-requests'], 'read')
+  assert.equal(job.if, 'github.event.pull_request.merged == true')
+})
+
+test('develop merge issue closer ignores template comments and code examples', async () => {
+  const result = await runCloseIssueOnDevelopMergeWorkflow({
+    body: [
+      '## 為什麼',
+      '<!-- 背景、需求，或關聯的 issue（e.g. closes #123） -->',
+      '',
+      '```',
+      'closes #456',
+      '```',
+      '',
+      '`fixes #789`',
+      '',
+      '實際完成 closes #494',
+    ].join('\n'),
+  })
+
+  assert.deepEqual(
+    result.closed.map((issue) => issue.issue_number),
+    [494],
+  )
+  assert.deepEqual(
+    result.comments.map((comment) => comment.issue_number),
+    [494],
+  )
+})
+
+test('develop merge issue closer reads closing keywords from PR commits', async () => {
+  const result = await runCloseIssueOnDevelopMergeWorkflow({
+    body: '## 為什麼\nrefs #111',
+    commits: [
+      { commit: { message: 'fix: old work\n\ncloses #333' } },
+      { commit: { message: 'fix: prepare workflow\n\nrefs #222' } },
+      { commit: { message: 'fix: close develop issue\n\ncloses #494' } },
+    ],
+  })
+
+  assert.deepEqual(result.requestedCommits, [
+    {
+      owner: 'nurockplayer',
+      repo: 'tachigo',
+      pull_number: 512,
+      per_page: 100,
+    },
+  ])
+  assert.deepEqual(
+    result.closed.map((issue) => issue.issue_number),
+    [494],
+  )
 })
 
 test('auto-ready workflow is opt-in for auto-ready PRs on protected base branches', async () => {

--- a/.github/workflows/close-issue-on-develop-merge.yml
+++ b/.github/workflows/close-issue-on-develop-merge.yml
@@ -1,0 +1,126 @@
+name: Close issue when PR merges into develop
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Close issues referenced by closing keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const body = pr.body || ''
+            const prNumber = pr.number
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+
+            const stripIgnoredMarkdown = (text) =>
+              (text || '')
+                .replace(/<!--[\s\S]*?-->/g, '\n')
+                .replace(/```[\s\S]*?```/g, '\n')
+                .replace(/~~~[\s\S]*?~~~/g, '\n')
+                .replace(/`[^`\n]*`/g, '\n')
+
+            const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            const sameRepoPrefix = `${escapeRegExp(owner)}/${escapeRegExp(repo)}`
+            const closingPattern = new RegExp(
+              `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+(?:${sameRepoPrefix})?#(\\d+)`,
+              'gi',
+            )
+
+            const findClosingIssueNumbers = (text) => {
+              const issueNumbers = []
+              const sanitized = stripIgnoredMarkdown(text)
+              let match
+              closingPattern.lastIndex = 0
+              while ((match = closingPattern.exec(sanitized)) !== null) {
+                issueNumbers.push(parseInt(match[1], 10))
+              }
+              return issueNumbers
+            }
+
+            const issueSources = new Map()
+            const addIssueNumbers = (issueNumbers, source) => {
+              for (const issueNumber of issueNumbers) {
+                if (!Number.isInteger(issueNumber)) continue
+                if (!issueSources.has(issueNumber)) {
+                  issueSources.set(issueNumber, source)
+                }
+              }
+            }
+
+            addIssueNumbers(findClosingIssueNumbers(body), 'PR body')
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            })
+
+            const lastCommit = commits.at(-1)
+            if (lastCommit) {
+              addIssueNumbers(findClosingIssueNumbers(lastCommit.commit?.message || ''), 'last PR commit message')
+            }
+
+            const issueNumbers = [...issueSources.keys()]
+            if (issueNumbers.length === 0) {
+              core.info(`PR #${prNumber}: no closing keywords found in body or commits.`)
+              return
+            }
+
+            let hasFailure = false
+            for (const issueNumber of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                })
+
+                if (issue.pull_request) {
+                  core.warning(`#${issueNumber} is a pull request, skipping.`)
+                  continue
+                }
+
+                if (issue.state === 'closed') {
+                  core.info(`Issue #${issueNumber} is already closed, skipping.`)
+                  continue
+                }
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: `PR #${prNumber} 已 merge into \`develop\`，且 ${issueSources.get(issueNumber)} 包含 closing keyword，因此關閉此 issue。`,
+                })
+
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  state: 'closed',
+                  state_reason: 'completed',
+                })
+
+                core.notice(`Closed issue #${issueNumber} (referenced by PR #${prNumber}).`)
+              } catch (error) {
+                hasFailure = true
+                core.error(`Failed to close issue #${issueNumber}: ${error?.message || error}`)
+              }
+            }
+
+            if (hasFailure) {
+              core.setFailed('Failed to close one or more issues referenced by closing keywords.')
+            }


### PR DESCRIPTION
## 什麼改動
新增 GitHub Actions workflow，在 PR merge into `develop` 後關閉同 repo closing keyword 對應的 issue。

## 為什麼
closes #498

Repository default branch 是 `main`，但日常 feature PR 會先 merge into `develop`。GitHub 原生 closing keyword 只會在 PR merge into default branch 時自動關 issue，因此需要在 `develop` merge 當下補上 repo workflow。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#498
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 GitHub default branch
  - 不改 release PR 流程
  - 不關閉跨 repo issue
  - 不解析 PR body / commit message 中 HTML comment、code block、inline code 裡的範例 closing keyword

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 merge into `develop` 的 PR 也能依 closing keyword 關閉同 repo issue。
- Approx changed lines：~253
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Workflow 只在 `pull_request.closed` 且 PR merge into `develop` 時執行。
- [x] 支援 PR body 的 closing keyword。
- [x] 支援最後一個 PR commit message 的 closing keyword。
- [x] 不解析 HTML comments、fenced code blocks、inline code 裡的範例文字。
- [x] 關閉 issue 前留言說明 PR 已 merge into `develop`。
- [x] 有 workflow regression tests 覆蓋誤關與漏關情境。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
# tests 33
# pass 33
# fail 0

git diff --check
# pass
```

## 備註
此 workflow merge 進 `develop` 後才會開始對後續 PR 生效，不會 retroactively 關閉已 merge PR 對應的 issue。

## Notes for Claude Code Review
- 請特別確認 closing keyword parser 不會誤讀 PR template 的 HTML comment 範例。
- 請確認 workflow 只處理同 repo issue，且不會在非 merged / 非 develop PR closed event 上執行。
