### PR TITLE
[infra] Path-aware CI gates

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -32,6 +32,21 @@ function successfulDevelopRequiredCheckRuns(...overrides) {
   return [...developRequiredCheckRuns, ...overrides]
 }
 
+const validStandardPrBody = `
+refs #209
+
+Source of truth: https://github.com/nurockplayer/tachigo/issues/209
+
+Depends on PR: none
+
+Backend contract already in develop:
+- [x] yes
+- [ ] no
+
+本 PR 明確不做
+- deploy workflow
+`
+
 function parseYaml(filePath) {
   const script = `
 require 'yaml'
@@ -145,6 +160,54 @@ async function runCiAutoReadyAfterCiWorkflow({
     },
     ...options,
   })
+}
+
+async function runCiScopeGateWorkflow({ eventName = 'pull_request', prOverrides = {}, files = [] } = {}) {
+  const parsedWorkflow = parseYaml(workflowPath)
+  const script = parsedWorkflow.jobs['scope-gate'].steps[0].with.script
+  const outputs = new Map()
+  const notices = []
+  const basePr = {
+    number: 209,
+    body: validStandardPrBody,
+    title: '[infra] Path-aware / layered CI',
+    base: { ref: 'develop' },
+    head: { ref: 'chore/path-aware-layered-ci', repo: { full_name: 'nurockplayer/tachigo' } },
+    labels: [],
+  }
+  const pr = {
+    ...basePr,
+    ...prOverrides,
+    base: { ...basePr.base, ...(prOverrides.base || {}) },
+    head: {
+      ...basePr.head,
+      ...(prOverrides.head || {}),
+      repo: { ...basePr.head.repo, ...(prOverrides.head?.repo || {}) },
+    },
+    labels: prOverrides.labels || basePr.labels,
+  }
+  const github = {
+    rest: {
+      pulls: {
+        listFiles: async () => ({ data: files }),
+      },
+    },
+    paginate: async (fn, args) => {
+      const result = await fn(args)
+      return result.data || result
+    },
+  }
+  const core = {
+    notice: (message) => notices.push(message),
+    setOutput: (name, value) => outputs.set(name, value),
+  }
+  const context = {
+    repo: { owner: 'nurockplayer', repo: 'tachigo' },
+    payload: eventName === 'pull_request' ? { pull_request: pr } : {},
+  }
+
+  await AsyncFunction('context', 'github', 'core', script)(context, github, core)
+  return { notices, outputs: Object.fromEntries(outputs) }
 }
 
 async function runAutoReadyScript({
@@ -515,6 +578,81 @@ test('docs/template-only PRs skip heavy product CI in scope gate', async () => {
     /\^\\.github\\\/workflows\\\/ci\\.yml\$/,
     'ci.yml changes must request backend integration validation',
   )
+})
+
+test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
+  const result = await runCiScopeGateWorkflow({
+    files: [{ filename: 'apps/extension/src/App.tsx', additions: 12, deletions: 3, status: 'modified' }],
+  })
+
+  assert.deepEqual(result.outputs, {
+    run_ci: 'true',
+    run_backend: 'false',
+    run_backend_integration: 'false',
+    run_frontend: 'true',
+    run_dashboard: 'false',
+    run_contracts: 'false',
+  })
+})
+
+test('scope gate emits full CI outputs for push events and release promotion PRs', async () => {
+  const push = await runCiScopeGateWorkflow({ eventName: 'push' })
+  const releasePromotion = await runCiScopeGateWorkflow({
+    prOverrides: {
+      title: '[release] develop to main',
+      base: { ref: 'main' },
+      head: { ref: 'develop' },
+      body: `
+refs #209
+
+Source of truth: https://github.com/nurockplayer/tachigo/issues/209
+
+Depends on PR: none
+
+Backend contract already in develop:
+- [x] yes
+- [ ] no
+
+本 PR 明確不做
+- production deploy
+`,
+    },
+    files: [{ filename: 'docs/README.md', additions: 1, deletions: 0, status: 'modified' }],
+  })
+
+  const fullOutputs = {
+    run_ci: 'true',
+    run_backend: 'true',
+    run_backend_integration: 'true',
+    run_frontend: 'true',
+    run_dashboard: 'true',
+    run_contracts: 'true',
+  }
+  assert.deepEqual(push.outputs, fullOutputs)
+  assert.deepEqual(releasePromotion.outputs, fullOutputs)
+  assert.equal(
+    releasePromotion.notices.some((notice) => notice.includes('Skipping backend integration tests')),
+    false,
+  )
+})
+
+test('CI product jobs are gated by path-aware scope outputs', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const backendBuild = workflowJobBlock(workflow, 'backend-build')
+  const backend = workflowJobBlock(workflow, 'backend')
+  const atlas = workflowJobBlock(workflow, 'atlas-migration-tooling')
+  const backendIntegration = workflowJobBlock(workflow, 'backend-integration')
+  const frontend = workflowJobBlock(workflow, 'frontend')
+  const dashboard = workflowJobBlock(workflow, 'dashboard')
+  const contracts = workflowJobBlock(workflow, 'contracts')
+
+  assert.match(backendBuild, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
+  assert.match(backend, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
+  assert.match(atlas, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
+  assert.match(backendIntegration, /needs\.scope-gate\.outputs\.run_backend_integration == 'true'/)
+  assert.match(frontend, /needs\.scope-gate\.outputs\.run_frontend == 'true'/)
+  assert.match(dashboard, /needs\.scope-gate\.outputs\.run_dashboard == 'true'/)
+  assert.match(contracts, /needs\.scope-gate\.outputs\.run_contracts == 'true'/)
 })
 
 test('global auto-merge workflow excludes Dependabot PRs', async () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,53 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_ci: ${{ steps.evaluate.outputs.run_ci }}
+      run_backend: ${{ steps.evaluate.outputs.run_backend }}
       run_backend_integration: ${{ steps.evaluate.outputs.run_backend_integration }}
+      run_frontend: ${{ steps.evaluate.outputs.run_frontend }}
+      run_dashboard: ${{ steps.evaluate.outputs.run_dashboard }}
+      run_contracts: ${{ steps.evaluate.outputs.run_contracts }}
     steps:
       - name: Evaluate PR scope for CI
         id: evaluate
         uses: actions/github-script@v7
         with:
           script: |
+            const setCiOutputs = ({
+              runCi,
+              runBackend,
+              runBackendIntegration,
+              runFrontend,
+              runDashboard,
+              runContracts,
+            }) => {
+              core.setOutput('run_ci', runCi ? 'true' : 'false')
+              core.setOutput('run_backend', runBackend ? 'true' : 'false')
+              core.setOutput('run_backend_integration', runBackendIntegration ? 'true' : 'false')
+              core.setOutput('run_frontend', runFrontend ? 'true' : 'false')
+              core.setOutput('run_dashboard', runDashboard ? 'true' : 'false')
+              core.setOutput('run_contracts', runContracts ? 'true' : 'false')
+            }
+            const setFullCiOutputs = () => setCiOutputs({
+              runCi: true,
+              runBackend: true,
+              runBackendIntegration: true,
+              runFrontend: true,
+              runDashboard: true,
+              runContracts: true,
+            })
+            const setSkippedCiOutputs = () => setCiOutputs({
+              runCi: false,
+              runBackend: false,
+              runBackendIntegration: false,
+              runFrontend: false,
+              runDashboard: false,
+              runContracts: false,
+            })
+
             const pr = context.payload.pull_request
             if (!pr) {
               core.notice('Non-PR event detected; running CI without scope gate restrictions.')
-              core.setOutput('run_ci', 'true')
-              core.setOutput('run_backend_integration', 'true')
+              setFullCiOutputs()
               return
             }
 
@@ -51,8 +86,7 @@ jobs:
             const labels = (pr.labels || []).map((label) => label.name)
             if (labels.some((label) => bypassLabels.has(label))) {
               core.notice('Scope gate bypassed by scope-exception label.')
-              core.setOutput('run_ci', 'true')
-              core.setOutput('run_backend_integration', 'true')
+              setFullCiOutputs()
               return
             }
 
@@ -94,6 +128,12 @@ jobs:
             const touches = {
               backend: allFilePaths.some((name) =>
                 name.startsWith('backend/') || name.startsWith('services/api/'),
+              ),
+              extension: allFilePaths.some((name) =>
+                name.startsWith('tachimint/') || name.startsWith('apps/extension/'),
+              ),
+              dashboard: allFilePaths.some((name) =>
+                name.startsWith('dashboard/') || name.startsWith('apps/dashboard/'),
               ),
               frontend: allFilePaths.some((name) =>
                 name.startsWith('dashboard/') ||
@@ -156,18 +196,53 @@ jobs:
               /^docker-compose(?:\..+)?\.ya?ml$/,
               /^\.github\/workflows\/ci\.yml$/,
             ]
+            const ciWorkflowPaths = [
+              /^\.github\/workflows\/ci\.yml$/,
+              /^\.github\/workflows\/ci\.test\.mjs$/,
+            ]
+            const dockerComposePaths = [/^docker-compose(?:\..+)?\.ya?ml$/]
+            const frontendWorkspacePaths = [
+              /^package\.json$/,
+              /^pnpm-lock\.yaml$/,
+              /^pnpm-workspace\.yaml$/,
+            ]
+            const runFullCi = runCi && (
+              isReleasePromotionPr ||
+              allFilePaths.some((name) => ciWorkflowPaths.some((pattern) => pattern.test(name)))
+            )
+            const touchesDockerCompose = allFilePaths.some((name) =>
+              dockerComposePaths.some((pattern) => pattern.test(name)),
+            )
+            const touchesFrontendWorkspace = allFilePaths.some((name) =>
+              frontendWorkspacePaths.some((pattern) => pattern.test(name)),
+            )
+            const runBackend = runFullCi || (runCi && (touches.backend || touchesDockerCompose))
+            const runFrontend = runFullCi || (runCi && (touches.extension || touchesFrontendWorkspace || touchesDockerCompose))
+            const runDashboard = runFullCi || (runCi && (touches.dashboard || touchesFrontendWorkspace || touchesDockerCompose))
+            const runContracts = runFullCi || (runCi && touches.contracts)
             const runBackendIntegration = allFilePaths.some((name) =>
               backendIntegrationPaths.some((pattern) => pattern.test(name)),
             )
+            const shouldRunBackendIntegration = runFullCi || (runCi && runBackendIntegration)
 
-            core.setOutput('run_ci', runCi ? 'true' : 'false')
-            core.setOutput('run_backend_integration', runBackendIntegration ? 'true' : 'false')
+            if (runCi) {
+              setCiOutputs({
+                runCi,
+                runBackend,
+                runBackendIntegration: shouldRunBackendIntegration,
+                runFrontend,
+                runDashboard,
+                runContracts,
+              })
+            } else {
+              setSkippedCiOutputs()
+            }
             if (isDocsTemplateOrMetadataOnly) {
               core.notice('Skipping heavy product CI because this PR only changes docs/templates/metadata.')
             } else if (!runCi) {
               core.notice('Skipping heavy CI because this PR does not currently pass scope rules.')
             }
-            if (runCi && !runBackendIntegration) {
+            if (runCi && !shouldRunBackendIntegration) {
               core.notice('Skipping backend integration tests because this PR does not touch backend, contracts, docker compose, or CI workflow files.')
             }
 
@@ -175,7 +250,7 @@ jobs:
     timeout-minutes: 5
     name: Check backend CI cache wiring
     needs: [scope-gate]
-    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
+    if: needs.scope-gate.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -244,7 +319,7 @@ jobs:
     timeout-minutes: 15
     name: Build backend image
     needs: [scope-gate]
-    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
+    if: needs.scope-gate.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -266,7 +341,7 @@ jobs:
     timeout-minutes: 10
     name: Backend tests
     needs: [scope-gate]
-    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
+    if: needs.scope-gate.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -288,7 +363,7 @@ jobs:
     timeout-minutes: 10
     name: Atlas migration tooling
     needs: [scope-gate]
-    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
+    if: needs.scope-gate.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -337,7 +412,7 @@ jobs:
     name: Backend integration tests
     needs: [scope-gate]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (needs.scope-gate.outputs.run_ci == 'true' && needs.scope-gate.outputs.run_backend_integration == 'true')
+    if: needs.scope-gate.outputs.run_backend_integration == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -354,7 +429,7 @@ jobs:
     timeout-minutes: 15
     name: Frontend build
     needs: [scope-gate]
-    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
+    if: needs.scope-gate.outputs.run_frontend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -380,7 +455,7 @@ jobs:
     timeout-minutes: 15
     name: Dashboard build
     needs: [scope-gate]
-    if: github.event_name == 'push' || needs.scope-gate.outputs.run_ci == 'true'
+    if: needs.scope-gate.outputs.run_dashboard == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -400,6 +475,8 @@ jobs:
   contracts:
     timeout-minutes: 20
     name: Contracts build
+    needs: [scope-gate]
+    if: needs.scope-gate.outputs.run_contracts == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 什麼改動
- 擴充 `scope-gate`，輸出 `run_backend`、`run_frontend`、`run_dashboard`、`run_contracts` 等 path-aware CI gates。
- 將 backend / extension frontend / dashboard / contracts jobs 接到各自的 scope output，PR 只跑受影響的 product area。
- 更新 `.github/workflows/ci.test.mjs`，用 regression tests 固定 path-aware outputs、push/release full CI 與 job gating 行為。

## 為什麼
Milestone 4 的 CI 分層目標需要 PR CI 依 changed paths 減少不必要的 heavy jobs，同時保留 `push` 與 release promotion 的完整 CI。

closes #209

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#209
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 deploy workflow
  - 不導入 security scanner
  - 不修改 branch protection / required checks 設定
  - 不重寫 `pr-scope-police.yml`

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓主要 CI workflow 在 PR 上依 changed paths 跑必要 product jobs，並保留 push / release PR 完整 CI。
- Approx changed lines：~245
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] PR CI 可依 changed paths 減少不必要 job
- [x] push to `develop` 仍跑完整 CI
- [x] `develop -> main` release PR 有完整 gate
- [x] skipped jobs 不會造成 required checks 判斷混亂

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
tests 33
pass 33
fail 0

git diff --check
pass
```

## 備註
本機沒有安裝 `actionlint`，因此沒有額外執行 GitHub Actions lint；workflow YAML 由既有 Node regression tests 透過 Ruby YAML parser 解析驗證。

## Notes for Claude Code Review
- 請特別看 `scope-gate` path mapping：extension、dashboard、backend、contracts、docker compose、root pnpm workspace 與 CI workflow 變更的分流是否符合預期。
- `Frontend build` / `Dashboard build` / `Contracts build` 保留既有 job name，未要求同 PR 修改 branch protection。
