### PR TITLE
[chore] Audit root docs classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Key backend variables:
 ## Architecture
 
 See [docs/architecture.md](docs/architecture.md) for the full system diagram.
-For the current frontend migration decision, see [docs/tachimint-chrome-sidepanel-migration.md](docs/tachimint-chrome-sidepanel-migration.md).
+For the frontend migration decision record, see [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md).
 
 ## Documentation
 

--- a/design/tachimint/extension-ui-prompts-codex.md
+++ b/design/tachimint/extension-ui-prompts-codex.md
@@ -295,4 +295,4 @@ viewer 畫面要有：
 - `tachimint/src/hooks/useClickBoost.ts`
 - `tachimint/src/hooks/useBits.ts`
 - `docs/watch-to-points-design.md`
-- `docs/history/2026-04-16-chrome-extension-terminology-audit.md`
+- [docs/history/2026-04-16-chrome-extension-terminology-audit.md](../../docs/history/2026-04-16-chrome-extension-terminology-audit.md)

--- a/design/tachimint/extension-ui-prompts-codex.md
+++ b/design/tachimint/extension-ui-prompts-codex.md
@@ -295,4 +295,4 @@ viewer 畫面要有：
 - `tachimint/src/hooks/useClickBoost.ts`
 - `tachimint/src/hooks/useBits.ts`
 - `docs/watch-to-points-design.md`
-- `docs/chrome-extension-terminology-audit.md`
+- `docs/history/2026-04-16-chrome-extension-terminology-audit.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,56 @@
 # Tachigo Docs
 
-本目錄收納工程文件。文件分成兩種定位：
-
-- **現況 source of truth**：描述目前仍有效的架構、政策、規格。檔名不加日期，內容改變時直接更新。
-- **歷史紀錄**：像 SQL migration log 一樣，記錄某次遷移、盤點或決策當下的背景與結果。檔名使用日期開頭，完成後原則上只做狀態校正，不作為 active TODO。
+本目錄收納工程文件。root 只保留仍需要被日常引用的現況文件、active plan/proposal，或暫時保留待後續分類的討論參考；已完成的一次性盤點、遷移或決策紀錄放在 `docs/history/`。
 
 ## 目錄分類
 
 | 位置 | 用途 | 命名 |
 |---|---|---|
-| `docs/` | 目前仍有效的架構、API、政策與設計文件 | `<topic>.md` |
-| `docs/history/` | 已完成的一次性遷移、盤點、整理紀錄 | `YYYY-MM-DD-<topic>.md` |
+| `docs/` | 目前仍有效的架構、API、政策、設計文件，或仍在進行中的 plan/proposal | `<topic>.md` |
+| `docs/history/` | 已完成的一次性遷移、盤點、整理或決策紀錄 | `YYYY-MM-DD-<topic>.md` |
 | `docs/ai/` | 既有 AI 協作指南與 agent-facing 文件 | `<topic>.md` |
 | `docs/superpowers/` | 既有 Superpowers specs / plans 歷史文件 | 維持既有日期命名 |
 | `plans/` | 實作前計畫與完成後的執行紀錄 | `<feature-slug>.md` |
+
+## Root Source Of Truth
+
+| 文件 | 定位 |
+|---|---|
+| [`architecture.md`](architecture.md) | 系統整體架構與主要資料流 |
+| [`auth-architecture.md`](auth-architecture.md) | Auth 現況與 migration guardrails |
+| [`auto-merge-policy.md`](auto-merge-policy.md) | Auto-merge 與 approve 語義 |
+| [`dependabot-update-policy.md`](dependabot-update-policy.md) | Dependabot 更新政策 |
+| [`draft-pr-auto-ready.md`](draft-pr-auto-ready.md) | Draft PR auto-ready 現行流程 |
+| [`pr-scope-policy.md`](pr-scope-policy.md) | PR scope 與 required checks policy |
+| [`sequence-diagram.md`](sequence-diagram.md) | Watch / points / dashboard 主要時序圖 |
+| [`tokenomics.md`](tokenomics.md) | `$TACHI` 平台幣經濟模型 |
+| [`uuid-v7.md`](uuid-v7.md) | UUID 版本策略 |
+| [`watch-to-points-design.md`](watch-to-points-design.md) | Watch-to-points 已完成設計 |
+
+## Active Plans / Proposals
+
+| 文件 | 定位 |
+|---|---|
+| [`atlas-migration-plan.md`](atlas-migration-plan.md) | #463 Atlas migration 拆分實作計畫；不得單獨視為已完成狀態 |
+| [`atlas-schema-reconciliation.md`](atlas-schema-reconciliation.md) | #463 baseline 前 schema reconciliation evidence / procedure |
+
+## Root Reference / Discussion Notes
+
+| 文件 | 定位 |
+|---|---|
+| [`extension-ui-prompts.md`](extension-ui-prompts.md) | Tachimint UI prompt reference，不是產品 runtime source of truth |
+| [`feature-discussion.md`](feature-discussion.md) | 早期產品討論紀錄；仍保留供背景參考，不得單獨視為 implementation source of truth |
+| [`tachimint-loyalty-claim-boundary.md`](tachimint-loyalty-claim-boundary.md) | Tachimint / claim flow 邊界討論短文件，不是正式 architecture source of truth |
+
+## Historical Records
+
+| 文件 | 定位 |
+|---|---|
+| [`history/2026-04-16-chrome-extension-terminology-audit.md`](history/2026-04-16-chrome-extension-terminology-audit.md) | Chrome / Twitch / extension terminology 盤點 |
+| [`history/2026-04-16-tachimint-chrome-sidepanel-migration.md`](history/2026-04-16-tachimint-chrome-sidepanel-migration.md) | Tachimint Chrome sidepanel migration decision record |
+| [`history/2026-04-18-git-lfs-assets.md`](history/2026-04-18-git-lfs-assets.md) | Git LFS asset handling 決策與操作紀錄 |
+| [`history/2026-04-30-monorepo-directory-refactor.md`](history/2026-04-30-monorepo-directory-refactor.md) | Monorepo directory refactor 歷史紀錄 |
+| [`history/2026-05-01-dashboard-stack-evaluation.md`](history/2026-05-01-dashboard-stack-evaluation.md) | Dashboard Refine.dev 技術選型決策紀錄 |
 
 ## 命名原則
 
@@ -21,4 +58,4 @@
 - 歷史紀錄與決策紀錄使用日期開頭，例如 `2026-04-30-monorepo-directory-refactor.md`。
 - 日期使用該事件完成、merge 或正式採納的日期；若只有月份，使用最接近的完成日期並在文件內說明。
 - 已完成但仍保留的歷史文件，文件頂端應標註狀態與最後校正日期。
-- 本規範先定義新增分類與命名原則，不要求批次搬移既有目錄；未列出的既有目錄應維持現況，待後續 PR 另行收斂。
+- 狀態不明文件不得在盤點 PR 中硬搬或硬刪；只能補狀態標記，或另開 issue 做 source-of-truth 判定。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@
 
 ## 主要資料流
 
-> 補充：`tachimint` 的前端 runtime 方向已定為 Chrome sidepanel extension；本階段 viewer identity 與既有 API contract 仍沿用 Twitch / extension auth 流程。詳見 [docs/tachimint-chrome-sidepanel-migration.md](tachimint-chrome-sidepanel-migration.md)。
+> 補充：`tachimint` 的前端 runtime 方向已定為 Chrome sidepanel extension；本階段 viewer identity 與既有 API contract 仍沿用 Twitch / extension auth 流程。詳見 [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](history/2026-04-16-tachimint-chrome-sidepanel-migration.md)。
 
 ```
 觀眾觀看直播（定時 Heartbeat）

--- a/docs/draft-pr-auto-ready.md
+++ b/docs/draft-pr-auto-ready.md
@@ -1,6 +1,6 @@
 # Draft PR auto-ready
 
-**Status**: implemented; rollout validation in progress
+**Status**: implemented; current workflow source of truth
 **Created**: 2026-05-02
 **Issue**: https://github.com/nurockplayer/tachigo/issues/470
 **Implementation PRs**: https://github.com/nurockplayer/tachigo/pull/472, https://github.com/nurockplayer/tachigo/pull/488

--- a/docs/feature-discussion.md
+++ b/docs/feature-discussion.md
@@ -3,6 +3,8 @@
 > **專案名稱：** tachigo、tachiya
 > **日期：** 2026-03-27
 > **參與成員：** nurockplayer、新理解、5lime、Erick、YUAN
+> **狀態：** 早期產品討論紀錄；仍保留於 `docs/` root 供背景參考，但不得單獨視為 implementation source of truth。
+> **最後校正：** 2026-05-05（#490 docs root audit）
 
 ---
 

--- a/docs/history/2026-04-16-chrome-extension-terminology-audit.md
+++ b/docs/history/2026-04-16-chrome-extension-terminology-audit.md
@@ -1,8 +1,9 @@
 # Chrome Extension 名詞盤點
 
 > 用途：盤點 repo 內 `Chrome Extension`、`Twitch Extension` 與泛用 `extension` 命名的混用情況。
-> 狀態：盤點文件；Chrome sidepanel migration 方向已定案，但本文件本身不是完整實作 spec。
+> 狀態：歷史盤點文件；Chrome sidepanel migration 方向已定案，但本文件本身不是完整實作 spec。
 > 最後更新：2026-04-16
+> 最後校正：2026-05-05（#490 docs root audit）
 
 ---
 
@@ -13,7 +14,7 @@
 1. `tachimint` 的既有可運作實作是 **Twitch-hosted extension runtime**
 2. `tachimint` 的新方向已定為 **Chrome sidepanel extension runtime**
 3. 本階段前端與後端仍依賴 `window.Twitch.ext`、`extension_jwt`、Twitch helper script 等流程
-4. 本輪 migration 的 decision source of truth 為 [docs/tachimint-chrome-sidepanel-migration.md](tachimint-chrome-sidepanel-migration.md)
+4. 本輪 migration 的 decision source of truth 為 [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](2026-04-16-tachimint-chrome-sidepanel-migration.md)
 
 因此，這份文件的用途是說明術語與現況的落差，協助後續 migration 拆題；它不是完整 migration spec。
 
@@ -31,16 +32,16 @@
 
 以下文件已在本輪 docs 收斂中處理：
 
-- [docs/architecture.md](architecture.md)
-- [docs/feature-discussion.md](feature-discussion.md)
-- [docs/tokenomics.md](tokenomics.md)
-- [docs/watch-to-points-design.md](watch-to-points-design.md)
-- [apps/extension/README.md](../apps/extension/README.md)
+- [docs/architecture.md](../architecture.md)
+- [docs/feature-discussion.md](../feature-discussion.md)
+- [docs/tokenomics.md](../tokenomics.md)
+- [docs/watch-to-points-design.md](../watch-to-points-design.md)
+- [apps/extension/README.md](../../apps/extension/README.md)
 
 以下文件已另拆處理，不混在本 PR：
 
-- [docs/sequence-diagram.md](sequence-diagram.md) - 另拆 PR 處理，流程圖描述現況需單獨評估
-- [docs/extension-ui-prompts.md](extension-ui-prompts.md) - 已拆至 #154，避免超出 terminology cleanup / audit 邊界
+- [docs/sequence-diagram.md](../sequence-diagram.md) - 另拆 PR 處理，流程圖描述現況需單獨評估
+- [docs/extension-ui-prompts.md](../extension-ui-prompts.md) - 已拆至 #154，避免超出 terminology cleanup / audit 邊界
 
 ---
 
@@ -50,13 +51,13 @@
 
 這些項目不是單純改字詞就能處理：
 
-- [apps/extension/index.html](../apps/extension/index.html)
+- [apps/extension/index.html](../../apps/extension/index.html)
   - 仍載入 Twitch Extension Helper
-- [apps/extension/src/mock/twitch-ext.ts](../apps/extension/src/mock/twitch-ext.ts)
+- [apps/extension/src/mock/twitch-ext.ts](../../apps/extension/src/mock/twitch-ext.ts)
   - 本地開發使用 `window.Twitch.ext` mock
-- [apps/extension/src/types/twitch-ext.d.ts](../apps/extension/src/types/twitch-ext.d.ts)
+- [apps/extension/src/types/twitch-ext.d.ts](../../apps/extension/src/types/twitch-ext.d.ts)
   - 型別直接綁定 Twitch helper
-- [apps/extension/src/services/api.ts](../apps/extension/src/services/api.ts)
+- [apps/extension/src/services/api.ts](../../apps/extension/src/services/api.ts)
   - 使用 `extension_jwt`、`loginWithTwitchExtension`
 
 ### B. 實作層泛用 `extension` 命名
@@ -119,7 +120,7 @@
 1. `apps/extension/` 保留，作為唯一正式 extension 前端 surface
 2. Chrome sidepanel 是已定案產品方向
 3. 本階段仍沿用 Twitch identity 與既有 backend contract
-4. 新的 migration decision source of truth 為 [docs/tachimint-chrome-sidepanel-migration.md](tachimint-chrome-sidepanel-migration.md)
+4. 新的 migration decision source of truth 為 [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](2026-04-16-tachimint-chrome-sidepanel-migration.md)
 
 仍待後續 implementation PR 處理：
 

--- a/docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md
+++ b/docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md
@@ -1,8 +1,9 @@
 # Tachimint Chrome Sidepanel Migration Decision
 
 > 用途：記錄 `tachimint` 前端 migration 的已定案方向，作為後續 PR 的共同 source of truth。
-> 狀態：已定案的 migration decision，不是完整實作 spec。
+> 狀態：歷史 migration decision record，不是完整實作 spec。
 > 最後更新：2026-04-16
+> 最後校正：2026-05-05（#490 docs root audit）
 
 ---
 

--- a/docs/history/2026-04-18-git-lfs-assets.md
+++ b/docs/history/2026-04-18-git-lfs-assets.md
@@ -1,8 +1,9 @@
 # Git LFS Asset Handling Plan
 
 > 用途：記錄 `tachigo` 對大型前端 binary assets 採用 Git LFS 的決策、設定方式與 PR #265 後續修復流程。
-> 狀態：決策與操作計畫；本分支同時落地 `apps/extension/src/assets/` 的 Git LFS tracking 與 frontend CI checkout 設定。
+> 狀態：歷史決策與操作紀錄；本分支已落地 `apps/extension/src/assets/` 的 Git LFS tracking 與 frontend CI checkout 設定。
 > 最後更新：2026-04-18
+> 最後校正：2026-05-05（#490 docs root audit）
 
 ---
 

--- a/docs/history/2026-05-01-dashboard-stack-evaluation.md
+++ b/docs/history/2026-05-01-dashboard-stack-evaluation.md
@@ -1,5 +1,10 @@
 # Dashboard 技術選型評估
 
+> 用途：記錄 dashboard 技術選型評估與 Refine.dev 採納決策。
+> 狀態：歷史決策紀錄，不是 active implementation plan。
+> 最後更新：2026-05-01
+> 最後校正：2026-05-05（#490 docs root audit）
+
 ## 背景
 
 目前 `tachigo` 已有一個獨立的 `apps/dashboard/` 前端專案，技術基礎如下：
@@ -20,15 +25,15 @@
 
 ### 已有基礎
 
-- [`apps/dashboard/src/App.tsx`](../apps/dashboard/src/App.tsx)
+- [`apps/dashboard/src/App.tsx`](../../apps/dashboard/src/App.tsx)
   - 已建立登入頁、受保護路由、Layout 與幾個基礎頁面
-- [`apps/dashboard/src/components/Layout.tsx`](../apps/dashboard/src/components/Layout.tsx)
+- [`apps/dashboard/src/components/Layout.tsx`](../../apps/dashboard/src/components/Layout.tsx)
   - 已有基本側邊欄與頁面容器
-- [`apps/dashboard/src/pages/LoginPage.tsx`](../apps/dashboard/src/pages/LoginPage.tsx)
+- [`apps/dashboard/src/pages/LoginPage.tsx`](../../apps/dashboard/src/pages/LoginPage.tsx)
   - 已完成登入 UI，並串接登入 API
-- [`apps/dashboard/src/services/auth.ts`](../apps/dashboard/src/services/auth.ts)
+- [`apps/dashboard/src/services/auth.ts`](../../apps/dashboard/src/services/auth.ts)
   - 已有 login/logout 邏輯與 token 設定
-- [`services/api/internal/router/router.go`](../services/api/internal/router/router.go)
+- [`services/api/internal/router/router.go`](../../services/api/internal/router/router.go)
   - 後端已提供 auth 與部分 dashboard/API 路由骨架
 
 ### 尚未成形的部分
@@ -39,12 +44,12 @@
 
 ### 目前技術風險
 
-- [`apps/dashboard/src/services/auth.ts`](../apps/dashboard/src/services/auth.ts)
+- [`apps/dashboard/src/services/auth.ts`](../../apps/dashboard/src/services/auth.ts)
   - `accessToken` 僅保存在記憶體；但 `main.tsx` 啟動時會 `await restoreSession()`，透過 httpOnly refresh cookie 還原 token，頁面重整不會立即掉登入
   - Refine `authProvider` 尚未整合，目前 route guard 仍由 `ProtectedRoute` 處理
-- [`apps/dashboard/src/components/ProtectedRoute.tsx`](../apps/dashboard/src/components/ProtectedRoute.tsx)
+- [`apps/dashboard/src/components/ProtectedRoute.tsx`](../../apps/dashboard/src/components/ProtectedRoute.tsx)
   - 現在的 route guard 只適合非常早期原型
-- [`apps/dashboard/README.md`](../apps/dashboard/README.md)
+- [`apps/dashboard/README.md`](../../apps/dashboard/README.md)
   - 仍是 Vite 預設內容，尚未反映專案實際開發方式
 
 ---
@@ -165,4 +170,4 @@
 
 實作規劃見：
 
-- [`plans/refine-dashboard-mvp.md`](../plans/refine-dashboard-mvp.md)
+- [`plans/refine-dashboard-mvp.md`](../../plans/refine-dashboard-mvp.md)

--- a/docs/watch-to-points-design.md
+++ b/docs/watch-to-points-design.md
@@ -301,15 +301,15 @@ ON CONFLICT (user_id, channel_id) DO UPDATE SET
 
 | 檔案 | 改動點 |
 |---|---|
-| `backend/internal/models/points.go` | `PointsLedger.BeforeCreate`、`PointsTransaction.BeforeCreate` |
-| `backend/internal/models/watch_session.go` | `WatchSession.BeforeCreate` |
-| `backend/internal/services/watch_service.go` | `ID: uuid.New()` for WatchSession |
+| `services/api/internal/models/points.go` | `PointsLedger.BeforeCreate`、`PointsTransaction.BeforeCreate` |
+| `services/api/internal/models/watch_session.go` | `WatchSession.BeforeCreate` |
+| `services/api/internal/services/watch_service.go` | `ID: uuid.New()` for WatchSession |
 
 其餘 model（`user.go`、`auth_provider.go`、`address.go`、`refresh_token.go`、`email_auth.go`）與 `extension_service.go` 留給 Issue #61 獨立處理。詳見 [docs/uuid-v7.md](uuid-v7.md)。
 
 ### PR #62 重疊分析
 
-PR #62（`users.role` VARCHAR → ENUM）也改動了 `backend/cmd/server/main.go`，本次計劃同樣需要修改此檔案。
+PR #62（`users.role` VARCHAR → ENUM）也改動了 `services/api/cmd/server/main.go`，本次計劃同樣需要修改此檔案。
 
 | 項目 | PR #62 改動 | 本次計劃改動 |
 |---|---|---|
@@ -340,5 +340,5 @@ PR #62（`users.role` VARCHAR → ENUM）也改動了 `backend/cmd/server/main.g
 - [Issue #58](https://github.com/nurockplayer/tachigo/issues/58) — auth_providers 設計討論
 - [PR #52](https://github.com/nurockplayer/tachigo/pull/52) — Phase 1 & 2 實作
 - [PR #64](https://github.com/nurockplayer/tachigo/pull/64) — Watch-to-Points 補強 + Channel Config
-- 實作：[backend/internal/services/watch_service.go](../backend/internal/services/watch_service.go)
-- Migration：[backend/migrations/003_watch_points.sql](../backend/migrations/003_watch_points.sql)
+- 實作：[services/api/internal/services/watch_service.go](../services/api/internal/services/watch_service.go)
+- Migration：[services/api/migrations/003_watch_points.sql](../services/api/migrations/003_watch_points.sql)

--- a/docs/watch-to-points-design.md
+++ b/docs/watch-to-points-design.md
@@ -297,13 +297,13 @@ ON CONFLICT (user_id, channel_id) DO UPDATE SET
 
 ### Issue #61 — UUID v7（本次已處理 watch-points 相關部分）
 
-本次已在 watch-points 相關檔案中同步改為 `uuid.New7()`（時序 UUID，降低 B-tree index fragmentation 風險）：
+本次已在 watch-points 相關檔案中同步改為 `uuid.NewV7()`（時序 UUID，降低 B-tree index fragmentation 風險）：
 
 | 檔案 | 改動點 |
 |---|---|
 | `services/api/internal/models/points.go` | `PointsLedger.BeforeCreate`、`PointsTransaction.BeforeCreate` |
 | `services/api/internal/models/watch_session.go` | `WatchSession.BeforeCreate` |
-| `services/api/internal/services/watch_service.go` | `ID: uuid.New()` for WatchSession |
+| `services/api/internal/services/watch_service.go` | `newUUID()` uses `uuid.NewV7()` with `uuid.New()` fallback |
 
 其餘 model（`user.go`、`auth_provider.go`、`address.go`、`refresh_token.go`、`email_auth.go`）與 `extension_service.go` 留給 Issue #61 獨立處理。詳見 [docs/uuid-v7.md](uuid-v7.md)。
 


### PR DESCRIPTION
## 什麼改動
- 將明確已完成的一次性 docs root 紀錄搬到 `docs/history/`，檔名改為 `YYYY-MM-DD-<topic>.md`。
- 更新 moved docs 的狀態 / 最後校正標記與相對連結。
- 更新 `docs/README.md`，補上 root source of truth、active plans/proposals、reference notes、historical records 分類。
- 補 `feature-discussion.md` 與 `draft-pr-auto-ready.md` 的狀態標記，並修正 moved docs 造成的引用與 root docs stale paths。

## 為什麼
closes #490

`docs/` root 同時混有現況 source of truth、一次性歷史紀錄、active plan/proposal 與狀態不明文件。這次依 #490 做第二階段盤點，把明確 historical 的文件移到 `docs/history/`，對狀態不明文件只補分類 / 狀態，不猜測內容是否仍有效。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#490
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 `plans/` 歸檔
  - 不修改 `docs/superpowers/`
  - 不批次重寫文件內容
  - 不修改任何 product code、CI、backend、frontend
  - 不硬判狀態不明文件是否仍有效

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 盤點並整理 `docs/` root 文件定位，將明確 historical 文件移到 `docs/history/`。
- Approx changed lines：~130
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `docs/` root 不再混入明確已完成的一次性歷史紀錄
- [x] 被搬入 `docs/history/` 的文件都有狀態標記與最後校正日期
- [x] 狀態不明文件沒有被硬搬或硬刪，並有清楚後續處理方式
- [x] `docs/README.md` 與實際目錄一致

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
git diff --check HEAD~1..HEAD
# pass

rg -n "docs/(chrome-extension-terminology-audit|git-lfs-assets|tachimint-chrome-sidepanel-migration|dashboard-stack-evaluation)\\.md|\\((chrome-extension-terminology-audit|git-lfs-assets|tachimint-chrome-sidepanel-migration|dashboard-stack-evaluation)\\.md\\)" . -g '*.md'
# no matches

node -e '<markdown local link checker>' $(git diff --name-only HEAD~1..HEAD -- '*.md')
# pass
```

## 備註
全 repo Markdown link checker 目前會被既有、未修改的 design doc link 擋住；本 PR 驗證改用「本 commit 變更的 Markdown 檔案」範圍。

## Notes for Claude Code Review
- 請特別確認 moved docs 的分類是否只限明確 historical records。
- 請確認 `docs/README.md` 沒有把 active plan/proposal 誤標成已完成 source of truth。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 重新整理文件目錄與分類，新增更細的來源/計畫/參考/歷史區分。
  * 更新文件間的交叉參照與指向，將多處連結改為指向歷史決策紀錄。
  * 補充或調整文件元資訊（狀態、最後更新/校正時間）並微調說明與路徑參考。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->