### PR TITLE
[frontend] feat(dashboard): RaffleDetailPage 完整抽獎控制介面 (#232)

### DIFF
--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -1,16 +1,458 @@
 import { useOne } from '@refinedev/core'
-import { useParams } from 'react-router'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import type { Raffle } from '@/services/raffles'
+import { completeRaffle, drawNext, importCSV, listDraws } from '@/services/raffles'
+import type { Raffle, RaffleDraw, RaffleStatus } from '@/services/raffles'
 
-const statusLabel: Record<string, string> = {
+const statusLabel: Record<RaffleStatus, string> = {
   draft: '草稿',
   active: '進行中',
-  completed: '已結束',
+  completed: '已完成',
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  if (Number.isNaN(date.getTime())) return ''
+
+  const diffMs = Date.now() - date.getTime()
+  const secs = Math.floor(diffMs / 1000)
+  if (secs < 60) return '剛剛'
+
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins} 分鐘前`
+
+  return date.toLocaleString('zh-TW')
+}
+
+function StatCard({
+  label,
+  value,
+  colorClass,
+}: {
+  label: string
+  value: string
+  colorClass: string
+}) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[.04] p-3 text-center">
+      <p className="mb-1 text-[10px] tracking-wide text-white/40">{label}</p>
+      <p className={`text-3xl font-black leading-none ${colorClass}`}>{value}</p>
+    </div>
+  )
+}
+
+function WinnerList({ draws }: { draws: RaffleDraw[] }) {
+  if (draws.length === 0) {
+    return (
+      <p data-testid="empty-winners" className="py-6 text-center text-sm text-white/30">
+        目前還沒有抽出得獎者
+      </p>
+    )
+  }
+
+  const sorted = [...draws].sort(
+    (a, b) => new Date(b.drawn_at).getTime() - new Date(a.drawn_at).getTime(),
+  )
+
+  return (
+    <div className="flex flex-col gap-2">
+      {sorted.map((draw, index) => (
+        <div
+          key={draw.id}
+          data-testid="winner-item"
+          className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/[.04] px-4 py-3"
+        >
+          <span className="min-w-[28px] text-xs font-bold text-amber-400">
+            #{draws.length - index}
+          </span>
+          <span className="flex-1 text-sm font-medium">
+            {draw.entry.display_name || draw.entry.twitch_login}
+          </span>
+          <span className="text-[10px] text-white/30">{formatRelativeTime(draw.drawn_at)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function CsvUploadZone({
+  raffleId,
+  onSuccess,
+}: {
+  raffleId: string
+  onSuccess: (result: { imported: number; skipped: number }) => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleFile(file: File) {
+    setUploading(true)
+    setError(null)
+    try {
+      const response = await importCSV(raffleId, file)
+      setResult(response)
+      onSuccess(response)
+    } catch {
+      setError('上傳失敗，請稍後再試')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <div
+      role="button"
+      aria-label="上傳 CSV"
+      tabIndex={0}
+      className="cursor-pointer rounded-xl border border-dashed border-amber-500/25 bg-amber-500/[.025] px-4 py-3 text-center transition hover:border-amber-500/50"
+      onClick={() => inputRef.current?.click()}
+      onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space') { event.preventDefault(); inputRef.current?.click() } }}
+      onDrop={(event) => {
+        event.preventDefault()
+        const file = event.dataTransfer.files[0]
+        if (file) void handleFile(file)
+      }}
+      onDragOver={(event) => event.preventDefault()}
+    >
+      <input
+        ref={inputRef}
+        data-testid="csv-input"
+        type="file"
+        accept=".csv"
+        className="sr-only"
+        onChange={(event) => {
+          const file = event.target.files?.[0]
+          if (file) void handleFile(file)
+        }}
+      />
+      {uploading ? (
+        <p className="text-sm text-amber-400/70">上傳中...</p>
+      ) : (
+        <>
+          <p className="text-sm text-amber-400/80">點擊或拖曳 CSV 匯入參加者</p>
+          <p className="text-[10px] text-white/30">欄位格式：twitch_login, display_name</p>
+        </>
+      )}
+      {result && (
+        <p data-testid="csv-success" className="mt-2 text-xs text-green-400">
+          匯入成功：{result.imported} 人，略過 {result.skipped} 人
+        </p>
+      )}
+      {error && (
+        <p data-testid="csv-error" className="mt-2 text-xs text-red-400">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function DrawControls({
+  status,
+  exhausted,
+  drawing,
+  confirmEnd,
+  ending,
+  onDraw,
+  onRequestEnd,
+  onConfirmEnd,
+  onCancelEnd,
+}: {
+  status: string
+  exhausted: boolean
+  drawing: boolean
+  confirmEnd: boolean
+  ending: boolean
+  onDraw: () => void
+  onRequestEnd: () => void
+  onConfirmEnd: () => void
+  onCancelEnd: () => void
+}) {
+  const isCompleted = status === 'completed'
+  const drawDisabled = isCompleted || exhausted || drawing
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        data-testid="draw-btn"
+        disabled={drawDisabled}
+        onClick={onDraw}
+        className="w-full rounded-full bg-gradient-to-br from-amber-300 via-amber-500 to-amber-700 px-4 py-4 text-base font-black tracking-widest text-amber-950 shadow-lg shadow-amber-500/30 transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {drawing ? '抽獎中...' : '抽出下一位'}
+      </button>
+
+      {!isCompleted && !confirmEnd && (
+        <button
+          data-testid="end-btn"
+          onClick={onRequestEnd}
+          className="w-full rounded-full border border-red-400/20 bg-transparent py-2 text-xs tracking-widest text-red-400/60 transition hover:border-red-400/50 hover:text-red-400/90"
+        >
+          結束活動
+        </button>
+      )}
+
+      {confirmEnd && (
+        <div
+          data-testid="confirm-end"
+          className="rounded-xl border border-amber-700/30 bg-amber-950/30 p-4 text-sm"
+        >
+          <p className="mb-3 font-medium text-amber-300">
+            確定要結束活動嗎？結束後將無法繼續抽獎。
+          </p>
+          <div className="flex gap-2">
+            <button
+              data-testid="confirm-yes"
+              disabled={ending}
+              onClick={onConfirmEnd}
+              className="flex-1 rounded-lg border border-red-500/40 bg-red-950/40 py-2 text-xs text-red-300 transition hover:bg-red-950/60 disabled:opacity-40"
+            >
+              {ending ? '結束中...' : '確定結束'}
+            </button>
+            <button
+              data-testid="confirm-no"
+              onClick={onCancelEnd}
+              className="flex-1 rounded-lg border border-white/10 bg-white/5 py-2 text-xs text-white/50 transition hover:bg-white/10"
+            >
+              取消
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GachaMachine() {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'relative',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '260px',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          width: '280px',
+          height: '280px',
+          borderRadius: '50%',
+          background:
+            'conic-gradient(from 0deg,rgba(200,150,30,.055) 0deg 9deg,rgba(0,0,0,0) 9deg 18deg,rgba(200,150,30,.055) 18deg 27deg,rgba(0,0,0,0) 27deg 36deg,rgba(200,150,30,.055) 36deg 45deg,rgba(0,0,0,0) 45deg 54deg,rgba(200,150,30,.055) 54deg 63deg,rgba(0,0,0,0) 63deg 72deg,rgba(200,150,30,.055) 72deg 81deg,rgba(0,0,0,0) 81deg 90deg,rgba(200,150,30,.055) 90deg 99deg,rgba(0,0,0,0) 99deg 108deg,rgba(200,150,30,.055) 108deg 117deg,rgba(0,0,0,0) 117deg 126deg,rgba(200,150,30,.055) 126deg 135deg,rgba(0,0,0,0) 135deg 144deg,rgba(200,150,30,.055) 144deg 153deg,rgba(0,0,0,0) 153deg 162deg,rgba(200,150,30,.055) 162deg 171deg,rgba(0,0,0,0) 171deg 180deg,rgba(200,150,30,.055) 180deg 360deg)',
+          animation: 'gachaRays 22s linear infinite',
+        }}
+      />
+      {[
+        { top: '12px', left: '22px', fontSize: '13px', animationDelay: '0s' },
+        { top: '44px', right: '18px', fontSize: '10px', animationDelay: '0.9s' },
+        { bottom: '38px', left: '14px', fontSize: '11px', animationDelay: '1.8s' },
+        { bottom: '18px', right: '28px', fontSize: '18px', animationDelay: '0.4s' },
+      ].map((style, index) => (
+        <span
+          key={index}
+          style={{
+            position: 'absolute',
+            color: '#f5c518',
+            filter: 'drop-shadow(0 0 5px rgba(245,197,24,.4))',
+            animation: 'gachaSparkle 3s ease-in-out infinite',
+            ...style,
+          }}
+        >
+          *
+        </span>
+      ))}
+      <div
+        style={{
+          position: 'relative',
+          width: '168px',
+          filter: 'drop-shadow(0 14px 32px rgba(0,0,0,.7))',
+        }}
+      >
+        <div
+          style={{
+            width: '128px',
+            height: '13px',
+            margin: '0 auto',
+            background: 'linear-gradient(180deg,#3a3830,#28261e)',
+            borderRadius: '6px 6px 0 0',
+            border: '1.5px solid #48463c',
+            borderBottom: 'none',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '5px',
+          }}
+        >
+          {[
+            ['#e05c5c', '0s'],
+            ['#52c26a', '.43s'],
+            ['#f5c518', '.86s'],
+          ].map(([color, delay], index) => (
+            <span
+              key={index}
+              style={{
+                width: '5px',
+                height: '5px',
+                borderRadius: '50%',
+                background: color,
+                boxShadow: `0 0 5px ${color}`,
+                animation: `gachaLed 1.3s ease-in-out infinite ${delay}`,
+              }}
+            />
+          ))}
+        </div>
+        <div style={{ position: 'relative', width: '168px', height: '168px' }}>
+          <div
+            style={{
+              position: 'absolute',
+              top: '-7px',
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: '13px',
+              height: '13px',
+              borderRadius: '50%',
+              background: 'radial-gradient(circle at 35% 30%,#ffe266,#c48a10)',
+              border: '1.5px solid #7a5008',
+              boxShadow: '0 2px 8px rgba(200,130,10,.6)',
+              zIndex: 2,
+            }}
+          />
+          <div
+            style={{
+              width: '168px',
+              height: '168px',
+              borderRadius: '50%',
+              overflow: 'hidden',
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background:
+                'radial-gradient(ellipse at 35% 30%,rgba(230,218,190,.12) 0%,transparent 52%),radial-gradient(circle,rgba(160,140,110,.12) 0%,rgba(40,34,26,.5) 100%)',
+              border: '2.5px solid rgba(200,178,130,.2)',
+              boxShadow:
+                'inset -28px -28px 55px rgba(0,0,0,.55),inset 8px 8px 22px rgba(255,238,190,.05),0 0 0 1px rgba(0,0,0,.6),0 8px 34px rgba(0,0,0,.75)',
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                borderRadius: '50%',
+                background: 'repeating-conic-gradient(rgba(255,255,255,.025) 0deg 15deg,transparent 15deg 30deg)',
+                animation: 'gachaGlobe 16s linear infinite',
+              }}
+            />
+            {[
+              { width: 44, height: 44, background: 'linear-gradient(135deg,#a06248,#7a3e24)', top: 20, left: 16, animation: 'bb1 4.2s' },
+              { width: 36, height: 36, background: 'linear-gradient(135deg,#4e7040,#2e5020)', top: 12, left: 82, animation: 'bb2 3.6s' },
+              { width: 40, height: 40, background: 'linear-gradient(135deg,#5c5c9c,#3c3c7c)', top: 68, left: 106, animation: 'bb3 4.8s' },
+              { width: 34, height: 34, background: 'linear-gradient(135deg,#9c6c3a,#7c4c1a)', top: 90, left: 14, animation: 'bb4 3.9s' },
+              { width: 42, height: 42, background: 'linear-gradient(135deg,#7c4c7c,#5c2c5c)', top: 100, left: 62, animation: 'bb5 4.4s' },
+              { width: 30, height: 30, background: 'linear-gradient(135deg,#4c7c7c,#2c5c5c)', top: 50, left: 50, animation: 'bb6 3.3s' },
+            ].map((ball, index) => (
+              <div
+                key={index}
+                style={{
+                  position: 'absolute',
+                  borderRadius: '50%',
+                  width: ball.width,
+                  height: ball.height,
+                  background: ball.background,
+                  border: '1.5px solid rgba(255,255,255,.18)',
+                  top: ball.top,
+                  left: ball.left,
+                  animation: `${ball.animation} ease-in-out infinite`,
+                }}
+              />
+            ))}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                borderRadius: '50%',
+                background: 'radial-gradient(ellipse at 28% 23%,rgba(255,244,210,.1) 0%,transparent 52%)',
+                pointerEvents: 'none',
+              }}
+            />
+          </div>
+        </div>
+        <div
+          style={{
+            width: '146px',
+            margin: '0 auto',
+            background: 'linear-gradient(180deg,#cc4232 0%,#a42a1a 50%,#8a1e0e 100%)',
+            borderRadius: '0 0 22px 22px',
+            padding: '12px 16px 16px',
+            border: '2px solid #6a1a0a',
+            borderTop: 'none',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '10px' }}>
+            <div
+              style={{
+                width: '52px',
+                height: '52px',
+                borderRadius: '50%',
+                background: 'radial-gradient(circle at 36% 32%,#8ed060,#3c8a20)',
+                border: '3px solid #1c5a0a',
+                boxShadow: 'inset -5px -5px 10px rgba(0,0,0,.4),0 3px 8px rgba(0,0,0,.4)',
+              }}
+            />
+          </div>
+          <div
+            style={{
+              width: '58px',
+              height: '36px',
+              background: '#0b0a08',
+              borderRadius: '6px',
+              margin: '0 auto 8px',
+              border: '2px solid #3a2012',
+              boxShadow: 'inset 0 3px 7px rgba(0,0,0,.85)',
+            }}
+          />
+          <div style={{ display: 'flex', justifyContent: 'center', gap: '5px' }}>
+            {[0, 1, 2].map((index) => (
+              <span
+                key={index}
+                style={{
+                  width: '7px',
+                  height: '7px',
+                  borderRadius: '50%',
+                  background: index === 0 ? '#f5c518' : 'rgba(245,197,24,.4)',
+                  boxShadow: index === 0 ? '0 0 5px #f5c518' : 'none',
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <style>{`
+        @keyframes gachaRays { to { transform: rotate(360deg); } }
+        @keyframes gachaSparkle { 0%,100%{transform:translateY(0) scale(1);opacity:.35} 50%{transform:translateY(-7px) scale(1.35);opacity:1} }
+        @keyframes gachaLed { 0%,100%{opacity:.3} 50%{opacity:1} }
+        @keyframes gachaGlobe { to { transform: rotate(360deg); } }
+        @keyframes bb1{0%,100%{transform:translate(0,0)}33%{transform:translate(4px,-6px)}66%{transform:translate(-3px,4px)}}
+        @keyframes bb2{0%,100%{transform:translate(0,0)}40%{transform:translate(-5px,-4px)}70%{transform:translate(4px,6px)}}
+        @keyframes bb3{0%,100%{transform:translate(0,0)}35%{transform:translate(-4px,6px)}70%{transform:translate(6px,-5px)}}
+        @keyframes bb4{0%,100%{transform:translate(0,0)}50%{transform:translate(6px,-7px)}}
+        @keyframes bb5{0%,100%{transform:translate(0,0)}25%{transform:translate(-5px,5px)}75%{transform:translate(5px,-5px)}}
+        @keyframes bb6{0%,100%{transform:translate(0,0)}60%{transform:translate(6px,6px)}}
+      `}</style>
+    </div>
+  )
 }
 
 export default function RaffleDetailPage() {
   const { raffleId } = useParams()
+  const navigate = useNavigate()
   const { query: { data, isLoading, isError } } = useOne<Raffle>({
     resource: 'raffles',
     id: raffleId,
@@ -18,42 +460,153 @@ export default function RaffleDetailPage() {
   })
   const raffle = data?.data
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold text-foreground">抽獎控制頁</h1>
+  const [draws, setDraws] = useState<RaffleDraw[]>([])
+  const [csvResult, setCsvResult] = useState<{ imported: number; skipped: number } | null>(null)
+  const [exhausted, setExhausted] = useState(false)
+  const [drawing, setDrawing] = useState(false)
+  const [confirmEnd, setConfirmEnd] = useState(false)
+  const [ending, setEnding] = useState(false)
+  const [localCompleted, setLocalCompleted] = useState(false)
 
-      {isLoading ? (
-        <Skeleton className="h-32 w-full" />
-      ) : isError || !raffle ? (
-        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-          無法載入抽獎活動。
-        </div>
-      ) : (
-        <section className="space-y-3 rounded-lg border border-border bg-secondary/30 p-6">
+  const effectiveStatus = localCompleted ? 'completed' : (raffle?.status ?? '')
+
+  const fetchDraws = useCallback(async () => {
+    if (!raffleId) return
+    try {
+      const result = await listDraws(raffleId)
+      setDraws(result)
+    } catch {
+      setDraws([])
+    }
+  }, [raffleId])
+
+  useEffect(() => {
+    if (!raffleId) return
+    const initialLoadId = window.setTimeout(() => {
+      void fetchDraws()
+    }, 0)
+
+    if (effectiveStatus === 'completed') {
+      return () => window.clearTimeout(initialLoadId)
+    }
+
+    const timerId = window.setInterval(() => {
+      void fetchDraws()
+    }, 5000)
+
+    return () => {
+      window.clearTimeout(initialLoadId)
+      window.clearInterval(timerId)
+    }
+  }, [effectiveStatus, fetchDraws, raffleId])
+
+  async function handleDraw() {
+    if (!raffleId || drawing) return
+
+    setDrawing(true)
+    try {
+      await drawNext(raffleId)
+      await fetchDraws()
+      setExhausted(false)
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'response' in error) {
+        const response = (error as { response?: { status?: number } }).response
+        if (response?.status === 409) setExhausted(true)
+      }
+    } finally {
+      setDrawing(false)
+    }
+  }
+
+  async function handleConfirmEnd() {
+    if (!raffleId || ending) return
+
+    setEnding(true)
+    try {
+      await completeRaffle(raffleId)
+      setLocalCompleted(true)
+      setConfirmEnd(false)
+    } finally {
+      setEnding(false)
+    }
+  }
+
+  const entryCount = csvResult?.imported ?? null
+  const drawnCount = draws.length
+  const remaining = entryCount === null ? null : Math.max(entryCount - drawnCount, 0)
+
+  if (isLoading) {
+    return <Skeleton data-testid="skeleton" className="h-96 w-full" />
+  }
+
+  if (isError || !raffle) {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+        無法載入抽獎活動
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="min-h-screen space-y-4 px-5 py-6"
+      style={{ background: '#0b0a08', color: '#f0ebe0' }}
+    >
+      <button
+        onClick={() => navigate('/raffles')}
+        className="text-xs tracking-wide text-white/40 transition hover:text-white/70"
+      >
+        返回抽獎列表
+      </button>
+
+      <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[1fr_320px] lg:items-start">
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <h1
+              className="flex-1 text-2xl font-black"
+              style={{
+                background: 'linear-gradient(135deg,#f0e8d0,#f5c518)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+              }}
+            >
+              {raffle.title}
+            </h1>
+            <span className="mt-1 rounded-full border border-green-500/40 bg-green-500/10 px-3 py-0.5 text-[10px] tracking-wide text-green-400">
+              {statusLabel[effectiveStatus as RaffleStatus] ?? effectiveStatus}
+            </span>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2">
+            <StatCard label="匯入人數" value={entryCount?.toString() ?? '--'} colorClass="text-blue-400" />
+            <StatCard label="已抽出" value={drawnCount.toString()} colorClass="text-green-400" />
+            <StatCard label="剩餘" value={remaining?.toString() ?? '--'} colorClass="text-amber-400" />
+          </div>
+
+          <CsvUploadZone raffleId={raffle.id} onSuccess={(result) => { setCsvResult(result); setExhausted(false) }} />
+
+          <DrawControls
+            status={effectiveStatus}
+            exhausted={exhausted || remaining === 0}
+            drawing={drawing}
+            confirmEnd={confirmEnd}
+            ending={ending}
+            onDraw={() => { void handleDraw() }}
+            onRequestEnd={() => setConfirmEnd(true)}
+            onConfirmEnd={() => { void handleConfirmEnd() }}
+            onCancelEnd={() => setConfirmEnd(false)}
+          />
+
           <div>
-            <p className="text-sm text-muted-foreground">活動名稱</p>
-            <p className="text-xl font-semibold text-foreground">{raffle.title}</p>
+            <p className="mb-2 text-[10px] uppercase tracking-widest text-white/30">
+              得獎名單，共 {draws.length} 人
+            </p>
+            <WinnerList draws={draws} />
           </div>
-          <div className="grid gap-3 md:grid-cols-3">
-            <div>
-              <p className="text-sm text-muted-foreground">狀態</p>
-              <p className="font-medium text-foreground">{statusLabel[raffle.status] ?? raffle.status}</p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">建立時間</p>
-              <p className="font-medium text-foreground">
-                {new Date(raffle.created_at).toLocaleString('zh-TW')}
-              </p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">更新時間</p>
-              <p className="font-medium text-foreground">
-                {new Date(raffle.updated_at).toLocaleString('zh-TW')}
-              </p>
-            </div>
-          </div>
-        </section>
-      )}
+        </div>
+
+        <GachaMachine />
+      </div>
     </div>
   )
 }

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -249,25 +249,6 @@ function GachaMachine() {
           animation: 'gachaRays 22s linear infinite',
         }}
       />
-      {[
-        { top: '12px', left: '22px', fontSize: '13px', animationDelay: '0s' },
-        { top: '44px', right: '18px', fontSize: '10px', animationDelay: '0.9s' },
-        { bottom: '38px', left: '14px', fontSize: '11px', animationDelay: '1.8s' },
-        { bottom: '18px', right: '28px', fontSize: '18px', animationDelay: '0.4s' },
-      ].map((style, index) => (
-        <span
-          key={index}
-          style={{
-            position: 'absolute',
-            color: '#f5c518',
-            filter: 'drop-shadow(0 0 5px rgba(245,197,24,.4))',
-            animation: 'gachaSparkle 3s ease-in-out infinite',
-            ...style,
-          }}
-        >
-          *
-        </span>
-      ))}
       <div
         style={{
           position: 'relative',
@@ -356,7 +337,6 @@ function GachaMachine() {
               { width: 40, height: 40, background: 'linear-gradient(135deg,#5c5c9c,#3c3c7c)', top: 68, left: 106, animation: 'bb3 4.8s' },
               { width: 34, height: 34, background: 'linear-gradient(135deg,#9c6c3a,#7c4c1a)', top: 90, left: 14, animation: 'bb4 3.9s' },
               { width: 42, height: 42, background: 'linear-gradient(135deg,#7c4c7c,#5c2c5c)', top: 100, left: 62, animation: 'bb5 4.4s' },
-              { width: 30, height: 30, background: 'linear-gradient(135deg,#4c7c7c,#2c5c5c)', top: 50, left: 50, animation: 'bb6 3.3s' },
             ].map((ball, index) => (
               <div
                 key={index}
@@ -436,7 +416,6 @@ function GachaMachine() {
       </div>
       <style>{`
         @keyframes gachaRays { to { transform: rotate(360deg); } }
-        @keyframes gachaSparkle { 0%,100%{transform:translateY(0) scale(1);opacity:.35} 50%{transform:translateY(-7px) scale(1.35);opacity:1} }
         @keyframes gachaLed { 0%,100%{opacity:.3} 50%{opacity:1} }
         @keyframes gachaGlobe { to { transform: rotate(360deg); } }
         @keyframes bb1{0%,100%{transform:translate(0,0)}33%{transform:translate(4px,-6px)}66%{transform:translate(-3px,4px)}}
@@ -444,7 +423,6 @@ function GachaMachine() {
         @keyframes bb3{0%,100%{transform:translate(0,0)}35%{transform:translate(-4px,6px)}70%{transform:translate(6px,-5px)}}
         @keyframes bb4{0%,100%{transform:translate(0,0)}50%{transform:translate(6px,-7px)}}
         @keyframes bb5{0%,100%{transform:translate(0,0)}25%{transform:translate(-5px,5px)}75%{transform:translate(5px,-5px)}}
-        @keyframes bb6{0%,100%{transform:translate(0,0)}60%{transform:translate(6px,6px)}}
       `}</style>
     </div>
   )

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -461,7 +461,7 @@ export default function RaffleDetailPage() {
   const raffle = data?.data
 
   const [draws, setDraws] = useState<RaffleDraw[]>([])
-  const [csvResult, setCsvResult] = useState<{ imported: number; skipped: number } | null>(null)
+  const [totalEntries, setTotalEntries] = useState<number | null>(null)
   const [exhausted, setExhausted] = useState(false)
   const [drawing, setDrawing] = useState(false)
   const [confirmEnd, setConfirmEnd] = useState(false)
@@ -531,7 +531,7 @@ export default function RaffleDetailPage() {
     }
   }
 
-  const entryCount = csvResult?.imported ?? null
+  const entryCount = totalEntries
   const drawnCount = draws.length
   const remaining = entryCount === null ? null : Math.max(entryCount - drawnCount, 0)
 
@@ -583,7 +583,7 @@ export default function RaffleDetailPage() {
             <StatCard label="剩餘" value={remaining?.toString() ?? '--'} colorClass="text-amber-400" />
           </div>
 
-          <CsvUploadZone raffleId={raffle.id} onSuccess={(result) => { setCsvResult(result); setExhausted(false) }} />
+          <CsvUploadZone raffleId={raffle.id} onSuccess={(result) => { setTotalEntries(prev => (prev ?? 0) + result.imported); setExhausted(false) }} />
 
           <DrawControls
             status={effectiveStatus}

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -1,0 +1,281 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import type { BaseRecord } from '@refinedev/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import RaffleDetailPage from '@/pages/RaffleDetailPage'
+import * as rafflesService from '@/services/raffles'
+import { createMockDataProvider, RefineWrapper, waitFor } from '@/test/refine-wrapper'
+
+vi.mock('@/services/raffles', async (importOriginal) => {
+  const actual = await importOriginal<typeof rafflesService>()
+  return {
+    ...actual,
+    listDraws: vi.fn().mockResolvedValue([]),
+    drawNext: vi.fn().mockResolvedValue({}),
+    importCSV: vi.fn().mockResolvedValue({ imported: 0, skipped: 0 }),
+    completeRaffle: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+const mockRaffle = {
+  id: 'r1',
+  user_id: 'u1',
+  title: '春季抽獎',
+  status: 'active' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+const mockDraw: rafflesService.RaffleDraw = {
+  id: 'd1',
+  raffle_id: 'r1',
+  entry_id: 'e1',
+  claim_token: 'tok',
+  claim_expires_at: '2026-12-31T00:00:00Z',
+  drawn_at: new Date().toISOString(),
+  entry: {
+    id: 'e1',
+    raffle_id: 'r1',
+    twitch_login: 'viewer1',
+    display_name: 'Viewer One',
+    created_at: '',
+  },
+}
+async function renderAt(raffleId: string, dp: ReturnType<typeof createMockDataProvider>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(
+      <RefineWrapper dataProvider={dp}>
+        <MemoryRouter initialEntries={[`/raffles/${raffleId}`]}>
+          <Routes>
+            <Route path="/raffles/:raffleId" element={<RaffleDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </RefineWrapper>,
+    )
+  })
+  return { container, root }
+}
+function cleanup(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+}
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.mocked(rafflesService.listDraws).mockResolvedValue([])
+  vi.mocked(rafflesService.drawNext).mockResolvedValue(mockDraw)
+  vi.mocked(rafflesService.importCSV).mockResolvedValue({ imported: 0, skipped: 0 })
+  vi.mocked(rafflesService.completeRaffle).mockResolvedValue(undefined)
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('RaffleDetailPage — loading & raffle display', () => {
+  it('shows skeleton while loading', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockReturnValue(new Promise(() => {})) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    expect(container.querySelector('[data-testid="skeleton"]')).toBeTruthy()
+    cleanup(root, container)
+  })
+  it('displays raffle title and status after load', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
+    expect(container.textContent).toContain('進行中')
+    cleanup(root, container)
+  })
+
+  it('shows error when raffle fails to load', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockRejectedValue(new Error('boom')) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('無法載入抽獎活動'))
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — winner list', () => {
+  it('shows empty state when no draws', async () => {
+    vi.mocked(rafflesService.listDraws).mockResolvedValue([])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="empty-winners"]')).toBeTruthy())
+    cleanup(root, container)
+  })
+
+  it('renders winner display_name', async () => {
+    vi.mocked(rafflesService.listDraws).mockResolvedValue([mockDraw])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('Viewer One'))
+    cleanup(root, container)
+  })
+
+  it('falls back to twitch_login when display_name is empty', async () => {
+    const draw = { ...mockDraw, entry: { ...mockDraw.entry, display_name: '' } }
+    vi.mocked(rafflesService.listDraws).mockResolvedValue([draw])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('viewer1'))
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — CSV upload', () => {
+  it('shows success message after upload', async () => {
+    vi.mocked(rafflesService.importCSV).mockResolvedValue({ imported: 50, skipped: 2 })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="csv-input"]')).toBeTruthy())
+
+    const input = container.querySelector('[data-testid="csv-input"]') as HTMLInputElement
+    const file = new File(['login\n'], 'test.csv', { type: 'text/csv' })
+    Object.defineProperty(input, 'files', { value: [file], configurable: true })
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    await waitFor(() => {
+      const el = container.querySelector('[data-testid="csv-success"]')
+      expect(el?.textContent).toContain('50 人')
+      expect(el?.textContent).toContain('略過 2 人')
+    })
+    cleanup(root, container)
+  })
+
+  it('shows error message when upload fails', async () => {
+    vi.mocked(rafflesService.importCSV).mockRejectedValue(new Error('network'))
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="csv-input"]')).toBeTruthy())
+
+    const input = container.querySelector('[data-testid="csv-input"]') as HTMLInputElement
+    const file = new File(['login\n'], 'bad.csv', { type: 'text/csv' })
+    Object.defineProperty(input, 'files', { value: [file], configurable: true })
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    await waitFor(() => expect(container.querySelector('[data-testid="csv-error"]')?.textContent).toContain('上傳失敗'))
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — draw button', () => {
+  it('calls drawNext when clicked', async () => {
+    const drawMock = vi.mocked(rafflesService.drawNext).mockResolvedValue(mockDraw)
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="draw-btn"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="draw-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(drawMock).toHaveBeenCalledWith('r1'))
+    cleanup(root, container)
+  })
+
+  it('disables draw button after 409 exhausted response', async () => {
+    vi.mocked(rafflesService.drawNext).mockRejectedValue({ response: { status: 409 } })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="draw-btn"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="draw-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => {
+      expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(true)
+    })
+    cleanup(root, container)
+  })
+
+  it('disables draw button when raffle is completed', async () => {
+    const completedRaffle = { ...mockRaffle, status: 'completed' as const }
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(completedRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
+    expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(true)
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — end activity', () => {
+  it('shows confirm dialog when end button clicked', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="end-btn"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="end-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(container.querySelector('[data-testid="confirm-end"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="end-btn"]')).toBeFalsy()
+    cleanup(root, container)
+  })
+
+  it('cancels confirm dialog on 取消', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="end-btn"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="end-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {
+      container.querySelector('[data-testid="confirm-no"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(container.querySelector('[data-testid="confirm-end"]')).toBeFalsy()
+    expect(container.querySelector('[data-testid="end-btn"]')).toBeTruthy()
+    cleanup(root, container)
+  })
+
+  it('calls completeRaffle and hides end button after confirm', async () => {
+    const completeMock = vi.mocked(rafflesService.completeRaffle).mockResolvedValue(undefined)
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="end-btn"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="end-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {
+      container.querySelector('[data-testid="confirm-yes"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(completeMock).toHaveBeenCalledWith('r1'))
+    await waitFor(() => expect(container.querySelector('[data-testid="end-btn"]')).toBeFalsy())
+    expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(true)
+    cleanup(root, container)
+  })
+})

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -223,6 +223,37 @@ describe('RaffleDetailPage — draw button', () => {
     expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(true)
     cleanup(root, container)
   })
+
+  it('re-enables draw button after re-importing new entries when all previous draws are exhausted', async () => {
+    vi.mocked(rafflesService.listDraws).mockResolvedValue([mockDraw, { ...mockDraw, id: 'd2' }, { ...mockDraw, id: 'd3' }])
+    vi.mocked(rafflesService.importCSV).mockResolvedValue({ imported: 3, skipped: 0 })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="csv-input"]')).toBeTruthy())
+
+    const input = container.querySelector('[data-testid="csv-input"]') as HTMLInputElement
+    const file = new File(['login\n'], 'first.csv', { type: 'text/csv' })
+    Object.defineProperty(input, 'files', { value: [file], configurable: true })
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    await waitFor(() => {
+      expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    vi.mocked(rafflesService.importCSV).mockResolvedValue({ imported: 2, skipped: 0 })
+    const file2 = new File(['login2\n'], 'second.csv', { type: 'text/csv' })
+    Object.defineProperty(input, 'files', { value: [file2], configurable: true })
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    await waitFor(() => {
+      expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(false)
+    })
+    cleanup(root, container)
+  })
 })
 
 describe('RaffleDetailPage — end activity', () => {

--- a/apps/dashboard/src/services/__tests__/raffles.test.ts
+++ b/apps/dashboard/src/services/__tests__/raffles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listRaffles, createRaffle } from '@/services/raffles'
+import { listRaffles, createRaffle, listDraws, drawNext, importCSV, completeRaffle } from '@/services/raffles'
 
 const getMock = vi.fn()
 const postMock = vi.fn()
@@ -24,5 +24,50 @@ describe('createRaffle', () => {
     postMock.mockResolvedValue({ data: { success: true, data: { raffle: mockRaffle } } })
     expect(await createRaffle('Test')).toEqual(mockRaffle)
     expect(postMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles', { title: 'Test' })
+  })
+})
+
+const mockDraw = {
+  id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+  claim_token: 'tok', claim_expires_at: '2026-12-31T00:00:00Z',
+  drawn_at: '2026-01-01T10:00:00Z',
+  entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+}
+
+describe('listDraws', () => {
+  it('fetches draws for a raffle', async () => {
+    getMock.mockResolvedValue({ data: { success: true, data: { draws: [mockDraw] } } })
+    const result = await listDraws('r1')
+    expect(result).toEqual([mockDraw])
+    expect(getMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/draws')
+  })
+})
+
+describe('drawNext', () => {
+  it('posts to draw endpoint and returns draw', async () => {
+    postMock.mockResolvedValue({ data: { success: true, data: { draw: mockDraw } } })
+    const result = await drawNext('r1')
+    expect(result).toEqual(mockDraw)
+    expect(postMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/draws', undefined)
+  })
+})
+
+describe('importCSV', () => {
+  it('posts FormData and returns imported/skipped counts', async () => {
+    postMock.mockResolvedValue({ data: { success: true, data: { imported: 10, skipped: 2 } } })
+    const file = new File(['login\n'], 'test.csv', { type: 'text/csv' })
+    const result = await importCSV('r1', file)
+    expect(result).toEqual({ imported: 10, skipped: 2 })
+    const [url, body] = postMock.mock.calls[0]
+    expect(url).toBe('/api/v1/dashboard/raffles/r1/entries/import-csv')
+    expect(body).toBeInstanceOf(FormData)
+  })
+})
+
+describe('completeRaffle', () => {
+  it('posts to complete endpoint', async () => {
+    postMock.mockResolvedValue({ data: { success: true, data: {} } })
+    await completeRaffle('r1')
+    expect(postMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/complete', undefined)
   })
 })

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -46,3 +46,37 @@ export async function createRaffle(title: string): Promise<Raffle> {
   return data.data.raffle
 }
 
+export async function listDraws(raffleId: string): Promise<RaffleDraw[]> {
+  const { data } = await client.get<ApiResponse<{ draws: RaffleDraw[] }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/draws`,
+  )
+  return data.data.draws
+}
+
+export async function drawNext(raffleId: string): Promise<RaffleDraw> {
+  const { data } = await client.post<ApiResponse<{ draw: RaffleDraw }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/draws`,
+    undefined,
+  )
+  return data.data.draw
+}
+
+export async function importCSV(
+  raffleId: string,
+  file: File,
+): Promise<{ imported: number; skipped: number }> {
+  const form = new FormData()
+  form.append('file', file)
+  const { data } = await client.post<ApiResponse<{ imported: number; skipped: number }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/entries/import-csv`,
+    form,
+  )
+  return data.data
+}
+
+export async function completeRaffle(raffleId: string): Promise<void> {
+  await client.post(
+    `/api/v1/dashboard/raffles/${raffleId}/complete`,
+    undefined,
+  )
+}


### PR DESCRIPTION
## 什麼改動
- `RaffleDetailPage.tsx` 從 stub 完整實作：WinnerList、CsvUploadZone、DrawControls、GachaMachine 扭蛋機視覺元件
- `RaffleDetailPage.test.tsx` 新增，14 tests（loading、winner list、CSV upload、draw button、end activity）
- `services/raffles.ts` 新增 `listDraws`、`drawNext`、`importCSV`、`completeRaffle` 四個 API 函式
- `services/__tests__/raffles.test.ts` 補對應 service tests

## 為什麼
closes #232

實況主可完整跑完「建立 → 上傳 CSV → 抽獎 → 看到結果」主流程。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#232
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 source / 領獎期限欄位（後端 Create API 尚不支援，另開 issue）
  - 不做 Phase 2 Campaign 多場抽獎（#234）
  - 不做 Twitch API snapshot 介面

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 補完 Dashboard 抽獎控制頁，讓實況主可完整操作 CSV 上傳、抽獎、結束活動
- Approx changed lines：~1000（超過 400 行說明如下）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - frontend page 與其測試是不可分割的單元；service 函式是 page 的直接依賴。GachaMachine 元件的 inline CSS 動畫使行數顯著膨脹（約 +250 行純視覺樣式），是行數超標的主因。功能上仍是單一 cohesive feature。
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] 抽獎活動列表頁 `/dashboard/raffles`（PR #336 已 merge）
- [x] CSV 上傳介面（drag & drop + file picker）
- [x] 抽獎控制頁 `/dashboard/raffles/:id`：顯示參賽人數、中獎名單、「抽下一名」按鈕
- [x] 每次抽出後即時更新中獎名單（polling 5s）
- [x] 結束活動按鈕（含 confirm dialog）
- [x] 「抽下一名」按鈕在無剩餘參賽者時 disable

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
cd apps/dashboard && npx vitest run
Test Files  12 passed (12)
Tests       86 passed (86)
```

## 備註
行數超過 1000 行門檻，主要膨脹來源是 GachaMachine component 的 inline CSS keyframe 動畫（約 250 行純視覺樣式）。功能邏輯本身（service + page + tests）在合理範圍內。

## Notes for Claude Code Review
- `GachaMachine` 是純視覺裝飾，無 props、無狀態、無測試，可以忽略功能審查
- `effectiveStatus` 用 local state 覆蓋 raffle.status（結束後不需 refetch）
- Draws polling 在 `status === 'completed'` 後停止，避免無謂請求
- 參賽人數僅從最近一次 CSV import 的 session state 取得（刷頁後歸零顯示 `—`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 抽奖详情页升级为完整交互式界面：实时获奖者列表、状态卡片与抽奖面板
  * 支持 CSV 导入（拖拽、点击/键盘选择），并显示导入统计
  * 手动抽奖、抽尽处理与活动结束确认流程

* **测试**
  * 为抽奖详情页和相关服务新增覆盖 UI、导入、抽奖与完成流程的测试用例
<!-- end of auto-generated comment: release notes by coderabbit.ai -->