### PR TITLE
[backend] Backend security scanner CI

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -204,6 +204,7 @@ async function runCiScopeGateWorkflow({ eventName = 'pull_request', prOverrides 
   }
   const context = {
     repo: { owner: 'nurockplayer', repo: 'tachigo' },
+    eventName,
     payload: eventName === 'pull_request' ? { pull_request: pr } : {},
   }
 
@@ -655,7 +656,34 @@ test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
     run_ci: 'true',
     run_backend: 'false',
     run_backend_integration: 'false',
+    run_backend_scanners: 'false',
     run_frontend: 'true',
+    run_dashboard: 'false',
+    run_contracts: 'false',
+  })
+})
+
+test('scope gate emits backend scanner outputs for backend PRs and scheduled scans', async () => {
+  const backendPr = await runCiScopeGateWorkflow({
+    files: [{ filename: 'services/api/internal/services/watch_service.go', additions: 3, deletions: 1, status: 'modified' }],
+  })
+  const scheduled = await runCiScopeGateWorkflow({ eventName: 'schedule' })
+
+  assert.deepEqual(backendPr.outputs, {
+    run_ci: 'true',
+    run_backend: 'true',
+    run_backend_integration: 'true',
+    run_backend_scanners: 'true',
+    run_frontend: 'false',
+    run_dashboard: 'false',
+    run_contracts: 'false',
+  })
+  assert.deepEqual(scheduled.outputs, {
+    run_ci: 'true',
+    run_backend: 'false',
+    run_backend_integration: 'false',
+    run_backend_scanners: 'true',
+    run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
   })
@@ -690,6 +718,7 @@ Backend contract already in develop:
     run_ci: 'true',
     run_backend: 'true',
     run_backend_integration: 'true',
+    run_backend_scanners: 'true',
     run_frontend: 'true',
     run_dashboard: 'true',
     run_contracts: 'true',
@@ -708,6 +737,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   const backend = workflowJobBlock(workflow, 'backend')
   const atlas = workflowJobBlock(workflow, 'atlas-migration-tooling')
   const backendIntegration = workflowJobBlock(workflow, 'backend-integration')
+  const backendSecurityScanners = workflowJobBlock(workflow, 'backend-security-scanners')
   const frontend = workflowJobBlock(workflow, 'frontend')
   const dashboard = workflowJobBlock(workflow, 'dashboard')
   const contracts = workflowJobBlock(workflow, 'contracts')
@@ -716,9 +746,37 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   assert.match(backend, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
   assert.match(atlas, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
   assert.match(backendIntegration, /needs\.scope-gate\.outputs\.run_backend_integration == 'true'/)
+  assert.match(backendSecurityScanners, /needs\.scope-gate\.outputs\.run_backend_scanners == 'true'/)
   assert.match(frontend, /needs\.scope-gate\.outputs\.run_frontend == 'true'/)
   assert.match(dashboard, /needs\.scope-gate\.outputs\.run_dashboard == 'true'/)
   assert.match(contracts, /needs\.scope-gate\.outputs\.run_contracts == 'true'/)
+})
+
+test('backend security scanner job installs pinned staticcheck and govulncheck', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
+  const job = parsedWorkflow.jobs['backend-security-scanners']
+  const jobBlock = workflowJobBlock(workflow, 'backend-security-scanners')
+  const backendCi = parsedWorkflow.jobs['backend-ci']
+  const backendCiBlock = workflowJobBlock(workflow, 'backend-ci')
+
+  assert.deepEqual(parsedWorkflow.on.schedule, [{ cron: '17 2 * * 1' }])
+  assert.equal(job.name, 'Backend security scanners')
+  assert.equal(job.env.STATICCHECK_VERSION, 'v0.7.0')
+  assert.equal(job.env.GOVULNCHECK_VERSION, 'v1.3.0')
+  assert.match(jobBlock, /go-version: 1\.25\.9/)
+  assert.match(jobBlock, /go install honnef\.co\/go\/tools\/cmd\/staticcheck@\$STATICCHECK_VERSION/)
+  assert.match(jobBlock, /go install golang\.org\/x\/vuln\/cmd\/govulncheck@\$GOVULNCHECK_VERSION/)
+  assert.match(jobBlock, /working-directory: services\/api\n\s+run: staticcheck \.\/\.\.\./)
+  assert.match(jobBlock, /working-directory: services\/api\n\s+run: govulncheck \.\/\.\.\./)
+  assert.deepEqual(backendCi.needs, [
+    'backend-build',
+    'backend',
+    'backend-integration',
+    'backend-security-scanners',
+  ])
+  assert.match(backendCiBlock, /BACKEND_SECURITY_SCANNERS_RESULT/)
+  assert.match(backendCiBlock, /backend-security-scanners:\$BACKEND_SECURITY_SCANNERS_RESULT/)
 })
 
 test('global auto-merge workflow excludes Dependabot PRs', async () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  schedule:
+    - cron: "17 2 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -27,6 +29,7 @@ jobs:
       run_ci: ${{ steps.evaluate.outputs.run_ci }}
       run_backend: ${{ steps.evaluate.outputs.run_backend }}
       run_backend_integration: ${{ steps.evaluate.outputs.run_backend_integration }}
+      run_backend_scanners: ${{ steps.evaluate.outputs.run_backend_scanners }}
       run_frontend: ${{ steps.evaluate.outputs.run_frontend }}
       run_dashboard: ${{ steps.evaluate.outputs.run_dashboard }}
       run_contracts: ${{ steps.evaluate.outputs.run_contracts }}
@@ -40,6 +43,7 @@ jobs:
               runCi,
               runBackend,
               runBackendIntegration,
+              runBackendScanners,
               runFrontend,
               runDashboard,
               runContracts,
@@ -47,6 +51,7 @@ jobs:
               core.setOutput('run_ci', runCi ? 'true' : 'false')
               core.setOutput('run_backend', runBackend ? 'true' : 'false')
               core.setOutput('run_backend_integration', runBackendIntegration ? 'true' : 'false')
+              core.setOutput('run_backend_scanners', runBackendScanners ? 'true' : 'false')
               core.setOutput('run_frontend', runFrontend ? 'true' : 'false')
               core.setOutput('run_dashboard', runDashboard ? 'true' : 'false')
               core.setOutput('run_contracts', runContracts ? 'true' : 'false')
@@ -55,6 +60,7 @@ jobs:
               runCi: true,
               runBackend: true,
               runBackendIntegration: true,
+              runBackendScanners: true,
               runFrontend: true,
               runDashboard: true,
               runContracts: true,
@@ -63,6 +69,7 @@ jobs:
               runCi: false,
               runBackend: false,
               runBackendIntegration: false,
+              runBackendScanners: false,
               runFrontend: false,
               runDashboard: false,
               runContracts: false,
@@ -70,6 +77,19 @@ jobs:
 
             const pr = context.payload.pull_request
             if (!pr) {
+              if (context.eventName === 'schedule') {
+                core.notice('Scheduled backend scanner run detected; running backend scanners only.')
+                setCiOutputs({
+                  runCi: true,
+                  runBackend: false,
+                  runBackendIntegration: false,
+                  runBackendScanners: true,
+                  runFrontend: false,
+                  runDashboard: false,
+                  runContracts: false,
+                })
+                return
+              }
               core.notice('Non-PR event detected; running CI without scope gate restrictions.')
               setFullCiOutputs()
               return
@@ -220,6 +240,7 @@ jobs:
             const runFrontend = runFullCi || (runCi && (touches.extension || touchesFrontendWorkspace || touchesDockerCompose))
             const runDashboard = runFullCi || (runCi && (touches.dashboard || touchesFrontendWorkspace || touchesDockerCompose))
             const runContracts = runFullCi || (runCi && touches.contracts)
+            const runBackendScanners = runFullCi || (runCi && (touches.backend || touchesDockerCompose))
             const runBackendIntegration = allFilePaths.some((name) =>
               backendIntegrationPaths.some((pattern) => pattern.test(name)),
             )
@@ -230,6 +251,7 @@ jobs:
                 runCi,
                 runBackend,
                 runBackendIntegration: shouldRunBackendIntegration,
+                runBackendScanners,
                 runFrontend,
                 runDashboard,
                 runContracts,
@@ -425,6 +447,39 @@ jobs:
         working-directory: services/api
         run: go test -tags integration -v ./... -count=1
 
+  backend-security-scanners:
+    timeout-minutes: 10
+    name: Backend security scanners
+    needs: [scope-gate]
+    if: needs.scope-gate.outputs.run_backend_scanners == 'true'
+    runs-on: ubuntu-latest
+    env:
+      STATICCHECK_VERSION: v0.7.0
+      GOVULNCHECK_VERSION: v1.3.0
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.25.9
+
+      - name: Install scanner tools
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@$STATICCHECK_VERSION
+          go install golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION
+
+      - name: Add Go tools to PATH
+        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Run staticcheck
+        working-directory: services/api
+        run: staticcheck ./...
+
+      - name: Run govulncheck
+        working-directory: services/api
+        run: govulncheck ./...
+
   frontend:
     timeout-minutes: 15
     name: Frontend build
@@ -503,7 +558,7 @@ jobs:
   backend-ci:
     timeout-minutes: 5
     name: Backend CI (gate)
-    needs: [backend-build, backend, backend-integration]
+    needs: [backend-build, backend, backend-integration, backend-security-scanners]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -512,11 +567,13 @@ jobs:
           BACKEND_BUILD_RESULT: ${{ needs.backend-build.result }}
           BACKEND_RESULT: ${{ needs.backend.result }}
           BACKEND_INTEGRATION_RESULT: ${{ needs.backend-integration.result }}
+          BACKEND_SECURITY_SCANNERS_RESULT: ${{ needs.backend-security-scanners.result }}
         run: |
           for item in \
             "backend-build:$BACKEND_BUILD_RESULT" \
             "backend:$BACKEND_RESULT" \
-            "backend-integration:$BACKEND_INTEGRATION_RESULT"
+            "backend-integration:$BACKEND_INTEGRATION_RESULT" \
+            "backend-security-scanners:$BACKEND_SECURITY_SCANNERS_RESULT"
           do
             job="${item%%:*}"
             result="${item#*:}"

--- a/services/api/internal/handlers/streamer_handler_test.go
+++ b/services/api/internal/handlers/streamer_handler_test.go
@@ -239,7 +239,7 @@ func TestGetChannelStats_ForbiddenForOtherStreamer(t *testing.T) {
 	dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers/register", tokenA, `{"channel_id":"ch_A"}`)
 
 	// Streamer B — registered with a different email.
-	_, tokenB := env.registerUser(t, "streamer_b", "streamer_b@example.com", "password123")
+	_, _ = env.registerUser(t, "streamer_b", "streamer_b@example.com", "password123")
 	if err := env.db.Exec(`UPDATE users SET role = 'streamer' WHERE email = 'streamer_b@example.com'`).Error; err != nil {
 		t.Fatalf("set role: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestGetChannelStats_ForbiddenForOtherStreamer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("login streamer_b: %v", err)
 	}
-	tokenB = tokens.AccessToken
+	tokenB := tokens.AccessToken
 
 	w := dashboardRequest(t, env.router, http.MethodGet, "/api/v1/dashboard/channels/ch_A/stats", tokenB, "")
 	if w.Code != http.StatusForbidden {


### PR DESCRIPTION
## 什麼改動
- 在 CI scope gate 新增 `run_backend_scanners` 輸出，backend 相關 PR / full CI 會執行 backend scanner。
- 新增 weekly schedule（週一 02:17 UTC）觸發 backend scanner baseline。
- 新增 `backend-security-scanners` job，使用 pinned `staticcheck` / `govulncheck`，並由既有 `Backend CI (gate)` 彙總阻擋。
- 更新 workflow regression tests，固定 scanner 觸發條件與 job wiring。
- 修正一個既有 test unused assignment，讓 `staticcheck ./...` baseline clean。

## 為什麼
closes #504

#210 評估後建議 backend 第一階段導入 `staticcheck ./...` 與 `govulncheck ./...`，並讓 `govulncheck` 有 scheduled run 捕捉新揭露漏洞。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#504
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不導入 frontend / contracts scanner
  - 不修改 branch protection required checks；scanner 透過既有 `Backend CI (gate)` 阻擋
  - 不建立 blanket waiver

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 將 backend `staticcheck` / `govulncheck` 以 pinned tooling 導入 CI 與 weekly scan。
- Approx changed lines：~123
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] backend scanner job 在 `services/api` 變更 PR 會跑
- [x] `push` to `develop` / release PR 會跑 backend scanners
- [x] `staticcheck` baseline clean
- [x] `govulncheck` baseline clean
- [x] weekly scheduled run 會執行 backend scanners
- [x] workflow regression tests 固定 scanner 觸發條件

## 超出範圍內容
無；`streamer_handler_test.go` 的 token 宣告整理是 `staticcheck` baseline clean 所需。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
tests 38, pass 38, fail 0

GOTOOLCHAIN=go1.25.9 PATH=/tmp/tachigo-go-tools-1259:$PATH staticcheck ./...
exit 0

GOTOOLCHAIN=go1.25.9 PATH=/tmp/tachigo-go-tools-1259:$PATH govulncheck ./...
Your code is affected by 0 vulnerabilities.

GOTOOLCHAIN=go1.25.9 go test ./...
all packages passed

GOTOOLCHAIN=go1.25.9 go vet ./...
exit 0
```

## 備註
Scanner job 明確 pin Go `1.25.9`，因為 `govulncheck` 會把 scanner toolchain 的 Go standard library 納入結果；`go1.25.0` 與本機 `go1.26.1` 會回報已由 `go1.25.9` / `go1.26.2` 修正的標準函式庫漏洞。這裡維持 backend 目前 Go minor，僅用安全 patch 避免 baseline 一開始就被 vulnerable runtime 擋住。

## Notes for Claude Code Review
- 請特別看 `run_backend_scanners` 的 scope gate 條件：backend / docker compose / full CI / schedule 會跑，frontend-only 不跑。
- Branch protection required checks 沒有新增 context；scanner failure 會由既有 `Backend CI (gate)` 反映。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 后端安全扫描器现已集成至 CI/CD 流程，自动运行代码质量检查工具。

## 错误修复
* 修复了权限变更后的身份验证令牌验证问题。

## 测试
* 为新的后端安全扫描功能添加了覆盖测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->