### PR TITLE
[infra] Frontend dependency review gate

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -14,6 +14,7 @@ const autoReadyWorkflowPath = path.join(currentDir, 'auto-ready-pr.yml')
 const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rerequest.yml')
 const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-on-develop-merge.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
+const dependabotPolicyPath = path.join(repoRoot, 'docs', 'dependabot-update-policy.md')
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 const developRequiredCheckRuns = [
   'Scope gate',
@@ -154,6 +155,7 @@ async function runCiAutoReadyAfterCiWorkflow({
     env: {
       SCOPE_GATE_RESULT: 'success',
       BACKEND_CI_RESULT: 'success',
+      DEPENDENCY_REVIEW_RESULT: 'success',
       FRONTEND_RESULT: 'success',
       DASHBOARD_RESULT: 'success',
       CONTRACTS_RESULT: 'success',
@@ -657,10 +659,27 @@ test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
     run_backend: 'false',
     run_backend_integration: 'false',
     run_backend_scanners: 'false',
+    run_dependency_review: 'false',
     run_frontend: 'true',
     run_dashboard: 'false',
     run_contracts: 'false',
   })
+})
+
+test('scope gate emits dependency review output only for dependency file PRs', async () => {
+  const extensionLockfile = await runCiScopeGateWorkflow({
+    files: [{ filename: 'apps/extension/pnpm-lock.yaml', additions: 9, deletions: 2, status: 'modified' }],
+  })
+  const rootWorkspace = await runCiScopeGateWorkflow({
+    files: [{ filename: 'pnpm-workspace.yaml', additions: 1, deletions: 1, status: 'modified' }],
+  })
+  const frontendSource = await runCiScopeGateWorkflow({
+    files: [{ filename: 'apps/extension/src/App.tsx', additions: 9, deletions: 2, status: 'modified' }],
+  })
+
+  assert.equal(extensionLockfile.outputs.run_dependency_review, 'true')
+  assert.equal(rootWorkspace.outputs.run_dependency_review, 'true')
+  assert.equal(frontendSource.outputs.run_dependency_review, 'false')
 })
 
 test('scope gate emits backend scanner outputs for backend PRs and scheduled scans', async () => {
@@ -674,6 +693,7 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
     run_backend: 'true',
     run_backend_integration: 'true',
     run_backend_scanners: 'true',
+    run_dependency_review: 'false',
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
@@ -683,6 +703,7 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
     run_backend: 'false',
     run_backend_integration: 'false',
     run_backend_scanners: 'true',
+    run_dependency_review: 'false',
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
@@ -719,6 +740,7 @@ Backend contract already in develop:
     run_backend: 'true',
     run_backend_integration: 'true',
     run_backend_scanners: 'true',
+    run_dependency_review: 'false',
     run_frontend: 'true',
     run_dashboard: 'true',
     run_contracts: 'true',
@@ -738,6 +760,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   const atlas = workflowJobBlock(workflow, 'atlas-migration-tooling')
   const backendIntegration = workflowJobBlock(workflow, 'backend-integration')
   const backendSecurityScanners = workflowJobBlock(workflow, 'backend-security-scanners')
+  const dependencyReview = workflowJobBlock(workflow, 'dependency-review')
   const frontend = workflowJobBlock(workflow, 'frontend')
   const dashboard = workflowJobBlock(workflow, 'dashboard')
   const contracts = workflowJobBlock(workflow, 'contracts')
@@ -747,6 +770,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   assert.match(atlas, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
   assert.match(backendIntegration, /needs\.scope-gate\.outputs\.run_backend_integration == 'true'/)
   assert.match(backendSecurityScanners, /needs\.scope-gate\.outputs\.run_backend_scanners == 'true'/)
+  assert.match(dependencyReview, /needs\.scope-gate\.outputs\.run_dependency_review == 'true'/)
   assert.match(frontend, /needs\.scope-gate\.outputs\.run_frontend == 'true'/)
   assert.match(dashboard, /needs\.scope-gate\.outputs\.run_dashboard == 'true'/)
   assert.match(contracts, /needs\.scope-gate\.outputs\.run_contracts == 'true'/)
@@ -777,6 +801,38 @@ test('backend security scanner job installs pinned staticcheck and govulncheck',
   ])
   assert.match(backendCiBlock, /BACKEND_SECURITY_SCANNERS_RESULT/)
   assert.match(backendCiBlock, /backend-security-scanners:\$BACKEND_SECURITY_SCANNERS_RESULT/)
+})
+
+test('dependency review CI job gates only frontend dependency files', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
+  const job = parsedWorkflow.jobs['dependency-review']
+  const jobBlock = workflowJobBlock(workflow, 'dependency-review')
+
+  assert.equal(job.name, 'Dependency Review')
+  assert.equal(job['timeout-minutes'], 10)
+  assert.equal(job.needs, 'scope-gate')
+  assert.equal(job.if, "github.event_name == 'pull_request' && needs.scope-gate.outputs.run_dependency_review == 'true'")
+  assert.match(jobBlock, /uses: actions\/checkout@v4/)
+  assert.match(jobBlock, /uses: actions\/dependency-review-action@v4/)
+  assert.match(jobBlock, /fail-on-severity: high/)
+  assert.match(jobBlock, /fail-on-scopes: runtime/)
+  assert.match(jobBlock, /vulnerability-check: true/)
+  assert.match(jobBlock, /license-check: false/)
+  assert.match(jobBlock, /comment-summary-in-pr: never/)
+  assert.match(jobBlock, /show-openssf-scorecard: false/)
+})
+
+test('dependency review policy documents Dependabot split and waiver handling', async () => {
+  const policy = await readFile(dependabotPolicyPath, 'utf8')
+
+  assert.match(policy, /Dependency Review Gate/)
+  assert.match(policy, /high\/critical production dependency vulnerabilities/)
+  assert.match(policy, /development dependency findings are report-only/)
+  assert.match(policy, /Dependabot opens routine version and security update PRs/)
+  assert.match(policy, /False Positives And Waivers/)
+  assert.match(policy, /Owner:/)
+  assert.match(policy, /Expires on:/)
 })
 
 test('global auto-merge workflow excludes Dependabot PRs', async () => {
@@ -944,7 +1000,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
 
   assert.equal(job.name, 'Auto-ready draft PR after CI')
   assert.equal(job.if, "always() && github.event_name == 'pull_request'")
-  assert.deepEqual(job.needs, ['scope-gate', 'backend-ci', 'frontend', 'dashboard', 'contracts'])
+  assert.deepEqual(job.needs, ['scope-gate', 'backend-ci', 'dependency-review', 'frontend', 'dashboard', 'contracts'])
   assert.equal(job.permissions['pull-requests'], 'write')
   assert.equal(job.permissions.contents, 'write')
   assert.equal(job.permissions.issues, 'write')
@@ -957,6 +1013,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /const successConclusions = new Set\(\['success', 'neutral', 'skipped'\]\)/)
   assert.match(jobBlock, /SCOPE_GATE_RESULT/)
   assert.match(jobBlock, /BACKEND_CI_RESULT/)
+  assert.match(jobBlock, /DEPENDENCY_REVIEW_RESULT/)
   assert.match(jobBlock, /FRONTEND_RESULT/)
   assert.match(jobBlock, /DASHBOARD_RESULT/)
   assert.match(jobBlock, /CONTRACTS_RESULT/)
@@ -1019,6 +1076,16 @@ test('CI auto-ready job retries auto-merge for already-ready auto-ready PRs', as
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
   ])
+})
+
+test('CI auto-ready job waits when dependency review fails', async () => {
+  const result = await runCiAutoReadyAfterCiWorkflow({
+    env: { DEPENDENCY_REVIEW_RESULT: 'failure' },
+    checkRuns: successfulDevelopRequiredCheckRuns(),
+  })
+
+  assert.deepEqual(result.graphqlCalls, [])
+  assert.deepEqual(result.labelsAdded, [])
 })
 
 test('auto-ready workflow arms native auto-merge after marking a PR ready', async () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       run_backend: ${{ steps.evaluate.outputs.run_backend }}
       run_backend_integration: ${{ steps.evaluate.outputs.run_backend_integration }}
       run_backend_scanners: ${{ steps.evaluate.outputs.run_backend_scanners }}
+      run_dependency_review: ${{ steps.evaluate.outputs.run_dependency_review }}
       run_frontend: ${{ steps.evaluate.outputs.run_frontend }}
       run_dashboard: ${{ steps.evaluate.outputs.run_dashboard }}
       run_contracts: ${{ steps.evaluate.outputs.run_contracts }}
@@ -44,6 +45,7 @@ jobs:
               runBackend,
               runBackendIntegration,
               runBackendScanners,
+              runDependencyReview,
               runFrontend,
               runDashboard,
               runContracts,
@@ -52,6 +54,7 @@ jobs:
               core.setOutput('run_backend', runBackend ? 'true' : 'false')
               core.setOutput('run_backend_integration', runBackendIntegration ? 'true' : 'false')
               core.setOutput('run_backend_scanners', runBackendScanners ? 'true' : 'false')
+              core.setOutput('run_dependency_review', runDependencyReview ? 'true' : 'false')
               core.setOutput('run_frontend', runFrontend ? 'true' : 'false')
               core.setOutput('run_dashboard', runDashboard ? 'true' : 'false')
               core.setOutput('run_contracts', runContracts ? 'true' : 'false')
@@ -61,6 +64,7 @@ jobs:
               runBackend: true,
               runBackendIntegration: true,
               runBackendScanners: true,
+              runDependencyReview: false,
               runFrontend: true,
               runDashboard: true,
               runContracts: true,
@@ -70,6 +74,7 @@ jobs:
               runBackend: false,
               runBackendIntegration: false,
               runBackendScanners: false,
+              runDependencyReview: false,
               runFrontend: false,
               runDashboard: false,
               runContracts: false,
@@ -84,6 +89,7 @@ jobs:
                   runBackend: false,
                   runBackendIntegration: false,
                   runBackendScanners: true,
+                  runDependencyReview: false,
                   runFrontend: false,
                   runDashboard: false,
                   runContracts: false,
@@ -226,6 +232,15 @@ jobs:
               /^pnpm-lock\.yaml$/,
               /^pnpm-workspace\.yaml$/,
             ]
+            const dependencyReviewPaths = [
+              /^apps\/dashboard\/package\.json$/,
+              /^apps\/dashboard\/pnpm-lock\.yaml$/,
+              /^apps\/extension\/package\.json$/,
+              /^apps\/extension\/pnpm-lock\.yaml$/,
+              /^package\.json$/,
+              /^pnpm-lock\.yaml$/,
+              /^pnpm-workspace\.yaml$/,
+            ]
             const runFullCi = runCi && (
               isReleasePromotionPr ||
               allFilePaths.some((name) => ciWorkflowPaths.some((pattern) => pattern.test(name)))
@@ -241,6 +256,9 @@ jobs:
             const runDashboard = runFullCi || (runCi && (touches.dashboard || touchesFrontendWorkspace || touchesDockerCompose))
             const runContracts = runFullCi || (runCi && touches.contracts)
             const runBackendScanners = runFullCi || (runCi && (touches.backend || touchesDockerCompose))
+            const runDependencyReview = runCi && allFilePaths.some((name) =>
+              dependencyReviewPaths.some((pattern) => pattern.test(name)),
+            )
             const runBackendIntegration = allFilePaths.some((name) =>
               backendIntegrationPaths.some((pattern) => pattern.test(name)),
             )
@@ -252,6 +270,7 @@ jobs:
                 runBackend,
                 runBackendIntegration: shouldRunBackendIntegration,
                 runBackendScanners,
+                runDependencyReview,
                 runFrontend,
                 runDashboard,
                 runContracts,
@@ -480,6 +499,25 @@ jobs:
         working-directory: services/api
         run: govulncheck ./...
 
+  dependency-review:
+    timeout-minutes: 10
+    name: Dependency Review
+    needs: scope-gate
+    if: github.event_name == 'pull_request' && needs.scope-gate.outputs.run_dependency_review == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime
+          vulnerability-check: true
+          license-check: false
+          comment-summary-in-pr: never
+          show-openssf-scorecard: false
+
   frontend:
     timeout-minutes: 15
     name: Frontend build
@@ -587,7 +625,7 @@ jobs:
   auto-ready-after-ci:
     timeout-minutes: 5
     name: Auto-ready draft PR after CI
-    needs: [scope-gate, backend-ci, frontend, dashboard, contracts]
+    needs: [scope-gate, backend-ci, dependency-review, frontend, dashboard, contracts]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -602,6 +640,7 @@ jobs:
         env:
           SCOPE_GATE_RESULT: ${{ needs.scope-gate.result }}
           BACKEND_CI_RESULT: ${{ needs.backend-ci.result }}
+          DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           DASHBOARD_RESULT: ${{ needs.dashboard.result }}
           CONTRACTS_RESULT: ${{ needs.contracts.result }}
@@ -632,6 +671,7 @@ jobs:
             const requiredJobResults = [
               ['scope-gate', process.env.SCOPE_GATE_RESULT],
               ['backend-ci', process.env.BACKEND_CI_RESULT],
+              ['dependency-review', process.env.DEPENDENCY_REVIEW_RESULT],
               ['frontend', process.env.FRONTEND_RESULT],
               ['dashboard', process.env.DASHBOARD_RESULT],
               ['contracts', process.env.CONTRACTS_RESULT],
@@ -888,7 +928,7 @@ jobs:
   notify-discord:
     timeout-minutes: 5
     name: Notify Discord on failure
-    needs: [workflow-regression, commit-message-regression, pr-metadata-regression, check-cache-wiring, atlas-migration-tooling, backend-ci, frontend, dashboard, contracts]
+    needs: [workflow-regression, commit-message-regression, pr-metadata-regression, check-cache-wiring, atlas-migration-tooling, backend-ci, dependency-review, frontend, dashboard, contracts]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/docs/dependabot-update-policy.md
+++ b/docs/dependabot-update-policy.md
@@ -64,3 +64,55 @@ The `dependabot-automerge.yml` workflow remains conservative:
 
 If a Dependabot PR touches runtime behavior or a production dependency, review it
 as a normal PR instead of relying on automation.
+
+## Dependency Review Gate
+
+Dependabot opens routine version and security update PRs. Dependency Review is
+the complementary PR gate for dependency changes opened by humans or automation:
+it compares the dependency diff in the PR and blocks newly introduced
+high/critical production dependency vulnerabilities before they enter
+`develop`.
+
+The gate runs only when dependency manifests or lockfiles for the frontend
+workspace change:
+
+- `apps/dashboard/package.json`
+- `apps/dashboard/pnpm-lock.yaml`
+- `apps/extension/package.json`
+- `apps/extension/pnpm-lock.yaml`
+- `package.json`
+- `pnpm-lock.yaml`
+- `pnpm-workspace.yaml`
+
+Policy:
+
+- high/critical production dependency vulnerabilities are blocking
+- development dependency findings are report-only in the first rollout
+- license findings are not part of this gate
+- broad `pnpm audit` remains out of scope because it scans the whole current
+  tree instead of focusing on dependency changes in the PR
+
+Development dependency findings can become blockers later only when the finding
+affects packaged extension code or build-time execution in a way that creates a
+real production risk.
+
+## False Positives And Waivers
+
+Do not add blanket waivers for Dependency Review. If a false positive or
+temporarily accepted finding blocks a production dependency change, document the
+exception in the PR body and create a follow-up issue before merging.
+
+Waiver notes must include:
+
+- Owner:
+- Accepted on:
+- Expires on:
+- Affected package:
+- Finding ID:
+- Why this is accepted:
+- Recheck trigger:
+
+Waivers expire by default after 90 days. Security findings related to auth,
+wallet signatures, token accounting, deploy credentials, or packaged extension
+runtime behavior require human review even when the finding appears in a
+development dependency.


### PR DESCRIPTION
## 什麼改動
- 在 CI scope gate 新增 `run_dependency_review` 輸出，只針對 frontend/dashboard/root dependency manifest 或 lockfile 變更開啟。
- 新增 `Dependency Review` CI job，使用 `actions/dependency-review-action@v4`。
- 設定 high/critical runtime dependency vulnerability blocking，development scope 第一階段不阻擋。
- 讓 `auto-ready-after-ci` 等待 Dependency Review job 結果，避免 auto-merge 跳過這個 gate。
- 更新 workflow regression tests 與 Dependabot policy 文件。

## 為什麼
closes #505

#210 建議 frontend / dashboard dependency changes 加入 GitHub Dependency Review gate，補足 Dependabot 對既有依賴更新的視角，避免新的高風險 production dependency vulnerabilities 透過 lockfile 變更進入 repo。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#505
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不導入 broad `pnpm audit`
  - 不修改 Dependabot schedule / grouping
  - 不導入 OSV Scanner blocking gate
  - 不修改 branch protection；auto-ready 會等待 Dependency Review job 結果

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 將 frontend/dashboard dependency review gate 接進 CI 與 auto-ready 流程。
- Approx changed lines：~165
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #505 明確要求 workflow regression 與 policy 文件一起更新，才能固定觸發條件與 waiver 流程。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] lockfile dependency PR 會跑 Dependency Review
- [x] 新增 high / critical production vulnerability 時 CI 會 fail
- [x] 非 dependency PR 不會多跑無關 scanner
- [x] policy 文件說明 false positive / waiver 流程

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
tests 42, pass 42, fail 0

git diff --check
exit 0

actionlint .github/workflows/ci.yml
not run: actionlint is not installed locally
```

## 備註
Dependency Review Action 設定依 GitHub 官方文件使用 `fail-on-severity: high` 與 `fail-on-scopes: runtime`，讓 high/critical runtime dependency findings 阻擋；development dependency findings 先保留為 report-only。

## Notes for Claude Code Review
- 請特別看 `run_dependency_review` 是否只對 `apps/dashboard`、`apps/extension`、root dependency manifest/lockfile 變更為 true。
- `Dependency Review` 不是新增 branch protection required check，但 `auto-ready-after-ci` 會等待它的 job result，避免 Codex task auto-merge 繞過 gate。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了依赖项审查作为 CI 流程中的必需检查门控

* **文档**
  * 发布了依赖机器人更新政策文档，包含依赖项审查触发条件、漏洞评估政策和虚假警报处理规程

* **配置更新**
  * CI 工作流已扩展，现包含依赖项审查任务及相关验证逻辑

<!-- end of auto-generated comment: release notes by coderabbit.ai -->