### PR TITLE
[chore] Add GitHub Actions debugging playbook

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -7,6 +7,7 @@ AI-facing collaboration guidance lives here unless a tool requires a specific pa
 - `claude-codex-cheatsheet.md` — quick reference for Claude Code and Codex collaboration.
 - `claude-codex-workflow.md` — full workflow guide for low-token Claude Code usage.
 - `code-review-refactor.md` — local Claude Code review workflow notes.
+- `github-actions-debugging.md` — playbook for PR, CI, scope gate, and auto-ready debugging.
 - `token-budget.md` — token budget guidance for AI-assisted work.
 
 ## Root-Level Exceptions

--- a/docs/ai/github-actions-debugging.md
+++ b/docs/ai/github-actions-debugging.md
@@ -1,0 +1,110 @@
+# GitHub Actions Debugging Playbook
+
+這份 playbook 用在 tachigo 的 PR / CI / auto-ready 流程出問題時。目標是先判斷失敗屬於哪一層，再決定要修 PR metadata、workflow 邏輯，還是真的修產品程式碼。
+
+## 使用時機
+
+- PR 開了，但重型 CI 沒有跑。
+- `PR Scope Police` 失敗，但不確定是欄位、scope，還是 diff 大小問題。
+- `auto-ready` label 已加，但 draft PR 沒有自動轉成 ready。
+- required checks 看起來都過了，但 auto-merge 沒有 armed。
+- 修改 `.github/workflows/*.yml` 後，需要確認 workflow script regression 沒壞。
+
+## 先分層
+
+遇到 CI 紅燈時，先把問題分成下面幾類。
+
+| 層級 | 代表訊號 | 先看哪裡 |
+| --- | --- | --- |
+| PR metadata | title/body/template 欄位不合規 | `docs/pr-scope-policy.md`、`.github/PULL_REQUEST_TEMPLATE.md` |
+| Scope gate | 重型 CI 被跳過 | `.github/workflows/ci.yml` 的 `scope-gate` job |
+| Scope police | PR 被標記或擋下 | `.github/workflows/pr-scope-police.yml` |
+| Workflow regression | workflow script 本身壞掉 | `.github/workflows/ci.test.mjs` |
+| Product CI | backend/frontend/dashboard/contract 測試失敗 | 對應 product surface 的 job log |
+| Auto-ready | draft PR 沒轉 ready 或 auto-merge 沒 armed | `.github/workflows/auto-ready-pr.yml`、`ci.yml` 的 `auto-ready-after-ci` |
+
+## 常見情境
+
+### 重型 CI 沒有跑
+
+先確認這是不是預期行為。
+
+1. 如果 PR 只改 `docs/`、template、repo metadata，重型 product CI 會被跳過。
+2. 如果 PR metadata 不合格，`scope-gate` 會把重型 CI 關掉。
+3. 如果 frontend PR 依賴尚未 merge 的 backend contract，重型 CI 會被 dependency gate 擋住。
+
+本地先跑：
+
+```bash
+make pr-meta-check TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md
+```
+
+### PR Scope Police 失敗
+
+先對照 `docs/pr-scope-policy.md`，不要直接改 workflow。
+
+常見原因：
+
+- PR title 沒有 `[backend]`、`[frontend]`、`[contract]`、`[discussion]`、`[release]`、`[infra]` 或 `[chore]` prefix。
+- PR body 缺 `Source of truth`、`Depends on PR` 或 `本 PR 明確不做`。
+- 同一個 PR 同時碰 backend / frontend / contracts surface。
+- 檔案數或 diff 行數超過限制。
+- frontend PR 依賴未落地 backend contract，但 PR body 沒標清楚 stacked / blocked 狀態。
+
+### Auto-ready 沒有轉 ready
+
+先確認 PR 是否符合 auto-ready 條件：
+
+- PR 是 draft。
+- 有 `auto-ready` label。
+- base branch 是 `develop` 或 `main`。
+- head branch 來自同一個 repo。
+- 不是 Dependabot PR。
+- required check snapshot 中列出的 checks 都已經是 success、neutral 或 skipped。
+
+`develop` 的 required check snapshot 目前在 `.github/workflows/auto-ready-pr.yml`：
+
+- `Scope gate`
+- `Frontend build`
+- `Dashboard build`
+- `Contracts build`
+- `Backend CI (gate)`
+
+如果 GitHub UI 上的 check 名稱、app id 或 workflow job 名稱改了，要同步更新 workflow regression tests。
+
+### 修改 workflow 後
+
+凡是改到 `.github/workflows/ci.yml`、`.github/workflows/pr-scope-police.yml`、`.github/workflows/auto-ready-pr.yml` 或 related workflow script，至少跑：
+
+```bash
+node --test .github/workflows/ci.test.mjs
+```
+
+如果改到 backend CI cache wiring，也跑：
+
+```bash
+bash infra/scripts/check-backend-ci-cache.sh
+```
+
+如果改到 PR 開啟或 metadata preflight script，也跑：
+
+```bash
+bash infra/scripts/pr-open.test.sh
+```
+
+## 不要做的事
+
+- 不要為了讓 docs / metadata PR 轉綠，把 backend 或 frontend 修補混進同一個 PR。
+- 不要用 `scope-exception` 當一般逃生門；只有真的不可拆時才用。
+- 不要在不理解 `scope-gate` 輸出前直接改 product code。
+- 不要把影片或外部工具示範當成 tachigo 的 implementation source of truth。
+- 不要在 workflow debug PR 順手調整產品功能、schema、API contract 或 UI。
+
+## 建議處理順序
+
+1. 讀失敗 job 的 summary 和 notice，判斷是哪一層。
+2. 若是 metadata / scope 問題，先修 PR body 或拆 PR。
+3. 若是 workflow script 問題，跑 `.github/workflows/ci.test.mjs` 復現。
+4. 若是 product CI 問題，只在該 product surface 的獨立 PR 中修。
+5. 若發現需要新機制，先開 issue 或 discussion，不混入當前修補 PR。
+


### PR DESCRIPTION
## 什麼改動
新增 `docs/ai/github-actions-debugging.md`，整理 tachigo 專用的 GitHub Actions / PR / Scope gate / auto-ready 偵錯 playbook，並更新 `docs/ai/README.md` 索引。

## 為什麼
closes #512

Gemini CLI 讀取 GitHub Actions debugging demo 後，判斷影片不適合作為 tachigo 的產品功能來源，但適合轉成專案內 CI / PR 偵錯流程文件。這份文件讓之後遇到 CI 紅燈時，可以先分辨是 PR metadata、Scope gate、Scope Police、workflow regression、product CI，還是 auto-ready 條件問題。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#512
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 GitHub Actions workflow 行為
  - 不新增 VS Code 設定、npm package 或 automation
  - 不修改 backend / frontend / dashboard / contracts 產品程式碼
  - 不更動 PR Scope Police 或 auto-ready policy

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 tachigo 專用 GitHub Actions 偵錯 playbook。
- Approx changed lines：~111
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `docs/ai/` 有 GitHub Actions debugging playbook
- [x] `docs/ai/README.md` 有索引連結
- [x] 文件內容對齊現有 workflow 與本地驗證入口

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
node --test .github/workflows/ci.test.mjs
tests 38
pass 38
fail 0
```

## 備註
測試過程出現 Ruby PATH 權限 warning：`Insecure world writable dir /Users/tachikoma/.local in PATH`。測試仍通過，且本 PR 未修改相關環境設定。

## Notes for Claude Code Review
- 請特別確認文件沒有把影片內容擴張成 tachigo 產品功能或新 automation。
- 這是 docs-only PR，沒有 backend contract 或 product surface 行為變更。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档

* **文档** 
  * 新增 GitHub Actions 调试指南，提供 CI 故障分层诊断流程，涵盖常见失败场景、文件检查清单，以及本地和 CI 环境的推荐排查指令和最佳实践。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->