### PR TITLE
[infra] Contracts Slither report workflow

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -15,6 +15,7 @@ const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rer
 const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-on-develop-merge.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 const dependabotPolicyPath = path.join(repoRoot, 'docs', 'dependabot-update-policy.md')
+const securityScannerEvaluationPath = path.join(repoRoot, 'docs', 'security-scanner-evaluation.md')
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 const developRequiredCheckRuns = [
   'Scope gate',
@@ -159,6 +160,7 @@ async function runCiAutoReadyAfterCiWorkflow({
       FRONTEND_RESULT: 'success',
       DASHBOARD_RESULT: 'success',
       CONTRACTS_RESULT: 'success',
+      CONTRACTS_SLITHER_RESULT: 'success',
       ...env,
     },
     ...options,
@@ -663,6 +665,7 @@ test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
     run_frontend: 'true',
     run_dashboard: 'false',
     run_contracts: 'false',
+    run_contracts_slither: 'false',
   })
 })
 
@@ -697,6 +700,7 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
+    run_contracts_slither: 'false',
   })
   assert.deepEqual(scheduled.outputs, {
     run_ci: 'true',
@@ -707,6 +711,26 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
+    run_contracts_slither: 'true',
+  })
+})
+
+test('scope gate emits contracts Slither output for contracts PRs', async () => {
+  const result = await runCiScopeGateWorkflow({
+    prOverrides: { title: '[contract] Update TachiToken' },
+    files: [{ filename: 'contracts/src/TachiToken.sol', additions: 4, deletions: 1, status: 'modified' }],
+  })
+
+  assert.deepEqual(result.outputs, {
+    run_ci: 'true',
+    run_backend: 'false',
+    run_backend_integration: 'true',
+    run_backend_scanners: 'false',
+    run_dependency_review: 'false',
+    run_frontend: 'false',
+    run_dashboard: 'false',
+    run_contracts: 'true',
+    run_contracts_slither: 'true',
   })
 })
 
@@ -744,6 +768,7 @@ Backend contract already in develop:
     run_frontend: 'true',
     run_dashboard: 'true',
     run_contracts: 'true',
+    run_contracts_slither: 'true',
   }
   assert.deepEqual(push.outputs, fullOutputs)
   assert.deepEqual(releasePromotion.outputs, fullOutputs)
@@ -764,6 +789,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   const frontend = workflowJobBlock(workflow, 'frontend')
   const dashboard = workflowJobBlock(workflow, 'dashboard')
   const contracts = workflowJobBlock(workflow, 'contracts')
+  const contractsSlither = workflowJobBlock(workflow, 'contracts-slither')
 
   assert.match(backendBuild, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
   assert.match(backend, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
@@ -774,6 +800,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   assert.match(frontend, /needs\.scope-gate\.outputs\.run_frontend == 'true'/)
   assert.match(dashboard, /needs\.scope-gate\.outputs\.run_dashboard == 'true'/)
   assert.match(contracts, /needs\.scope-gate\.outputs\.run_contracts == 'true'/)
+  assert.match(contractsSlither, /needs\.scope-gate\.outputs\.run_contracts_slither == 'true'/)
 })
 
 test('backend security scanner job installs pinned staticcheck and govulncheck', async () => {
@@ -833,6 +860,47 @@ test('dependency review policy documents Dependabot split and waiver handling', 
   assert.match(policy, /False Positives And Waivers/)
   assert.match(policy, /Owner:/)
   assert.match(policy, /Expires on:/)
+})
+
+test('contracts Slither report job uploads SARIF and keeps findings report-only', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
+  const job = parsedWorkflow.jobs['contracts-slither']
+  const jobBlock = workflowJobBlock(workflow, 'contracts-slither')
+
+  assert.equal(job.name, 'Contracts Slither report')
+  assert.equal(job['timeout-minutes'], 20)
+  assert.deepEqual(job.needs, ['scope-gate'])
+  assert.equal(job.if, "needs.scope-gate.outputs.run_contracts_slither == 'true'")
+  assert.equal(job.permissions.contents, 'read')
+  assert.equal(job.permissions['security-events'], 'write')
+  assert.match(jobBlock, /uses: actions\/checkout@v4/)
+  assert.match(jobBlock, /uses: foundry-rs\/foundry-toolchain@v1/)
+  assert.match(jobBlock, /working-directory: contracts\n\s+run: forge install OpenZeppelin\/openzeppelin-contracts@v5\.6\.1 --no-git/)
+  assert.match(jobBlock, /uses: crytic\/slither-action@v0\.4\.2/)
+  assert.match(jobBlock, /id: slither/)
+  assert.match(jobBlock, /target: contracts/)
+  assert.match(jobBlock, /slither-version: 0\.11\.5/)
+  assert.match(jobBlock, /sarif: slither\.sarif/)
+  assert.match(jobBlock, /fail-on: none/)
+  assert.match(jobBlock, /uses: github\/codeql-action\/upload-sarif@v3/)
+  assert.match(jobBlock, /sarif_file: \$\{\{ steps\.slither\.outputs\.sarif \}\}/)
+  assert.match(jobBlock, /uses: actions\/upload-artifact@v4/)
+  assert.match(jobBlock, /name: slither-report/)
+  assert.match(jobBlock, /path: \$\{\{ steps\.slither\.outputs\.sarif \}\}/)
+  assert.doesNotMatch(jobBlock, /continue-on-error: true/)
+})
+
+test('contracts Slither policy documents baseline triage and waiver handling', async () => {
+  const policy = await readFile(securityScannerEvaluationPath, 'utf8')
+
+  assert.match(policy, /Contracts Slither Report/)
+  assert.match(policy, /fail-on: none/)
+  assert.match(policy, /slither-report/)
+  assert.match(policy, /Owner:/)
+  assert.match(policy, /Accepted on:/)
+  assert.match(policy, /Expires on:/)
+  assert.match(policy, /GitHub code scanning/)
 })
 
 test('global auto-merge workflow excludes Dependabot PRs', async () => {
@@ -1000,7 +1068,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
 
   assert.equal(job.name, 'Auto-ready draft PR after CI')
   assert.equal(job.if, "always() && github.event_name == 'pull_request'")
-  assert.deepEqual(job.needs, ['scope-gate', 'backend-ci', 'dependency-review', 'frontend', 'dashboard', 'contracts'])
+  assert.deepEqual(job.needs, ['scope-gate', 'backend-ci', 'dependency-review', 'frontend', 'dashboard', 'contracts', 'contracts-slither'])
   assert.equal(job.permissions['pull-requests'], 'write')
   assert.equal(job.permissions.contents, 'write')
   assert.equal(job.permissions.issues, 'write')
@@ -1017,6 +1085,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /FRONTEND_RESULT/)
   assert.match(jobBlock, /DASHBOARD_RESULT/)
   assert.match(jobBlock, /CONTRACTS_RESULT/)
+  assert.match(jobBlock, /CONTRACTS_SLITHER_RESULT/)
   assert.match(jobBlock, /const markedReady = pr\.draft === true/)
   assert.match(jobBlock, /if \(markedReady\) \{[\s\S]*markPullRequestReadyForReview/)
   assert.match(jobBlock, /pr\.user\?\.login === 'dependabot\[bot\]'/)
@@ -1081,6 +1150,16 @@ test('CI auto-ready job retries auto-merge for already-ready auto-ready PRs', as
 test('CI auto-ready job waits when dependency review fails', async () => {
   const result = await runCiAutoReadyAfterCiWorkflow({
     env: { DEPENDENCY_REVIEW_RESULT: 'failure' },
+    checkRuns: successfulDevelopRequiredCheckRuns(),
+  })
+
+  assert.deepEqual(result.graphqlCalls, [])
+  assert.deepEqual(result.labelsAdded, [])
+})
+
+test('CI auto-ready job waits when contracts Slither report fails', async () => {
+  const result = await runCiAutoReadyAfterCiWorkflow({
+    env: { CONTRACTS_SLITHER_RESULT: 'failure' },
     checkRuns: successfulDevelopRequiredCheckRuns(),
   })
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       run_frontend: ${{ steps.evaluate.outputs.run_frontend }}
       run_dashboard: ${{ steps.evaluate.outputs.run_dashboard }}
       run_contracts: ${{ steps.evaluate.outputs.run_contracts }}
+      run_contracts_slither: ${{ steps.evaluate.outputs.run_contracts_slither }}
     steps:
       - name: Evaluate PR scope for CI
         id: evaluate
@@ -49,6 +50,7 @@ jobs:
               runFrontend,
               runDashboard,
               runContracts,
+              runContractsSlither,
             }) => {
               core.setOutput('run_ci', runCi ? 'true' : 'false')
               core.setOutput('run_backend', runBackend ? 'true' : 'false')
@@ -58,6 +60,7 @@ jobs:
               core.setOutput('run_frontend', runFrontend ? 'true' : 'false')
               core.setOutput('run_dashboard', runDashboard ? 'true' : 'false')
               core.setOutput('run_contracts', runContracts ? 'true' : 'false')
+              core.setOutput('run_contracts_slither', runContractsSlither ? 'true' : 'false')
             }
             const setFullCiOutputs = () => setCiOutputs({
               runCi: true,
@@ -68,6 +71,7 @@ jobs:
               runFrontend: true,
               runDashboard: true,
               runContracts: true,
+              runContractsSlither: true,
             })
             const setSkippedCiOutputs = () => setCiOutputs({
               runCi: false,
@@ -78,12 +82,13 @@ jobs:
               runFrontend: false,
               runDashboard: false,
               runContracts: false,
+              runContractsSlither: false,
             })
 
             const pr = context.payload.pull_request
             if (!pr) {
               if (context.eventName === 'schedule') {
-                core.notice('Scheduled backend scanner run detected; running backend scanners only.')
+                core.notice('Scheduled backend scanner and contracts Slither report run detected; running scanner jobs only.')
                 setCiOutputs({
                   runCi: true,
                   runBackend: false,
@@ -93,6 +98,7 @@ jobs:
                   runFrontend: false,
                   runDashboard: false,
                   runContracts: false,
+                  runContractsSlither: true,
                 })
                 return
               }
@@ -256,6 +262,7 @@ jobs:
             const runDashboard = runFullCi || (runCi && (touches.dashboard || touchesFrontendWorkspace || touchesDockerCompose))
             const runContracts = runFullCi || (runCi && touches.contracts)
             const runBackendScanners = runFullCi || (runCi && (touches.backend || touchesDockerCompose))
+            const runContractsSlither = runFullCi || (runCi && touches.contracts)
             const runDependencyReview = runCi && allFilePaths.some((name) =>
               dependencyReviewPaths.some((pattern) => pattern.test(name)),
             )
@@ -274,6 +281,7 @@ jobs:
                 runFrontend,
                 runDashboard,
                 runContracts,
+                runContractsSlither,
               })
             } else {
               setSkippedCiOutputs()
@@ -593,6 +601,48 @@ jobs:
         working-directory: contracts
         run: forge fmt --check
 
+  contracts-slither:
+    timeout-minutes: 20
+    name: Contracts Slither report
+    needs: [scope-gate]
+    if: needs.scope-gate.outputs.run_contracts_slither == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install Solidity dependencies
+        working-directory: contracts
+        run: forge install OpenZeppelin/openzeppelin-contracts@v5.6.1 --no-git
+
+      - name: Run Slither
+        id: slither
+        uses: crytic/slither-action@v0.4.2
+        with:
+          target: contracts
+          slither-version: 0.11.5
+          sarif: slither.sarif
+          fail-on: none
+
+      - name: Upload Slither SARIF
+        if: always() && steps.slither.outputs.sarif != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.slither.outputs.sarif }}
+
+      - name: Upload Slither report artifact
+        if: always() && steps.slither.outputs.sarif != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: slither-report
+          path: ${{ steps.slither.outputs.sarif }}
+          if-no-files-found: warn
+
   backend-ci:
     timeout-minutes: 5
     name: Backend CI (gate)
@@ -625,7 +675,7 @@ jobs:
   auto-ready-after-ci:
     timeout-minutes: 5
     name: Auto-ready draft PR after CI
-    needs: [scope-gate, backend-ci, dependency-review, frontend, dashboard, contracts]
+    needs: [scope-gate, backend-ci, dependency-review, frontend, dashboard, contracts, contracts-slither]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -644,6 +694,7 @@ jobs:
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           DASHBOARD_RESULT: ${{ needs.dashboard.result }}
           CONTRACTS_RESULT: ${{ needs.contracts.result }}
+          CONTRACTS_SLITHER_RESULT: ${{ needs.contracts-slither.result }}
         with:
           script: |
             const owner = context.repo.owner
@@ -675,6 +726,7 @@ jobs:
               ['frontend', process.env.FRONTEND_RESULT],
               ['dashboard', process.env.DASHBOARD_RESULT],
               ['contracts', process.env.CONTRACTS_RESULT],
+              ['contracts-slither', process.env.CONTRACTS_SLITHER_RESULT],
             ]
 
             for (const [job, result] of requiredJobResults) {
@@ -928,7 +980,7 @@ jobs:
   notify-discord:
     timeout-minutes: 5
     name: Notify Discord on failure
-    needs: [workflow-regression, commit-message-regression, pr-metadata-regression, check-cache-wiring, atlas-migration-tooling, backend-ci, dependency-review, frontend, dashboard, contracts]
+    needs: [workflow-regression, commit-message-regression, pr-metadata-regression, check-cache-wiring, atlas-migration-tooling, backend-ci, dependency-review, frontend, dashboard, contracts, contracts-slither]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/docs/security-scanner-evaluation.md
+++ b/docs/security-scanner-evaluation.md
@@ -100,6 +100,42 @@ Rationale:
 - The project currently has a small token contract surface; report-only gives
   useful signal while keeping the first CI hardening pass low risk.
 
+#### Contracts Slither Report
+
+The `Contracts Slither report` CI job runs the pinned Crytic Slither GitHub
+Action against `contracts` and keeps detector findings report-only with
+`fail-on: none`. Workflow infrastructure failures should still fail the job, but
+Slither findings themselves should be reviewed through GitHub code scanning and
+the uploaded `slither-report` artifact.
+
+Baseline triage flow:
+
+1. Open the GitHub code scanning alert, or download the `slither-report`
+   artifact when code scanning is unavailable.
+2. Record each baseline finding with the detector name, severity, affected
+   contract/function, owner, and decision.
+3. Classify the decision as `fix now`, `accepted risk`, `false positive`, or
+   `follow-up issue`.
+4. For accepted risks and false positives, add a waiver before relying on the
+   report as reviewed.
+5. Recheck waivers when the affected contract changes, the detector changes, or
+   the waiver expires.
+
+Suggested Slither waiver format:
+
+```markdown
+## Slither / <detector or finding id>
+
+- Owner:
+- Accepted on:
+- Expires on:
+- Affected contract/function:
+- Severity:
+- Decision:
+- Why this is accepted:
+- Recheck trigger:
+```
+
 ### Gas Snapshot
 
 Use Foundry `forge snapshot` and eventually `forge snapshot --check`.


### PR DESCRIPTION
## 什麼改動
新增 `contracts-slither` CI job，使用 pinned `crytic/slither-action@v0.4.2` 與 `slither-analyzer 0.11.5` 對 `contracts` 產出 report-only SARIF，並上傳 GitHub code scanning 與 `slither-report` artifact。

更新 scope gate、auto-ready、Discord failure notification 與 workflow regression tests，讓 Slither job 只在 contracts / full CI / scheduled / push to develop 相關情境執行，且 auto-ready 會等待 workflow 成功或 skipped。

## 為什麼
closes #506

#210 建議 contracts 第一階段先用 Slither 產出可追蹤報告，不直接把 findings 設為 blocking；#506 要求補上 SARIF/artifact 與 baseline triage / waiver 文件。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#506
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不導入其他 Solidity scanner
  - 不改合約程式碼或 gas snapshot
  - 不把 Slither findings 設為 required/blocking gate

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 為 contracts 加上 Slither report-only CI 與 baseline triage 文件。
- Approx changed lines：~171
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #506 驗收同時要求 Slither workflow、report artifact/SARIF，以及 triage / waiver 文件；workflow regression tests 用來鎖住 gating 與 report-only 行為。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] contracts PR 會產出 Slither report
- [x] scanner findings 以 `fail-on: none` 保持 report-only；workflow/job 本身失敗仍會阻塞 auto-ready
- [x] findings 會上傳 GitHub code scanning SARIF 與 `slither-report` artifact
- [x] docs 說明 baseline findings 的 triage / waiver 流程

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
# tests 46, pass 46, fail 0

git diff --check
# no output

go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml
# failed only on pre-existing backend scanner shellcheck SC2086 at ci.yml:495

go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore SC2086 .github/workflows/ci.yml
# no output
```

## 備註
Slither findings 是 report-only；`contracts-slither` job 失敗仍代表 workflow infrastructure 不能正常執行，會讓 auto-ready 暫停。

## Notes for Claude Code Review
- `run_contracts_slither` 對 contracts PR、scheduled run、push / release / CI full-run 情境為 true；一般 frontend/backend dependency PR 不會額外跑 Slither。
- `fail-on: none` 只放寬 detector findings，不加 `continue-on-error`，避免 workflow 執行錯誤被吞掉。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在 CI 工作流中添加了智能合约 Slither 安全扫描，可自动检测代码漏洞并上传扫描报告

* **测试**
  * 扩展 CI 工作流测试覆盖范围，验证安全扫描功能的集成与行为

* **文档**
  * 新增安全扫描评估文档，包括发现工作流和问题豁免模板

<!-- end of auto-generated comment: release notes by coderabbit.ai -->