### PR TITLE
[infra] Contracts gas snapshot policy

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -15,6 +15,7 @@ const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rer
 const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-on-develop-merge.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 const dependabotPolicyPath = path.join(repoRoot, 'docs', 'dependabot-update-policy.md')
+const contractsGasSnapshotPolicyPath = path.join(repoRoot, 'docs', 'contracts-gas-snapshot-policy.md')
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 const developRequiredCheckRuns = [
   'Scope gate',
@@ -159,6 +160,7 @@ async function runCiAutoReadyAfterCiWorkflow({
       FRONTEND_RESULT: 'success',
       DASHBOARD_RESULT: 'success',
       CONTRACTS_RESULT: 'success',
+      CONTRACTS_GAS_SNAPSHOT_RESULT: 'success',
       ...env,
     },
     ...options,
@@ -663,6 +665,7 @@ test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
     run_frontend: 'true',
     run_dashboard: 'false',
     run_contracts: 'false',
+    run_contracts_gas_report: 'false',
   })
 })
 
@@ -697,6 +700,7 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
+    run_contracts_gas_report: 'false',
   })
   assert.deepEqual(scheduled.outputs, {
     run_ci: 'true',
@@ -707,6 +711,26 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
+    run_contracts_gas_report: 'false',
+  })
+})
+
+test('scope gate emits contracts gas report output for contracts PRs', async () => {
+  const result = await runCiScopeGateWorkflow({
+    prOverrides: { title: '[contract] Update TachiToken' },
+    files: [{ filename: 'contracts/src/TachiToken.sol', additions: 4, deletions: 1, status: 'modified' }],
+  })
+
+  assert.deepEqual(result.outputs, {
+    run_ci: 'true',
+    run_backend: 'false',
+    run_backend_integration: 'true',
+    run_backend_scanners: 'false',
+    run_dependency_review: 'false',
+    run_frontend: 'false',
+    run_dashboard: 'false',
+    run_contracts: 'true',
+    run_contracts_gas_report: 'true',
   })
 })
 
@@ -744,6 +768,7 @@ Backend contract already in develop:
     run_frontend: 'true',
     run_dashboard: 'true',
     run_contracts: 'true',
+    run_contracts_gas_report: 'true',
   }
   assert.deepEqual(push.outputs, fullOutputs)
   assert.deepEqual(releasePromotion.outputs, fullOutputs)
@@ -764,6 +789,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   const frontend = workflowJobBlock(workflow, 'frontend')
   const dashboard = workflowJobBlock(workflow, 'dashboard')
   const contracts = workflowJobBlock(workflow, 'contracts')
+  const contractsGasSnapshot = workflowJobBlock(workflow, 'contracts-gas-snapshot')
 
   assert.match(backendBuild, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
   assert.match(backend, /needs\.scope-gate\.outputs\.run_backend == 'true'/)
@@ -774,6 +800,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   assert.match(frontend, /needs\.scope-gate\.outputs\.run_frontend == 'true'/)
   assert.match(dashboard, /needs\.scope-gate\.outputs\.run_dashboard == 'true'/)
   assert.match(contracts, /needs\.scope-gate\.outputs\.run_contracts == 'true'/)
+  assert.match(contractsGasSnapshot, /needs\.scope-gate\.outputs\.run_contracts_gas_report == 'true'/)
 })
 
 test('backend security scanner job installs pinned staticcheck and govulncheck', async () => {
@@ -833,6 +860,40 @@ test('dependency review policy documents Dependabot split and waiver handling', 
   assert.match(policy, /False Positives And Waivers/)
   assert.match(policy, /Owner:/)
   assert.match(policy, /Expires on:/)
+})
+
+test('contracts gas snapshot job publishes a report-only artifact', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
+  const job = parsedWorkflow.jobs['contracts-gas-snapshot']
+  const jobBlock = workflowJobBlock(workflow, 'contracts-gas-snapshot')
+
+  assert.equal(job.name, 'Contracts gas snapshot report')
+  assert.equal(job['timeout-minutes'], 20)
+  assert.deepEqual(job.needs, ['scope-gate'])
+  assert.equal(job.if, "needs.scope-gate.outputs.run_contracts_gas_report == 'true'")
+  assert.match(jobBlock, /uses: actions\/checkout@v4/)
+  assert.match(jobBlock, /uses: foundry-rs\/foundry-toolchain@v1/)
+  assert.match(jobBlock, /working-directory: contracts\n\s+run: forge install OpenZeppelin\/openzeppelin-contracts@v5\.6\.1 --no-git/)
+  assert.match(jobBlock, /working-directory: contracts\n\s+run: forge snapshot --snap gas-snapshot\.report/)
+  assert.match(jobBlock, /cat gas-snapshot\.report/)
+  assert.match(jobBlock, /uses: actions\/upload-artifact@v4/)
+  assert.match(jobBlock, /name: contracts-gas-snapshot-report/)
+  assert.match(jobBlock, /path: contracts\/gas-snapshot\.report/)
+  assert.doesNotMatch(jobBlock, /--check/)
+  assert.doesNotMatch(jobBlock, /continue-on-error: true/)
+})
+
+test('contracts gas snapshot policy documents baseline and reviewer handling', async () => {
+  const policy = await readFile(contractsGasSnapshotPolicyPath, 'utf8')
+
+  assert.match(policy, /Gas Snapshot Policy/)
+  assert.match(policy, /contracts-gas-snapshot-report/)
+  assert.match(policy, /`.gas-snapshot` is not committed/)
+  assert.match(policy, /Tolerance/)
+  assert.match(policy, /Intentional gas changes checklist/)
+  assert.match(policy, /Reviewer accepted the gas impact/)
+  assert.match(policy, /forge snapshot --check/)
 })
 
 test('global auto-merge workflow excludes Dependabot PRs', async () => {
@@ -1000,7 +1061,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
 
   assert.equal(job.name, 'Auto-ready draft PR after CI')
   assert.equal(job.if, "always() && github.event_name == 'pull_request'")
-  assert.deepEqual(job.needs, ['scope-gate', 'backend-ci', 'dependency-review', 'frontend', 'dashboard', 'contracts'])
+  assert.deepEqual(job.needs, ['scope-gate', 'backend-ci', 'dependency-review', 'frontend', 'dashboard', 'contracts', 'contracts-gas-snapshot'])
   assert.equal(job.permissions['pull-requests'], 'write')
   assert.equal(job.permissions.contents, 'write')
   assert.equal(job.permissions.issues, 'write')
@@ -1017,6 +1078,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /FRONTEND_RESULT/)
   assert.match(jobBlock, /DASHBOARD_RESULT/)
   assert.match(jobBlock, /CONTRACTS_RESULT/)
+  assert.match(jobBlock, /CONTRACTS_GAS_SNAPSHOT_RESULT/)
   assert.match(jobBlock, /const markedReady = pr\.draft === true/)
   assert.match(jobBlock, /if \(markedReady\) \{[\s\S]*markPullRequestReadyForReview/)
   assert.match(jobBlock, /pr\.user\?\.login === 'dependabot\[bot\]'/)
@@ -1081,6 +1143,16 @@ test('CI auto-ready job retries auto-merge for already-ready auto-ready PRs', as
 test('CI auto-ready job waits when dependency review fails', async () => {
   const result = await runCiAutoReadyAfterCiWorkflow({
     env: { DEPENDENCY_REVIEW_RESULT: 'failure' },
+    checkRuns: successfulDevelopRequiredCheckRuns(),
+  })
+
+  assert.deepEqual(result.graphqlCalls, [])
+  assert.deepEqual(result.labelsAdded, [])
+})
+
+test('CI auto-ready job waits when contracts gas snapshot report fails', async () => {
+  const result = await runCiAutoReadyAfterCiWorkflow({
+    env: { CONTRACTS_GAS_SNAPSHOT_RESULT: 'failure' },
     checkRuns: successfulDevelopRequiredCheckRuns(),
   })
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       run_frontend: ${{ steps.evaluate.outputs.run_frontend }}
       run_dashboard: ${{ steps.evaluate.outputs.run_dashboard }}
       run_contracts: ${{ steps.evaluate.outputs.run_contracts }}
+      run_contracts_gas_report: ${{ steps.evaluate.outputs.run_contracts_gas_report }}
     steps:
       - name: Evaluate PR scope for CI
         id: evaluate
@@ -49,6 +50,7 @@ jobs:
               runFrontend,
               runDashboard,
               runContracts,
+              runContractsGasReport,
             }) => {
               core.setOutput('run_ci', runCi ? 'true' : 'false')
               core.setOutput('run_backend', runBackend ? 'true' : 'false')
@@ -58,6 +60,7 @@ jobs:
               core.setOutput('run_frontend', runFrontend ? 'true' : 'false')
               core.setOutput('run_dashboard', runDashboard ? 'true' : 'false')
               core.setOutput('run_contracts', runContracts ? 'true' : 'false')
+              core.setOutput('run_contracts_gas_report', runContractsGasReport ? 'true' : 'false')
             }
             const setFullCiOutputs = () => setCiOutputs({
               runCi: true,
@@ -68,6 +71,7 @@ jobs:
               runFrontend: true,
               runDashboard: true,
               runContracts: true,
+              runContractsGasReport: true,
             })
             const setSkippedCiOutputs = () => setCiOutputs({
               runCi: false,
@@ -78,6 +82,7 @@ jobs:
               runFrontend: false,
               runDashboard: false,
               runContracts: false,
+              runContractsGasReport: false,
             })
 
             const pr = context.payload.pull_request
@@ -93,6 +98,7 @@ jobs:
                   runFrontend: false,
                   runDashboard: false,
                   runContracts: false,
+                  runContractsGasReport: false,
                 })
                 return
               }
@@ -255,6 +261,7 @@ jobs:
             const runFrontend = runFullCi || (runCi && (touches.extension || touchesFrontendWorkspace || touchesDockerCompose))
             const runDashboard = runFullCi || (runCi && (touches.dashboard || touchesFrontendWorkspace || touchesDockerCompose))
             const runContracts = runFullCi || (runCi && touches.contracts)
+            const runContractsGasReport = runFullCi || (runCi && touches.contracts)
             const runBackendScanners = runFullCi || (runCi && (touches.backend || touchesDockerCompose))
             const runDependencyReview = runCi && allFilePaths.some((name) =>
               dependencyReviewPaths.some((pattern) => pattern.test(name)),
@@ -274,6 +281,7 @@ jobs:
                 runFrontend,
                 runDashboard,
                 runContracts,
+                runContractsGasReport,
               })
             } else {
               setSkippedCiOutputs()
@@ -593,6 +601,37 @@ jobs:
         working-directory: contracts
         run: forge fmt --check
 
+  contracts-gas-snapshot:
+    timeout-minutes: 20
+    name: Contracts gas snapshot report
+    needs: [scope-gate]
+    if: needs.scope-gate.outputs.run_contracts_gas_report == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install dependencies
+        working-directory: contracts
+        run: forge install OpenZeppelin/openzeppelin-contracts@v5.6.1 --no-git
+
+      - name: Generate gas snapshot report
+        working-directory: contracts
+        run: forge snapshot --snap gas-snapshot.report
+
+      - name: Print gas snapshot report
+        working-directory: contracts
+        run: cat gas-snapshot.report
+
+      - name: Upload gas snapshot report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: contracts-gas-snapshot-report
+          path: contracts/gas-snapshot.report
+          if-no-files-found: error
+
   backend-ci:
     timeout-minutes: 5
     name: Backend CI (gate)
@@ -625,7 +664,7 @@ jobs:
   auto-ready-after-ci:
     timeout-minutes: 5
     name: Auto-ready draft PR after CI
-    needs: [scope-gate, backend-ci, dependency-review, frontend, dashboard, contracts]
+    needs: [scope-gate, backend-ci, dependency-review, frontend, dashboard, contracts, contracts-gas-snapshot]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -644,6 +683,7 @@ jobs:
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           DASHBOARD_RESULT: ${{ needs.dashboard.result }}
           CONTRACTS_RESULT: ${{ needs.contracts.result }}
+          CONTRACTS_GAS_SNAPSHOT_RESULT: ${{ needs.contracts-gas-snapshot.result }}
         with:
           script: |
             const owner = context.repo.owner
@@ -675,6 +715,7 @@ jobs:
               ['frontend', process.env.FRONTEND_RESULT],
               ['dashboard', process.env.DASHBOARD_RESULT],
               ['contracts', process.env.CONTRACTS_RESULT],
+              ['contracts-gas-snapshot', process.env.CONTRACTS_GAS_SNAPSHOT_RESULT],
             ]
 
             for (const [job, result] of requiredJobResults) {
@@ -928,7 +969,7 @@ jobs:
   notify-discord:
     timeout-minutes: 5
     name: Notify Discord on failure
-    needs: [workflow-regression, commit-message-regression, pr-metadata-regression, check-cache-wiring, atlas-migration-tooling, backend-ci, dependency-review, frontend, dashboard, contracts]
+    needs: [workflow-regression, commit-message-regression, pr-metadata-regression, check-cache-wiring, atlas-migration-tooling, backend-ci, dependency-review, frontend, dashboard, contracts, contracts-gas-snapshot]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/docs/contracts-gas-snapshot-policy.md
+++ b/docs/contracts-gas-snapshot-policy.md
@@ -1,0 +1,36 @@
+# Contracts Gas Snapshot Policy
+
+**Source of truth**: #507
+**Status**: report-only first rollout
+
+## Decision
+
+The first production-readiness rollout keeps gas snapshots report-only. CI runs
+`forge snapshot --snap gas-snapshot.report` for contracts changes and uploads
+the `contracts-gas-snapshot-report` artifact for review.
+
+`.gas-snapshot` is not committed yet because the project has not assigned a
+baseline owner or agreed on a drift tolerance. This avoids turning normal
+contract iteration into a low-signal blocking gate before the team has reviewed
+the first baseline.
+
+## Tolerance
+
+- No tolerance is active while the job is report-only.
+- When the baseline is intentionally committed, start with `0%` tolerance unless
+  the baseline review records a specific noisy measurement.
+- Any non-zero tolerance must be documented in the PR that enables
+  `forge snapshot --check`.
+
+## Intentional gas changes checklist
+
+- Link the contract or test change that caused the gas delta.
+- Paste the relevant lines from the `contracts-gas-snapshot-report` artifact.
+- Explain whether the delta is expected, acceptable, and user-visible.
+- Reviewer accepted the gas impact before merge.
+
+## Promotion conditions for a blocking drift gate
+
+- Commit `.gas-snapshot` with an explicit owner.
+- Update CI to run `forge snapshot --check` against the committed baseline.
+- Document the tolerance value and how intentional deltas update the baseline.


### PR DESCRIPTION
## 什麼改動
新增 `contracts-gas-snapshot` CI job，讓 contracts / full CI 情境產出 `forge snapshot --snap gas-snapshot.report`，並上傳 `contracts-gas-snapshot-report` artifact。

更新 workflow regression tests 與 `docs/contracts-gas-snapshot-policy.md`，文件化第一階段不 commit `.gas-snapshot`、不啟用 drift gate、tolerance 暫不生效，以及 intentional gas changes 的 reviewer checklist。

## 為什麼
closes #507

#210 將 gas snapshot 列為 contracts quality signal，但第一版尚未有 baseline owner 與 tolerance policy。這個 PR 先讓 reviewer 在 contracts PR 看到 gas snapshot report，不把 gas drift 變成 blocking gate。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#507
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不把 gas snapshot 當作 security scanner
  - 不要求第一版 blocking
  - 不修改合約邏輯
  - 不 commit `.gas-snapshot` baseline

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 為 contracts 加上 report-only gas snapshot artifact 與 baseline policy。
- Approx changed lines：~148
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #507 驗收要求 report artifact、版本控制決策、tolerance 決策與 reviewer checklist；workflow regression tests 用來鎖住 report-only 行為。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] contracts PR 可以看到 gas snapshot report artifact
- [x] intentional gas changes 有明確 reviewer checklist
- [x] `.gas-snapshot` 暫不 commit，README 說明原因與後續升級條件
- [x] 第一版不使用 `forge snapshot --check`，不啟用 blocking drift gate

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
# tests 46, pass 46, fail 0

git diff --check
# no output

go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore SC2086 .github/workflows/ci.yml
# no output
```

## 備註
本機沒有安裝 `forge`，所以 gas snapshot 的實際產物由 PR CI 的 `foundry-rs/foundry-toolchain@v1` job 驗證。

## Notes for Claude Code Review
- `contracts-gas-snapshot` 不使用 `--check`，因此 gas drift 不會因缺 baseline 而 blocking。
- job 不加 `continue-on-error`；如果 workflow infrastructure 或 Foundry execution 失敗，auto-ready 會停住。
- #514 尚未 merge；本 PR 從目前 `origin/develop` 切出，與 #514 獨立，但兩者都碰 `.github/workflows/ci.yml`，#514 merge 後可能需要更新 branch。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在 CI 流程中新增合约 Gas 快照支持，用于自动跟踪和报告合约燃气使用情况。

* **文档**
  * 新增合约 Gas 快照政策文档，说明初期以报告模式运行、容忍度规则及基线处理流程。

* **测试**
  * 扩展 CI 测试覆盖，新增合约 Gas 快照任务及其政策的测试用例，确保失败路径和门控机制正常工作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->