### PR TITLE
[infra] Scheduled dependency inventory scan

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -13,10 +13,12 @@ const autoMergeWorkflowPath = path.join(currentDir, 'auto-merge.yml')
 const autoReadyWorkflowPath = path.join(currentDir, 'auto-ready-pr.yml')
 const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rerequest.yml')
 const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-on-develop-merge.yml')
+const dependencyInventoryWorkflowPath = path.join(currentDir, 'dependency-inventory.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 const dependabotPolicyPath = path.join(repoRoot, 'docs', 'dependabot-update-policy.md')
 const securityScannerEvaluationPath = path.join(repoRoot, 'docs', 'security-scanner-evaluation.md')
 const contractsGasSnapshotPolicyPath = path.join(repoRoot, 'docs', 'contracts-gas-snapshot-policy.md')
+const dependencyInventoryPolicyPath = path.join(repoRoot, 'docs', 'dependency-inventory-policy.md')
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 const developRequiredCheckRuns = [
   'Scope gate',
@@ -944,6 +946,87 @@ test('contracts gas snapshot policy documents baseline and reviewer handling', a
   assert.match(policy, /Intentional gas changes checklist/)
   assert.match(policy, /Reviewer accepted the gas impact/)
   assert.match(policy, /forge snapshot --check/)
+})
+
+test('dependency inventory workflow publishes report-only OSV scans by surface', async () => {
+  const workflow = await readFile(dependencyInventoryWorkflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(dependencyInventoryWorkflowPath)
+
+  assert.equal(parsedWorkflow.name, 'Dependency inventory scan')
+  assert.deepEqual(parsedWorkflow.on.schedule, [{ cron: '41 3 * * 2' }])
+  assert.ok(Object.hasOwn(parsedWorkflow.on, 'workflow_dispatch'))
+  assert.equal(parsedWorkflow.permissions.contents, 'read')
+  assert.equal(parsedWorkflow.permissions.actions, 'read')
+  assert.equal(parsedWorkflow.permissions['security-events'], 'write')
+  assert.equal(parsedWorkflow.concurrency.group, 'dependency-inventory-${{ github.repository }}')
+  assert.equal(parsedWorkflow.concurrency['cancel-in-progress'], false)
+
+  const go = parsedWorkflow.jobs['osv-go-modules']
+  const pnpm = parsedWorkflow.jobs['osv-pnpm-lockfiles']
+  const containerArchives = parsedWorkflow.jobs['build-container-inventory-archives']
+  const backendImage = parsedWorkflow.jobs['osv-container-backend-image']
+  const extensionImage = parsedWorkflow.jobs['osv-container-extension-image']
+  const dashboardImage = parsedWorkflow.jobs['osv-container-dashboard-image']
+
+  for (const job of [go, pnpm, backendImage, extensionImage, dashboardImage]) {
+    assert.equal(job.uses, 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5')
+    assert.equal(job.with['fail-on-vuln'], false)
+    assert.equal(job.with['upload-sarif'], true)
+  }
+
+  assert.match(go.with['scan-args'], /--lockfile=services\/api\/go\.mod/)
+  assert.equal(go.with['results-file-name'], 'osv-go-modules.sarif')
+  assert.equal(go.with['matrix-property'], 'go-')
+
+  assert.match(pnpm.with['scan-args'], /--lockfile=pnpm-lock\.yaml/)
+  assert.match(pnpm.with['scan-args'], /--lockfile=apps\/extension\/pnpm-lock\.yaml/)
+  assert.match(pnpm.with['scan-args'], /--lockfile=apps\/dashboard\/pnpm-lock\.yaml/)
+  assert.equal(pnpm.with['results-file-name'], 'osv-pnpm-lockfiles.sarif')
+  assert.equal(pnpm.with['matrix-property'], 'pnpm-')
+
+  assert.equal(containerArchives.name, 'Build dependency inventory image archives')
+  assert.equal(containerArchives['timeout-minutes'], 30)
+  assert.match(workflowJobBlock(workflow, 'build-container-inventory-archives'), /docker build -t tachigo-backend-inventory:latest \.\/services\/api/)
+  assert.match(workflowJobBlock(workflow, 'build-container-inventory-archives'), /docker save tachigo-backend-inventory:latest -o tachigo-backend-image\.tar/)
+  assert.match(workflowJobBlock(workflow, 'build-container-inventory-archives'), /name: dependency-inventory-backend-image/)
+  assert.match(workflowJobBlock(workflow, 'build-container-inventory-archives'), /name: dependency-inventory-extension-image/)
+  assert.match(workflowJobBlock(workflow, 'build-container-inventory-archives'), /name: dependency-inventory-dashboard-image/)
+
+  assert.equal(backendImage.needs, 'build-container-inventory-archives')
+  assert.equal(backendImage.with['download-artifact'], 'dependency-inventory-backend-image')
+  assert.equal(backendImage.with['results-file-name'], 'osv-container-backend-image.sarif')
+  assert.equal(backendImage.with['matrix-property'], 'container-backend-')
+  assert.match(backendImage.with['scan-args'], /scan\nimage\n--archive\ntachigo-backend-image\.tar/)
+
+  assert.equal(extensionImage.with['download-artifact'], 'dependency-inventory-extension-image')
+  assert.equal(extensionImage.with['results-file-name'], 'osv-container-extension-image.sarif')
+  assert.equal(extensionImage.with['matrix-property'], 'container-extension-')
+  assert.match(extensionImage.with['scan-args'], /scan\nimage\n--archive\ntachigo-extension-image\.tar/)
+
+  assert.equal(dashboardImage.with['download-artifact'], 'dependency-inventory-dashboard-image')
+  assert.equal(dashboardImage.with['results-file-name'], 'osv-container-dashboard-image.sarif')
+  assert.equal(dashboardImage.with['matrix-property'], 'container-dashboard-')
+  assert.match(dashboardImage.with['scan-args'], /scan\nimage\n--archive\ntachigo-dashboard-image\.tar/)
+})
+
+test('dependency inventory policy documents OSV triage ownership and non-blocking rollout', async () => {
+  const policy = await readFile(dependencyInventoryPolicyPath, 'utf8')
+
+  assert.match(policy, /Scheduled Dependency Inventory/)
+  assert.match(policy, /Source of truth.*#508/)
+  assert.match(policy, /Report owner/)
+  assert.match(policy, /Triage SLA/)
+  assert.match(policy, /Go module manifest/)
+  assert.match(policy, /pnpm lockfiles/)
+  assert.match(policy, /Container images/)
+  assert.match(policy, /Dependabot alerts/)
+  assert.match(policy, /Dependency Review/)
+  assert.match(policy, /not a required check/)
+  assert.match(policy, /weekly/)
+  assert.match(policy, /workflow_dispatch/)
+  assert.match(policy, /False positives and waivers/)
+  assert.match(policy, /Owner:/)
+  assert.match(policy, /Expires on:/)
 })
 
 test('global auto-merge workflow excludes Dependabot PRs', async () => {

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -826,7 +826,7 @@ test('backend security scanner job installs pinned staticcheck and govulncheck',
   assert.equal(job.name, 'Backend security scanners')
   assert.equal(job.env.STATICCHECK_VERSION, 'v0.7.0')
   assert.equal(job.env.GOVULNCHECK_VERSION, 'v1.3.0')
-  assert.match(jobBlock, /go-version: 1\.25\.9/)
+  assert.match(jobBlock, /go-version: 1\.25\.10/)
   assert.match(jobBlock, /go install honnef\.co\/go\/tools\/cmd\/staticcheck@\$STATICCHECK_VERSION/)
   assert.match(jobBlock, /go install golang\.org\/x\/vuln\/cmd\/govulncheck@\$GOVULNCHECK_VERSION/)
   assert.match(jobBlock, /working-directory: services\/api\n\s+run: staticcheck \.\/\.\.\./)

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -967,6 +967,7 @@ test('dependency inventory workflow publishes report-only OSV scans by surface',
   const backendImage = parsedWorkflow.jobs['osv-container-backend-image']
   const extensionImage = parsedWorkflow.jobs['osv-container-extension-image']
   const dashboardImage = parsedWorkflow.jobs['osv-container-dashboard-image']
+  const notifyDiscord = parsedWorkflow.jobs['notify-discord']
 
   for (const job of [go, pnpm, backendImage, extensionImage, dashboardImage]) {
     assert.equal(job.uses, 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5')
@@ -1007,6 +1008,19 @@ test('dependency inventory workflow publishes report-only OSV scans by surface',
   assert.equal(dashboardImage.with['results-file-name'], 'osv-container-dashboard-image.sarif')
   assert.equal(dashboardImage.with['matrix-property'], 'container-dashboard-')
   assert.match(dashboardImage.with['scan-args'], /scan\nimage\n--archive\ntachigo-dashboard-image\.tar/)
+
+  assert.equal(notifyDiscord.name, 'Notify Discord on dependency inventory failure')
+  assert.deepEqual(notifyDiscord.needs, [
+    'osv-go-modules',
+    'osv-pnpm-lockfiles',
+    'build-container-inventory-archives',
+    'osv-container-backend-image',
+    'osv-container-extension-image',
+    'osv-container-dashboard-image',
+  ])
+  assert.equal(notifyDiscord.if, 'failure()')
+  assert.match(workflowJobBlock(workflow, 'notify-discord'), /secrets\.DISCORD_CI_WEBHOOK_URL/)
+  assert.match(workflowJobBlock(workflow, 'notify-discord'), /Dependency inventory scan failed/)
 })
 
 test('dependency inventory policy documents OSV triage ownership and non-blocking rollout', async () => {
@@ -1025,6 +1039,7 @@ test('dependency inventory policy documents OSV triage ownership and non-blockin
   assert.match(policy, /weekly/)
   assert.match(policy, /workflow_dispatch/)
   assert.match(policy, /False positives and waivers/)
+  assert.match(policy, /Surface: Go module manifest \/ pnpm lockfiles \/ Container images/)
   assert.match(policy, /Owner:/)
   assert.match(policy, /Expires on:/)
 })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,7 +497,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
 
       - name: Install scanner tools
         run: |

--- a/.github/workflows/dependency-inventory.yml
+++ b/.github/workflows/dependency-inventory.yml
@@ -138,3 +138,22 @@ jobs:
       upload-sarif: true
       fail-on-vuln: false
       matrix-property: container-dashboard-
+
+  notify-discord:
+    timeout-minutes: 5
+    name: Notify Discord on dependency inventory failure
+    needs:
+      - osv-go-modules
+      - osv-pnpm-lockfiles
+      - build-container-inventory-archives
+      - osv-container-backend-image
+      - osv-container-extension-image
+      - osv-container-dashboard-image
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send failure notification
+        run: |
+          curl -X POST "${{ secrets.DISCORD_CI_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"content\": \"Dependency inventory scan failed on \`${{ github.ref_name }}\` (${{ github.event_name }})\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"

--- a/.github/workflows/dependency-inventory.yml
+++ b/.github/workflows/dependency-inventory.yml
@@ -1,0 +1,140 @@
+name: Dependency inventory scan
+
+on:
+  schedule:
+    - cron: "41 3 * * 2"
+  workflow_dispatch:
+
+concurrency:
+  group: dependency-inventory-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  osv-go-modules:
+    name: OSV Go module inventory
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      scan-args: |-
+        --lockfile=services/api/go.mod
+      results-file-name: osv-go-modules.sarif
+      upload-sarif: true
+      fail-on-vuln: false
+      matrix-property: go-
+
+  osv-pnpm-lockfiles:
+    name: OSV pnpm lockfiles inventory
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      scan-args: |-
+        --lockfile=pnpm-lock.yaml
+        --lockfile=apps/extension/pnpm-lock.yaml
+        --lockfile=apps/dashboard/pnpm-lock.yaml
+      results-file-name: osv-pnpm-lockfiles.sarif
+      upload-sarif: true
+      fail-on-vuln: false
+      matrix-property: pnpm-
+
+  build-container-inventory-archives:
+    timeout-minutes: 30
+    name: Build dependency inventory image archives
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build backend inventory image
+        run: docker build -t tachigo-backend-inventory:latest ./services/api
+
+      - name: Save backend inventory image
+        run: docker save tachigo-backend-inventory:latest -o tachigo-backend-image.tar
+
+      - name: Upload backend inventory image archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-inventory-backend-image
+          path: tachigo-backend-image.tar
+          if-no-files-found: error
+          retention-days: 5
+
+      - name: Build extension inventory image
+        run: docker build -t tachigo-extension-inventory:latest ./apps/extension
+
+      - name: Save extension inventory image
+        run: docker save tachigo-extension-inventory:latest -o tachigo-extension-image.tar
+
+      - name: Upload extension inventory image archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-inventory-extension-image
+          path: tachigo-extension-image.tar
+          if-no-files-found: error
+          retention-days: 5
+
+      - name: Build dashboard inventory image
+        run: docker build -t tachigo-dashboard-inventory:latest ./apps/dashboard
+
+      - name: Save dashboard inventory image
+        run: docker save tachigo-dashboard-inventory:latest -o tachigo-dashboard-image.tar
+
+      - name: Upload dashboard inventory image archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-inventory-dashboard-image
+          path: tachigo-dashboard-image.tar
+          if-no-files-found: error
+          retention-days: 5
+
+  osv-container-backend-image:
+    name: OSV backend image inventory
+    needs: build-container-inventory-archives
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      download-artifact: dependency-inventory-backend-image
+      scan-args: |-
+        scan
+        image
+        --archive
+        tachigo-backend-image.tar
+      results-file-name: osv-container-backend-image.sarif
+      upload-sarif: true
+      fail-on-vuln: false
+      matrix-property: container-backend-
+
+  osv-container-extension-image:
+    name: OSV extension image inventory
+    needs: build-container-inventory-archives
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      download-artifact: dependency-inventory-extension-image
+      scan-args: |-
+        scan
+        image
+        --archive
+        tachigo-extension-image.tar
+      results-file-name: osv-container-extension-image.sarif
+      upload-sarif: true
+      fail-on-vuln: false
+      matrix-property: container-extension-
+
+  osv-container-dashboard-image:
+    name: OSV dashboard image inventory
+    needs: build-container-inventory-archives
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      download-artifact: dependency-inventory-dashboard-image
+      scan-args: |-
+        scan
+        image
+        --archive
+        tachigo-dashboard-image.tar
+      results-file-name: osv-container-dashboard-image.sarif
+      upload-sarif: true
+      fail-on-vuln: false
+      matrix-property: container-dashboard-

--- a/docs/dependency-inventory-policy.md
+++ b/docs/dependency-inventory-policy.md
@@ -1,0 +1,119 @@
+# Scheduled Dependency Inventory
+
+**Source of truth**: #508
+**Status**: report-only first rollout
+
+## Decision
+
+The first scheduled dependency inventory rollout uses OSV Scanner as a weekly
+and manually runnable report. The workflow runs through `workflow_dispatch` and
+on a weekly schedule, uploads separate SARIF reports, and sends results to
+GitHub code scanning.
+
+This is not a required check. Vulnerability findings should not block PRs in
+this rollout because the repository already has narrower PR-time signals:
+
+- Dependabot alerts and update PRs cover known dependency updates over time.
+- Dependency Review blocks newly introduced high or critical production
+  dependency vulnerabilities in frontend lockfile changes.
+- `govulncheck` remains the lower-noise Go gate because it accounts for
+  reachability instead of only package versions.
+
+OSV Scanner still adds value as an inventory sweep because vulnerability data
+changes even when repository files do not.
+
+## Report surfaces
+
+### Go module manifest
+
+The Go report scans `services/api/go.mod`, which is the Go module manifest
+supported by OSV Scanner for source scans.
+
+Use this report to catch ecosystem advisories that may not yet be visible during
+normal code review. If OSV reports a Go package vulnerability, first compare it
+with `govulncheck` because reachable findings have higher priority than
+package-version-only findings.
+
+### pnpm lockfiles
+
+The pnpm report scans the root lockfile plus the extension and dashboard
+lockfiles:
+
+- `pnpm-lock.yaml`
+- `apps/extension/pnpm-lock.yaml`
+- `apps/dashboard/pnpm-lock.yaml`
+
+Use this report as an inventory view, not as a second PR gate. New vulnerable
+runtime dependencies should still be handled by Dependency Review on the PR that
+introduced the lockfile change.
+
+### Container images
+
+The container report builds and exports the backend, extension, and dashboard
+images, then scans the image archives. This separates base image and OS package
+findings from language lockfile findings.
+
+Container findings are expected to be noisier than lockfile findings because dev
+images include toolchains. Treat them as maintenance inventory until the project
+has production-specific image targets and an agreed base image update cadence.
+
+## Report owner
+
+The production-readiness maintainer owns the weekly inventory run and is
+responsible for routing findings to the relevant surface owner:
+
+- Backend owner: Go module findings.
+- Frontend owner: pnpm lockfile findings for extension and dashboard.
+- Infra owner: container image findings and base image update policy.
+
+## Triage SLA
+
+- Review each weekly report within three business days.
+- For critical or actively exploited findings, open or update a tracking issue
+  by the next business day.
+- For high severity findings with a clear upgrade path, target the next normal
+  maintenance window.
+- For medium, low, unknown, duplicate, or unreachable findings, record the
+  decision during the weekly report review.
+
+## Avoiding duplicate noise
+
+Do not file a new issue only because OSV repeats an existing Dependabot alert,
+Dependency Review finding, or `govulncheck` finding. Link the OSV report to the
+existing issue or PR instead.
+
+Create a separate issue only when OSV adds new information, such as a container
+base image package that Dependabot does not cover, a lockfile finding without an
+existing alert, or evidence that a previous waiver has expired.
+
+## False positives and waivers
+
+Accepted findings need an owner and an expiry date. Prefer fixing or upgrading
+over waiving when a safe update exists.
+
+Suggested waiver format:
+
+```markdown
+## OSV / <vulnerability id>
+
+- Owner:
+- Accepted on:
+- Expires on:
+- Surface: Go lockfiles / pnpm lockfiles / Container images
+- Affected package:
+- Source report:
+- Decision: false positive / accepted risk / duplicate / follow-up issue
+- Why this is accepted:
+- Recheck trigger:
+```
+
+## Promotion conditions for a blocking gate
+
+Do not promote OSV inventory to a required check until all of the following are
+true:
+
+- The weekly report has run long enough to establish a clean or triaged baseline.
+- Duplicate handling with Dependabot alerts and Dependency Review is stable.
+- Container findings have a production image target or an explicit base image
+  owner.
+- Waivers have owners, expiry dates, and recheck triggers.

--- a/docs/dependency-inventory-policy.md
+++ b/docs/dependency-inventory-policy.md
@@ -99,7 +99,7 @@ Suggested waiver format:
 - Owner:
 - Accepted on:
 - Expires on:
-- Surface: Go lockfiles / pnpm lockfiles / Container images
+- Surface: Go module manifest / pnpm lockfiles / Container images
 - Affected package:
 - Source report:
 - Decision: false positive / accepted risk / duplicate / follow-up issue


### PR DESCRIPTION
## 什麼改動
新增 `Dependency inventory scan` workflow，提供 weekly schedule 與 `workflow_dispatch` 手動重跑入口。

workflow 以 OSV Scanner report-only 模式分開產出 Go module、pnpm lockfiles、backend image、extension image、dashboard image 的 SARIF / artifact 訊號，並新增 regression tests 鎖住第一版不 blocking 的設定。

新增 `docs/dependency-inventory-policy.md`，文件化 report owner、triage SLA、Dependabot / Dependency Review 去重方式、false positive waiver 格式，以及未來升級成 blocking gate 的條件。

另外將 backend security scanner job 的 Go toolchain 從 `1.25.9` 更新到 `1.25.10`，修正初次 CI run 因 Go stdlib reachable vulnerabilities 而失敗的問題。

## 為什麼
closes #508

#210 建議 OSV Scanner 第一階段不要成為 PR blocking gate，但可以作為 scheduled dependency / vulnerability inventory report，用來補足「程式碼沒變但漏洞資料庫更新」的情境。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#508
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不把 OSV Scanner 設成 required check
  - 不取代 Dependabot alerts 或 Dependency Review
  - 不掃描 production secrets 或 deploy credentials
  - 不加入 deploy / release gate

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 scheduled/manual dependency inventory report，並文件化 owner 與 triage policy。
- Approx changed lines：~344
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #508 驗收同時要求 weekly/manual report、Go/pnpm/container 區分、owner/triage 流程與低訊號時不導入 blocking gate 的文件化；workflow regression tests 用來鎖住 report-only 行為。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] weekly report 可手動重跑
- [x] report 明確區分 Go、pnpm、container image findings
- [x] findings 有 owner / triage 流程
- [x] 若訊號低，文件化不導入 blocking gate 的理由

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
# tests 51, pass 51, fail 0

go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dependency-inventory.yml
# no output

go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore SC2086 .github/workflows/*.yml
# no output

git diff --check
# no output
```

## 備註
OSV Scanner Action 最新 GitHub release / tag 目前使用 `v2.3.5`。官方 README badge 提到 `v2.3.6`，但 tags / releases 查到可用最新 tag 是 `v2.3.5`，因此本 PR pin 到可驗證 tag。

## Notes for Claude Code Review
- 所有 OSV jobs 都設定 `fail-on-vuln: false`；漏洞 findings 會進 SARIF / artifact，但不會把 scheduled inventory 變成 required gate。
- Go source scan 使用官方支援的 `services/api/go.mod`，避免掃 `go.sum` 造成 no packages found。
- Container image scan 先 `docker save` 成 archive，再交給 OSV reusable workflow 掃 `scan image --archive`，避免啟動 image runtime。
- `govulncheck` 初次 CI run 在 Go `1.25.9` 偵測到標準函式庫 reachable vulnerabilities；fixed in Go `1.25.10`，因此同步更新 scanner job toolchain。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加定期依赖项清单工作流（定期 + 手动触发），对 Go 模块、pnpm 锁文件和容器镜像执行扫描并上传 SARIF，处于报告优先阶段且不阻断 PR；失败时触发的通知会发送到指定渠道（仅在整体失败时）。
* **文档**
  * 新增依赖清单政策，包含报告面、归属与 SLA、误报/豁免处理与灰度投放规则。
* **Chores**
  * 将后端安全扫描运行时版本更新至最新稳定版本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->