### PR TITLE
[chore] Tune Dependabot production update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,16 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - chore
+    allow:
+      - dependency-type: production
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
+      - dependency-type: development
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
+          - version-update:semver-major
     cooldown:
       semver-major-days: 30
       semver-minor-days: 21
@@ -68,6 +78,16 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - chore
+    allow:
+      - dependency-type: production
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
+      - dependency-type: development
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
+          - version-update:semver-major
     cooldown:
       semver-major-days: 30
       semver-minor-days: 21

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -9,6 +9,8 @@ const currentDir = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(currentDir, '..', '..')
 const workflowPath = path.join(currentDir, 'ci.yml')
 const scopePolicePath = path.join(currentDir, 'pr-scope-police.yml')
+const dependabotConfigPath = path.join(repoRoot, '.github', 'dependabot.yml')
+const dependabotAutomergeWorkflowPath = path.join(currentDir, 'dependabot-automerge.yml')
 const autoMergeWorkflowPath = path.join(currentDir, 'auto-merge.yml')
 const autoReadyWorkflowPath = path.join(currentDir, 'auto-ready-pr.yml')
 const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rerequest.yml')
@@ -829,10 +831,49 @@ test('dependency review policy documents Dependabot split and waiver handling', 
   assert.match(policy, /Dependency Review Gate/)
   assert.match(policy, /high\/critical production dependency vulnerabilities/)
   assert.match(policy, /development dependency findings are report-only/)
-  assert.match(policy, /Dependabot opens routine version and security update PRs/)
+  assert.match(policy, /Dependabot opens routine version update PRs for the configured update levels/)
+  assert.match(policy, /security update PRs for alert-triggered fixes/)
+  assert.match(policy, /Production security update\s+PRs remain manual-review changes/)
   assert.match(policy, /False Positives And Waivers/)
   assert.match(policy, /Owner:/)
   assert.match(policy, /Expires on:/)
+})
+
+test('Dependabot pnpm version updates skip routine production patch releases', () => {
+  const config = parseYaml(dependabotConfigPath)
+  const pnpmUpdates = config.updates.filter((update) => update['package-ecosystem'] === 'npm')
+
+  assert.equal(pnpmUpdates.length, 2)
+  for (const update of pnpmUpdates) {
+    assert.deepEqual(update.allow, [
+      {
+        'dependency-type': 'production',
+        'update-types': [
+          'version-update:semver-minor',
+          'version-update:semver-major',
+        ],
+      },
+      {
+        'dependency-type': 'development',
+        'update-types': [
+          'version-update:semver-patch',
+          'version-update:semver-minor',
+          'version-update:semver-major',
+        ],
+      },
+    ])
+  }
+})
+
+test('Dependabot auto-merge keeps production dependency updates on manual review', async () => {
+  const workflow = await readFile(dependabotAutomergeWorkflowPath, 'utf8')
+  const jobBlock = workflowJobBlock(workflow, 'automerge')
+
+  assert.doesNotMatch(jobBlock, /BASE_REF: \$\{\{ github\.event\.pull_request\.base\.ref \}\}/)
+  assert.doesNotMatch(jobBlock, /DEFAULT_BRANCH: \$\{\{ github\.event\.repository\.default_branch \}\}/)
+  assert.doesNotMatch(jobBlock, /default-branch production patch update \(security-alert path\)/)
+  assert.match(jobBlock, /\[\[ "\$DEPENDENCY_TYPE" != "direct:development" \]\]/)
+  assert.match(jobBlock, /reason="production dependency requires manual review"/)
 })
 
 test('global auto-merge workflow excludes Dependabot PRs', async () => {

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,12 +35,14 @@ jobs:
           auto_merge=false
           reason="manual review required"
 
-          if [[ ",$LABELS," == *",security,"* ]]; then
-            auto_merge=true
-            reason="security update"
-          elif [[ ",$LABELS," == *",safe-to-automerge,"* ]]; then
+          if [[ ",$LABELS," == *",safe-to-automerge,"* ]]; then
             auto_merge=true
             reason="manual override label: safe-to-automerge"
+          elif [[ "$DEPENDENCY_TYPE" != "direct:development" ]]; then
+            reason="production dependency requires manual review"
+          elif [[ ",$LABELS," == *",security,"* ]]; then
+            auto_merge=true
+            reason="security update"
           elif [[ "$DEPENDENCY_TYPE" == "direct:development" ]] && \
                [[ "$UPDATE_TYPE" == "version-update:semver-patch" || "$UPDATE_TYPE" == "version-update:semver-minor" ]] && \
                [[ "$DEPENDENCY_NAMES" != *"typescript"* ]] && \
@@ -52,9 +54,7 @@ jobs:
             auto_merge=true
             reason="safe devDependency patch/minor update"
           else
-            if [[ "$DEPENDENCY_TYPE" != "direct:development" ]]; then
-              reason="non-dev dependency"
-            elif [[ "$UPDATE_TYPE" != "version-update:semver-patch" && "$UPDATE_TYPE" != "version-update:semver-minor" ]]; then
+            if [[ "$UPDATE_TYPE" != "version-update:semver-patch" && "$UPDATE_TYPE" != "version-update:semver-minor" ]]; then
               reason="major or unsupported update type"
             elif [[ "$DEPENDENCY_NAMES" == *"typescript"* ]]; then
               reason="typescript update requires manual review"

--- a/docs/dependabot-update-policy.md
+++ b/docs/dependabot-update-policy.md
@@ -37,6 +37,18 @@ The production/development split keeps runtime dependency updates visible while
 still batching development tooling changes such as TypeScript, ESLint, Vite, and
 test tooling.
 
+Routine pnpm version updates intentionally skip production patch releases. For
+production dependencies, Dependabot opens routine version update PRs only for
+minor and major releases; this avoids review noise for tiny runtime bumps.
+Development dependencies still receive patch, minor, and major routine version
+updates.
+
+This `allow.update-types` boundary applies only to version updates. Dependabot
+security update PRs remain enabled, including patch-level production updates
+triggered by security alerts on the default branch. Production security update
+PRs remain manual-review changes because dependency upgrades can introduce new
+supply-chain, compatibility, or runtime risks even when they fix a known issue.
+
 ## Cooldown
 
 High-frequency frontend tooling updates use Dependabot cooldown:
@@ -56,22 +68,24 @@ still allowing security alerts and runtime dependency updates to remain visible.
 
 The `dependabot-automerge.yml` workflow remains conservative:
 
-- security updates may auto-merge when checks pass
-- updates explicitly labeled `safe-to-automerge` may auto-merge when checks pass
+- direct development security updates may auto-merge when checks pass
 - selected direct development patch/minor updates may auto-merge
-- production dependency updates, major updates, and excluded tooling packages do
-  not auto-merge by default
+- updates explicitly labeled `safe-to-automerge` may auto-merge when checks pass;
+  this is a manual override label, not a bot-only decision
+- production dependency updates, including security patches, and excluded tooling
+  packages do not auto-merge by default
 
-If a Dependabot PR touches runtime behavior or a production dependency, review it
-as a normal PR instead of relying on automation.
+If a Dependabot PR touches runtime behavior or a production dependency, review
+it as a normal PR instead of relying on automation unless a maintainer has
+explicitly applied `safe-to-automerge` after review.
 
 ## Dependency Review Gate
 
-Dependabot opens routine version and security update PRs. Dependency Review is
-the complementary PR gate for dependency changes opened by humans or automation:
-it compares the dependency diff in the PR and blocks newly introduced
-high/critical production dependency vulnerabilities before they enter
-`develop`.
+Dependabot opens routine version update PRs for the configured update levels and
+security update PRs for alert-triggered fixes. Dependency Review is the
+complementary PR gate for dependency changes opened by humans or automation: it
+compares the dependency diff in the PR and blocks newly introduced high/critical
+production dependency vulnerabilities before they enter `develop`.
 
 The gate runs only when dependency manifests or lockfiles for the frontend
 workspace change:


### PR DESCRIPTION
## 什麼改動
- 調整 pnpm workspace 的 Dependabot version update policy：production dependency routine patch 不再開 PR，production minor/major 仍開 PR，development dependency 仍保留 patch/minor/major。
- 調整 Dependabot auto-merge policy：production dependency 更新一律保留人工 review，包含 security patch；只有 `safe-to-automerge` 人工 override 可放行。
- 更新 Dependabot policy 文件與 workflow regression tests。

## 為什麼
closes #525

降低 routine production patch 造成的 review noise，同時避免把 production dependency security patch 自動合併，因為 dependency upgrade 本身仍可能引入 supply-chain、相容性或 runtime 風險。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#525
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 scheduled dependency / vulnerability inventory scan workflow（#508 範圍）
  - 不調整 backend / frontend product code
  - 不關閉 Dependabot security update PR

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 降低 pnpm production patch version update PR 噪音，並要求 production dependency 更新保留人工 review。
- Approx changed lines：~113
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Workflow policy 調整需要 regression tests 鎖住行為，policy 文件同步描述 reviewer 邊界。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Routine pnpm production patch version updates no longer open Dependabot PRs.
- [x] Dependabot security update PRs remain enabled.
- [x] Production dependency updates, including security patches, do not auto-merge without manual `safe-to-automerge`.
- [x] Policy docs and workflow regression tests cover the new boundary.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
tests 51
pass 51
fail 0
```

## 備註
PR #520 曾誤以 #508 作為 source of truth；#508 是 scheduled dependency / vulnerability inventory scan，現在只列在「本 PR 明確不做」中。

## Notes for Claude Code Review
- 請特別確認 `dependabot/fetch-metadata` 回傳的 `dependency-type` 是否足以涵蓋 production dependency manual-review 邏輯。
- GitHub Dependabot 對 pnpm 仍使用 `package-ecosystem: npm`；本 PR 只改 policy，不改 ecosystem value。
