### PR TITLE
[backend] test: cover web3 verify flow

### DIFF
--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -479,10 +479,21 @@ func TestWeb3VerifyHandler_SuccessSetsRefreshCookieAndConsumesNonce(t *testing.T
 	assertRefreshCookieSet(t, w, "", http.SameSiteLaxMode, false)
 
 	resp := parseBody(t, w.Body.Bytes())
-	data, _ := resp["data"].(map[string]interface{})
-	tokens, _ := data["tokens"].(map[string]interface{})
-	if tokens["access_token"] == "" || tokens["refresh_token"] == "" {
-		t.Fatalf("expected non-empty tokens in response: %#v", tokens)
+	data, ok := resp["data"].(map[string]interface{})
+	if !ok || data == nil {
+		t.Fatalf("expected data map in response, resp=%#v", resp)
+	}
+	tokens, ok := data["tokens"].(map[string]interface{})
+	if !ok || tokens == nil {
+		t.Fatalf("expected tokens map in response, data=%#v", data)
+	}
+	accessToken, ok := tokens["access_token"].(string)
+	if !ok || accessToken == "" {
+		t.Fatalf("expected non-empty access_token in response: %#v", tokens)
+	}
+	refreshToken, ok := tokens["refresh_token"].(string)
+	if !ok || refreshToken == "" {
+		t.Fatalf("expected non-empty refresh_token in response: %#v", tokens)
 	}
 
 	var provider models.AuthProvider

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -2,11 +2,15 @@ package handlers_test
 
 import (
 	"bytes"
-	"fmt"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/tachigo/tachigo/internal/models"
 )
 
 // ─── Register ────────────────────────────────────────────────────────────────
@@ -451,6 +455,76 @@ func TestWeb3NonceHandler_MissingAddress(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("want 400, got %d", w.Code)
+	}
+}
+
+func TestWeb3VerifyHandler_SuccessSetsRefreshCookieAndConsumesNonce(t *testing.T) {
+	env := newTestEnv(t)
+	key, addr := newHandlerTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "handler-web3-verify-success"
+	nonceRecord := seedHandlerWalletNonce(t, env, addr, nonce)
+	msg := handlerSIWEMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := handlerSignSIWE(t, msg, key)
+	body := fmt.Sprintf(`{"address":%q,"nonce":%q,"signature":%q}`, addr, nonce, sig)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/web3/verify", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	assertRefreshCookieSet(t, w, "", http.SameSiteLaxMode, false)
+
+	resp := parseBody(t, w.Body.Bytes())
+	data, _ := resp["data"].(map[string]interface{})
+	tokens, _ := data["tokens"].(map[string]interface{})
+	if tokens["access_token"] == "" || tokens["refresh_token"] == "" {
+		t.Fatalf("expected non-empty tokens in response: %#v", tokens)
+	}
+
+	var provider models.AuthProvider
+	if err := env.db.Where("provider = ? AND provider_id = ?", models.ProviderWeb3, addr).First(&provider).Error; err != nil {
+		t.Fatalf("web3 provider not found: %v", err)
+	}
+
+	var nonceCount int64
+	env.db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
+	if nonceCount != 0 {
+		t.Fatalf("nonce should be consumed, got %d rows", nonceCount)
+	}
+}
+
+func TestWeb3VerifyHandler_InvalidSignatureReturns401AndKeepsNonce(t *testing.T) {
+	env := newTestEnv(t)
+	_, addr := newHandlerTestWallet(t)
+	wrongKey, _ := newHandlerTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "handler-web3-verify-bad-signature"
+	nonceRecord := seedHandlerWalletNonce(t, env, addr, nonce)
+	msg := handlerSIWEMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := handlerSignSIWE(t, msg, wrongKey)
+	body := fmt.Sprintf(`{"address":%q,"nonce":%q,"signature":%q}`, addr, nonce, sig)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/web3/verify", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if resp["error"] != "invalid wallet signature" {
+		t.Fatalf("want invalid wallet signature error, got %#v", resp["error"])
+	}
+
+	var nonceCount int64
+	env.db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
+	if nonceCount != 1 {
+		t.Fatalf("invalid signature should keep nonce for retry, got %d rows", nonceCount)
 	}
 }
 

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -245,6 +245,128 @@ func TestWeb3Nonce_ReplacesExisting(t *testing.T) {
 	}
 }
 
+func TestWeb3Verify_SuccessConsumesNonceAndIssuesTokens(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	key, addr := newTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "web3-verify-success"
+	nonceRecord := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+
+	user, tokens, err := svc.Web3Verify(Web3VerifyInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil || tokens == nil {
+		t.Fatal("expected user and tokens")
+	}
+	if tokens.AccessToken == "" || tokens.RefreshToken == "" {
+		t.Fatal("expected non-empty token pair")
+	}
+
+	var provider models.AuthProvider
+	if err := db.Where("user_id = ? AND provider = ?", user.ID, models.ProviderWeb3).First(&provider).Error; err != nil {
+		t.Fatalf("web3 provider not found: %v", err)
+	}
+	if provider.ProviderID != addr {
+		t.Fatalf("provider_id: want %s, got %s", addr, provider.ProviderID)
+	}
+
+	var nonceCount int64
+	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
+	if nonceCount != 0 {
+		t.Fatalf("nonce should be consumed, got %d rows", nonceCount)
+	}
+}
+
+func TestWeb3Verify_ReplayConsumedNonceReturnsInvalidNonce(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	key, addr := newTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "web3-verify-replay"
+	nonceRecord := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+	input := Web3VerifyInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	}
+
+	if _, _, err := svc.Web3Verify(input); err != nil {
+		t.Fatalf("first verify failed: %v", err)
+	}
+	_, _, err := svc.Web3Verify(input)
+	if err != ErrInvalidNonce {
+		t.Fatalf("want ErrInvalidNonce on replay, got %v", err)
+	}
+}
+
+func TestWeb3Verify_InvalidSignatureKeepsNonce(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	_, addr := newTestWallet(t)
+	wrongKey, _ := newTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "web3-verify-bad-signature"
+	nonceRecord := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, wrongKey)
+
+	_, _, err := svc.Web3Verify(Web3VerifyInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err != ErrInvalidSignature {
+		t.Fatalf("want ErrInvalidSignature, got %v", err)
+	}
+
+	var nonceCount int64
+	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
+	if nonceCount != 1 {
+		t.Fatalf("invalid signature should keep nonce for retry, got %d rows", nonceCount)
+	}
+}
+
+func TestWeb3Verify_ExpiredNonceReturnsInvalidNonceAndDeletesRecord(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	key, addr := newTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "web3-verify-expired"
+	seedExpiredWalletNonce(t, db, addr, nonce)
+
+	var nonceRecord models.Web3Nonce
+	if err := db.Where("nonce = ?", nonce).First(&nonceRecord).Error; err != nil {
+		t.Fatalf("find seeded nonce: %v", err)
+	}
+	msg := siweMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+
+	_, _, err := svc.Web3Verify(Web3VerifyInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err != ErrInvalidNonce {
+		t.Fatalf("want ErrInvalidNonce, got %v", err)
+	}
+
+	var nonceCount int64
+	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
+	if nonceCount != 0 {
+		t.Fatalf("expired nonce should be deleted, got %d rows", nonceCount)
+	}
+}
+
 // ─── UnlinkProvider ──────────────────────────────────────────────────────────
 
 func TestUnlinkProvider_LastProvider_NoPassword(t *testing.T) {


### PR DESCRIPTION
## 什麼改動
- 補上 `AuthService.Web3Verify` 的 service 層回歸測試。
- 補上 `/api/v1/auth/web3/verify` handler 層成功與錯簽名測試。

## 為什麼
Web3 verify 是 auth 高風險路徑，先補一個小型 test-only PR，鎖住 nonce 消耗、replay 防護、錯簽名與過期 nonce 行為。

refs #420

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#420
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 production code。
  - 不用 DB failure injection 覆蓋 Web3Verify 的 nonce / token / provider persistence error propagation；已拆到 #526。
  - 不補鏈上 Go client 測試。
  - 不補 migration apply integration 測試。
  - 不補 frontend hook 測試。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 為 Web3 verify auth flow 補上 nonce / signature 行為回歸測試。
- Approx changed lines：~200
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - 後續小 PR 預計補鏈上 Go client 測試與 migration apply integration 測試。
  - #526 追蹤 Web3Verify DB failure propagation 測試。

## Acceptance Criteria
- [x] Web3 verify 成功流程會建立 Web3 provider、簽發 token，並消耗 nonce。
- [x] 已消耗 nonce 不能 replay。
- [x] 錯簽名會回傳 invalid signature，且保留 nonce 供使用者重試。
- [x] 過期 nonce 會回傳 invalid nonce 並刪除記錄。
- [x] Handler 成功時會設定 refresh cookie；錯簽名時回 401。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
go test ./internal/services -run 'TestWeb3' -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.385s

go test ./internal/handlers -run 'TestWeb3' -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.563s

go test ./internal/services ./internal/handlers -count=1
ok  	github.com/tachigo/tachigo/internal/services	2.826s
ok  	github.com/tachigo/tachigo/internal/handlers	24.088s

go test ./...
ok  	github.com/tachigo/tachigo/cmd/loader	(cached)
ok  	github.com/tachigo/tachigo/cmd/server	(cached)
ok  	github.com/tachigo/tachigo/docs	(cached)
ok  	github.com/tachigo/tachigo/internal/config	(cached)
ok  	github.com/tachigo/tachigo/internal/contract	(cached)
?   	github.com/tachigo/tachigo/internal/database	[no test files]
ok  	github.com/tachigo/tachigo/internal/handlers	(cached)
ok  	github.com/tachigo/tachigo/internal/middleware	(cached)
ok  	github.com/tachigo/tachigo/internal/models	(cached)
ok  	github.com/tachigo/tachigo/internal/router	(cached)
?   	github.com/tachigo/tachigo/internal/schema	[no test files]
ok  	github.com/tachigo/tachigo/internal/services	(cached)
```

## 備註
這是測試補強 PR，刻意先不混入鏈上 client、migration 或 frontend hook 覆蓋。
本 PR 鎖住 Web3Verify 的一般行為路徑；#420 類型的 DB Create / Delete failure propagation 會由 #526 另行補更聚焦的 failure-path 測試。

## Notes for Claude Code Review
- 請特別確認這包是否維持 test-only scope。
- `refs #420` 是因為該 issue 明確涵蓋 Web3 nonce replay / auth_service token-provider 風險；本 PR 不關閉該 issue。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 添加对 Web3 钱包验证的端到端与服务层测试覆盖：成功场景会颁发访问/刷新令牌、设置刷新 cookie 并消费 nonce。
  * 添加无效签名测试，返回 401 并保留 nonce 以便重试。
  * 添加重放已消费 nonce 的失败测试，以及过期 nonce 会被拒绝并删除的测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
