### PR TITLE
[infra] fix: bump backend scanner go patch version

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -824,7 +824,7 @@ test('backend security scanner job installs pinned staticcheck and govulncheck',
   assert.equal(job.name, 'Backend security scanners')
   assert.equal(job.env.STATICCHECK_VERSION, 'v0.7.0')
   assert.equal(job.env.GOVULNCHECK_VERSION, 'v1.3.0')
-  assert.match(jobBlock, /go-version: 1\.25\.9/)
+  assert.match(jobBlock, /go-version: 1\.25\.10/)
   assert.match(jobBlock, /go install honnef\.co\/go\/tools\/cmd\/staticcheck@\$STATICCHECK_VERSION/)
   assert.match(jobBlock, /go install golang\.org\/x\/vuln\/cmd\/govulncheck@\$GOVULNCHECK_VERSION/)
   assert.match(jobBlock, /working-directory: services\/api\n\s+run: staticcheck \.\/\.\.\./)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,7 +497,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
 
       - name: Install scanner tools
         run: |


### PR DESCRIPTION
## 什麼改動
將 Backend security scanners job 使用的 Go patch 版本從 `1.25.9` 更新到 `1.25.10`，並同步更新 workflow regression test 的版本斷言。

## 為什麼
closes #522

PR #521 的 `Backend security scanners` 目前在 `govulncheck ./...` 階段被 Go 1.25.9 標準函式庫漏洞擋下；這些 findings 已在 Go 1.25.10 修補。此 PR 只更新 scanner job 的 Go patch 版本，讓 required scanner gate 使用已修補的 toolchain。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#522
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 backend application code
  - 不修改 Go dependency manifests
  - 不處理 #521 測試覆蓋內容

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Bump Backend security scanners to Go 1.25.10 so govulncheck runs with the patched standard library.
- Approx changed lines：~4
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #521 covers Web3 verify test coverage separately.

## Acceptance Criteria
- [x] Backend security scanner job installs Go 1.25.10.
- [x] Workflow regression test pins the updated scanner Go version.
- [x] No backend/source behavior changes.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
tests 49
pass 49
fail 0

bash infra/scripts/check-backend-ci-cache.sh
pass

git diff --check
pass
```

## 備註
此 PR 是針對 #521 required scanner failure 拆出的 CI-only 修復。

## Notes for Claude Code Review
- Root cause from the failing scanner run: `govulncheck` used Go 1.25.9 and reported standard-library vulnerabilities fixed in Go 1.25.10.
- The PR intentionally does not touch `services/api/go.mod`; application build jobs continue to use the module's `go-version-file` path.
