### PR TITLE
[backend] test: cover Web3Verify DB failure propagation

### DIFF
--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -267,9 +267,7 @@ func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPai
 		return nil, nil, ErrInvalidNonce
 	}
 	if nonceRecord.IsExpired() {
-		if err := s.db.Delete(&nonceRecord).Error; err != nil {
-			return nil, nil, err
-		}
+		s.db.Delete(&nonceRecord)
 		return nil, nil, ErrInvalidNonce
 	}
 

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -267,7 +267,9 @@ func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPai
 		return nil, nil, ErrInvalidNonce
 	}
 	if nonceRecord.IsExpired() {
-		s.db.Delete(&nonceRecord)
+		if err := s.db.Delete(&nonceRecord).Error; err != nil {
+			return nil, nil, err
+		}
 		return nil, nil, ErrInvalidNonce
 	}
 
@@ -278,7 +280,9 @@ func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPai
 	}
 
 	// Nonce is consumed
-	s.db.Delete(&nonceRecord)
+	if err := s.db.Delete(&nonceRecord).Error; err != nil {
+		return nil, nil, err
+	}
 
 	// Upsert user
 	checksumAddr := common.HexToAddress(input.Address).Hex()
@@ -429,7 +433,9 @@ func (s *AuthService) upsertOAuthUser(
 		newAP.RefreshToken = &rt
 		newAP.TokenExpiresAt = &token.Expiry
 	}
-	s.db.Create(&newAP)
+	if err := s.db.Create(&newAP).Error; err != nil {
+		return nil, nil, err
+	}
 
 	tokens, err := s.issueTokenPair(&user)
 	return &user, tokens, err

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -400,6 +400,9 @@ func TestWeb3Verify_RefreshTokenCreateFailureReturnsError(t *testing.T) {
 	if tokens != nil {
 		t.Fatalf("tokens should be nil when refresh token create fails, got %#v", tokens)
 	}
+	if !strings.Contains(err.Error(), "no such table: refresh_tokens") {
+		t.Fatalf("want refresh token table error, got %v", err)
+	}
 }
 
 func TestWeb3Verify_ReplayConsumedNonceReturnsInvalidNonce(t *testing.T) {
@@ -481,6 +484,53 @@ func TestWeb3Verify_ExpiredNonceReturnsInvalidNonceAndDeletesRecord(t *testing.T
 	db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
 	if nonceCount != 0 {
 		t.Fatalf("expired nonce should be deleted, got %d rows", nonceCount)
+	}
+}
+
+func TestWeb3Verify_ExpiredNonceDeleteFailureStillReturnsInvalidNonce(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	key, addr := newTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "web3-verify-expired-delete-failure"
+	seedExpiredWalletNonce(t, db, addr, nonce)
+
+	var nonceRecord models.Web3Nonce
+	if err := db.Where("nonce = ?", nonce).First(&nonceRecord).Error; err != nil {
+		t.Fatalf("find seeded nonce: %v", err)
+	}
+	msg := siweMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+
+	if err := db.Exec(`
+		CREATE TRIGGER fail_expired_web3_nonce_delete
+		BEFORE DELETE ON web3_nonces
+		BEGIN
+			SELECT RAISE(ABORT, 'forced expired web3 nonce cleanup failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create expired nonce delete trigger: %v", err)
+	}
+
+	user, tokens, err := svc.Web3Verify(Web3VerifyInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err != ErrInvalidNonce {
+		t.Fatalf("want ErrInvalidNonce despite cleanup failure, got %v (user=%#v tokens=%#v)", err, user, tokens)
+	}
+
+	var providerCount int64
+	db.Model(&models.AuthProvider{}).Where("provider = ?", models.ProviderWeb3).Count(&providerCount)
+	if providerCount != 0 {
+		t.Fatalf("provider should not be created after expired nonce, got %d rows", providerCount)
+	}
+
+	var tokenCount int64
+	db.Model(&models.RefreshToken{}).Count(&tokenCount)
+	if tokenCount != 0 {
+		t.Fatalf("refresh token should not be created after expired nonce, got %d rows", tokenCount)
 	}
 }
 

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -285,6 +285,123 @@ func TestWeb3Verify_SuccessConsumesNonceAndIssuesTokens(t *testing.T) {
 	}
 }
 
+func TestWeb3Verify_NonceDeleteFailureReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	key, addr := newTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "web3-verify-delete-failure"
+	nonceRecord := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+
+	if err := db.Exec(`
+		CREATE TRIGGER fail_web3_nonce_delete
+		BEFORE DELETE ON web3_nonces
+		BEGIN
+			SELECT RAISE(ABORT, 'forced web3 nonce delete failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create nonce delete trigger: %v", err)
+	}
+
+	user, tokens, err := svc.Web3Verify(Web3VerifyInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err == nil {
+		t.Fatalf("want nonce delete error, got nil (user=%#v tokens=%#v)", user, tokens)
+	}
+	if !strings.Contains(err.Error(), "forced web3 nonce delete failure") {
+		t.Fatalf("want forced delete error, got %v", err)
+	}
+
+	var providerCount int64
+	db.Model(&models.AuthProvider{}).Where("provider = ?", models.ProviderWeb3).Count(&providerCount)
+	if providerCount != 0 {
+		t.Fatalf("provider should not be created after nonce delete failure, got %d rows", providerCount)
+	}
+
+	var tokenCount int64
+	db.Model(&models.RefreshToken{}).Count(&tokenCount)
+	if tokenCount != 0 {
+		t.Fatalf("refresh token should not be created after nonce delete failure, got %d rows", tokenCount)
+	}
+}
+
+func TestWeb3Verify_ProviderCreateFailureReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	key, addr := newTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "web3-verify-provider-failure"
+	nonceRecord := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+
+	if err := db.Exec(`
+		CREATE TRIGGER fail_auth_provider_insert
+		BEFORE INSERT ON auth_providers
+		BEGIN
+			SELECT RAISE(ABORT, 'forced auth provider create failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create auth provider trigger: %v", err)
+	}
+
+	user, tokens, err := svc.Web3Verify(Web3VerifyInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err == nil {
+		t.Fatalf("want provider create error, got nil (user=%#v tokens=%#v)", user, tokens)
+	}
+	if !strings.Contains(err.Error(), "forced auth provider create failure") {
+		t.Fatalf("want forced provider create error, got %v", err)
+	}
+
+	var providerCount int64
+	db.Model(&models.AuthProvider{}).Where("provider = ?", models.ProviderWeb3).Count(&providerCount)
+	if providerCount != 0 {
+		t.Fatalf("provider should not be created after provider create failure, got %d rows", providerCount)
+	}
+
+	var tokenCount int64
+	db.Model(&models.RefreshToken{}).Count(&tokenCount)
+	if tokenCount != 0 {
+		t.Fatalf("refresh token should not be created after provider create failure, got %d rows", tokenCount)
+	}
+}
+
+func TestWeb3Verify_RefreshTokenCreateFailureReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	key, addr := newTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "web3-verify-token-failure"
+	nonceRecord := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+
+	if err := db.Exec("DROP TABLE refresh_tokens").Error; err != nil {
+		t.Fatalf("drop refresh_tokens: %v", err)
+	}
+
+	user, tokens, err := svc.Web3Verify(Web3VerifyInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err == nil {
+		t.Fatalf("want refresh token create error, got nil (user=%#v tokens=%#v)", user, tokens)
+	}
+	if tokens != nil {
+		t.Fatalf("tokens should be nil when refresh token create fails, got %#v", tokens)
+	}
+}
+
 func TestWeb3Verify_ReplayConsumedNonceReturnsInvalidNonce(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewAuthService(db, testConfig())


### PR DESCRIPTION
## 什麼改動
補上 `AuthService.Web3Verify` 的 DB failure propagation 覆蓋，並讓必要 persistence 操作失敗時回傳 error，不再吞掉後繼續成功登入。

## 為什麼
closes #526

PR #521 補了 Web3 verify 的主要行為測試，但 CodeRabbit review 指出仍缺少針對 #420「DB error 被吞掉」類型的直接失敗注入測試。這包只收斂 #526 指定的 nonce / provider / refresh token persistence failure。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#526
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 API handler / response schema / frontend
  - 不處理 OAuth 既有 provider token update 的 `Save` failure path
  - 不把 Web3Verify 改成 transaction-atomic flow

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 Web3Verify 在 nonce consume、provider link、refresh token create 失敗時回傳 DB error 並避免靜默成功。
- Approx changed lines：~126
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接暴露 Web3Verify DB error 被吞掉的既有 bug，production change 只有對應的 `.Error` propagation。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Web3Verify has at least one focused DB failure propagation test for nonce consume/delete.
- [x] Token/provider DB failure behavior is covered or explicitly scoped into separate follow-up issues.
- [x] Tests fail if Web3Verify silently returns success after a required DB write/delete fails.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
go test ./internal/services -run TestWeb3Verify_NonceDeleteFailureReturnsError -count=1
RED before fix: failed because Web3Verify returned nil error with user/tokens.

go test ./internal/services -run TestWeb3Verify_ProviderCreateFailureReturnsError -count=1
RED before fix: failed because Web3Verify returned nil error with user/tokens.

go test ./internal/services -run 'TestWeb3Verify_' -count=1
PASS

go test ./...
PASS
```

## 備註
有嘗試跑專案建議的 Docker backend test command，但本機 Docker daemon 目前無法連線：`Cannot connect to the Docker daemon at unix:///Users/tachikoma/.orbstack/run/docker.sock`。

## Notes for Claude Code Review
- 請特別看 `Web3Verify` 的 nonce consume failure 是否應該直接傳 DB error；這包沿用 #526 對「不要靜默成功」的定義。
- Provider create failure 目前會在建立 user 後回 error；這包沒有擴張到 transaction atomicity。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 改进了Web3身份验证的错误处理：在清理已使用/过期的临时凭证时会正确捕获并返回删除失败的错误。
  * 增强了OAuth用户关联的持久化检查：在保存外部认证关联失败时会返回错误，避免不完整数据写入。

* **测试**
  * 新增多种失败路径测试，验证在删除凭证、插入认证关联或创建刷新令牌失败时的容错与副作用。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/527)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->