### PR TITLE
[infra] Fix Dependabot automerge merge method

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -8,6 +8,7 @@ const currentDir = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(currentDir, '..', '..')
 const workflowPath = path.join(currentDir, 'ci.yml')
 const scopePolicePath = path.join(currentDir, 'pr-scope-police.yml')
+const dependabotAutomergeWorkflowPath = path.join(currentDir, 'dependabot-automerge.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 
 test('frontend CI job runs the frontend test command', async () => {
@@ -33,6 +34,13 @@ test('CI scope gate runs product validation for Dependabot maintenance PRs', asy
     workflow,
     /const runCi =\n\s+\(isReleasePromotionPr && releaseBodyValid\) \|\|\n\s+bodyValidForCi &&/,
   )
+})
+
+test('Dependabot auto-merge uses repository-supported merge commits', async () => {
+  const workflow = await readFile(dependabotAutomergeWorkflowPath, 'utf8')
+
+  assert.match(workflow, /gh pr merge --auto --merge "\$PR_URL"/)
+  assert.doesNotMatch(workflow, /gh pr merge --auto --squash/)
 })
 
 test('PR size thresholds match CLAUDE.md', async () => {

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.actor == 'dependabot[bot]' && steps.policy.outputs.auto_merge == 'true'
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## 什麼改動
修正 `main` 上生效的 Dependabot Auto Merge workflow：把 repo 不支援的 squash merge 改成 merge commit，並補上 workflow regression test。

## 為什麼
refs #524

PR #524 目標分支是 `main`，目前失敗的 `Dependabot Auto Merge / automerge` job 來自 `main` 上的 `.github/workflows/dependabot-automerge.yml`。該 workflow 執行 `gh pr merge --auto --squash`，但 repository 設定不允許 squash merge、只允許 merge commit，因此 auto-merge job 會紅 X。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#524
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不調整 repository merge policy
  - 不修改 Dependabot dependency update policy
  - 不手動重跑或重建 PR #524
  - 不帶入 `develop` 的其他變更

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 `main` 上的 Dependabot auto-merge 使用 repository 支援的 merge commit。
- Approx changed lines：~10
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `main` 上的 Dependabot auto-merge 不再呼叫 `gh pr merge --auto --squash`
- [x] `main` 上的 Dependabot auto-merge 改用 repo 支援的 `gh pr merge --auto --merge`
- [x] Workflow regression test 覆蓋 merge method，避免回歸
- [x] PR diff 只包含 hotfix 相關兩個 workflow 檔，不帶入 `develop` 大量差異

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk node --test .github/workflows/ci.test.mjs
4 pass / 0 fail

rtk git --no-optional-locks diff --check -- .github/workflows/dependabot-automerge.yml .github/workflows/ci.test.mjs
pass
```

## 備註
這個 PR 現在以 `main` 為 base，直接修正 #524 目前使用中的 workflow。PR #524 既有紅 X 仍需要重新觸發 Dependabot workflow 後才會更新。

## Notes for Claude Code Review
- 已依 review 要求把修正改為送到 `main` 的 hotfix 路徑。
- 已確認 repository 設定允許 merge commit、不允許 squash merge。
