### PR TITLE
[infra] fix: use merge mode for dependabot automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.actor == 'dependabot[bot]' && steps.policy.outputs.auto_merge == 'true'
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## 什麼改動
- 將 `.github/workflows/dependabot-automerge.yml` 的 `gh pr merge --auto --squash` 改為 `gh pr merge --auto --merge`，讓 Dependabot 能在本 repo 的 merge 策略下自動通過。

## 為什麼
- PR #524 在本 repo 不允許 squash merge，原有流程會因 `--squash` 無法完成自動合併。

## Release Context
- Release type：n/a

## Scope 對齊
- Source of truth：#524
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改動任何依賴版本本身與業務邏輯，只修正 automerge workflow 命令。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 調整 Dependabot auto-merge 的合併策略。
- Approx changed lines：~2
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 自動合併步驟由 `--squash` 改為 `--merge`
- [x] 原有條件判斷、權限環境與審核授權流程維持不變

## 測試方式
- [ ] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
- 未改動程式邏輯，僅調整 workflow 指令。

## Notes
- closes #524
