### PR TITLE
[backend] fix: validate Google userinfo response

### DIFF
--- a/services/api/internal/services/twitch_client.go
+++ b/services/api/internal/services/twitch_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"golang.org/x/oauth2"
 )
@@ -48,9 +49,19 @@ func fetchGoogleUser(ctx context.Context, cfg *oauth2.Config, token *oauth2.Toke
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("google API returned %d", resp.StatusCode)
+	}
+
 	var info googleUserInfo
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
 		return nil, err
+	}
+	if strings.TrimSpace(info.Sub) == "" {
+		return nil, fmt.Errorf("google user missing sub")
+	}
+	if strings.TrimSpace(info.Email) == "" {
+		return nil, fmt.Errorf("google user missing email")
 	}
 	return &info, nil
 }

--- a/services/api/internal/services/twitch_client_test.go
+++ b/services/api/internal/services/twitch_client_test.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func googleUserTestContext(status int, body string) context.Context {
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != "https://www.googleapis.com/oauth2/v3/userinfo" {
+				return nil, http.ErrNotSupported
+			}
+			return &http.Response{
+				StatusCode: status,
+				Status:     http.StatusText(status),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	}
+	return context.WithValue(context.Background(), oauth2.HTTPClient, client)
+}
+
+func TestFetchGoogleUser_Non2xxStatusReturnsError(t *testing.T) {
+	ctx := googleUserTestContext(http.StatusUnauthorized, `{"sub":"google-123","email":"viewer@example.com"}`)
+
+	_, err := fetchGoogleUser(ctx, &oauth2.Config{}, &oauth2.Token{AccessToken: "token"})
+	if err == nil {
+		t.Fatal("want error for non-2xx Google userinfo response, got nil")
+	}
+	if !strings.Contains(err.Error(), "google API returned 401") {
+		t.Fatalf("want status error, got %v", err)
+	}
+}
+
+func TestFetchGoogleUser_MissingSubReturnsError(t *testing.T) {
+	ctx := googleUserTestContext(http.StatusOK, `{"email":"viewer@example.com","name":"Viewer"}`)
+
+	_, err := fetchGoogleUser(ctx, &oauth2.Config{}, &oauth2.Token{AccessToken: "token"})
+	if err == nil {
+		t.Fatal("want error for missing Google sub, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing sub") {
+		t.Fatalf("want missing sub error, got %v", err)
+	}
+}
+
+func TestFetchGoogleUser_MissingEmailReturnsError(t *testing.T) {
+	ctx := googleUserTestContext(http.StatusOK, `{"sub":"google-123","name":"Viewer"}`)
+
+	_, err := fetchGoogleUser(ctx, &oauth2.Config{}, &oauth2.Token{AccessToken: "token"})
+	if err == nil {
+		t.Fatal("want error for missing Google email, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing email") {
+		t.Fatalf("want missing email error, got %v", err)
+	}
+}


### PR DESCRIPTION
## 什麼改動
- `fetchGoogleUser` 只接受 Google userinfo 的 2xx response。
- decode 後驗證 `sub` 與 `email` 非空，避免錯誤回應或不完整資料進入 OAuth upsert。
- 補 focused tests 覆蓋非 2xx、missing sub、missing email。

## 為什麼
closes #421

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#421
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 OAuth handler response schema
  - 不修改 Twitch OAuth flow
  - 不調整 OAuth upsert transaction / persistence 行為

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 Google OAuth userinfo 在非 2xx 或缺少 `sub/email` 時回傳 error，不進入 OAuth upsert。
- Approx changed lines：~82
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接覆蓋 #421 指出的 Google userinfo validation bug，production change 只加入對應 validation。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] HTTP 非 2xx 時回傳 error。
- [x] Sub / email 為空時回傳 error。
- [x] CI 通過（本地已跑 backend 測試；GitHub CI gate 已通過）。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```bash
go test ./internal/services -run 'TestFetchGoogleUser_' -count=1
# Go test: 3 passed in 1 packages

go test ./internal/services -count=1
# Go test: 252 passed in 1 packages

go test ./...
# Go test: 562 passed in 12 packages
```

## 備註
本 PR 使用 `oauth2.HTTPClient` 注入測試 HTTP client，避免碰外部 Google endpoint。