### PR TITLE
[backend] fix: propagate email auth token delete errors

### DIFF
--- a/services/api/internal/services/email_auth_service.go
+++ b/services/api/internal/services/email_auth_service.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	ErrAlreadyVerified          = errors.New("email already verified")
-	ErrInvalidVerifyToken        = errors.New("invalid or expired verification token")
-	ErrInvalidResetToken         = errors.New("invalid or expired password reset token")
-	ErrPasswordResetEmailSend    = errors.New("failed to send password reset email")
+	ErrAlreadyVerified        = errors.New("email already verified")
+	ErrInvalidVerifyToken     = errors.New("invalid or expired verification token")
+	ErrInvalidResetToken      = errors.New("invalid or expired password reset token")
+	ErrPasswordResetEmailSend = errors.New("failed to send password reset email")
 )
 
 const (
@@ -57,7 +57,9 @@ func (s *EmailAuthService) SendVerificationEmail(ctx context.Context, userID uui
 	}
 
 	// Replace any existing verification token for this user
-	s.db.Where("user_id = ?", userID).Delete(&models.EmailVerification{})
+	if err := s.db.Where("user_id = ?", userID).Delete(&models.EmailVerification{}).Error; err != nil {
+		return err
+	}
 
 	if err := s.db.Create(&models.EmailVerification{
 		UserID:    userID,
@@ -114,7 +116,9 @@ func (s *EmailAuthService) ForgotPassword(ctx context.Context, email string) err
 	}
 
 	// Replace any existing reset token for this email
-	s.db.Where("email = ?", email).Delete(&models.PasswordReset{})
+	if err := s.db.Where("email = ?", email).Delete(&models.PasswordReset{}).Error; err != nil {
+		return err
+	}
 
 	if err := s.db.Create(&models.PasswordReset{
 		Email:     email,
@@ -155,8 +159,7 @@ func (s *EmailAuthService) ResetPassword(rawToken, newPassword string) error {
 		return err
 	}
 
-	s.db.Delete(&record)
-	return nil
+	return s.db.Delete(&record).Error
 }
 
 // ─── Email templates ──────────────────────────────────────────────────────────

--- a/services/api/internal/services/email_auth_service.go
+++ b/services/api/internal/services/email_auth_service.go
@@ -92,8 +92,7 @@ func (s *EmailAuthService) VerifyEmail(rawToken string) error {
 		return err
 	}
 
-	s.db.Delete(&record)
-	return nil
+	return s.db.Delete(&record).Error
 }
 
 // ─── Password Reset ───────────────────────────────────────────────────────────

--- a/services/api/internal/services/email_auth_service_test.go
+++ b/services/api/internal/services/email_auth_service_test.go
@@ -161,6 +161,36 @@ func TestVerifyEmail_Success(t *testing.T) {
 	}
 }
 
+func TestVerifyEmail_DeleteTokenFailureReturnsError(t *testing.T) {
+	svc, _ := newEmailAuthSvc(t)
+	userID := seedEmailUser(t, svc, "verify-consume-delete-failure@example.com", false)
+
+	rawToken, _ := generateNonce()
+	svc.db.Create(&models.EmailVerification{
+		UserID:    userID,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	if err := svc.db.Exec(`
+		CREATE TRIGGER fail_email_verification_consume_delete
+		BEFORE DELETE ON email_verifications
+		BEGIN
+			SELECT RAISE(ABORT, 'forced email verification consume delete failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create email verification consume delete trigger: %v", err)
+	}
+
+	err := svc.VerifyEmail(rawToken)
+	if err == nil {
+		t.Fatal("want delete error, got nil")
+	}
+	if !strings.Contains(err.Error(), "forced email verification consume delete failure") {
+		t.Fatalf("want forced delete error, got %v", err)
+	}
+}
+
 func TestVerifyEmail_InvalidToken(t *testing.T) {
 	svc, _ := newEmailAuthSvc(t)
 

--- a/services/api/internal/services/email_auth_service_test.go
+++ b/services/api/internal/services/email_auth_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,6 +94,38 @@ func TestSendVerificationEmail_ReplacesExistingToken(t *testing.T) {
 	svc.db.Model(&models.EmailVerification{}).Where("user_id = ?", userID).Count(&count)
 	if count != 1 {
 		t.Errorf("expected 1 verification token, got %d", count)
+	}
+}
+
+func TestSendVerificationEmail_DeleteExistingTokenFailureReturnsError(t *testing.T) {
+	svc, mailer := newEmailAuthSvc(t)
+	email := "verify-delete-failure@example.com"
+	userID := seedEmailUser(t, svc, email, false)
+	svc.db.Create(&models.EmailVerification{
+		UserID:    userID,
+		TokenHash: hashToken("existing-verify-token"),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	if err := svc.db.Exec(`
+		CREATE TRIGGER fail_email_verification_delete
+		BEFORE DELETE ON email_verifications
+		BEGIN
+			SELECT RAISE(ABORT, 'forced email verification delete failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create email verification delete trigger: %v", err)
+	}
+
+	err := svc.SendVerificationEmail(context.Background(), userID)
+	if err == nil {
+		t.Fatal("want delete error, got nil")
+	}
+	if !strings.Contains(err.Error(), "forced email verification delete failure") {
+		t.Fatalf("want forced delete error, got %v", err)
+	}
+	if len(mailer.sent) != 0 {
+		t.Fatalf("email should not be sent after delete failure, got %d sends", len(mailer.sent))
 	}
 }
 
@@ -237,6 +270,38 @@ func TestForgotPassword_ReplacesExistingToken(t *testing.T) {
 	}
 }
 
+func TestForgotPassword_DeleteExistingTokenFailureReturnsError(t *testing.T) {
+	svc, mailer := newEmailAuthSvc(t)
+	email := "reset-delete-failure@example.com"
+	seedEmailUser(t, svc, email, true)
+	svc.db.Create(&models.PasswordReset{
+		Email:     email,
+		TokenHash: hashToken("existing-reset-token"),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	if err := svc.db.Exec(`
+		CREATE TRIGGER fail_password_reset_delete
+		BEFORE DELETE ON password_resets
+		BEGIN
+			SELECT RAISE(ABORT, 'forced password reset delete failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create password reset delete trigger: %v", err)
+	}
+
+	err := svc.ForgotPassword(context.Background(), email)
+	if err == nil {
+		t.Fatal("want delete error, got nil")
+	}
+	if !strings.Contains(err.Error(), "forced password reset delete failure") {
+		t.Fatalf("want forced delete error, got %v", err)
+	}
+	if len(mailer.sent) != 0 {
+		t.Fatalf("email should not be sent after delete failure, got %d sends", len(mailer.sent))
+	}
+}
+
 // ─── ResetPassword ────────────────────────────────────────────────────────────
 
 func TestResetPassword_Success(t *testing.T) {
@@ -260,6 +325,37 @@ func TestResetPassword_Success(t *testing.T) {
 	svc.db.Model(&models.PasswordReset{}).Where("email = ?", email).Count(&count)
 	if count != 0 {
 		t.Error("reset token should be deleted after use")
+	}
+}
+
+func TestResetPassword_DeleteTokenFailureReturnsError(t *testing.T) {
+	svc, _ := newEmailAuthSvc(t)
+	email := "reset-consume-delete-failure@example.com"
+	seedEmailUser(t, svc, email, true)
+
+	rawToken, _ := generateNonce()
+	svc.db.Create(&models.PasswordReset{
+		Email:     email,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	if err := svc.db.Exec(`
+		CREATE TRIGGER fail_password_reset_consume_delete
+		BEFORE DELETE ON password_resets
+		BEGIN
+			SELECT RAISE(ABORT, 'forced password reset consume delete failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create password reset consume delete trigger: %v", err)
+	}
+
+	err := svc.ResetPassword(rawToken, "newpassword123")
+	if err == nil {
+		t.Fatal("want delete error, got nil")
+	}
+	if !strings.Contains(err.Error(), "forced password reset consume delete failure") {
+		t.Fatalf("want forced delete error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- `SendVerificationEmail` 在替換既有 verification token 時會回傳 delete error。
- `ForgotPassword` 在替換既有 reset token 時會回傳 delete error。
- `ResetPassword` 在成功更新密碼後若 reset token consume/delete 失敗，會回傳該 DB error。
- 補上三個 trigger-based regression tests。

## 為什麼
closes #422

`email_auth_service` 既有三處 token delete 會吞掉 DB error，可能讓舊 verification/reset token 繼續有效或讓 reset token 在密碼更新後仍可重複使用。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#422
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 email auth handler response schema
  - 不改 email template / mailer 行為
  - 不重構 token lifecycle 或 transaction 邊界

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 email auth 中指定的 token delete DB error 正確回傳給 caller。
- Approx changed lines：~107
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接覆蓋 #422 指定的三個 swallowed delete error path，production change 只加入對應 `.Error` propagation。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 所有列出的 token Delete 操作錯誤正確 return 給 caller。
- [x] CI 通過（本地已跑 backend 測試；GitHub CI pending）。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```bash
go test ./internal/services -run 'Test(SendVerificationEmail_DeleteExistingTokenFailureReturnsError|ForgotPassword_DeleteExistingTokenFailureReturnsError|ResetPassword_DeleteTokenFailureReturnsError)' -count=1
# Go test: 3 passed in 1 packages

go test ./internal/services -run 'Test(SendVerificationEmail|VerifyEmail|ForgotPassword|ResetPassword)' -count=1
# Go test: 18 passed in 1 packages

go test ./internal/services -count=1
# Go test: 252 passed in 1 packages

go test ./...
# Go test: 562 passed in 12 packages
```

## 備註
測試使用 SQLite trigger 注入 delete failure，避免改動 production code 的測試鉤子。