### PR TITLE
[chore] 更新根目錄 README 與架構地圖

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,45 @@ Viewers spend Bits to earn on-chain tokens; streamers manage rewards from the da
 
 ```
 tachigo/
+├── apps/
+│   ├── dashboard/    # Streamer / agency admin dashboard (React + TypeScript + Vite)
+│   └── extension/    # Chrome sidepanel frontend (React + TypeScript + Vite)
+├── contracts/        # Foundry smart contracts for TACHI token flows
+├── deployments/      # Chain deployment metadata
+├── design/           # Product and UI design artifacts
+├── docs/             # Architecture, policies, decisions, and AI workflow docs
+├── extensions/       # Legacy / migration-stage extension artifacts
+├── infra/            # Repo automation scripts and git hooks
+├── plans/            # Planning notes and implementation breakdowns
 ├── services/
 │   └── api/          # Go API (Gin + GORM + PostgreSQL)
-└── apps/
-    ├── extension/    # Chrome sidepanel frontend (React + TypeScript + Vite)
-    └── dashboard/    # Admin dashboard (React + TypeScript + Vite)
+└── docker-compose.yml
 ```
+
+## Documentation
+
+| Area | Link |
+|------|------|
+| System architecture | [docs/architecture.md](docs/architecture.md) |
+| Auth baseline | [docs/auth-architecture.md](docs/auth-architecture.md) |
+| Chrome sidepanel migration | [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md) |
+| PR scope policy | [docs/pr-scope-policy.md](docs/pr-scope-policy.md) |
+| Dependency update policy | [docs/dependabot-update-policy.md](docs/dependabot-update-policy.md) |
+| Dependency inventory policy | [docs/dependency-inventory-policy.md](docs/dependency-inventory-policy.md) |
+| Contracts gas snapshot policy | [docs/contracts-gas-snapshot-policy.md](docs/contracts-gas-snapshot-policy.md) |
+| Repo automation | [infra/README.md](infra/README.md) |
+| AI collaboration | [docs/ai/README.md](docs/ai/README.md) |
+| Agent rules | [CLAUDE.md](CLAUDE.md), [AGENTS.md](AGENTS.md) |
+
+## Features
+
+- **Watch Points** — viewers earn off-chain points from watch heartbeat activity.
+- **TACHI claim / spend flows** — backend services track spendable balances and bridge selected flows to on-chain mint / burn behavior.
+- **Twitch Extension / Chrome sidepanel** — `apps/extension` hosts the migration-stage viewer experience with Twitch identity and extension auth compatibility.
+- **Streamer / agency dashboard** — `apps/dashboard` provides the management surface for channels, streamers, and operational settings.
+- **Agency and channel configuration** — backend services model agency ownership, streamer relationships, and per-channel reward settings.
+- **Airdrop and raffle systems** — backend jobs and APIs support viewer rewards, campaign-style interactions, and result delivery.
+- **Security and dependency operations** — CI includes scope gates, backend scanners, dependency inventory reports, and PR review automation.
 
 ## Quick start
 
@@ -105,17 +138,6 @@ Key backend variables:
 
 See [docs/architecture.md](docs/architecture.md) for the full system diagram.
 For the frontend migration decision record, see [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md).
-
-## Documentation
-
-- [docs/auth-architecture.md](docs/auth-architecture.md) — current auth state 與 migration guardrails baseline
-- [docs/architecture.md](docs/architecture.md) — system architecture
-- [docs/ai/README.md](docs/ai/README.md) — AI 協作文檔首頁與 root entrypoint 例外
-- [docs/ai/claude-codex-cheatsheet.md](docs/ai/claude-codex-cheatsheet.md) — quick reference for Claude Code + Codex collaboration
-- [docs/ai/claude-codex-workflow.md](docs/ai/claude-codex-workflow.md) — full workflow guide for low-token Claude Code usage
-- [infra/README.md](infra/README.md) — repo automation scripts and git hooks
-- [docs/pr-scope-policy.md](docs/pr-scope-policy.md) — PR 邊界規則、required checks、scope police 設定
-- [CLAUDE.md](CLAUDE.md) — repo-specific collaboration rules and command entry points
 
 ## CI
 


### PR DESCRIPTION
## 什麼改動
- 更新根目錄 `README.md` 的 Structure 目錄樹，補上目前存在的重要目錄與用途。
- 在 Structure 後方加入 Documentation 快速連結表。
- 新增 Features 區塊，簡述 Watch Points、TACHI flows、Extension、Dashboard、Agency、Airdrop 等核心模組。

## 為什麼
根目錄 README 已無法反映目前 repo 全貌；這張 PR 對齊 #356，讓新讀者可以從 root README 快速理解專案結構與文件入口。

closes #356

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#356
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改任何程式碼
  - 不補子目錄 README
  - 不新增英文版文件
  - 不修改 `docs/` 下的技術文件內容

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 更新 root README，使目錄結構、功能概覽與重要文件入口對齊目前 repo 狀態。
- Approx changed lines：~50
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 目錄樹與實際目錄結構一致
- [x] 包含功能模組簡介
- [x] 包含重要文件的快速連結

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk git --no-optional-locks diff --check
# exit 0

rtk ls README.md docs/architecture.md docs/auth-architecture.md docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md docs/pr-scope-policy.md docs/dependabot-update-policy.md docs/dependency-inventory-policy.md docs/contracts-gas-snapshot-policy.md infra/README.md docs/ai/README.md CLAUDE.md AGENTS.md
# all listed files exist
```

## 備註
Docs-only PR；Scope gate 應跳過 product heavy CI。

## Notes for Claude Code Review
- 請特別確認 README 的功能描述是否有過度承諾；我只依照現有 repo 模組與 #356 要求整理入口。