### PR TITLE
[infra] make rebase notifications idempotent

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -16,6 +16,7 @@ const autoReadyWorkflowPath = path.join(currentDir, 'auto-ready-pr.yml')
 const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rerequest.yml')
 const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-on-develop-merge.yml')
 const dependencyInventoryWorkflowPath = path.join(currentDir, 'dependency-inventory.yml')
+const notifyRebaseNeededWorkflowPath = path.join(currentDir, 'notify-rebase-needed.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 const dependabotPolicyPath = path.join(repoRoot, 'docs', 'dependabot-update-policy.md')
 const securityScannerEvaluationPath = path.join(repoRoot, 'docs', 'security-scanner-evaluation.md')
@@ -423,6 +424,68 @@ async function runCloseIssueOnDevelopMergeWorkflow({
 
   await AsyncFunction('context', 'github', 'core', script)(context, github, core)
   return { closed, comments, errors, failures, notices, requestedCommits, warnings }
+}
+
+async function runNotifyRebaseNeededWorkflow({
+  mergedPrOverrides = {},
+  openPRs = [],
+  freshPRsByNumber = {},
+  commentsByIssueNumber = {},
+} = {}) {
+  const parsedWorkflow = parseYaml(notifyRebaseNeededWorkflowPath)
+  const script = parsedWorkflow.jobs.notify.steps[0].with.script
+  const commentsCreated = []
+  const commentsListed = []
+  const infos = []
+  const mergedPR = {
+    number: 600,
+    title: 'Merged backend fix',
+    html_url: 'https://github.com/nurockplayer/tachigo/pull/600',
+    ...mergedPrOverrides,
+  }
+  const github = {
+    rest: {
+      pulls: {
+        list: async () => ({ data: openPRs }),
+        get: async ({ pull_number }) => ({
+          data: freshPRsByNumber[pull_number] || openPRs.find((pr) => pr.number === pull_number),
+        }),
+      },
+      issues: {
+        listComments: async (args) => {
+          commentsListed.push(args)
+          return { data: commentsByIssueNumber[args.issue_number] || [] }
+        },
+        createComment: async (args) => {
+          commentsCreated.push(args)
+          return { data: { id: commentsCreated.length } }
+        },
+      },
+    },
+    paginate: async (fn, args) => {
+      const result = await fn(args)
+      return result.data || result
+    },
+  }
+  const core = {
+    info: (message) => infos.push(message),
+  }
+  const context = {
+    repo: { owner: 'nurockplayer', repo: 'tachigo' },
+    payload: { pull_request: mergedPR },
+  }
+
+  await AsyncFunction('context', 'github', 'core', 'setTimeout', script)(
+    context,
+    github,
+    core,
+    (callback) => {
+      callback()
+      return 0
+    },
+  )
+
+  return { commentsCreated, commentsListed, infos }
 }
 
 test('frontend CI job runs the frontend test command', async () => {
@@ -1138,6 +1201,39 @@ test('develop merge issue closer only runs after merged PRs close into develop',
   assert.equal(parsedWorkflow.permissions.issues, 'write')
   assert.equal(parsedWorkflow.permissions['pull-requests'], 'read')
   assert.equal(job.if, 'github.event.pull_request.merged == true')
+})
+
+test('notify rebase workflow uses read-only pull request permission', async () => {
+  const parsedWorkflow = parseYaml(notifyRebaseNeededWorkflowPath)
+
+  assert.equal(parsedWorkflow.permissions.issues, 'write')
+  assert.equal(parsedWorkflow.permissions['pull-requests'], 'read')
+})
+
+test('notify rebase workflow skips duplicate notification for the same PR head', async () => {
+  const result = await runNotifyRebaseNeededWorkflow({
+    openPRs: [
+      { number: 601 },
+    ],
+    freshPRsByNumber: {
+      601: {
+        number: 601,
+        mergeable_state: 'dirty',
+        head: { sha: 'dirty-head-sha' },
+      },
+    },
+    commentsByIssueNumber: {
+      601: [
+        {
+          body: '<!-- notify-rebase-needed:head=dirty-head-sha -->\n> existing notification',
+        },
+      ],
+    },
+  })
+
+  assert.equal(result.commentsListed.length, 1)
+  assert.deepEqual(result.commentsCreated, [])
+  assert.match(result.infos.join('\n'), /already has a rebase notification/)
 })
 
 test('develop merge issue closer ignores template comments and code examples', async () => {

--- a/.github/workflows/notify-rebase-needed.yml
+++ b/.github/workflows/notify-rebase-needed.yml
@@ -6,7 +6,7 @@ on:
     branches: [develop]
 
 permissions:
-  pull-requests: write
+  pull-requests: read
   issues: write
 
 jobs:
@@ -55,18 +55,34 @@ jobs:
             }
 
             for (const pr of dirty) {
+              const headSha = pr.head?.sha || pr.updated_at || 'unknown'
+              const marker = `<!-- notify-rebase-needed:head=${headSha} -->`
+              const body = [
+                marker,
+                `> [!WARNING]`,
+                `> **PR #${mergedPR.number}** ([${mergedPR.title}](${mergedPR.html_url})) 已 merge 進 \`develop\`，本 PR 目前有衝突，請 rebase。`,
+                `>`,
+                `> \`\`\`bash`,
+                `> git fetch origin && git rebase origin/develop`,
+                `> \`\`\``,
+              ].join('\n')
+
+              const existingComments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pr.number,
+                per_page: 100,
+              })
+              if (existingComments.some((comment) => comment.body?.includes(marker))) {
+                core.info(`PR #${pr.number} already has a rebase notification for head ${headSha}.`)
+                continue
+              }
+
               await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: pr.number,
-                body: [
-                  `> [!WARNING]`,
-                  `> **PR #${mergedPR.number}** ([${mergedPR.title}](${mergedPR.html_url})) 已 merge 進 \`develop\`，本 PR 目前有衝突，請 rebase。`,
-                  `>`,
-                  `> \`\`\`bash`,
-                  `> git fetch origin && git rebase origin/develop`,
-                  `> \`\`\``,
-                ].join('\n'),
+                body,
               })
               core.info(`Notified PR #${pr.number}`)
             }


### PR DESCRIPTION
## 什麼改動
- 將 `.github/workflows/notify-rebase-needed.yml` 的 `pull-requests` permission 從 `write` 降為 `read`。
- 在發 rebase-needed comment 前先呼叫 `issues.listComments`，以 target PR head sha 的隱藏 marker 做 idempotency check。
- 補 workflow regression tests，涵蓋最小權限與同一個 PR head 不重複通知。

## 為什麼
CodeRabbit follow-up 指出 notify-rebase-needed workflow 可能在連續 merge 時對同一個衝突 PR 重複留言，且目前 pull request permission 過大。這張 PR 對齊 #367，保留現有通知行為但讓它可重入且權限更小。

closes #367

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#367
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改通知邏輯以外的 workflow 行為
  - 不擴張到其他 workflow
  - 不修改 product code

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 notify-rebase-needed workflow 對同一個 PR head 的衝突通知具備重複通知防護，並降低 pull request 權限。
- Approx changed lines：~130
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 重複通知情境有防護（idempotency check）
- [x] `.github/workflows/notify-rebase-needed.yml` 的 `permissions.pull-requests` 改為 `read`

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk node --test .github/workflows/ci.test.mjs
# tests 58, pass 58, fail 0

rtk git --no-optional-locks diff --check
# exit 0
```

## 備註
Idempotency marker 綁定 target PR 的 head sha；同一個 head 不重複留言，PR rebase 後 head 改變時仍可重新通知。

## Notes for Claude Code Review
- 請確認用 hidden marker dedupe 是否符合 #367 對「同一個 conflicting PR 不重複通知」的預期；這比比對完整 comment body 更能避免連續 merge 造成的重複通知。