### PR TITLE
[chore] add backend API README

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,0 +1,185 @@
+# tachigo API
+
+`services/api` 是 tachigo 的 Go 後端服務，負責 auth、Twitch / Google OAuth、Twitch Extension auth、Watch Points、TACHI claim / spend、Streamer / Agency dashboard API、Airdrop 與 Raffle 流程。
+
+## 快速啟動
+
+需求：
+
+- Go：以 [`go.mod`](go.mod) 為準，目前是 Go 1.25.0
+- Docker / Docker Compose：建議用來啟動 PostgreSQL 與完整本機 stack
+- `make`：repo root 與本目錄都有 Makefile
+
+從 repo root 啟動完整 stack：
+
+```bash
+make dev
+```
+
+常用 root 指令：
+
+```bash
+make setup  # 建立本機 .env，並設定 git hooks
+make dev    # docker compose up --build
+make up     # docker compose up --build -d
+make down   # 停止 stack
+make logs   # 追蹤所有服務 log
+```
+
+後端啟動後：
+
+- API health check：<http://localhost:8080/health>
+- Swagger UI：<http://localhost:8080/swagger/index.html>
+- API base path：`/api/v1`
+
+## 只啟動後端
+
+如果只想跑後端服務，可以在 `services/api` 目錄操作：
+
+```bash
+cd services/api
+cp .env.example .env
+make db-up
+make run
+```
+
+`make db-up` 會用 Docker 啟動一個 `tachigo-postgres` container，host port 是 `5432`，對應 `.env.example` 內的預設 `DATABASE_URL`。
+
+常用後端指令：
+
+```bash
+make run    # go run ./cmd/server
+make build  # go build -o bin/tachigo ./cmd/server
+make test   # go test ./... -v
+make tidy   # go mod tidy
+make db-up  # 啟動單獨 PostgreSQL
+make db-down
+```
+
+使用 root `docker compose` 時，API container 會連到 compose network 內的 `postgres:5432`；PostgreSQL 對 host 暴露在 `localhost:5433`。
+
+## 環境變數
+
+本機開發先複製範本：
+
+```bash
+cp services/api/.env.example services/api/.env
+```
+
+`.env.example` 目前包含：
+
+| 變數 | 用途 |
+| --- | --- |
+| `PORT` | API server port，預設 `8080` |
+| `APP_ENV` | 執行環境；`development` 會放寬 production secret validation |
+| `DATABASE_URL` | PostgreSQL DSN；root compose 會覆寫成 container network DSN |
+| `JWT_ACCESS_SECRET` | access token 簽章 secret，production 必須至少 32 字元 |
+| `JWT_REFRESH_SECRET` | refresh token 簽章 secret，必須和 access secret 不同 |
+| `JWT_ACCESS_TTL_MINUTES` | access token 有效分鐘數 |
+| `JWT_REFRESH_TTL_DAYS` | refresh token 有效天數 |
+| `TWITCH_CLIENT_ID` | Twitch OAuth app client id |
+| `TWITCH_CLIENT_SECRET` | Twitch OAuth app client secret |
+| `TWITCH_REDIRECT_URL` | Twitch OAuth callback URL |
+| `TWITCH_EXTENSION_SECRET` | Twitch Extension dashboard 內的 base64 extension secret |
+| `TACHIYA_INTERNAL_SHARED_SECRET` | tachiya -> tachigo server-to-server request shared secret |
+| `TACHIYA_BASE_URL` | tachiya internal API base URL |
+| `GOOGLE_CLIENT_ID` | Google OAuth client id |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
+| `GOOGLE_REDIRECT_URL` | Google OAuth callback URL |
+| `TACHI_CONTRACT_ADDRESS` | Sepolia 上的 TachiToken contract address |
+| `SEPOLIA_SIGNER_KEY` | 後端送鏈上交易用的 Sepolia testnet signer private key；不可 commit 真實值 |
+| `ALLOWED_ORIGINS` | CORS allowlist，使用逗號分隔 |
+
+`config.Load()` 也支援以下變數；需要 email 或前端連結行為時可以加入 `.env`：
+
+| 變數 | 用途 |
+| --- | --- |
+| `SMTP_HOST` / `SMTP_PORT` | 寄信服務 host / port |
+| `SMTP_USERNAME` / `SMTP_PASSWORD` | SMTP credential |
+| `SMTP_FROM` | 系統信件寄件者 |
+| `FRONTEND_URL` | email link 使用的前端 base URL |
+
+## Swagger
+
+Swagger 入口：
+
+```text
+http://localhost:8080/swagger/index.html
+```
+
+Swagger source 由 handler annotations 與 `cmd/server/main.go` 的 API metadata 產生，輸出在 [`docs/`](docs/)。
+
+在 Docker dev container 內，Air 會依照 [`.air.toml`](.air.toml) 的 `pre_cmd` 自動執行：
+
+```bash
+swag init -g cmd/server/main.go --output docs --quiet
+```
+
+如果在本機直接修改 Swagger annotation，也可以在 `services/api` 手動執行同一個指令。
+
+## 資料庫與 migrations
+
+目前 server startup 會執行：
+
+- 建立 `user_role` enum
+- `db.AutoMigrate(schema.AutoMigrateModels()...)`
+- 需要 PostgreSQL partial index / FK / runtime repair 的 idempotent SQL patch
+
+[`migrations/`](migrations/) 內的 `001-019` SQL 是現有 schema history / manual setup reference。Atlas 遷移正在 #463 路線中推進；在正式 runner 完成前，不要把這個目錄誤認為 production migration pipeline。
+
+若需要在乾淨 local PostgreSQL 上重播目前 SQL reference，可以使用：
+
+```bash
+cd services/api
+for file in migrations/*.sql; do
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+done
+```
+
+注意：這個 loop 只適合本機驗證或 schema reconciliation。正式環境變更要依當前 PR / issue 的 migration strategy 執行。
+
+## 分層結構
+
+主要目錄：
+
+| 路徑 | 說明 |
+| --- | --- |
+| `cmd/server` | API server entrypoint、config load、DB setup、service wiring |
+| `cmd/loader` | Atlas external schema loader |
+| `internal/config` | env parsing、production secret validation |
+| `internal/database` | GORM / PostgreSQL connection |
+| `internal/router` | Gin router、middleware、route grouping、Swagger route |
+| `internal/handlers` | HTTP request / response layer |
+| `internal/services` | domain logic 與 transaction boundaries |
+| `internal/models` | GORM models 與 persisted schema shape |
+| `internal/schema` | server AutoMigrate 與 Atlas loader 共用的 model list |
+| `migrations` | historical / manual SQL migration reference |
+| `docs` | generated Swagger artifacts |
+
+通常修改順序：
+
+1. Model / schema shape：先確認 issue 是否真的允許 schema change。
+2. Service：放 domain logic、交易與錯誤處理。
+3. Handler / router：只做 HTTP boundary、auth / role middleware 與 DTO mapping。
+4. Tests：依風險補 service / handler / workflow regression tests。
+
+## 測試
+
+後端測試預設使用 SQLite in-memory，少數 PostgreSQL-specific 測試使用 testcontainers 或 `DATABASE_URL`。
+
+常用指令：
+
+```bash
+cd services/api
+go test ./...
+go test ./internal/services -count=1
+go test ./internal/handlers -count=1
+```
+
+從 repo root 用 Docker 跑：
+
+```bash
+docker compose run --no-deps --rm app go test ./...
+```
+
+新增 API endpoint 時，請同步檢查 handler tests、router auth / role boundary、Swagger annotation，以及 `services/api/docs/` 產物是否需要更新。


### PR DESCRIPTION
## 什麼改動
- 新增 `services/api/README.md`，整理 tachigo API 的啟動方式、環境變數、Swagger、資料庫 / migrations、分層結構與測試方式。
- 以目前 repo 實際路徑 `services/api` 撰寫；issue 內舊稱 `backend/` 對應到現在的 API service 目錄。

## 為什麼
後端 API 目前沒有子專案 README，新進開發者需要從多個檔案推回啟動方式、Swagger 入口、env 與 migration 現況。這張 PR 對齊 #355，補上單一入口文件。

closes #355

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#355
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改現有程式碼或 API contract
  - 不補其他子目錄 README
  - 不新增英文版文件

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 `services/api` 子專案 README，讓開發者能快速啟動後端並找到 API 文件。
- Approx changed lines：~185
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `services/api/README.md` 存在且涵蓋 issue 要求的 Go / make / Docker Compose / local run / env / Swagger / migrations / layer overview
- [x] 新進開發者能從文件快速理解如何啟動後端並找到 API 文件

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk git --no-optional-locks diff --check
# exit 0

rtk ls services/api/go.mod services/api/docs services/api/.air.toml services/api/migrations services/api/cmd/server services/api/cmd/loader services/api/internal/config services/api/internal/database services/api/internal/router services/api/internal/handlers services/api/internal/services services/api/internal/models services/api/internal/schema
# all listed paths exist
```

## 備註
Docs-only PR；未執行 Go test，因為沒有修改產品程式碼。

## Notes for Claude Code Review
- 請確認 migration 段落是否足夠保守：README 明確說目前沒有正式 production migration runner，避免把 `migrations/` 寫成已落地的部署流程。