### PR TITLE
[frontend] update dashboard and extension README docs

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,34 +1,89 @@
 # Tachigo Dashboard
 
-Tachigo Dashboard 是 Vite + React + TypeScript 應用，管理介面。
+`apps/dashboard` 是給 Streamer / Agency / Admin 使用的後台管理介面，負責查看營運概況、管理 streamers、設定頻道獎勵、檢視交易紀錄與操作 raffle 流程。
 
-## 啟動方式
+## 快速啟動
+
+需求：
+
+- Node.js / pnpm：以 [`package.json`](package.json) 的 `packageManager` 為準
+- 後端 API：預設連到 `http://localhost:8080`
 
 ```bash
+cd apps/dashboard
 pnpm install
 pnpm dev
 ```
 
-預設 Vite dev server 使用 `5174`。API base URL 使用 `VITE_API_URL`，未設定時回退到 `http://localhost:8080`。
+Vite dev server 預設在：
 
-## 目前架構
+```text
+http://localhost:5174
+```
 
-`src/App.tsx` 使用 React Router v7 `createBrowserRouter`，並以 `ProtectedRoute`（驗證 `isAuthenticated()`）保護需要登入的路由。
+常用指令：
 
-認證邏輯集中在 `src/services/auth.ts`，使用 in-memory access token + httpOnly refresh cookie。`src/main.tsx` 在 app 啟動時呼叫 `restoreSession()` 取回 access token；各頁面的 API request path 由各 service 函式自行帶入 `/api/v1` prefix。
+```bash
+pnpm dev
+pnpm build
+pnpm test
+pnpm lint
+pnpm preview
+```
 
-## 規劃中：Refine.dev 架構遷移
+也可以從 repo root 用 Docker Compose 啟動完整 stack：
 
-以下異動正在進行，尚未合併到 develop（追蹤 #456）：
+```bash
+make dev
+```
 
-- `src/providers/authProvider.ts`：為 Refine `<Authenticated>` 提供 `check()` 介面；`check()` 內部同樣呼叫 `restoreSession()`，`main.tsx` 的啟動呼叫不變
-- `src/providers/dataProvider.ts`：以 `@refinedev/simple-rest` 為 base，實際 request 使用既有 axios client；`/api/v1` prefix 作為 base URL 的一部分（非中介層自動注入）
-- `src/App.tsx`：改以 `<Refine>` 包住 React Router，resources 定義 `streamers`、`raffles`、`transactions`、`settings`
-- dataProvider base URL 使用 `VITE_API_URL`，未設定時回退到 `http://localhost:8080`，並加上 `/api/v1` 作為路徑前綴
+## 連接後端
 
-## API response envelope
+建立本機 env：
 
-後端 response 格式如下（非標準 simple-rest）：
+```bash
+cp apps/dashboard/.env.example apps/dashboard/.env
+```
+
+目前支援的 API base URL 變數：
+
+| 變數 | 用途 |
+| --- | --- |
+| `VITE_TACHIGO_API_URL` | Tachigo API origin，例如 `http://localhost:8080` |
+| `VITE_API_URL` | 舊本機 env 的 fallback key；新設定請優先使用 `VITE_TACHIGO_API_URL` |
+
+Dashboard API client 會自行帶上 `/api/v1` path prefix。登入後的 request 使用 in-memory access token，refresh flow 透過後端 httpOnly cookie。
+
+## 主要模組
+
+目前 router / resources 由 [`src/App.tsx`](src/App.tsx) 定義：
+
+| 路由 | 用途 |
+| --- | --- |
+| `/login` | Dashboard auth |
+| `/` | 營運概覽 dashboard |
+| `/streamers` | Streamer list |
+| `/streamers/:streamerId` | Streamer detail / stats |
+| `/raffles` | Raffle list |
+| `/raffles/:raffleId` | Raffle detail / draw management |
+| `/transactions` | Viewer points transaction history |
+| `/settings` | Reward / channel settings entry |
+
+核心實作位置：
+
+| 路徑 | 說明 |
+| --- | --- |
+| `src/pages/` | Route-level pages |
+| `src/components/` | Layout、route guard 與共用 UI |
+| `src/services/` | Axios client、auth、channels、raffles API calls |
+| `src/providers/` | Refine authProvider / dataProvider |
+| `src/test/` | Refine test wrapper |
+
+## Refine / API response
+
+Dashboard 目前使用 Refine + React Router。`dataProvider` 以 `@refinedev/simple-rest` 為基底，再配合既有 Axios client 對接 tachigo API。
+
+後端 response envelope 不是標準 simple-rest 格式，常見形狀如下：
 
 ```json
 { "data": { "raffles": [] } }
@@ -40,10 +95,15 @@ pnpm dev
 { "data": { "raffle": {} } }
 ```
 
-## 常用指令
+新增 resource 時，請同步確認 `src/providers/dataProvider.ts` 的 resource path mapping 與 unwrap logic。
+
+## 測試與 build
 
 ```bash
+cd apps/dashboard
 pnpm test
 pnpm lint
 pnpm build
 ```
+
+PR 若修改頁面或 dataProvider，建議至少跑相關 Vitest，加上 `pnpm build` 確認 TypeScript 與 Vite build 都通過。

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -1,27 +1,112 @@
-# tachimint
+# Tachimint Extension
 
-Twitch Extension frontend for tachigo.
-Built with React + TypeScript + Vite.
+`apps/extension` 是 tachigo viewer 端的 Chrome sidepanel / extension frontend，使用 React + TypeScript + Vite。它保留 Twitch Extension auth compatibility，同時以 Chrome Manifest V3 side panel 作為目前主要 runtime。
 
-目前實作仍依賴 Twitch-hosted runtime / helper 與 `extension_jwt` 流程。
-若未來要改成 Chrome Extension，需要另行定義 migration spec，而不是直接把現況文件整批改名。
+## 快速啟動
 
-## Dev
+需求：
 
-Run from the repo root:
-
-```bash
-make dev          # starts Vite dev server at http://localhost:5173
-```
-
-`window.Twitch.ext` is automatically mocked in dev mode.
-No Twitch Developer Rig needed for UI development.
-
-## Build
+- Node.js：[`package.json`](package.json) 目前要求 `>=22.12.0`
+- pnpm：以 `packageManager` 為準
+- 後端 API：預設連到 `http://localhost:8080`
 
 ```bash
-docker compose run --no-deps --rm frontend npm run build
-# output -> dist/
+cd apps/extension
+pnpm install
+pnpm dev
 ```
 
-Upload `dist/` to the Twitch Developer Console to test as a hosted extension.
+Vite dev server 預設在：
+
+```text
+http://localhost:5173
+```
+
+開發模式會注入 `window.Twitch.ext` mock，因此一般 UI 開發不需要 Twitch Developer Rig。
+
+常用指令：
+
+```bash
+pnpm dev
+pnpm build
+pnpm test
+pnpm lint
+pnpm check:i18n
+pnpm preview
+```
+
+也可以從 repo root 啟動完整 stack：
+
+```bash
+make dev
+```
+
+## 連接後端
+
+建立本機 env：
+
+```bash
+cp apps/extension/.env.example apps/extension/.env
+```
+
+| 變數 | 用途 |
+| --- | --- |
+| `VITE_TACHIGO_API_URL` | Tachigo API origin，例如 `http://localhost:8080` |
+
+Chrome manifest 目前允許 `http://localhost:8080/*` host permission；若本機 API origin 改變，請同步檢查 [`public/manifest.json`](public/manifest.json)。
+
+## Chrome Extension 載入方式
+
+先產出 `dist/`：
+
+```bash
+cd apps/extension
+pnpm build
+```
+
+在 Chrome 載入 unpacked extension：
+
+1. 開啟 `chrome://extensions`
+2. 開啟 Developer mode
+3. 點選 **Load unpacked**
+4. 選擇 `apps/extension/dist`
+5. 點擊 Tachimint extension action，或從 Chrome side panel 開啟
+
+目前 Manifest V3 設定在 [`public/manifest.json`](public/manifest.json)：
+
+- `side_panel.default_path` 指向 `sidepanel.html`
+- background service worker 由 `src/extension/background.ts` build 成 `assets/background.js`
+- content script 由 `src/extension/content.ts` build 成 `assets/content.js`
+
+## `sidepanel.html` 與 `index.html`
+
+| Entry | 用途 |
+| --- | --- |
+| `sidepanel.html` | Chrome side panel entry；manifest 的 `default_path` 指向這個檔案 |
+| `index.html` | Vite popup / legacy Twitch-hosted entry；會載入 Twitch Extension Helper，提供 `window.Twitch.ext` runtime |
+
+兩個 entry 都載入 `src/main.tsx`，實際 UI flow 由 React app 決定。
+
+## 主要模組
+
+| 路徑 | 說明 |
+| --- | --- |
+| `src/app/` | Viewer UI panels、claim / coupon / raffle result 等互動流程 |
+| `src/extension/` | Chrome runtime bridge、background、content、storage 與 manifest-facing types |
+| `src/hooks/` | Watch heartbeat、click boost、T-Point、raffle result hooks |
+| `src/services/` | Tachigo API client 與 auth recovery |
+| `src/i18n/` | i18next setup 與語系資源 |
+| `src/mock/` | Dev mode Twitch Extension mock |
+| `src/styles/` | Fonts 與 global styles |
+
+## 測試與 build
+
+```bash
+cd apps/extension
+pnpm test
+pnpm lint
+pnpm check:i18n
+pnpm build
+```
+
+修改 extension runtime、manifest 或 API origin 時，請同時確認相關 tests，例如 `src/extension/runtime-config.test.ts` 與 `src/services/api.test.ts`。


### PR DESCRIPTION
## 什麼改動
- 更新 `apps/dashboard/README.md`，說明 Dashboard 是 Streamer / Agency / Admin 後台，補上主要路由、模組、API env 與啟動 / build 指令。
- 更新 `apps/extension/README.md`，說明 Chrome sidepanel 現況、`dist/` load unpacked 流程、`sidepanel.html` / `index.html` 差異與常用指令。
- 以目前 monorepo 實際路徑 `apps/dashboard` / `apps/extension` 對齊 issue #353 中舊稱的 `dashboard` / `tachimint`。

## 為什麼
前端子專案 README 與現況不一致，尤其 extension 已是 Chrome Manifest V3 sidepanel runtime。這張 PR 對齊 #353，讓新進開發者能直接從子專案 README 啟動、連後端並載入 unpacked extension。

closes #353

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#353
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改任何程式碼
  - 不補 backend / services/api 文件
  - 不新增英文版文件

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 更新 Dashboard 與 Extension 子專案 README，使啟動方式、後端連線與 Chrome extension 載入步驟對齊目前程式碼。
- Approx changed lines：~203
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `apps/dashboard/README.md` 描述業務背景且不再是 Vite 預設內容
- [x] `apps/extension/README.md` 包含 Chrome Extension 載入步驟
- [x] 標明 `pnpm dev` / `pnpm build` 與 API env 設定

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk git --no-optional-locks diff --check
# exit 0

rtk ls apps/dashboard/package.json apps/dashboard/src/App.tsx apps/extension/package.json apps/extension/public/manifest.json apps/extension/sidepanel.html apps/extension/index.html apps/extension/src/main.tsx
# all listed paths exist
```

## 備註
Docs-only PR；未執行 frontend build，因為沒有修改 app source。

## Notes for Claude Code Review
- 請確認 extension README 對 `index.html` 的描述是否符合目前仍保留 Twitch helper 的 legacy / popup entry 角色。