### PR TITLE
[infra] gate backend integration on cache wiring

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -791,10 +791,12 @@ Backend contract already in develop:
 
 test('CI product jobs are gated by path-aware scope outputs', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
   const backendBuild = workflowJobBlock(workflow, 'backend-build')
   const backend = workflowJobBlock(workflow, 'backend')
   const atlas = workflowJobBlock(workflow, 'atlas-migration-tooling')
   const backendIntegration = workflowJobBlock(workflow, 'backend-integration')
+  const backendIntegrationJob = parsedWorkflow.jobs['backend-integration']
   const backendSecurityScanners = workflowJobBlock(workflow, 'backend-security-scanners')
   const dependencyReview = workflowJobBlock(workflow, 'dependency-review')
   const frontend = workflowJobBlock(workflow, 'frontend')
@@ -814,6 +816,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   assert.match(contracts, /needs\.scope-gate\.outputs\.run_contracts == 'true'/)
   assert.match(contractsSlither, /needs\.scope-gate\.outputs\.run_contracts_slither == 'true'/)
   assert.match(contractsGasSnapshot, /needs\.scope-gate\.outputs\.run_contracts_gas_report == 'true'/)
+  assert.deepEqual(backendIntegrationJob.needs, ['scope-gate', 'check-cache-wiring'])
 })
 
 test('PR commit message check skips formal release promotion PRs', () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,7 +469,7 @@ jobs:
   backend-integration:
     timeout-minutes: 20
     name: Backend integration tests
-    needs: [scope-gate]
+    needs: [scope-gate, check-cache-wiring]
     runs-on: ubuntu-latest
     if: needs.scope-gate.outputs.run_backend_integration == 'true'
     steps:


### PR DESCRIPTION
## 什麼改動
- 將 `.github/workflows/ci.yml` 的 `backend-integration` job `needs` 從 `scope-gate` 擴充為 `scope-gate` + `check-cache-wiring`。
- 補 `.github/workflows/ci.test.mjs` regression，固定 `backend-integration` 必須依賴 cache wiring check。

## 為什麼
#284 要把 backend cache wiring 驗證從告警升級為 integration tests 前置門禁。這樣 cache wiring 失敗時，backend integration tests 不會開始跑，避免在已知 CI cache 設定錯誤時繼續消耗時間。

closes #284

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#284
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 cache 驗證腳本本身
  - 不調整其他 CI job 結構或觸發條件
  - 不修改產品程式碼

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 backend integration tests 依賴 backend cache wiring check，將 cache wiring 失敗升級為 integration test 前置門禁。
- Approx changed lines：~5
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `backend-integration` job 的 `needs` 包含 `check-cache-wiring`
- [x] workflow regression test 驗證 cache wiring dependency

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk node --test .github/workflows/ci.test.mjs
# tests 56, pass 56, fail 0

rtk git --no-optional-locks diff --check
# exit 0
```

## 備註
這張 PR 只保證 cache wiring failure 會阻擋 `backend-integration` 開始執行；沒有改動 `check-backend-ci-cache.sh` 的判斷內容。

## Notes for Claude Code Review
- 請確認目前只把 `check-cache-wiring` 放到 `backend-integration.needs` 是否符合 #284，不把它擴張到其他 jobs。