### PR TITLE
[frontend] align dashboard resource endpoints

### DIFF
--- a/apps/dashboard/src/providers/__tests__/dataProvider.test.ts
+++ b/apps/dashboard/src/providers/__tests__/dataProvider.test.ts
@@ -68,4 +68,59 @@ describe('dataProvider API URL', () => {
     )
     expect(mockClient.patch).not.toHaveBeenCalled()
   })
+
+  it('transactions getList 走 points history endpoint 並傳遞 channel_id', async () => {
+    vi.stubEnv('VITE_TACHIGO_API_URL', 'https://api.example.test/')
+    mockClient.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          transactions: [
+            {
+              id: 'tx-1',
+              type: 'earn',
+              amount: 12,
+            },
+          ],
+        },
+      },
+    })
+
+    const { dataProvider } = await import('@/providers/dataProvider')
+
+    const result = await dataProvider.getList({
+      resource: 'transactions',
+      meta: { params: { channel_id: 'channel-123' } },
+    })
+
+    expect(mockClient.get).toHaveBeenCalledWith(
+      'https://api.example.test/api/v1/users/me/points/history',
+      {
+        params: {
+          channel_id: 'channel-123',
+          pagination: undefined,
+          sorters: undefined,
+          filters: undefined,
+        },
+      },
+    )
+    expect(result.data).toEqual([
+      {
+        id: 'tx-1',
+        type: 'earn',
+        amount: 12,
+      },
+    ])
+  })
+
+  it('settings resource 目前明確不支援，避免打到不存在的 dashboard settings endpoint', async () => {
+    vi.stubEnv('VITE_TACHIGO_API_URL', 'https://api.example.test/')
+
+    const { dataProvider } = await import('@/providers/dataProvider')
+
+    await expect(dataProvider.getList({ resource: 'settings' })).rejects.toThrow(
+      'Dashboard settings resource is not wired to a backend endpoint yet',
+    )
+
+    expect(mockClient.get).not.toHaveBeenCalled()
+  })
 })

--- a/apps/dashboard/src/providers/dataProvider.ts
+++ b/apps/dashboard/src/providers/dataProvider.ts
@@ -28,8 +28,18 @@ const resourcePaths: Record<string, string> = {
   'streamer-stats': '/dashboard/streamers',
   raffles: '/dashboard/raffles',
   transactions: '/users/me/points/history',
-  settings: '/dashboard/settings',
   'channel-configs': '/dashboard/channels',
+}
+
+const unsupportedResources: Record<string, string> = {
+  settings: 'Dashboard settings resource is not wired to a backend endpoint yet',
+}
+
+function assertResourceSupported(resource: string) {
+  const message = unsupportedResources[resource]
+  if (message) {
+    throw new Error(message)
+  }
 }
 
 function resourcePath(resource: string) {
@@ -135,6 +145,8 @@ export const dataProvider: DataProvider = {
     filters,
     meta,
   }: GetListParams): Promise<GetListResponse<TData>> => {
+    assertResourceSupported(resource)
+
     const { data } = await client.get(apiUrl(resourcePath(resource)), {
       params: {
         ...(meta?.params as object | undefined),
@@ -155,6 +167,8 @@ export const dataProvider: DataProvider = {
     resource,
     id,
   }: GetOneParams): Promise<GetOneResponse<TData>> => {
+    assertResourceSupported(resource)
+
     const { data } = await client.get(apiUrl(pathWithId(resource, id)))
 
     return {
@@ -166,6 +180,8 @@ export const dataProvider: DataProvider = {
     resource,
     variables,
   }: CreateParams<TVariables>): Promise<CreateResponse<TData>> => {
+    assertResourceSupported(resource)
+
     const { data } = await client.post(apiUrl(resourcePath(resource)), variables)
 
     return {
@@ -178,6 +194,8 @@ export const dataProvider: DataProvider = {
     id,
     variables,
   }: UpdateParams<TVariables>): Promise<UpdateResponse<TData>> => {
+    assertResourceSupported(resource)
+
     const request = updateMethod(resource)
     const { data } = await request(apiUrl(pathWithId(resource, id)), variables)
 
@@ -190,6 +208,8 @@ export const dataProvider: DataProvider = {
     resource,
     id,
   }: DeleteOneParams<TVariables>): Promise<DeleteOneResponse<TData>> => {
+    assertResourceSupported(resource)
+
     const { data } = await client.delete(apiUrl(pathWithId(resource, id)))
 
     return {


### PR DESCRIPTION
Source of truth: closes #467

Scope 對齊:
- [x] `transactions` getList 鎖定現有 backend contract：`/api/v1/users/me/points/history`，並透過 `meta.params.channel_id` 傳遞 channel。
- [x] `settings` 不再映射到不存在的 `/api/v1/dashboard/settings`。
- [x] `settings` resource 在 dataProvider 層明確丟出 unsupported error，避免未來 hooks 靜默打錯 endpoint。
- [x] 補上 dataProvider 單元測試覆蓋 transactions/settings 行為。

Backend contract already in develop:
- [x] yes
- [ ] no

Depends on PR: none

本 PR 明確不做:
- 不新增 backend endpoint。
- 不完成 Settings UI。
- 不重構整個 dashboard dataProvider。

驗證:
- rtk zsh -lc 'eval "$(fnm env --shell zsh)"; fnm use 24; pnpm test -- src/providers/__tests__/dataProvider.test.ts' （RED: settings unsupported 測試先失敗，確認會抓到舊行為）\n- rtk zsh -lc 'eval "$(fnm env --shell zsh)"; fnm use 24; pnpm test' （apps/dashboard）=> 12 files / 89 tests passed\n- rtk zsh -lc 'eval "$(fnm env --shell zsh)"; fnm use 24; pnpm build' （apps/dashboard）=> passed，僅既有 chunk size warning\n- rtk zsh -lc 'eval "$(fnm env --shell zsh)"; fnm use 24; pnpm lint' （apps/dashboard）=> passed\n- rtk git --no-optional-locks diff --cached --check => passed