### PR TITLE
[infra] limit auto-merge workflow to develop

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.base.ref == 'develop'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -1124,7 +1124,7 @@ test('global auto-merge workflow excludes Dependabot PRs', async () => {
   ])
   assert.equal(
     parsedWorkflow.jobs['enable-auto-merge'].if,
-    "github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'",
+    "github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.base.ref == 'develop'",
   )
   assert.doesNotMatch(workflow, /if: github\.event\.pull_request\.draft == false\s*$/m)
 })


### PR DESCRIPTION
Source of truth: closes #347

Scope 對齊:
- [x] 將 global auto-merge workflow 限制為 `base.ref == develop`。
- [x] 保留既有條件：非 draft、非 Dependabot。
- [x] 補 workflow regression test，避免 non-develop / release promotion PR 被這支 workflow 自動排 merge。

Backend contract already in develop:
- [x] yes
- [ ] no

Depends on PR: none

本 PR 明確不做:
- 不改 branch protection；develop required checks 已於 #148 補上 `Scope police` 並關閉。
- 不改 repo 目前使用的 merge-commit auto-merge 策略。
- 不改 Dependabot 專用 auto-merge workflow。

驗證:
- RED: rtk node --test .github/workflows/ci.test.mjs --test-name-pattern 'global auto-merge workflow excludes Dependabot PRs' => failed，指出缺少 `github.event.pull_request.base.ref == 'develop'`。\n- GREEN: rtk node --test .github/workflows/ci.test.mjs => 56 passed。\n- rtk git --no-optional-locks diff --check => passed。\n- actionlint: not installed locally; workflow syntax is covered by existing Ruby YAML parse regression tests and CI will rerun workflow regression.