### PR TITLE
[contract] pin CI action refs by SHA

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -84,6 +84,14 @@ function workflowJobBlock(workflow, jobName) {
   return match[0]
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function pinnedActionRef(actionName, versionLabel) {
+  return new RegExp(`uses: ${escapeRegExp(actionName)}@[0-9a-f]{40} # ${escapeRegExp(versionLabel)}`)
+}
+
 function extractRequiredCheckSnapshots(script) {
   const marker = 'const requiredCheckSnapshots ='
   const markerIndex = script.indexOf(marker)
@@ -449,13 +457,25 @@ test('CI workflow uses infra script entrypoints', async () => {
   assert.doesNotMatch(workflow, /run: bash scripts\//)
 })
 
+test('CI workflow pins action references to full commit SHAs', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const actionRefs = [...workflow.matchAll(/uses:\s+([^@\s#]+)@([^\s#]+)(?:\s+#\s+([^\n]+))?/g)]
+
+  assert.ok(actionRefs.length > 0)
+
+  for (const [, actionName, ref, versionLabel] of actionRefs) {
+    assert.match(ref, /^[0-9a-f]{40}$/, `${actionName} must use a full 40-character SHA`)
+    assert.ok(versionLabel?.startsWith('v'), `${actionName} must keep the original version tag as a comment`)
+  }
+})
+
 test('backend CI job runs go test and go vet natively from services/api', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
   const backendJob = workflowJobBlock(workflow, 'backend')
 
   assert.match(
     backendJob,
-    /uses: actions\/setup-go@v6\n\s+with:\n\s+go-version-file: services\/api\/go\.mod/,
+    /uses: actions\/setup-go@[0-9a-f]{40} # v6\n\s+with:\n\s+go-version-file: services\/api\/go\.mod/,
   )
 
   assert.match(
@@ -571,9 +591,9 @@ test('CI workflow validates Atlas migration tooling without applying migrations'
 
   assert.match(
     atlasJob,
-    /uses: actions\/setup-go@v6\n\s+with:\n\s+go-version-file: services\/api\/go\.mod/,
+    /uses: actions\/setup-go@[0-9a-f]{40} # v6\n\s+with:\n\s+go-version-file: services\/api\/go\.mod/,
   )
-  assert.match(atlasJob, /uses: ariga\/setup-atlas@v0/)
+  assert.match(atlasJob, pinnedActionRef('ariga/setup-atlas', 'v0'))
   assert.match(atlasJob, /version: v0\.37\.0/)
   assert.match(
     atlasJob,
@@ -863,8 +883,8 @@ test('dependency review CI job gates only frontend dependency files', async () =
   assert.equal(job['timeout-minutes'], 10)
   assert.equal(job.needs, 'scope-gate')
   assert.equal(job.if, "github.event_name == 'pull_request' && needs.scope-gate.outputs.run_dependency_review == 'true'")
-  assert.match(jobBlock, /uses: actions\/checkout@v4/)
-  assert.match(jobBlock, /uses: actions\/dependency-review-action@v4/)
+  assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.match(jobBlock, pinnedActionRef('actions/dependency-review-action', 'v4'))
   assert.match(jobBlock, /fail-on-severity: high/)
   assert.match(jobBlock, /fail-on-scopes: runtime/)
   assert.match(jobBlock, /vulnerability-check: true/)
@@ -954,18 +974,18 @@ test('contracts Slither report job uploads SARIF and keeps findings report-only'
   assert.equal(job.if, "needs.scope-gate.outputs.run_contracts_slither == 'true'")
   assert.equal(job.permissions.contents, 'read')
   assert.equal(job.permissions['security-events'], 'write')
-  assert.match(jobBlock, /uses: actions\/checkout@v4/)
-  assert.match(jobBlock, /uses: foundry-rs\/foundry-toolchain@v1/)
+  assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.match(jobBlock, pinnedActionRef('foundry-rs/foundry-toolchain', 'v1'))
   assert.match(jobBlock, /working-directory: contracts\n\s+run: forge install OpenZeppelin\/openzeppelin-contracts@v5\.6\.1 --no-git/)
-  assert.match(jobBlock, /uses: crytic\/slither-action@v0\.4\.2/)
+  assert.match(jobBlock, pinnedActionRef('crytic/slither-action', 'v0.4.2'))
   assert.match(jobBlock, /id: slither/)
   assert.match(jobBlock, /target: contracts/)
   assert.match(jobBlock, /slither-version: 0\.11\.5/)
   assert.match(jobBlock, /sarif: slither\.sarif/)
   assert.match(jobBlock, /fail-on: none/)
-  assert.match(jobBlock, /uses: github\/codeql-action\/upload-sarif@v3/)
+  assert.match(jobBlock, pinnedActionRef('github/codeql-action/upload-sarif', 'v3'))
   assert.match(jobBlock, /sarif_file: \$\{\{ steps\.slither\.outputs\.sarif \}\}/)
-  assert.match(jobBlock, /uses: actions\/upload-artifact@v4/)
+  assert.match(jobBlock, pinnedActionRef('actions/upload-artifact', 'v4'))
   assert.match(jobBlock, /name: slither-report/)
   assert.match(jobBlock, /path: \$\{\{ steps\.slither\.outputs\.sarif \}\}/)
   assert.doesNotMatch(jobBlock, /continue-on-error: true/)
@@ -993,12 +1013,12 @@ test('contracts gas snapshot job publishes a report-only artifact', async () => 
   assert.equal(job['timeout-minutes'], 20)
   assert.deepEqual(job.needs, ['scope-gate'])
   assert.equal(job.if, "needs.scope-gate.outputs.run_contracts_gas_report == 'true'")
-  assert.match(jobBlock, /uses: actions\/checkout@v4/)
-  assert.match(jobBlock, /uses: foundry-rs\/foundry-toolchain@v1/)
+  assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.match(jobBlock, pinnedActionRef('foundry-rs/foundry-toolchain', 'v1'))
   assert.match(jobBlock, /working-directory: contracts\n\s+run: forge install OpenZeppelin\/openzeppelin-contracts@v5\.6\.1 --no-git/)
   assert.match(jobBlock, /working-directory: contracts\n\s+run: forge snapshot --snap gas-snapshot\.report/)
   assert.match(jobBlock, /cat gas-snapshot\.report/)
-  assert.match(jobBlock, /uses: actions\/upload-artifact@v4/)
+  assert.match(jobBlock, pinnedActionRef('actions/upload-artifact', 'v4'))
   assert.match(jobBlock, /name: contracts-gas-snapshot-report/)
   assert.match(jobBlock, /path: contracts\/gas-snapshot\.report/)
   assert.doesNotMatch(jobBlock, /--check/)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Evaluate PR scope for CI
         id: evaluate
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const setCiOutputs = ({
@@ -312,7 +312,7 @@ jobs:
     if: needs.scope-gate.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Verify Docker Buildx cache configuration
         run: bash infra/scripts/check-backend-ci-cache.sh
@@ -322,9 +322,9 @@ jobs:
     name: Workflow regression tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.12.0
 
@@ -336,7 +336,7 @@ jobs:
     name: Commit message regression tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Verify commit message hook assertions
         run: bash infra/scripts/commit-message-check.test.sh
@@ -346,7 +346,7 @@ jobs:
     name: PR metadata check regression tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -367,7 +367,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.base.ref != 'main' || github.event.pull_request.head.ref != 'develop')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -381,13 +381,13 @@ jobs:
     if: needs.scope-gate.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build backend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./services/api
           target: dev
@@ -403,10 +403,10 @@ jobs:
     if: needs.scope-gate.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: services/api/go.mod
 
@@ -425,17 +425,17 @@ jobs:
     if: needs.scope-gate.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: services/api/go.mod
 
       - name: Set up Atlas
-        uses: ariga/setup-atlas@v0
+        uses: ariga/setup-atlas@2f3c785c89a15e1c0d07bcae3900fb5feb969eea # v0
         with:
           version: v0.37.0
 
@@ -473,10 +473,10 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.scope-gate.outputs.run_backend_integration == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: services/api/go.mod
 
@@ -494,10 +494,10 @@ jobs:
       STATICCHECK_VERSION: v0.7.0
       GOVULNCHECK_VERSION: v1.3.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.10
 
@@ -524,10 +524,10 @@ jobs:
     if: github.event_name == 'pull_request' && needs.scope-gate.outputs.run_dependency_review == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           fail-on-scopes: runtime
@@ -543,7 +543,7 @@ jobs:
     if: needs.scope-gate.outputs.run_frontend == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           lfs: true
 
@@ -569,7 +569,7 @@ jobs:
     if: needs.scope-gate.outputs.run_dashboard == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build image
         run: docker compose build dashboard
@@ -590,10 +590,10 @@ jobs:
     if: needs.scope-gate.outputs.run_contracts == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       - name: Install dependencies
         working-directory: contracts
@@ -621,10 +621,10 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       - name: Install Solidity dependencies
         working-directory: contracts
@@ -632,7 +632,7 @@ jobs:
 
       - name: Run Slither
         id: slither
-        uses: crytic/slither-action@v0.4.2
+        uses: crytic/slither-action@b52cc1cbfee9ca3e8722dd5224299d16c9a6b80f # v0.4.2
         with:
           target: contracts
           slither-version: 0.11.5
@@ -641,13 +641,13 @@ jobs:
 
       - name: Upload Slither SARIF
         if: always() && steps.slither.outputs.sarif != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           sarif_file: ${{ steps.slither.outputs.sarif }}
 
       - name: Upload Slither report artifact
         if: always() && steps.slither.outputs.sarif != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: slither-report
           path: ${{ steps.slither.outputs.sarif }}
@@ -660,10 +660,10 @@ jobs:
     if: needs.scope-gate.outputs.run_contracts_gas_report == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       - name: Install dependencies
         working-directory: contracts
@@ -678,7 +678,7 @@ jobs:
         run: cat gas-snapshot.report
 
       - name: Upload gas snapshot report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: contracts-gas-snapshot-report
           path: contracts/gas-snapshot.report
@@ -727,7 +727,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Mark auto-ready draft PR ready
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           SCOPE_GATE_RESULT: ${{ needs.scope-gate.result }}
           BACKEND_CI_RESULT: ${{ needs.backend-ci.result }}

--- a/infra/scripts/check-backend-ci-cache.sh
+++ b/infra/scripts/check-backend-ci-cache.sh
@@ -15,6 +15,17 @@ require_in() {
   fi
 }
 
+require_regex_in() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if ! grep -Eq -- "$pattern" "$file"; then
+    echo "missing: $message" >&2
+    exit 1
+  fi
+}
+
 reject_in() {
   local file="$1"
   local pattern="$2"
@@ -27,15 +38,15 @@ reject_in() {
 }
 
 require_in "$compose_file" "image: tachigo-app:latest" "docker compose app service should use the CI-built image tag"
-require_in "$workflow" "docker/setup-buildx-action@v3" "backend CI should initialize Docker Buildx"
-require_in "$workflow" "docker/build-push-action@v6" "backend CI should build app image through build-push-action"
+require_regex_in "$workflow" "docker/setup-buildx-action@[0-9a-f]{40} # v3" "backend CI should initialize Docker Buildx"
+require_regex_in "$workflow" "docker/build-push-action@[0-9a-f]{40} # v6" "backend CI should build app image through build-push-action"
 require_in "$workflow" "context: ./services/api" "backend CI should build from services/api"
 require_in "$workflow" "target: dev" "backend CI should build the same dev target used by docker compose tests"
 require_in "$workflow" "cache-from: type=gha" "backend CI should restore Docker layers from GitHub Actions cache"
 require_in "$workflow" "cache-to: type=gha,mode=max" "backend CI should save Docker layers to GitHub Actions cache"
 require_in "$workflow" "load: false" "backend build should validate Docker cache without loading the image"
 require_in "$workflow" "tags: tachigo-app:latest" "backend CI should tag the image used by docker compose"
-require_in "$workflow" "actions/setup-go@v6" "backend unit tests should use native Go"
+require_regex_in "$workflow" "actions/setup-go@[0-9a-f]{40} # v6" "backend unit tests should use native Go"
 require_in "$workflow" "go-version-file: services/api/go.mod" "backend unit tests should read services/api/go.mod"
 require_in "$workflow" "working-directory: services/api" "backend unit tests should run from services/api"
 require_in "$workflow" "run: go test ./..." "backend unit tests should run natively"


### PR DESCRIPTION
refs #134

Source of truth: https://github.com/nurockplayer/tachigo/issues/134

closes #134

Scope 對齊
- Pin every action reference in `.github/workflows/ci.yml` to the current immutable 40-character commit SHA.
- Preserve the original version tag beside each SHA as an inline comment for reviewability.
- Add a workflow regression test that rejects unpinned `ci.yml` action refs.
- Update the backend CI cache wiring guard so it validates pinned Buildx/build-push/setup-go refs.

Backend contract already in develop:
- [x] yes
- [ ] no

Depends on PR: none

本 PR 明確不做
- 不修改 CI job 結構、觸發條件、permissions、env 或執行步驟邏輯。
- 不升級任何 action 版本；只鎖定目前 tag/branch 所指向的 commit SHA。
- 不修改 `contracts/README.md`，該範圍保留給 #135。

驗證
- [x] `rtk bash infra/scripts/check-backend-ci-cache.sh`
- [x] `rtk node --test .github/workflows/ci.test.mjs`（57 pass）
- [x] `rtk git --no-optional-locks diff --check`