### PR TITLE
[contract] clarify TachiToken router comment

### DIFF
--- a/contracts/src/TachiToken.sol
+++ b/contracts/src/TachiToken.sol
@@ -5,7 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title TachiToken
-/// @notice Soulbound ERC-20；持有者不可自由轉讓，所有流動操作須透過平台 Router Contract。
+/// @notice Soulbound ERC-20；持有者不可自由轉讓。
+/// @dev MVP 由 owner 執行 mint/burn；未來若需要協議內消費或結算，將在 Phase 2 透過 Router Contract 設計。
 contract TachiToken is ERC20, Ownable {
     uint256 public constant MAX_SUPPLY = 1_000_000_000 * 10 ** 18; // 10 億枚，單位為 wei（最小單位）
 


### PR DESCRIPTION
refs #543

Source of truth: https://github.com/nurockplayer/tachigo/issues/543

Related discussion: https://github.com/nurockplayer/tachigo/issues/168

closes #543

Scope 對齊
- Clarify the `TachiToken` contract comment so current owner-only mint/burn is not confused with future Phase 2 Router-mediated movement.
- Keep this as a comment-only contract documentation change.

Backend contract already in develop:
- [x] yes
- [ ] no

Depends on PR: none

本 PR 明確不做
- 不實作 Router Contract。
- 不定義完整 Router-mediated token flow spec。
- 不修改 mint/burn/transfer/approve 行為或 ABI。

驗證
- [x] `rtk git --no-optional-locks diff --check`
- [ ] `forge test`：本機未安裝 Foundry；交由 GitHub Contracts build 驗證