### PR TITLE
[backend] stabilize api tests in sandbox

### DIFF
--- a/services/api/Makefile
+++ b/services/api/Makefile
@@ -1,5 +1,7 @@
 .PHONY: run build tidy db-up db-down up down logs lint test
 
+GOCACHE ?= $(CURDIR)/.go-build-cache
+
 # ── Dev ───────────────────────────────────────────────────────────────────────
 run:
 	go run ./cmd/server
@@ -38,4 +40,5 @@ lint:
 	golangci-lint run ./...
 
 test:
-	go test ./... -v
+	mkdir -p "$(GOCACHE)"
+	GOCACHE="$(GOCACHE)" go test ./... -v

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tachigo/tachigo/internal/middleware"
 	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
+	"github.com/tachigo/tachigo/internal/testutil"
 )
 
 // raffleTestEnv wires only the raffle-related handlers.
@@ -811,13 +812,14 @@ func TestRaffle_Snapshot_NoTwitchToken(t *testing.T) {
 }
 
 func TestRaffle_Snapshot_TwitchScopeError(t *testing.T) {
-	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer mockTwitch.Close()
-
 	env := newRaffleTestEnv(t)
-	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
+	env.raffleSvc.SetTwitchBaseURL("https://twitch.test")
+	env.raffleSvc.SetHTTPClient(testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			return testutil.NewStringResponse(http.StatusForbidden, "{}"), nil
+		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
+	}))
 	token := env.registerStreamer(t, "s1", "s1@test.com", "pass1234")
 
 	// Look up the streamer's user ID and insert a twitch_api raffle directly.
@@ -908,12 +910,13 @@ func TestRaffle_Snapshot_Success(t *testing.T) {
 	_ = env.db.Exec(`UPDATE auth_providers SET provider_id = 'viewer_twitch_id_1' WHERE provider_id = 'twitch_id_viewer1'`)
 
 	sub := map[string]string{"user_id": "viewer_twitch_id_1", "user_login": "viewer1", "user_name": "Viewer1"}
-	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, twitchSubsJSON([]map[string]string{sub}, ""))
+	env.raffleSvc.SetTwitchBaseURL("https://twitch.test")
+	env.raffleSvc.SetHTTPClient(testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			return testutil.NewStringResponse(http.StatusOK, twitchSubsJSON([]map[string]string{sub}, "")), nil
+		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
 	}))
-	defer mockTwitch.Close()
-	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
 
 	raffleID := env.setupTwitchRaffle(t, "s1@test.com", "fake-token")
 
@@ -949,17 +952,17 @@ func TestRaffle_Snapshot_Pagination(t *testing.T) {
 	page1 := []map[string]string{{"user_id": "vid1", "user_login": "viewer1", "user_name": "Viewer1"}}
 	page2 := []map[string]string{{"user_id": "vid2", "user_login": "viewer2", "user_name": "Viewer2"}}
 	calls := 0
-	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		calls++
-		if r.URL.Query().Get("after") == "" {
-			fmt.Fprint(w, twitchSubsJSON(page1, "cursor-page2"))
-		} else {
-			fmt.Fprint(w, twitchSubsJSON(page2, ""))
+	env.raffleSvc.SetTwitchBaseURL("https://twitch.test")
+	env.raffleSvc.SetHTTPClient(testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			calls++
+			if r.URL.Query().Get("after") == "" {
+				return testutil.NewStringResponse(http.StatusOK, twitchSubsJSON(page1, "cursor-page2")), nil
+			}
+			return testutil.NewStringResponse(http.StatusOK, twitchSubsJSON(page2, "")), nil
 		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
 	}))
-	defer mockTwitch.Close()
-	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
 
 	raffleID := env.setupTwitchRaffle(t, "s1@test.com", "fake-token")
 
@@ -990,12 +993,13 @@ func TestRaffle_Snapshot_DuplicateSkip(t *testing.T) {
 	_ = env.db.Exec(`UPDATE auth_providers SET provider_id = 'vid1' WHERE provider_id = 'twitch_id_viewer1'`)
 
 	sub := map[string]string{"user_id": "vid1", "user_login": "viewer1", "user_name": "Viewer1"}
-	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, twitchSubsJSON([]map[string]string{sub}, ""))
+	env.raffleSvc.SetTwitchBaseURL("https://twitch.test")
+	env.raffleSvc.SetHTTPClient(testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			return testutil.NewStringResponse(http.StatusOK, twitchSubsJSON([]map[string]string{sub}, "")), nil
+		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
 	}))
-	defer mockTwitch.Close()
-	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
 
 	raffleID := env.setupTwitchRaffle(t, "s1@test.com", "fake-token")
 
@@ -1028,12 +1032,13 @@ func TestRaffle_Snapshot_UnlinkedSkip(t *testing.T) {
 
 	// Subscriber has no tachigo account.
 	sub := map[string]string{"user_id": "unknown_id", "user_login": "stranger", "user_name": "Stranger"}
-	mockTwitch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, twitchSubsJSON([]map[string]string{sub}, ""))
+	env.raffleSvc.SetTwitchBaseURL("https://twitch.test")
+	env.raffleSvc.SetHTTPClient(testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			return testutil.NewStringResponse(http.StatusOK, twitchSubsJSON([]map[string]string{sub}, "")), nil
+		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
 	}))
-	defer mockTwitch.Close()
-	env.raffleSvc.SetTwitchBaseURL(mockTwitch.URL)
 
 	raffleID := env.setupTwitchRaffle(t, "s1@test.com", "fake-token")
 

--- a/services/api/internal/services/airdrop_service_test.go
+++ b/services/api/internal/services/airdrop_service_test.go
@@ -495,9 +495,11 @@ func newConcurrentTestDB(t *testing.T) *gorm.DB {
 
 	dbPath := t.TempDir() + "/airdrop-concurrency.db"
 	// PRAGMAs in the DSN are applied per-connection by the SQLite driver, so
-	// every connection in the pool gets busy_timeout, WAL mode, and foreign
-	// keys — unlike executing PRAGMA statements after Open, which only affects
-	// the single connection that runs the query.
+	// foreign keys are enabled consistently.  This unit test serializes DB
+	// access through one connection because SQLite's single-writer locking can
+	// otherwise fail the test with "database is locked" before the application
+	// daily-limit assertion is reached. True concurrent SERIALIZABLE coverage
+	// lives in airdrop_service_pg_test.go.
 	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=on"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger:         logger.Default.LogMode(logger.Silent),
@@ -511,8 +513,8 @@ func newConcurrentTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("db handle: %v", err)
 	}
-	sqlDB.SetMaxOpenConns(8)
-	sqlDB.SetMaxIdleConns(8)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
 
 	if err := migrateTestDB(db); err != nil {
 		t.Fatalf("migrate concurrent test db: %v", err)

--- a/services/api/internal/services/raffle_scheduler_test.go
+++ b/services/api/internal/services/raffle_scheduler_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/models"
+	"github.com/tachigo/tachigo/internal/testutil"
 )
 
 func TestNextSchedulerRun(t *testing.T) {
@@ -91,15 +91,15 @@ func TestRunScheduledSnapshots_SkipsCompleted(t *testing.T) {
 }
 
 func TestRunScheduledSnapshots_TwitchAPISuccess(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"data":[],"pagination":{}}`)) //nolint:errcheck
-	}))
-	defer ts.Close()
-
 	db := newTestDB(t)
 	svc := NewRaffleService(db, "test-client-id", "", nil)
-	svc.SetTwitchBaseURL(ts.URL)
+	svc.SetTwitchBaseURL("https://twitch.test")
+	svc.httpClient = testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			return testutil.NewStringResponse(http.StatusOK, `{"data":[],"pagination":{}}`), nil
+		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
+	})
 
 	user := insertRaffleTestUser(t, db)
 	insertRaffleTwitchProvider(t, db, user.ID, "broadcaster123", "streamer_token")

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -68,6 +68,12 @@ func NewRaffleService(db *gorm.DB, twitchClientID, frontendURL string, mailer Ma
 }
 
 func (s *RaffleService) SetTwitchBaseURL(u string) { s.twitchBaseURL = u }
+func (s *RaffleService) SetHTTPClient(c *http.Client) {
+	if c == nil {
+		return
+	}
+	s.httpClient = c
+}
 
 // Create creates a new raffle owned by the given user.
 func (s *RaffleService) Create(userID uuid.UUID, title string) (*models.Raffle, error) {

--- a/services/api/internal/services/raffle_service_discord_test.go
+++ b/services/api/internal/services/raffle_service_discord_test.go
@@ -4,33 +4,41 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tachigo/tachigo/internal/testutil"
 )
 
-// discordCapture is an httptest.Server that captures the last Discord webhook POST body.
+// discordCapture is a RoundTripper-based fake that captures Discord webhook POST bodies.
 type discordCapture struct {
-	srv *httptest.Server
-	ch  chan string
+	url    string
+	client *http.Client
+	ch     chan string
 }
 
-func newDiscordCapture() *discordCapture {
-	dc := &discordCapture{ch: make(chan string, 1)}
-	dc.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func newDiscordCapture(t *testing.T) *discordCapture {
+	t.Helper()
+
+	dc := &discordCapture{
+		url: "https://discord.com/api/webhooks/123/test",
+		ch:  make(chan string, 1),
+	}
+	dc.client = testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
 		body, _ := io.ReadAll(r.Body)
 		select {
 		case dc.ch <- string(body):
 		default:
 		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
+		return testutil.NewStringResponse(http.StatusNoContent, ""), nil
+	})
 	return dc
 }
 
-func (dc *discordCapture) URL() string { return dc.srv.URL }
-func (dc *discordCapture) Close()      { dc.srv.Close() }
+func (dc *discordCapture) URL() string          { return dc.url }
+func (dc *discordCapture) Client() *http.Client { return dc.client }
+func (dc *discordCapture) Close()               {}
 
 func (dc *discordCapture) expectPayload(t *testing.T) map[string]interface{} {
 	t.Helper()
@@ -101,7 +109,7 @@ func TestSetDiscordWebhook_RejectsInvalidURL(t *testing.T) {
 
 func TestDrawNext_SendsDiscordNotification(t *testing.T) {
 	db := newTestDB(t)
-	dc := newDiscordCapture()
+	dc := newDiscordCapture(t)
 	defer dc.Close()
 
 	ownerID := seedUserWithEmail(t, db, "owner4@example.com")
@@ -112,7 +120,7 @@ func TestDrawNext_SendsDiscordNotification(t *testing.T) {
 	svc := &RaffleService{
 		db:          db,
 		frontendURL: "http://localhost:3000",
-		httpClient:  dc.srv.Client(),
+		httpClient:  dc.Client(),
 	}
 	// patch webhook URL directly into DB
 	webhookURL := dc.URL()
@@ -149,7 +157,7 @@ func TestDrawNext_SendsDiscordNotification(t *testing.T) {
 
 func TestDrawNext_SkipsDiscordWhenNoWebhook(t *testing.T) {
 	db := newTestDB(t)
-	dc := newDiscordCapture()
+	dc := newDiscordCapture(t)
 	defer dc.Close()
 
 	ownerID := seedUserWithEmail(t, db, "owner5@example.com")
@@ -157,7 +165,7 @@ func TestDrawNext_SkipsDiscordWhenNoWebhook(t *testing.T) {
 	raffleID := seedRaffle(t, db, ownerID)
 	seedEntry(t, db, raffleID, &winnerID, "winner5_twitch")
 
-	svc := &RaffleService{db: db, httpClient: dc.srv.Client()}
+	svc := &RaffleService{db: db, httpClient: dc.Client()}
 
 	draw, err := svc.DrawNext(raffleID, ownerID)
 	if err != nil {

--- a/services/api/internal/services/tachiya_client_test.go
+++ b/services/api/internal/services/tachiya_client_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	"github.com/tachigo/tachigo/internal/testutil"
 )
 
 func TestTachiyaHTTPClient_RedeemCoupon_Success(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := NewTachiyaHTTPClient("https://tachiya.test", "shared-secret")
+	client.httpClient = testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
 		if r.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", r.Method)
 		}
@@ -34,14 +36,10 @@ func TestTachiyaHTTPClient_RedeemCoupon_Success(t *testing.T) {
 			t.Fatalf("expected tcg_cost=100, got %d", req.TCGCost)
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"voucher_code": "VOUCHER-XYZ",
-		})
-	}))
-	defer server.Close()
-
-	client := NewTachiyaHTTPClient(server.URL, "shared-secret")
+		resp := testutil.NewStringResponse(http.StatusOK, `{"voucher_code":"VOUCHER-XYZ"}`)
+		resp.Header.Set("Content-Type", "application/json")
+		return resp, nil
+	})
 
 	voucherCode, err := client.RedeemCoupon(context.Background(), "coupon-123", 100)
 	if err != nil {
@@ -53,12 +51,10 @@ func TestTachiyaHTTPClient_RedeemCoupon_Success(t *testing.T) {
 }
 
 func TestTachiyaHTTPClient_RedeemCoupon_NonOKStatus(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	client := NewTachiyaHTTPClient(server.URL, "shared-secret")
+	client := NewTachiyaHTTPClient("https://tachiya.test", "shared-secret")
+	client.httpClient = testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		return testutil.NewStringResponse(http.StatusInternalServerError, ""), nil
+	})
 
 	if _, err := client.RedeemCoupon(context.Background(), "coupon-123", 100); err == nil {
 		t.Fatal("expected error but got nil")

--- a/services/api/internal/testutil/httptest_server.go
+++ b/services/api/internal/testutil/httptest_server.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func NewHTTPClient(rt RoundTripperFunc) *http.Client {
+	return &http.Client{Transport: rt}
+}
+
+func NewStringResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}


### PR DESCRIPTION
## 什麼改動
- 測試改用 RoundTripper stub，避免 `httptest` 綁定 listener 造成 sandbox/環境不穩
- 新增 `internal/testutil.RoundTripperFunc` 等 helper
- 在 `RaffleService` 增加可注入 HTTP client 的 test seam
- 移除未使用的 HTTP server helper（避免誤用 socket bind）

## 為什麼
- closes #552
- sandbox/某些 CI 環境對 socket bind 可能有限制，導致測試偶發失敗；以 Transport stub 取代 listener 可穩定化

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#552
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改任何 production handler 行為（僅新增可注入 seam）
  - 不新增/調整 DB schema

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 移除測試對 listener 綁定的依賴以提高穩定性
- Approx changed lines：~181
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 都是為了「測試穩定化」且互相依賴（helper + seam + 測試改寫 + 移除誤用 helper）
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 測試不再使用 `httptest.NewServer` / listener bind（改用 Transport stub）
- [x] `services/api` 測試在 sandbox 環境可穩定執行
- [x] 不影響 production 行為（預設仍走原本 HTTP client）

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
cd services/api
export GOCACHE=/tmp/go-build
go test ./...
```

## 備註
無

## Notes for Claude Code Review
- 請留意 `RaffleService` 的注入 seam 是否會影響 production 行為（預設仍用原本 client）
