### PR TITLE
[backend] configurable Sepolia RPC endpoint

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -37,6 +37,10 @@ GOOGLE_REDIRECT_URL=http://localhost:8080/api/v1/auth/google/callback
 # Set to the deployed TachiToken address on Sepolia; see deployments/sepolia.json.
 TACHI_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
 
+# Loaded by backend/internal/config/config.go (Config.Contract.RPCEndpoint).
+# RPC endpoint for Sepolia JSON-RPC (used when SEPOLIA_SIGNER_KEY is set).
+SEPOLIA_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
+
 # Loaded by backend/internal/config/config.go (Config.Contract.SepoliaSignerKey).
 # Purpose: signs transactions on behalf of the backend (e.g. future mint calls) on Sepolia testnet.
 # Management: use a dedicated testnet-only wallet; rotate if exposed.

--- a/services/api/cmd/server/main.go
+++ b/services/api/cmd/server/main.go
@@ -32,8 +32,6 @@ import (
 	"github.com/tachigo/tachigo/internal/services"
 )
 
-const defaultSepoliaRPCURL = "https://ethereum-sepolia-rpc.publicnode.com"
-
 func main() {
 	// Load .env (ignore error in production where env is set externally)
 	_ = godotenv.Load()
@@ -135,13 +133,12 @@ func main() {
 	streamerSvc := services.NewStreamerService(db, pointsSvc)
 	agencySvc := services.NewAgencyService(db)
 	airdropSvc := services.NewAirdropService(db, pointsSvc, channelConfigSvc)
-	// TODO: move Sepolia RPC URL into config.Contract.RPCEndpoint once config schema is extended.
 	var ethClient *ethclient.Client
 	if cfg.Contract.TachiContractAddress != "" && cfg.Contract.SepoliaSignerKey != "" {
 		var err error
 		dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer dialCancel()
-		ethClient, err = ethclient.DialContext(dialCtx, defaultSepoliaRPCURL)
+		ethClient, err = ethclient.DialContext(dialCtx, cfg.Contract.RPCEndpoint)
 		if err != nil {
 			log.Printf("warning: failed to connect Sepolia RPC: %v", err)
 			ethClient = nil

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -11,6 +11,7 @@ const (
 	defaultJWTAccessSecret  = "change-me-access-secret"
 	defaultJWTRefreshSecret = "change-me-refresh-secret"
 	minJWTSecretLength      = 32
+	defaultSepoliaRPCEndpoint = "https://ethereum-sepolia-rpc.publicnode.com"
 )
 
 type Config struct {
@@ -27,6 +28,7 @@ type Config struct {
 type ContractConfig struct {
 	TachiContractAddress string // TACHI_CONTRACT_ADDRESS
 	SepoliaSignerKey     string // SEPOLIA_SIGNER_KEY — never log or expose
+	RPCEndpoint          string // SEPOLIA_RPC_URL
 }
 
 type InternalConfig struct {
@@ -128,6 +130,7 @@ func Load() *Config {
 		Contract: ContractConfig{
 			TachiContractAddress: getEnv("TACHI_CONTRACT_ADDRESS", ""),
 			SepoliaSignerKey:     getEnv("SEPOLIA_SIGNER_KEY", ""),
+			RPCEndpoint:          getEnv("SEPOLIA_RPC_URL", defaultSepoliaRPCEndpoint),
 		},
 		Internal: InternalConfig{
 			TachiyaSharedSecret: getEnv("TACHIYA_INTERNAL_SHARED_SECRET", ""),

--- a/services/api/internal/config/config_test.go
+++ b/services/api/internal/config/config_test.go
@@ -161,3 +161,30 @@ func TestShouldValidateProductionSecrets(t *testing.T) {
 		})
 	}
 }
+
+func TestLoad_ContractRPCEndpoint(t *testing.T) {
+	t.Run("defaults to public Sepolia endpoint", func(t *testing.T) {
+		t.Setenv("SEPOLIA_RPC_URL", "")
+
+		cfg := Load()
+		if cfg == nil {
+			t.Fatalf("expected config, got nil")
+		}
+		if cfg.Contract.RPCEndpoint != defaultSepoliaRPCEndpoint {
+			t.Fatalf("expected default %q, got %q", defaultSepoliaRPCEndpoint, cfg.Contract.RPCEndpoint)
+		}
+	})
+
+	t.Run("supports env override", func(t *testing.T) {
+		override := "https://example.invalid"
+		t.Setenv("SEPOLIA_RPC_URL", override)
+
+		cfg := Load()
+		if cfg == nil {
+			t.Fatalf("expected config, got nil")
+		}
+		if cfg.Contract.RPCEndpoint != override {
+			t.Fatalf("expected %q, got %q", override, cfg.Contract.RPCEndpoint)
+		}
+	})
+}


### PR DESCRIPTION
## 什麼改動
- 新增 `Config.Contract.RPCEndpoint`，讓 Sepolia RPC endpoint 可用環境變數設定（`SEPOLIA_RPC_URL`）
- server wiring 改為使用 `cfg.Contract.RPCEndpoint` dial RPC
- 更新 `services/api/.env.example`
- 補上 config load 測試

## 為什麼
- closes #553
- 讓不同環境（本機/CI/部署）可用同一套設定方式切換 RPC 端點，避免硬編碼與臨時改碼

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#553
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改任何 contract / handler 行為
  - 不動 DB schema

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 Sepolia RPC endpoint 以 config/env 可調整
- Approx changed lines：~39
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 可透過 `SEPOLIA_RPC_URL` 設定 RPC endpoint
- [x] 未設定時使用預設 endpoint
- [x] `services/api` config 測試可驗證載入行為

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
cd services/api
export GOCACHE=/tmp/go-build
go test ./...
```

## 備註
無

## Notes for Claude Code Review
- 請特別看 `SEPOLIA_RPC_URL` 預設值與 `.env.example` 是否符合團隊期待
