### PR TITLE
[backend] log broadcast unknown burn metadata

### DIFF
--- a/services/api/internal/services/spend_service.go
+++ b/services/api/internal/services/spend_service.go
@@ -92,6 +92,10 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 			// Tx was broadcast but receipt is unknown (e.g. context deadline, RPC error).
 			// Do NOT roll back: the chain may have already burned the tokens.
 			if _, createErr := s.createPendingCouponRedemption(userID, couponID, reservation.amount, txHash); createErr != nil {
+				log.Printf(
+					"broadcast-unknown burn redemption record failed: user_id=%s coupon_id=%s amount=%d tx_hash=%s receipt_err=%v db_err=%v",
+					userID, couponID, reservation.amount, txHash, err, createErr,
+				)
 				return 0, "", fmt.Errorf("failed to record coupon_redemption for broadcast-unknown burn (burn tx_hash=%s coupon_id=%s): %w; receipt_err=%v", txHash, couponID, createErr, err)
 			}
 			return 0, "", fmt.Errorf("burn tx broadcast (txHash=%s) but receipt unknown: %w", txHash, err)

--- a/services/api/internal/services/spend_service_test.go
+++ b/services/api/internal/services/spend_service_test.go
@@ -1,9 +1,12 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -270,6 +273,51 @@ func TestRedeem_BurnBroadcastedButReceiptUnknown(t *testing.T) {
 	}
 	if txHash != "0xbroadcasted" {
 		t.Fatalf("expected tx_hash=0xbroadcasted, got %q", txHash)
+	}
+}
+
+func TestRedeem_BroadcastUnknownPendingRecordFailureLogsReconciliationMetadata(t *testing.T) {
+	db := newTestDB(t)
+	createErr := errors.New("forced coupon redemption create failure")
+	if err := db.Callback().Create().Before("gorm:create").Register("fail_coupon_redemption_create", func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "coupon_redemptions" {
+			tx.AddError(createErr)
+		}
+	}); err != nil {
+		t.Fatalf("register create callback: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	previousLogOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(previousLogOutput)
+
+	burnCaller := &mockBurnCaller{txHash: "0xbroadcasted", err: errors.New("context deadline exceeded")}
+	svc := &SpendService{db: db, burnCaller: burnCaller}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 300)
+
+	_, _, err := svc.Redeem(context.Background(), userID, "coupon-unknown", 100)
+	if !errors.Is(err, createErr) {
+		t.Fatalf("expected create error, got %v", err)
+	}
+
+	logOutput := logBuf.String()
+	wantFragments := []string{
+		"broadcast-unknown burn redemption record failed",
+		"user_id=" + userID.String(),
+		"coupon_id=coupon-unknown",
+		"amount=100",
+		"tx_hash=0xbroadcasted",
+		"receipt_err=context deadline exceeded",
+		"db_err=forced coupon redemption create failure",
+	}
+	for _, fragment := range wantFragments {
+		if !strings.Contains(logOutput, fragment) {
+			t.Fatalf("log output missing %q:\n%s", fragment, logOutput)
+		}
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- 在 broadcast-unknown burn path 中，當 pending `coupon_redemptions` record 建立失敗時寫入 reconciliation log。
- log 明確包含 `user_id`、`coupon_id`、`amount`、`tx_hash`、receipt error 與 DB error。
- 補上 focused regression test 覆蓋 pending redemption record creation failure path。

## 為什麼
closes #541

當 burn tx 已 broadcast、但 receipt 狀態未知時，系統會嘗試建立 pending `coupon_redemptions` 供人工 reconciliation。若這筆 pending record 建立也失敗，先前只回傳 service error，缺少 server log 內可營運查找的完整 metadata。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#541
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改變正常 DB 可寫時的 pending redemption 行為
  - 不改 HTTP response schema；handler 仍對此類內部錯誤回 generic 500
  - 不新增 reconciliation job 或補償流程

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 broadcast-unknown burn 的 pending redemption 寫入失敗可在 server log 中留下完整人工 reconciliation metadata。
- Approx changed lines：~52
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接覆蓋 #541 指定的 failure path，production change 只補對應 log。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `createPendingCouponRedemption` 失敗時，server log 明確包含 `user_id`、`coupon_id`、`amount`、`tx_hash`、receipt error、DB error。
- [x] HTTP response 不暴露敏感或內部錯誤細節，仍維持 generic 500（handler 對非分類 service error 仍走 `internal(c)`）。
- [x] 補測試覆蓋 redemption record creation failure path。
- [x] 不改變正常 DB 可寫時的 pending redemption 行為。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk env GOCACHE=/tmp/go-build go test ./internal/services -run TestRedeem_BroadcastUnknownPendingRecordFailureLogsReconciliationMetadata -count=1
# PASS

rtk env GOCACHE=/tmp/go-build go test ./internal/services -run TestRedeem_ -count=1
# PASS

rtk git --no-optional-locks diff --check
# PASS

rtk env GOCACHE=/tmp/go-build go test ./...
# FAIL in existing sandbox-only httptest.NewServer socket bind paths:
# - internal/handlers TestRaffle_Snapshot_TwitchScopeError
# - internal/services TestRunScheduledSnapshots_TwitchAPISuccess
# This is unrelated to #541 and matches the known #552 / PR #555 sandbox stabilization issue.
```

## 備註
本機 SSH `git push` 受 DNS 解析問題阻擋；此 PR 的遠端 branch/commit 由 GitHub connector 建立。等價本機 commit：`0c481dd`。

## Notes for Claude Code Review
- 請確認 log 欄位命名是否符合營運查找習慣：`user_id` / `coupon_id` / `amount` / `tx_hash` / `receipt_err` / `db_err`。
- 這包刻意不新增 structured logger 或 reconciliation job，避免超出 #541 scope。
