### PR TITLE
[infra] Repair Dependabot pnpm lockfile updates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,5 +18,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          changed_files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          if printf '%s\n' "$changed_files" | grep -Eq '^\.github/workflows/'; then
+            echo "Skipping auto-merge for workflow-file PR."
+            exit 0
+          fi
           gh pr merge --auto --merge "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           changed_files=$(gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename')
+            --jq '.[] | .filename, (.previous_filename // empty)')
           if printf '%s\n' "$changed_files" | grep -Eq '^\.github/workflows/'; then
             echo "Skipping auto-merge for workflow-file PR."
             exit 0

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -11,6 +11,7 @@ const workflowPath = path.join(currentDir, 'ci.yml')
 const scopePolicePath = path.join(currentDir, 'pr-scope-police.yml')
 const dependabotConfigPath = path.join(repoRoot, '.github', 'dependabot.yml')
 const dependabotAutomergeWorkflowPath = path.join(currentDir, 'dependabot-automerge.yml')
+const dependabotPnpmLockfileWorkflowPath = path.join(currentDir, 'dependabot-pnpm-lockfile.yml')
 const autoMergeWorkflowPath = path.join(currentDir, 'auto-merge.yml')
 const autoReadyWorkflowPath = path.join(currentDir, 'auto-ready-pr.yml')
 const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rerequest.yml')
@@ -880,6 +881,8 @@ test('dependency review policy documents Dependabot split and waiver handling', 
   assert.match(policy, /high\/critical production dependency vulnerabilities/)
   assert.match(policy, /development dependency findings are report-only/)
   assert.match(policy, /Dependabot opens routine version update PRs for the configured update levels/)
+  assert.match(policy, /dependabot-pnpm-lockfile\.yml/)
+  assert.match(policy, /shared-workspace-lockfile=false/)
   assert.match(policy, /security update PRs for alert-triggered fixes/)
   assert.match(policy, /Production security update\s+PRs remain manual-review changes/)
   assert.match(policy, /False Positives And Waivers/)
@@ -911,6 +914,33 @@ test('Dependabot pnpm version updates skip routine production patch releases', (
       },
     ])
   }
+})
+
+test('Dependabot pnpm lockfile repair is scoped to same-repo Dependabot PRs', async () => {
+  const workflow = await readFile(dependabotPnpmLockfileWorkflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(dependabotPnpmLockfileWorkflowPath)
+  const job = parsedWorkflow.jobs['repair-lockfiles']
+  const jobBlock = workflowJobBlock(workflow, 'repair-lockfiles')
+
+  assert.equal(job.name, 'Repair pnpm lockfiles')
+  assert.equal(job.permissions.contents, 'write')
+  assert.equal(job.permissions['pull-requests'], 'read')
+  assert.match(job.if, /github\.event\.pull_request\.user\.login == 'dependabot\[bot\]'/)
+  assert.match(job.if, /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/)
+  assert.match(jobBlock, /ref: \$\{\{ github\.event\.pull_request\.head\.ref \}\}/)
+  assert.match(jobBlock, /repository: \$\{\{ github\.event\.pull_request\.head\.repo\.full_name \}\}/)
+  assert.match(jobBlock, /corepack prepare pnpm@10\.33\.0 --activate/)
+  assert.match(
+    jobBlock,
+    /working-directory: apps\/dashboard\n\s+run: pnpm install --lockfile-only --ignore-scripts --config\.shared-workspace-lockfile=false/,
+  )
+  assert.match(
+    jobBlock,
+    /working-directory: apps\/extension\n\s+run: pnpm install --lockfile-only --ignore-scripts --config\.shared-workspace-lockfile=false/,
+  )
+  assert.match(jobBlock, /git add pnpm-lock\.yaml apps\/dashboard\/pnpm-lock\.yaml apps\/extension\/pnpm-lock\.yaml/)
+  assert.match(jobBlock, /git commit -m "chore\(deps\): repair pnpm lockfiles"/)
+  assert.match(jobBlock, /git push/)
 })
 
 test('Dependabot auto-merge keeps production dependency updates on manual review', async () => {

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -924,6 +924,7 @@ test('Dependabot pnpm lockfile repair is scoped to same-repo Dependabot PRs', as
 
   assert.equal(job.name, 'Repair pnpm lockfiles')
   assert.equal(job.permissions.contents, 'write')
+  assert.equal(job.permissions.actions, 'write')
   assert.equal(job.permissions['pull-requests'], 'read')
   assert.match(job.if, /github\.event\.pull_request\.user\.login == 'dependabot\[bot\]'/)
   assert.match(job.if, /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/)

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -1143,7 +1143,7 @@ test('dependency inventory policy documents OSV triage ownership and non-blockin
   assert.match(policy, /Expires on:/)
 })
 
-test('global auto-merge workflow excludes Dependabot PRs', async () => {
+test('global auto-merge workflow excludes Dependabot and workflow-file PRs', async () => {
   const workflow = await readFile(autoMergeWorkflowPath, 'utf8')
   const parsedWorkflow = parseYaml(autoMergeWorkflowPath)
 
@@ -1156,6 +1156,8 @@ test('global auto-merge workflow excludes Dependabot PRs', async () => {
     parsedWorkflow.jobs['enable-auto-merge'].if,
     "github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'",
   )
+  assert.match(workflow, /Skipping auto-merge for workflow-file PR/)
+  assert.ok(workflow.includes("grep -Eq '^\\.github/workflows/'"))
   assert.doesNotMatch(workflow, /if: github\.event\.pull_request\.draft == false\s*$/m)
 })
 

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -1157,6 +1157,10 @@ test('global auto-merge workflow excludes Dependabot and workflow-file PRs', asy
     "github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'",
   )
   assert.match(workflow, /Skipping auto-merge for workflow-file PR/)
+  assert.ok(
+    workflow.includes("--jq '.[] | .filename, (.previous_filename // empty)'"),
+    'workflow-file PR detection must include renamed-away workflow files',
+  )
   assert.ok(workflow.includes("grep -Eq '^\\.github/workflows/'"))
   assert.doesNotMatch(workflow, /if: github\.event\.pull_request\.draft == false\s*$/m)
 })

--- a/.github/workflows/dependabot-pnpm-lockfile.yml
+++ b/.github/workflows/dependabot-pnpm-lockfile.yml
@@ -1,0 +1,67 @@
+name: Dependabot pnpm Lockfile Repair
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - apps/dashboard/package.json
+      - apps/extension/package.json
+
+jobs:
+  repair-lockfiles:
+    name: Repair pnpm lockfiles
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+
+      - name: Enable pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+      - name: Detect changed frontend manifests
+        id: changed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            })
+            const filenames = new Set(files.map((file) => file.filename))
+            core.setOutput('dashboard', filenames.has('apps/dashboard/package.json') ? 'true' : 'false')
+            core.setOutput('extension', filenames.has('apps/extension/package.json') ? 'true' : 'false')
+
+      - name: Repair dashboard lockfile
+        if: steps.changed.outputs.dashboard == 'true'
+        working-directory: apps/dashboard
+        run: pnpm install --lockfile-only --ignore-scripts --config.shared-workspace-lockfile=false
+
+      - name: Repair extension lockfile
+        if: steps.changed.outputs.extension == 'true'
+        working-directory: apps/extension
+        run: pnpm install --lockfile-only --ignore-scripts --config.shared-workspace-lockfile=false
+
+      - name: Commit repaired lockfiles
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml apps/dashboard/pnpm-lock.yaml apps/extension/pnpm-lock.yaml
+          if git diff --cached --quiet; then
+            echo "No pnpm lockfile repair needed."
+          else
+            git commit -m "chore(deps): repair pnpm lockfiles"
+            git push
+          fi

--- a/.github/workflows/dependabot-pnpm-lockfile.yml
+++ b/.github/workflows/dependabot-pnpm-lockfile.yml
@@ -12,6 +12,7 @@ jobs:
     name: Repair pnpm lockfiles
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
+      actions: write
       contents: write
       pull-requests: read
     runs-on: ubuntu-latest
@@ -55,13 +56,23 @@ jobs:
         run: pnpm install --lockfile-only --ignore-scripts --config.shared-workspace-lockfile=false
 
       - name: Commit repaired lockfiles
+        id: commit-repair
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pnpm-lock.yaml apps/dashboard/pnpm-lock.yaml apps/extension/pnpm-lock.yaml
           if git diff --cached --quiet; then
             echo "No pnpm lockfile repair needed."
+            echo "repaired=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore(deps): repair pnpm lockfiles"
             git push
+            echo "repaired=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Dispatch CI for repaired head
+        if: steps.commit-repair.outputs.repaired == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: gh workflow run ci.yml --ref "$HEAD_REF"

--- a/docs/dependabot-update-policy.md
+++ b/docs/dependabot-update-policy.md
@@ -19,7 +19,10 @@ that updates an app `package.json` without the matching lockfile changes,
 `dependabot-pnpm-lockfile.yml` repairs the PR branch by running
 `pnpm install --lockfile-only --ignore-scripts --config.shared-workspace-lockfile=false`
 for the touched app. The workflow is limited to same-repository
-`dependabot[bot]` PRs and commits only root/app pnpm lockfile repairs.
+`dependabot[bot]` PRs and commits only root/app pnpm lockfile repairs. When it
+pushes a repair commit with `GITHUB_TOKEN`, it also dispatches the CI workflow
+for the repaired head because `GITHUB_TOKEN` push events do not create new
+`pull_request` or `push` workflow runs.
 
 ## Scheduling
 

--- a/docs/dependabot-update-policy.md
+++ b/docs/dependabot-update-policy.md
@@ -14,6 +14,13 @@ its own `pnpm-lock.yaml`:
 
 Do not change these entries to a non-existent `pnpm` ecosystem name.
 
+The repo also has a root pnpm workspace lockfile. If Dependabot opens a pnpm PR
+that updates an app `package.json` without the matching lockfile changes,
+`dependabot-pnpm-lockfile.yml` repairs the PR branch by running
+`pnpm install --lockfile-only --ignore-scripts --config.shared-workspace-lockfile=false`
+for the touched app. The workflow is limited to same-repository
+`dependabot[bot]` PRs and commits only root/app pnpm lockfile repairs.
+
 ## Scheduling
 
 Version updates target `develop` and run on Monday morning in `Asia/Taipei`:


### PR DESCRIPTION
refs #559

Source of truth: https://github.com/nurockplayer/tachigo/issues/559

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

本 PR 明確不做
- Does not change Dependabot dependency grouping policy.
- Does not auto-merge production dependency PRs.
- Does not alter frontend package versions.

## Summary

- Adds a same-repository Dependabot-only workflow that repairs pnpm lockfiles when app package.json files change without matching lockfile updates.
- Uses `pnpm install --lockfile-only --ignore-scripts --config.shared-workspace-lockfile=false` so app lockfiles are updated instead of only the root workspace lockfile.
- Skips the optional auto-merge workflow for PRs that touch `.github/workflows/*`, avoiding a known GitHub App workflow-permission failure.
- Documents the repair behavior and adds CI workflow regression coverage.

## Verification

- `node --test .github/workflows/ci.test.mjs`
- `git diff --check`

closes #559


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为 Dependabot 拉取请求添加了 pnpm 锁文件自动修复的工作流程。

* **错误修复**
  * 自动合并现在会跳过包含工作流文件的更改，并在检测到此类 PR 时输出跳过信息以防止合并。

* **文档**
  * 更新了 Dependabot 更新策略文档，说明锁文件修复与 CI 触发细节。

* **测试**
  * 为新工作流程与自动合并规则添加了测试覆盖。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/560)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->