### PR TITLE
[backend] Make email auth token consumption transactional

### DIFF
--- a/services/api/internal/services/email_auth_service.go
+++ b/services/api/internal/services/email_auth_service.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	ErrAlreadyVerified          = errors.New("email already verified")
-	ErrInvalidVerifyToken        = errors.New("invalid or expired verification token")
-	ErrInvalidResetToken         = errors.New("invalid or expired password reset token")
-	ErrPasswordResetEmailSend    = errors.New("failed to send password reset email")
+	ErrAlreadyVerified        = errors.New("email already verified")
+	ErrInvalidVerifyToken     = errors.New("invalid or expired verification token")
+	ErrInvalidResetToken      = errors.New("invalid or expired password reset token")
+	ErrPasswordResetEmailSend = errors.New("failed to send password reset email")
 )
 
 const (
@@ -85,13 +85,16 @@ func (s *EmailAuthService) VerifyEmail(rawToken string) error {
 		return ErrInvalidVerifyToken
 	}
 
-	if err := s.db.Model(&models.User{}).Where("id = ?", record.UserID).
-		Update("email_verified", true).Error; err != nil {
-		return err
-	}
-
-	s.db.Delete(&record)
-	return nil
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.User{}).Where("id = ?", record.UserID).
+			Update("email_verified", true).Error; err != nil {
+			return err
+		}
+		if err := tx.Delete(&record).Error; err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // ─── Password Reset ───────────────────────────────────────────────────────────
@@ -150,13 +153,16 @@ func (s *EmailAuthService) ResetPassword(rawToken, newPassword string) error {
 		return err
 	}
 
-	if err := s.db.Model(&models.User{}).Where("email = ?", record.Email).
-		Update("password_hash", string(hashed)).Error; err != nil {
-		return err
-	}
-
-	s.db.Delete(&record)
-	return nil
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.User{}).Where("email = ?", record.Email).
+			Update("password_hash", string(hashed)).Error; err != nil {
+			return err
+		}
+		if err := tx.Delete(&record).Error; err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // ─── Email templates ──────────────────────────────────────────────────────────

--- a/services/api/internal/services/email_auth_service_test.go
+++ b/services/api/internal/services/email_auth_service_test.go
@@ -191,6 +191,42 @@ func TestVerifyEmail_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestVerifyEmail_RollsBackUserUpdateWhenTokenDeleteFails(t *testing.T) {
+	svc, _ := newEmailAuthSvc(t)
+	userID := seedEmailUser(t, svc, "rollback_verify@example.com", false)
+
+	rawToken, _ := generateNonce()
+	svc.db.Create(&models.EmailVerification{
+		UserID:    userID,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	if err := svc.db.Exec(`
+		CREATE TRIGGER fail_email_verification_delete
+		BEFORE DELETE ON email_verifications
+		BEGIN
+			SELECT RAISE(FAIL, 'forced email verification delete failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create delete failure trigger: %v", err)
+	}
+
+	if err := svc.VerifyEmail(rawToken); err == nil {
+		t.Fatal("expected VerifyEmail to return delete failure")
+	}
+
+	var user models.User
+	svc.db.First(&user, "id = ?", userID)
+	if user.EmailVerified {
+		t.Error("email_verified should remain false when token delete fails")
+	}
+	var count int64
+	svc.db.Model(&models.EmailVerification{}).Where("user_id = ?", userID).Count(&count)
+	if count != 1 {
+		t.Errorf("expected verification token to remain after rollback, got %d", count)
+	}
+}
+
 // ─── ForgotPassword ───────────────────────────────────────────────────────────
 
 func TestForgotPassword_KnownEmail_SendsEmail(t *testing.T) {
@@ -329,5 +365,55 @@ func TestResetPassword_AllowsLoginWithNewPassword(t *testing.T) {
 	// New password should work
 	if _, _, err := authSvc.Login(LoginInput{Email: *user.Email, Password: "newpassword123"}); err != nil {
 		t.Errorf("new password should work, got %v", err)
+	}
+}
+
+func TestResetPassword_RollsBackPasswordHashWhenTokenDeleteFails(t *testing.T) {
+	db := newTestDB(t)
+	cfg := testConfig()
+	cfg.App.FrontendURL = "http://localhost:3000"
+	mailer := &mockMailer{}
+	emailSvc := NewEmailAuthService(db, cfg, mailer)
+	authSvc := NewAuthService(db, cfg)
+
+	user, _, err := authSvc.Register(RegisterInput{
+		Username: "rollbackreset",
+		Email:    "rollbackreset@example.com",
+		Password: "oldpassword",
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	rawToken, _ := generateNonce()
+	db.Create(&models.PasswordReset{
+		Email:     *user.Email,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	if err := db.Exec(`
+		CREATE TRIGGER fail_password_reset_delete
+		BEFORE DELETE ON password_resets
+		BEGIN
+			SELECT RAISE(FAIL, 'forced password reset delete failure');
+		END;
+	`).Error; err != nil {
+		t.Fatalf("create delete failure trigger: %v", err)
+	}
+
+	if err := emailSvc.ResetPassword(rawToken, "newpassword123"); err == nil {
+		t.Fatal("expected ResetPassword to return delete failure")
+	}
+
+	if _, _, err := authSvc.Login(LoginInput{Email: *user.Email, Password: "oldpassword"}); err != nil {
+		t.Errorf("old password should still work after rollback, got %v", err)
+	}
+	if _, _, err := authSvc.Login(LoginInput{Email: *user.Email, Password: "newpassword123"}); err != ErrInvalidCredentials {
+		t.Errorf("new password should not be active after rollback, got %v", err)
+	}
+	var count int64
+	db.Model(&models.PasswordReset{}).Where("email = ?", *user.Email).Count(&count)
+	if count != 1 {
+		t.Errorf("expected reset token to remain after rollback, got %d", count)
 	}
 }


### PR DESCRIPTION
## 什麼改動
- Wrap `VerifyEmail` user update + verification token delete in one DB transaction.
- Wrap `ResetPassword` password update + reset token delete in one DB transaction.
- Add rollback regression tests that force token delete failures with SQLite triggers.

## 為什麼
closes #561

Email verification and password reset token consumption could previously partially succeed if the user state update succeeded but token deletion failed. The caller could receive success or miss the delete failure while the token row remained reusable.

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#561
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Does not redesign email auth token schema.
  - Does not change handler response contracts.
  - Does not change token replacement behavior in send/forgot flows.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Make email auth token consumption atomic when the final token delete fails.
- Approx changed lines：~128
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Regression tests define the transaction rollback behavior for the service fix.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] If verification token delete fails, `email_verified` is not updated.
- [x] If password reset token delete fails, `password_hash` is not updated.
- [x] Existing invalid / expired token semantics are preserved.
- [x] Focused service tests cover rollback behavior.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
# RED before implementation
GOCACHE=/private/tmp/tachigo-go-build-cache go test ./internal/services -run 'Test(VerifyEmail|ResetPassword)_' -count=1
FAIL: expected VerifyEmail/ResetPassword to return delete failure

# GREEN after implementation
GOCACHE=/private/tmp/tachigo-go-build-cache go test ./internal/services -run 'Test(SendVerificationEmail|VerifyEmail|ForgotPassword|ResetPassword)_' -count=1
ok github.com/tachigo/tachigo/internal/services 1.030s

git diff --check
pass
```

Full `go test ./internal/services` is blocked in this sandbox by existing `httptest` listener restrictions (`bind: operation not permitted`) in raffle scheduler/Discord tests, unrelated to this PR.

## 備註
Shell `git push` could not resolve `github.com` in this environment, so this branch was created and updated through the GitHub connector.

## Notes for Claude Code Review
- Review the transaction boundary: only the user state update plus token delete are inside the transaction; invalid/expired token handling remains unchanged.
