### PR TITLE
[chore] Document GitHub SSH 443 push workaround

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -7,6 +7,7 @@ AI-facing collaboration guidance lives here unless a tool requires a specific pa
 - `claude-codex-cheatsheet.md` — quick reference for Claude Code and Codex collaboration.
 - `claude-codex-workflow.md` — full workflow guide for low-token Claude Code usage.
 - `code-review-refactor.md` — local Claude Code review workflow notes.
+- `github-ssh-443-push.md` — playbook for GitHub SSH over 443 when `git push` is unstable.
 - `github-actions-debugging.md` — playbook for PR, CI, scope gate, and auto-ready debugging.
 - `token-budget.md` — token budget guidance for AI-assisted work.
 

--- a/docs/ai/github-ssh-443-push.md
+++ b/docs/ai/github-ssh-443-push.md
@@ -1,0 +1,109 @@
+# GitHub SSH 443 Push Playbook
+
+當 Codex / Claude Code / 本機 shell 在 `git push` 時反覆遇到 GitHub DNS 或 SSH 連線問題，優先使用 repo-local 的 GitHub SSH over 443 設定，不要把 GitHub connector 當成長期替代方案。
+
+GitHub connector 適合查 issue、PR、review metadata；本機 branch、commit、push 仍應以 git transport 為主。
+
+## 適用症狀
+
+- `git push` 偶發或反覆出現 DNS 解析失敗。
+- 一般 SSH 路徑 `git@github.com:owner/repo.git` 不穩，但 GitHub 本身可連。
+- Codex 新 session 可以讀 repo，但 push 收尾常卡在 network / SSH transport。
+
+## Tachigo Repo 建議設定
+
+只改 `origin` 的 push URL，保留 fetch URL 不變：
+
+```bash
+rtk git --no-optional-locks remote set-url --push origin ssh://git@ssh.github.com:443/nurockplayer/tachigo.git
+rtk git --no-optional-locks remote -v
+```
+
+預期結果：
+
+```text
+origin  git@github.com:nurockplayer/tachigo.git (fetch)
+origin  ssh://git@ssh.github.com:443/nurockplayer/tachigo.git (push)
+```
+
+這是 repo-local 設定，會寫進 `.git/config`。同一個 clone 的新 Codex session 會自動沿用；不同 clone 或新 worktree 可能需要重設一次。
+
+## Host Key 驗證
+
+第一次改走 `ssh.github.com:443` 時，SSH 可能失敗：
+
+```text
+Host key verification failed.
+```
+
+先查本機是否已信任 GitHub 443 host key：
+
+```bash
+rtk ssh-keygen -F '[ssh.github.com]:443' -f ~/.ssh/known_hosts
+```
+
+若沒有紀錄，先掃描並計算 fingerprint：
+
+```bash
+rtk ssh-keyscan -p 443 -T 10 -t ed25519 ssh.github.com 2>/dev/null | rtk ssh-keygen -lf - -E sha256
+```
+
+GitHub 官方 ED25519 fingerprint 目前應為：
+
+```text
+SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU
+```
+
+以 GitHub 官方文件為準，不要盲目信任 `ssh-keyscan` 結果：
+
+<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints>
+
+確認 fingerprint 相符後，再新增 host key：
+
+```bash
+rtk ssh-keyscan -p 443 -T 10 -t ed25519 ssh.github.com >> ~/.ssh/known_hosts
+rtk chmod 600 ~/.ssh/known_hosts
+rtk ssh-keygen -F '[ssh.github.com]:443' -f ~/.ssh/known_hosts
+```
+
+## 驗證 Push 路徑
+
+使用 dry-run 驗證，不會真的寫入遠端：
+
+```bash
+rtk env GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' git --no-optional-locks push --dry-run origin HEAD
+```
+
+成功時會看到類似：
+
+```text
+To ssh://ssh.github.com:443/nurockplayer/tachigo.git
+ * [new branch]      HEAD -> <branch>
+```
+
+## 何時改全域 SSH Config
+
+repo-local push URL 是保守預設。只有在多個 GitHub repo 都反覆遇到同樣問題時，才考慮改 `~/.ssh/config`：
+
+```sshconfig
+Host github.com
+  HostName ssh.github.com
+  Port 443
+  User git
+```
+
+全域設定會影響所有 GitHub SSH 連線，修改前需先確認團隊或使用者接受這個行為。
+
+## 回復方式
+
+若要把 tachigo 的 push URL 改回一般 SSH：
+
+```bash
+rtk git --no-optional-locks remote set-url --push origin git@github.com:nurockplayer/tachigo.git
+```
+
+若要移除 repo-local push URL，讓 push 回到 fetch URL：
+
+```bash
+rtk git --no-optional-locks config --unset remote.origin.pushurl
+```

--- a/docs/ai/github-ssh-443-push.md
+++ b/docs/ai/github-ssh-443-push.md
@@ -42,10 +42,11 @@ Host key verification failed.
 rtk ssh-keygen -F '[ssh.github.com]:443' -f ~/.ssh/known_hosts
 ```
 
-若沒有紀錄，先掃描並計算 fingerprint：
+若沒有紀錄，先掃描一次並把同一份輸出留作後續寫入：
 
 ```bash
-rtk ssh-keyscan -p 443 -T 10 -t ed25519 ssh.github.com 2>/dev/null | rtk ssh-keygen -lf - -E sha256
+rtk ssh-keyscan -p 443 -T 10 -t ed25519 ssh.github.com 2>/dev/null > /tmp/github_ssh_443_ed25519.pub
+rtk ssh-keygen -lf /tmp/github_ssh_443_ed25519.pub -E sha256
 ```
 
 GitHub 官方 ED25519 fingerprint 目前應為：
@@ -58,12 +59,13 @@ SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU
 
 <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints>
 
-確認 fingerprint 相符後，再新增 host key：
+確認 fingerprint 相符後，再把同一份 key 新增到 `known_hosts`：
 
 ```bash
-rtk ssh-keyscan -p 443 -T 10 -t ed25519 ssh.github.com >> ~/.ssh/known_hosts
+rtk cat /tmp/github_ssh_443_ed25519.pub >> ~/.ssh/known_hosts
 rtk chmod 600 ~/.ssh/known_hosts
 rtk ssh-keygen -F '[ssh.github.com]:443' -f ~/.ssh/known_hosts
+rtk rm -f /tmp/github_ssh_443_ed25519.pub
 ```
 
 ## 驗證 Push 路徑


### PR DESCRIPTION
## 什麼改動
新增 `docs/ai/github-ssh-443-push.md`，記錄 GitHub SSH over 443 的 repo-local push workaround、host key 驗證、dry-run 檢查與回復方式。

更新 `docs/ai/README.md`，把新 playbook 加進 AI docs 索引。

## 為什麼
Codex / Claude Code / 本機 shell 遇到 `git push` DNS 或 SSH transport 不穩時，需要一份團隊可重複使用的排障文件，避免每次都改用 GitHub connector 當臨時繞路。

closes #563

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#563
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
  - [x] n/a；docs-only PR
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改全域 `~/.ssh/config`
  - 不變更 CI / GitHub Actions
  - 不改動產品或 backend / frontend runtime code

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 記錄 tachigo 遇到 GitHub SSH push 不穩時的 repo-local SSH 443 處理流程。
- Approx changed lines：~110
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 記錄 repo-local `origin.pushurl` 改走 `ssh.github.com:443` 的步驟。
- [x] 記錄 GitHub 443 host key fingerprint 驗證方式。
- [x] 記錄 push dry-run 驗證與回復方式。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk git --no-optional-locks diff --check origin/develop..HEAD
# pass

rtk rg -n "[ \t]$" docs/ai/github-ssh-443-push.md docs/ai/README.md
# no trailing whitespace matches
```

## 備註
This is a docs-only PR. No runtime behavior changes.

## Notes for Claude Code Review
- Review whether the playbook should stay repo-local by default or be expanded later into a global SSH config recommendation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档

* 新增 GitHub SSH over 端口 443 配置和故障排查指南，涵盖配置步骤、主机密钥验证、推送验证及恢复方案。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/564)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->