### PR TITLE
[backend] Fix refresh token rotation race

### DIFF
--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -151,23 +151,39 @@ func (s *AuthService) Login(input LoginInput) (*models.User, *TokenPair, error) 
 func (s *AuthService) Refresh(rawRefreshToken string) (*TokenPair, error) {
 	hash := hashToken(rawRefreshToken)
 
-	var stored models.RefreshToken
-	if err := s.db.Where("token_hash = ?", hash).First(&stored).Error; err != nil {
-		return nil, ErrInvalidToken
-	}
-	if stored.IsExpired() {
-		s.db.Delete(&stored)
-		return nil, ErrInvalidToken
-	}
+	var tokenPair *TokenPair
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var stored models.RefreshToken
+		if err := tx.Where("token_hash = ?", hash).First(&stored).Error; err != nil {
+			return ErrInvalidToken
+		}
+		if stored.IsExpired() {
+			tx.Delete(&stored)
+			return ErrInvalidToken
+		}
 
-	var user models.User
-	if err := s.db.First(&user, "id = ?", stored.UserID).Error; err != nil {
-		return nil, ErrUserNotFound
-	}
+		var user models.User
+		if err := tx.First(&user, "id = ?", stored.UserID).Error; err != nil {
+			return ErrUserNotFound
+		}
 
-	// Rotate: delete old, issue new
-	s.db.Delete(&stored)
-	return s.issueTokenPair(&user)
+		// Atomic rotation: zero affected rows means another request already used it.
+		result := tx.Delete(&stored)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrInvalidToken
+		}
+
+		var err error
+		tokenPair, err = s.issueTokenPairTx(tx, &user)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tokenPair, nil
 }
 
 func (s *AuthService) Logout(rawRefreshToken string) error {
@@ -320,7 +336,7 @@ func (s *AuthService) ValidateAccessToken(tokenStr string) (*Claims, error) {
 	return claims, nil
 }
 
-func (s *AuthService) issueTokenPair(user *models.User) (*TokenPair, error) {
+func (s *AuthService) issueTokenPairTx(tx *gorm.DB, user *models.User) (*TokenPair, error) {
 	// Access token
 	accessClaims := Claims{
 		UserID: user.ID.String(),
@@ -341,7 +357,7 @@ func (s *AuthService) issueTokenPair(user *models.User) (*TokenPair, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := s.db.Create(&models.RefreshToken{
+	if err := tx.Create(&models.RefreshToken{
 		UserID:    user.ID,
 		TokenHash: hashToken(rawRefresh),
 		ExpiresAt: time.Now().Add(s.cfg.JWT.RefreshTTL),
@@ -354,6 +370,10 @@ func (s *AuthService) issueTokenPair(user *models.User) (*TokenPair, error) {
 		RefreshToken: rawRefresh,
 		ExpiresIn:    int(s.cfg.JWT.AccessTTL.Seconds()),
 	}, nil
+}
+
+func (s *AuthService) issueTokenPair(user *models.User) (*TokenPair, error) {
+	return s.issueTokenPairTx(s.db, user)
 }
 
 // ─── OAuth upsert helper ─────────────────────────────────────────────────────

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -23,15 +23,16 @@ import (
 )
 
 var (
-	ErrUserNotFound       = errors.New("user not found")
-	ErrInvalidCredentials = errors.New("invalid credentials")
-	ErrEmailExists        = errors.New("email already registered")
-	ErrUsernameExists     = errors.New("username already taken")
-	ErrInvalidToken       = errors.New("invalid or expired token")
-	ErrProviderLinked     = errors.New("provider already linked to another account")
-	ErrInvalidNonce       = errors.New("invalid or expired nonce")
-	ErrInvalidSignature   = errors.New("invalid wallet signature")
-	ErrLastProvider       = errors.New("cannot unlink the only login method")
+	ErrUserNotFound        = errors.New("user not found")
+	ErrInvalidCredentials  = errors.New("invalid credentials")
+	ErrEmailExists         = errors.New("email already registered")
+	ErrUsernameExists      = errors.New("username already taken")
+	ErrInvalidToken        = errors.New("invalid or expired token")
+	errRefreshTokenExpired = errors.New("refresh token expired")
+	ErrProviderLinked      = errors.New("provider already linked to another account")
+	ErrInvalidNonce        = errors.New("invalid or expired nonce")
+	ErrInvalidSignature    = errors.New("invalid wallet signature")
+	ErrLastProvider        = errors.New("cannot unlink the only login method")
 )
 
 type TokenPair struct {
@@ -158,8 +159,7 @@ func (s *AuthService) Refresh(rawRefreshToken string) (*TokenPair, error) {
 			return ErrInvalidToken
 		}
 		if stored.IsExpired() {
-			tx.Delete(&stored)
-			return ErrInvalidToken
+			return errRefreshTokenExpired
 		}
 
 		var user models.User
@@ -180,6 +180,10 @@ func (s *AuthService) Refresh(rawRefreshToken string) (*TokenPair, error) {
 		tokenPair, err = s.issueTokenPairTx(tx, &user)
 		return err
 	})
+	if errors.Is(err, errRefreshTokenExpired) {
+		s.db.Where("token_hash = ?", hash).Delete(&models.RefreshToken{})
+		return nil, ErrInvalidToken
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/services/api/internal/services/auth_service_expired_refresh_test.go
+++ b/services/api/internal/services/auth_service_expired_refresh_test.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+func TestRefresh_ExpiredTokenDeletesStoredToken(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	_, tokens, err := svc.Register(RegisterInput{
+		Username: "expired_cleanup_user",
+		Email:    "expired-cleanup@example.com",
+		Password: "Password1!",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	hash := hashToken(tokens.RefreshToken)
+	if err := db.Model(&models.RefreshToken{}).
+		Where("token_hash = ?", hash).
+		Update("expires_at", time.Now().Add(-time.Hour)).Error; err != nil {
+		t.Fatalf("expire refresh token: %v", err)
+	}
+
+	_, err = svc.Refresh(tokens.RefreshToken)
+	if !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&models.RefreshToken{}).Where("token_hash = ?", hash).Count(&count).Error; err != nil {
+		t.Fatalf("count refresh token: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expired refresh token should be deleted, got %d rows", count)
+	}
+}

--- a/services/api/internal/services/auth_service_pg_test.go
+++ b/services/api/internal/services/auth_service_pg_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package services
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func TestRefresh_ConcurrentReuseOnlyAllowsSingleSuccess(t *testing.T) {
+	db := newPGTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	_, tokens, err := svc.Register(RegisterInput{
+		Username: "pg_refresh_race",
+		Email:    "pg-refresh-race@example.com",
+		Password: "Password1!",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	const callbackName = "test:block_refresh_token_lookup"
+	var lookupCount atomic.Int32
+	release := make(chan struct{})
+	bothLookupsReady := make(chan struct{})
+
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement == nil || tx.Statement.Table != "refresh_tokens" {
+			return
+		}
+		if lookupCount.Add(1) > 2 {
+			return
+		}
+		if lookupCount.Load() == 2 {
+			close(bothLookupsReady)
+		}
+		<-release
+	}); err != nil {
+		t.Fatalf("register query callback: %v", err)
+	}
+	defer func() {
+		if err := db.Callback().Query().Remove(callbackName); err != nil {
+			t.Fatalf("remove query callback: %v", err)
+		}
+	}()
+
+	type refreshResult struct {
+		tokens *TokenPair
+		err    error
+	}
+
+	start := make(chan struct{})
+	results := make(chan refreshResult, 2)
+	var wg sync.WaitGroup
+
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			tokenPair, err := svc.Refresh(tokens.RefreshToken)
+			results <- refreshResult{tokens: tokenPair, err: err}
+		}()
+	}
+
+	close(start)
+
+	select {
+	case <-bothLookupsReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for concurrent refresh lookups")
+	}
+	close(release)
+
+	wg.Wait()
+	close(results)
+
+	var successCount, invalidCount int
+	for result := range results {
+		if result.err == nil {
+			if result.tokens == nil || result.tokens.RefreshToken == "" {
+				t.Fatalf("successful refresh should return token pair, got %#v", result.tokens)
+			}
+			successCount++
+			continue
+		}
+		if result.err == ErrInvalidToken {
+			invalidCount++
+			continue
+		}
+		t.Fatalf("unexpected refresh error: %v", result.err)
+	}
+
+	if successCount != 1 || invalidCount != 1 {
+		t.Fatalf("want 1 success and 1 ErrInvalidToken, got success=%d invalid=%d", successCount, invalidCount)
+	}
+}

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -368,6 +369,26 @@ func TestDeleteExpiredRefreshTokens_RemovesExpiredOnly(t *testing.T) {
 	svc.db.Model(&models.RefreshToken{}).Where("token_hash = ?", hashToken(tokens.RefreshToken)).Count(&count)
 	if count != 1 {
 		t.Errorf("valid token should still exist, got count=%d", count)
+	}
+}
+
+func TestRefresh_SecondUseOfSameToken_ReturnsErrInvalidToken(t *testing.T) {
+	svc := NewAuthService(newTestDB(t), testConfig())
+	_, tokens, err := svc.Register(RegisterInput{
+		Email: "replay@example.com", Username: "replay_user", Password: "Password1!",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if _, err := svc.Refresh(tokens.RefreshToken); err != nil {
+		t.Fatalf("first Refresh: %v", err)
+	}
+
+	// Second use of the same token must fail.
+	_, err = svc.Refresh(tokens.RefreshToken)
+	if !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("want ErrInvalidToken on second refresh, got %v", err)
 	}
 }
 

--- a/services/api/internal/services/testutil_pg_test.go
+++ b/services/api/internal/services/testutil_pg_test.go
@@ -231,6 +231,15 @@ func migratePGTestDB(db *gorm.DB) error {
 			UNIQUE (user_id),
 			CHECK (balance >= 0)
 		)`,
+		`CREATE TABLE IF NOT EXISTS refresh_tokens (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			token_hash TEXT NOT NULL UNIQUE,
+			expires_at TIMESTAMPTZ NOT NULL,
+			created_at TIMESTAMPTZ
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id
+			ON refresh_tokens (user_id)`,
 	}
 
 	for _, stmt := range stmts {


### PR DESCRIPTION
## 什麼改動
將 refresh token rotation 改成 transaction 內的原子操作，避免同一顆 refresh token 被並發重放兩次以上；同時補上 replay regression test 與 PostgreSQL 並發 integration test。

## 為什麼
refs #419

Codex review 指出目前 `Refresh()` 先查、再刪、再簽發新 token pair，兩個並發請求可能同時讀到同一筆未過期 refresh token，各自成功換到新的 token pair，形成 refresh token replay race。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#419
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不調整其他 auth flow（logout、web3、provider unlink）
  - 不改動 API surface 或前端行為

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓同一顆 refresh token 在並發 refresh 下最多只成功兌換一次
- Approx changed lines：~185
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service 修正與回歸測試必須一起提交，否則無法證明 race 已被封住
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] rotation 操作改為原子 transaction
- [x] 重放同一 refresh token 第二次應得到 401
- [x] 相關測試覆蓋
- [x] CI 所需本地關鍵驗證已完成

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
$ go test ./internal/services -run 'TestRefresh_(RotatesToken|SecondUseOfSameToken_ReturnsErrInvalidToken|Success|InvalidToken|ExpiredToken)' -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.654s

$ go test -tags=integration ./internal/services -run TestRefresh_ConcurrentReuseOnlyAllowsSingleSuccess -count=1
ok  	github.com/tachigo/tachigo/internal/services	5.488s
```

## 備註
n/a

## Notes for Claude Code Review
- 請特別看 `Refresh()` transaction 內的 delete-and-reissue 路徑是否足夠嚴格，尤其是 `RowsAffected == 0` 時直接回 `ErrInvalidToken` 的判斷
- PostgreSQL integration test 依賴 `refresh_tokens` schema 補進 `testutil_pg_test.go`
