### PR TITLE
[backend] Bind Twitch receipt to paying user

### DIFF
--- a/services/api/internal/handlers/extension_handler_test.go
+++ b/services/api/internal/handlers/extension_handler_test.go
@@ -115,10 +115,11 @@ func signExtJWTForHandler(t *testing.T, twitchID, channelID string) string {
 	return signed
 }
 
-func signReceiptJWTForHandler(t *testing.T, txID, sku string, amount int, txType string) string {
+func signReceiptJWTForHandler(t *testing.T, txID, userID, sku string, amount int, txType string) string {
 	t.Helper()
 	type receiptData struct {
 		TransactionID string `json:"transactionId"`
+		UserID        string `json:"userId"`
 		SKU           string `json:"sku"`
 		Amount        int    `json:"amount"`
 		Type          string `json:"type"`
@@ -128,7 +129,7 @@ func signReceiptJWTForHandler(t *testing.T, txID, sku string, amount int, txType
 		jwt.RegisteredClaims
 	}
 	claims := receiptClaims{
-		Data: receiptData{TransactionID: txID, SKU: sku, Amount: amount, Type: txType},
+		Data: receiptData{TransactionID: txID, UserID: userID, SKU: sku, Amount: amount, Type: txType},
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 		},
@@ -155,7 +156,7 @@ func TestTPointComplete_DuplicateTransactionID_Returns409(t *testing.T) {
 	r, db := newExtHandlerEnv(t)
 	twitchID := seedTwitchUserForHandler(t, db)
 	extJWT := signExtJWTForHandler(t, twitchID, "ch-42")
-	receipt := signReceiptJWTForHandler(t, "tx-handler-dup", "TPOINT100", 100, "bits")
+	receipt := signReceiptJWTForHandler(t, "tx-handler-dup", twitchID, "TPOINT100", 100, "bits")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/extension/t-point/complete",
 		tpointBody(t, extJWT, receipt, "TPOINT100"))
@@ -180,7 +181,7 @@ func TestTPointComplete_InvalidReceiptAmount_Returns400(t *testing.T) {
 	r, db := newExtHandlerEnv(t)
 	twitchID := seedTwitchUserForHandler(t, db)
 	extJWT := signExtJWTForHandler(t, twitchID, "ch-42")
-	receipt := signReceiptJWTForHandler(t, "tx-bad-amount", "TPOINT100", 0, "bits")
+	receipt := signReceiptJWTForHandler(t, "tx-bad-amount", twitchID, "TPOINT100", 0, "bits")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/extension/t-point/complete",
 		tpointBody(t, extJWT, receipt, "TPOINT100"))
@@ -196,7 +197,24 @@ func TestTPointComplete_TooLongTransactionID_Returns400(t *testing.T) {
 	r, db := newExtHandlerEnv(t)
 	twitchID := seedTwitchUserForHandler(t, db)
 	extJWT := signExtJWTForHandler(t, twitchID, "ch-42")
-	receipt := signReceiptJWTForHandler(t, strings.Repeat("x", 256), "TPOINT100", 100, "bits")
+	receipt := signReceiptJWTForHandler(t, strings.Repeat("x", 256), twitchID, "TPOINT100", 100, "bits")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/extension/t-point/complete",
+		tpointBody(t, extJWT, receipt, "TPOINT100"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTPointComplete_ReceiptUserMismatch_Returns400(t *testing.T) {
+	r, db := newExtHandlerEnv(t)
+	twitchID := seedTwitchUserForHandler(t, db)
+	otherTwitchID := seedTwitchUserForHandler(t, db)
+	extJWT := signExtJWTForHandler(t, twitchID, "ch-42")
+	receipt := signReceiptJWTForHandler(t, "tx-handler-cross-user", otherTwitchID, "TPOINT100", 100, "bits")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/extension/t-point/complete",
 		tpointBody(t, extJWT, receipt, "TPOINT100"))

--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -37,6 +37,7 @@ type ExtensionClaims struct {
 type ReceiptClaims struct {
 	Data struct {
 		TransactionID string `json:"transactionId"`
+		UserID        string `json:"userId"`
 		SKU           string `json:"sku"`
 		Amount        int    `json:"amount"`
 		Type          string `json:"type"` // "bits" — Twitch SDK contract, do not rename
@@ -165,6 +166,9 @@ func (s *ExtensionService) CompleteTPointTransaction(extJWT, receipt, sku string
 	}
 
 	if receiptClaims.Data.SKU != sku {
+		return nil, nil, ErrInvalidReceipt
+	}
+	if receiptClaims.Data.UserID == "" || receiptClaims.Data.UserID != extClaims.UserID {
 		return nil, nil, ErrInvalidReceipt
 	}
 	if receiptClaims.Data.Type != "bits" {

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -76,15 +76,30 @@ func makeExtJWT(t *testing.T, twitchUserID, channelID string) string {
 	return signed
 }
 
-func makeReceiptJWT(t *testing.T, txID, sku string, amount int, txType string) string {
+func makeReceiptJWT(t *testing.T, txID, userID, sku string, amount int, txType string) string {
 	t.Helper()
-	claims := ReceiptClaims{}
-	claims.Data.TransactionID = txID
-	claims.Data.SKU = sku
-	claims.Data.Amount = amount
-	claims.Data.Type = txType
-	claims.RegisteredClaims = jwt.RegisteredClaims{
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	type receiptData struct {
+		TransactionID string `json:"transactionId"`
+		UserID        string `json:"userId"`
+		SKU           string `json:"sku"`
+		Amount        int    `json:"amount"`
+		Type          string `json:"type"`
+	}
+	type receiptClaims struct {
+		Data receiptData `json:"data"`
+		jwt.RegisteredClaims
+	}
+	claims := receiptClaims{
+		Data: receiptData{
+			TransactionID: txID,
+			UserID:        userID,
+			SKU:           sku,
+			Amount:        amount,
+			Type:          txType,
+		},
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signed, err := token.SignedString([]byte(testExtSecretRaw))
@@ -100,7 +115,7 @@ func TestCompleteTPointTransaction_Success(t *testing.T) {
 	channelID := "channel-42"
 
 	extJWT := makeExtJWT(t, twitchID, channelID)
-	receipt := makeReceiptJWT(t, "tx-success-001", "TPOINT100", 100, "bits")
+	receipt := makeReceiptJWT(t, "tx-success-001", twitchID, "TPOINT100", 100, "bits")
 
 	user, tokens, err := svc.CompleteTPointTransaction(extJWT, receipt, "TPOINT100")
 	if err != nil {
@@ -133,7 +148,7 @@ func TestCompleteTPointTransaction_DuplicateTransactionID_ReturnsErrDuplicate(t 
 	channelID := "channel-42"
 
 	extJWT := makeExtJWT(t, twitchID, channelID)
-	receipt := makeReceiptJWT(t, "tx-dup-001", "TPOINT100", 100, "bits")
+	receipt := makeReceiptJWT(t, "tx-dup-001", twitchID, "TPOINT100", 100, "bits")
 
 	if _, _, err := svc.CompleteTPointTransaction(extJWT, receipt, "TPOINT100"); err != nil {
 		t.Fatalf("first call failed: %v", err)
@@ -158,7 +173,7 @@ func TestCompleteTPointTransaction_PointsWriteFailure_ReturnsOriginalError(t *te
 	_, twitchID := seedTwitchUser(t, svc.db)
 	channelID := "channel-42"
 	extJWT := makeExtJWT(t, twitchID, channelID)
-	receipt := makeReceiptJWT(t, "tx-db-fail-001", "TPOINT100", 100, "bits")
+	receipt := makeReceiptJWT(t, "tx-db-fail-001", twitchID, "TPOINT100", 100, "bits")
 
 	if err := svc.db.Exec("DROP TABLE points_transactions").Error; err != nil {
 		t.Fatalf("drop points_transactions: %v", err)
@@ -186,31 +201,37 @@ func TestCompleteTPointTransaction_InvalidReceipt_Errors(t *testing.T) {
 	}{
 		{
 			name:    "amount zero",
-			receipt: func() string { return makeReceiptJWT(t, "tx-v1", "TPOINT100", 0, "bits") },
+			receipt: func() string { return makeReceiptJWT(t, "tx-v1", twitchID, "TPOINT100", 0, "bits") },
 			sku:     "TPOINT100",
 			wantErr: ErrInvalidReceiptAmount,
 		},
 		{
 			name:    "amount negative",
-			receipt: func() string { return makeReceiptJWT(t, "tx-v2", "TPOINT100", -50, "bits") },
+			receipt: func() string { return makeReceiptJWT(t, "tx-v2", twitchID, "TPOINT100", -50, "bits") },
 			sku:     "TPOINT100",
 			wantErr: ErrInvalidReceiptAmount,
 		},
 		{
 			name:    "wrong type",
-			receipt: func() string { return makeReceiptJWT(t, "tx-v3", "TPOINT100", 100, "subscription") },
+			receipt: func() string { return makeReceiptJWT(t, "tx-v3", twitchID, "TPOINT100", 100, "subscription") },
 			sku:     "TPOINT100",
 			wantErr: ErrInvalidReceiptType,
 		},
 		{
 			name:    "sku mismatch",
-			receipt: func() string { return makeReceiptJWT(t, "tx-v4", "OTHER_SKU", 100, "bits") },
+			receipt: func() string { return makeReceiptJWT(t, "tx-v4", twitchID, "OTHER_SKU", 100, "bits") },
 			sku:     "TPOINT100",
 			wantErr: ErrInvalidReceipt,
 		},
 		{
 			name:    "empty transactionId",
-			receipt: func() string { return makeReceiptJWT(t, "", "TPOINT100", 100, "bits") },
+			receipt: func() string { return makeReceiptJWT(t, "", twitchID, "TPOINT100", 100, "bits") },
+			sku:     "TPOINT100",
+			wantErr: ErrInvalidReceipt,
+		},
+		{
+			name:    "missing userId",
+			receipt: func() string { return makeReceiptJWT(t, "tx-v5", "", "TPOINT100", 100, "bits") },
 			sku:     "TPOINT100",
 			wantErr: ErrInvalidReceipt,
 		},
@@ -232,7 +253,7 @@ func TestCompleteTPointTransaction_TokenIssueFailure_PointsCreditedOnce_RetryErr
 	userID, twitchID := seedTwitchUser(t, svc.db)
 	channelID := "channel-retry"
 	extJWT := makeExtJWT(t, twitchID, channelID)
-	receipt := makeReceiptJWT(t, "tx-retry-001", "TPOINT100", 100, "bits")
+	receipt := makeReceiptJWT(t, "tx-retry-001", twitchID, "TPOINT100", 100, "bits")
 
 	// Drop refresh_tokens so issueTokenPair fails after points are written.
 	if err := svc.db.Exec("DROP TABLE refresh_tokens").Error; err != nil {
@@ -265,7 +286,7 @@ func TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken(t *te
 	svc, _ := newExtSvc(t)
 	_, twitchID := seedTwitchUser(t, svc.db)
 	extJWT := makeExtJWT(t, twitchID, "channel-42")
-	receipt := makeReceiptJWT(t, "tx-orphan-001", "TPOINT100", 100, "bits")
+	receipt := makeReceiptJWT(t, "tx-orphan-001", twitchID, "TPOINT100", 100, "bits")
 
 	// newTestDB provides per-test DB isolation: DROP TABLE here only affects this test.
 	// RefreshToken has no DeletedAt, so Count() is a direct row count.
@@ -285,5 +306,28 @@ func TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken(t *te
 	svc.db.Model(&models.RefreshToken{}).Count(&countAfter)
 	if countAfter != countBefore {
 		t.Errorf("points write failure must not create refresh tokens: got %d new record(s)", countAfter-countBefore)
+	}
+}
+
+func TestCompleteTPointTransaction_ReceiptUserMismatch_DoesNotCreditPoints(t *testing.T) {
+	svc, pointsSvc := newExtSvc(t)
+	userID, twitchID := seedTwitchUser(t, svc.db)
+	_, otherTwitchID := seedTwitchUser(t, svc.db)
+	channelID := "channel-42"
+
+	extJWT := makeExtJWT(t, twitchID, channelID)
+	receipt := makeReceiptJWT(t, "tx-cross-user-001", otherTwitchID, "TPOINT100", 100, "bits")
+
+	_, _, err := svc.CompleteTPointTransaction(extJWT, receipt, "TPOINT100")
+	if !errors.Is(err, ErrInvalidReceipt) {
+		t.Fatalf("want ErrInvalidReceipt for receipt user mismatch, got %v", err)
+	}
+
+	bal, err := pointsSvc.GetBalance(userID, channelID)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if bal.SpendableBalance != 0 {
+		t.Fatalf("receipt user mismatch must not credit points: got balance=%d", bal.SpendableBalance)
 	}
 }


### PR DESCRIPTION
## 什麼改動
後端 Twitch Extension T-Point/Bits receipt 完成流程現在會解析 receipt payload 的 `data.userId`，並要求它必須等於 extension JWT 的 `user_id`。同時補上 service 與 handler regression tests，確保跨使用者 receipt 不會被入點。

## 為什麼
closes #572

Twitch transaction complete callback 可能在同 channel 的多個 extension instance 被觀察到；後端必須自行確認 receipt 的付款者和提交者相同，避免點數錯歸戶。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#572
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 frontend initiator handling（#573）
  - 不新增 rate limit（#576）
  - 不變更 receipt idempotency schema

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 防止 Twitch receipt 被提交到非付款者帳號並錯誤入點。
- Approx changed lines：~112
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - handler 測試只驗證 service 安全錯誤會透過 API 回 400；不改 router 或 swagger contract。
- 若已拆分，相關 PR：
  - #573 frontend initiator guard

## Acceptance Criteria
- [x] A receipt for user A cannot credit points to user B.
- [x] Valid current-user receipt flow still succeeds.
- [x] Duplicate transaction id still returns conflict.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk go test ./internal/services -run 'TestCompleteTPointTransaction'
Go test: 13 passed in 1 packages

rtk go test ./internal/handlers -run 'TestTPointComplete'
Go test: 4 passed in 1 packages

rtk go test ./...
Go test: 581 passed in 13 packages
```

## 備註

## Notes for Claude Code Review
- 請特別看 `ReceiptClaims.Data.UserID` 的 JSON field 是否符合 Twitch receipt payload。
- 這張 PR 故意只做後端強制驗證；前端忽略 `initiator: other` 會在 #573 另開 PR。
