### PR TITLE
[chore] clarify Codex git permission handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - **Read-only** 可直接執行：讀檔、搜尋、PR / issue metadata、diff、CI 狀態、本機分析
 - **狀態變更**必須先詢問並取得明確同意：Edit / 寫檔、commit、push、branch switch / rebase / merge、GitHub comment / review / CR / Approve / Merge、issue / PR 建立或編輯
 - 若使用者在當輪訊息已明確要求修改檔案，視為已授權該次 Edit；但公開可見操作仍需再次確認
-- 在 Codex sandbox 中執行任何 `git` 指令時，預設直接使用提權執行
+- 在 Codex sandbox 中執行任何 `git` 指令時，必須第一時間使用提權執行；不得先用一般 sandbox 試跑再從失敗訊息補救
+- 若 `git` 指令未使用提權而失敗，優先視為 Codex 執行權限使用錯誤；不得歸因為 DNS、GitHub 網路或遠端服務問題
 
 ### Non-interactive 指令規則
 


### PR DESCRIPTION
## 什麼改動
- 更新 `AGENTS.md` 的操作權限邊界，要求 Codex sandbox 中的 `git` 指令第一時間使用提權執行。
- 補充未提權導致的 `git` 失敗應視為 Codex 執行權限使用錯誤，不得歸因為 DNS、GitHub 網路或遠端服務問題。

## 為什麼
Codex 在這個 repo 內執行 `git` 指令時需要先提權；若先用一般 sandbox 試跑，失敗訊息容易被誤診成 GitHub / DNS 問題。這次把規則寫進 agent guidelines，讓新 session 也能直接遵守。

closes #583

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#583
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 runtime code
  - 不改 GitHub 權限或 CI 設定
  - 不新增 DNS 歷史敘述

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 明確規範 Codex 在 sandbox 中執行 `git` 指令時必須第一時間提權。
- Approx changed lines：~3
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `AGENTS.md` 清楚規範 Codex `git` 指令提權要求
- [x] 規則不包含不準確的 DNS 歷史敘述
- [x] 變更限於 agent 操作文件

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
rtk git --no-pager diff -- AGENTS.md
AGENTS.md | 3 ++-
1 file changed, 2 insertions(+), 1 deletion(-)
```

## 備註
Docs-only PR；未執行 runtime test。

## Notes for Claude Code Review
- 請確認這條規則是否足夠明確阻止 Codex 先用一般 sandbox 跑 `git` 後再誤診失敗原因。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 更新操作规范文档，明确命令执行的权限要求和故障诊断流程。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/586)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->