### PR TITLE
[frontend] Ignore non-current-user Twitch transactions

### DIFF
--- a/apps/extension/src/hooks/useTPoint.test.tsx
+++ b/apps/extension/src/hooks/useTPoint.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { completeTPointTransaction } from '../services/api'
+import type { TPointTransaction } from '../types/twitch'
+import { useTPoint } from './useTPoint'
+
+vi.mock('../services/api', () => ({
+  completeTPointTransaction: vi.fn().mockResolvedValue({}),
+}))
+
+const mockedCompleteTPointTransaction = vi.mocked(completeTPointTransaction)
+
+function makeTransaction(initiator: TPointTransaction['initiator']): TPointTransaction {
+  return {
+    transactionId: 'tx-1',
+    product: {
+      sku: 'TPOINT100',
+      displayName: '100 T-Points',
+      cost: { amount: 100, type: 'bits' },
+      inDevelopment: false,
+    },
+    userId: 'viewer-1',
+    displayName: 'Viewer',
+    initiator,
+    transactionReceipt: 'receipt-jwt',
+  }
+}
+
+describe('useTPoint', () => {
+  let onTransactionComplete: ((tx: TPointTransaction) => void) | undefined
+  let onTransactionCancelled: (() => void) | undefined
+  let usedBitsSkus: string[]
+
+  beforeEach(() => {
+    mockedCompleteTPointTransaction.mockClear()
+    onTransactionComplete = undefined
+    onTransactionCancelled = undefined
+    usedBitsSkus = []
+
+    window.Twitch = {
+      ext: {
+        bits: {
+          getProducts: vi.fn(),
+          useBits: (sku: string) => {
+            usedBitsSkus.push(sku)
+          },
+          onTransactionComplete: vi.fn((callback) => {
+            onTransactionComplete = callback
+          }),
+          onTransactionCancelled: vi.fn((callback) => {
+            onTransactionCancelled = callback
+          }),
+        },
+        onAuthorized: vi.fn(),
+        onContext: vi.fn(),
+      },
+    }
+  })
+
+  it('does not submit receipt for transactions initiated by another viewer', async () => {
+    const { result } = renderHook(() => useTPoint('extension-jwt'))
+
+    act(() => {
+      result.current.buyWithTPoint('TPOINT100')
+    })
+
+    expect(usedBitsSkus).toEqual(['TPOINT100'])
+    expect(onTransactionComplete).toBeDefined()
+
+    await act(async () => {
+      onTransactionComplete?.(makeTransaction('other'))
+    })
+
+    expect(mockedCompleteTPointTransaction).not.toHaveBeenCalled()
+    expect(result.current.status).toBe('pending')
+  })
+
+  it('submits receipt for transactions initiated by the current viewer', async () => {
+    const { result } = renderHook(() => useTPoint('extension-jwt'))
+
+    act(() => {
+      result.current.buyWithTPoint('TPOINT100')
+    })
+
+    await act(async () => {
+      onTransactionComplete?.(makeTransaction('current_user'))
+    })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('success')
+    })
+    expect(mockedCompleteTPointTransaction).toHaveBeenCalledWith('extension-jwt', 'receipt-jwt', 'TPOINT100')
+  })
+
+  it('returns to idle when the transaction is cancelled', () => {
+    const { result } = renderHook(() => useTPoint('extension-jwt'))
+
+    act(() => {
+      result.current.buyWithTPoint('TPOINT100')
+    })
+    expect(result.current.status).toBe('pending')
+
+    act(() => {
+      onTransactionCancelled?.()
+    })
+
+    expect(result.current.status).toBe('idle')
+  })
+})

--- a/apps/extension/src/hooks/useTPoint.ts
+++ b/apps/extension/src/hooks/useTPoint.ts
@@ -17,6 +17,10 @@ export function useTPoint(jwt: string) {
       setError(null)
 
       ext.bits.onTransactionComplete(async (tx: TPointTransaction) => {
+        if (tx.initiator !== 'current_user') {
+          return
+        }
+
         try {
           await completeTPointTransaction(jwt, tx.transactionReceipt, tx.product.sku)
           setStatus('success')


### PR DESCRIPTION
## 什麼改動
前端 `useTPoint` 在收到 Twitch Bits transaction complete callback 時，只有 `initiator === "current_user"` 才會送 receipt 到後端入帳。

## 為什麼
closes #573

避免同一個 Extension iframe 收到其他 viewer 的 transaction complete event 時，誤把非當前使用者的 receipt 送到後端完成交易。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#573
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理後端 receipt 與 user 綁定檢查（#572 / #585）
  - 不調整 Twitch SDK transaction lifecycle 以外的流程

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 忽略非當前 viewer 發起的 Twitch Bits transaction complete event。
- Approx changed lines：~115
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接覆蓋本 PR 的 frontend guard 行為，無法再合理拆小。
- 若已拆分，相關 PR：
  - #585 後端 receipt user binding，獨立防線

## Acceptance Criteria
- [x] 非 current_user initiator 的 transaction complete callback 不會送出 receipt
- [x] current_user initiator 的 transaction complete callback 仍會正常送出 receipt
- [x] 新增 hook 測試覆蓋 ignore / submit / cancel 狀態

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
PATH="/Users/tachikoma/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" rtk pnpm test -- src/hooks/useTPoint.test.tsx
Test Files  12 passed (12)
Tests       41 passed (41)

PATH="/Users/tachikoma/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" rtk pnpm build
✓ built in 386ms
```

## 備註
本機系統 Node 載入 rolldown native binding 時遇到 code signature 問題，因此驗證使用 Codex bundled Node 執行。

## Notes for Claude Code Review
- 請特別確認 `initiator` enum 假設符合 Twitch Bits transaction callback 型別。
