### PR TITLE
[backend] Prevent production NoOpMailer token leaks

### DIFF
--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -172,6 +172,9 @@ func ValidateProductionSecrets(cfg *Config) error {
 	if cfg.JWT.AccessSecret == cfg.JWT.RefreshSecret {
 		return fmt.Errorf("JWT_ACCESS_SECRET and JWT_REFRESH_SECRET must be different")
 	}
+	if cfg.SMTP.Host == "" {
+		return fmt.Errorf("SMTP_HOST must be configured when email-dependent production flows are enabled")
+	}
 
 	return nil
 }

--- a/services/api/internal/config/config_test.go
+++ b/services/api/internal/config/config_test.go
@@ -21,6 +21,9 @@ func TestValidateProductionSecrets(t *testing.T) {
 					AccessSecret:  validAccess,
 					RefreshSecret: validRefresh,
 				},
+				SMTP: SMTPConfig{
+					Host: "smtp.example.com",
+				},
 			},
 		},
 		{
@@ -29,6 +32,9 @@ func TestValidateProductionSecrets(t *testing.T) {
 				JWT: JWTConfig{
 					AccessSecret:  "",
 					RefreshSecret: validRefresh,
+				},
+				SMTP: SMTPConfig{
+					Host: "smtp.example.com",
 				},
 			},
 			wantErr: "JWT_ACCESS_SECRET",
@@ -40,6 +46,9 @@ func TestValidateProductionSecrets(t *testing.T) {
 					AccessSecret:  validAccess,
 					RefreshSecret: "",
 				},
+				SMTP: SMTPConfig{
+					Host: "smtp.example.com",
+				},
 			},
 			wantErr: "JWT_REFRESH_SECRET",
 		},
@@ -49,6 +58,9 @@ func TestValidateProductionSecrets(t *testing.T) {
 				JWT: JWTConfig{
 					AccessSecret:  defaultJWTAccessSecret,
 					RefreshSecret: validRefresh,
+				},
+				SMTP: SMTPConfig{
+					Host: "smtp.example.com",
 				},
 			},
 			wantErr: "default",
@@ -60,6 +72,9 @@ func TestValidateProductionSecrets(t *testing.T) {
 					AccessSecret:  validAccess,
 					RefreshSecret: defaultJWTRefreshSecret,
 				},
+				SMTP: SMTPConfig{
+					Host: "smtp.example.com",
+				},
 			},
 			wantErr: "default",
 		},
@@ -69,6 +84,9 @@ func TestValidateProductionSecrets(t *testing.T) {
 				JWT: JWTConfig{
 					AccessSecret:  "short-secret",
 					RefreshSecret: validRefresh,
+				},
+				SMTP: SMTPConfig{
+					Host: "smtp.example.com",
 				},
 			},
 			wantErr: "at least 32 characters",
@@ -80,6 +98,9 @@ func TestValidateProductionSecrets(t *testing.T) {
 					AccessSecret:  validAccess,
 					RefreshSecret: "short-secret",
 				},
+				SMTP: SMTPConfig{
+					Host: "smtp.example.com",
+				},
 			},
 			wantErr: "at least 32 characters",
 		},
@@ -90,8 +111,21 @@ func TestValidateProductionSecrets(t *testing.T) {
 					AccessSecret:  validAccess,
 					RefreshSecret: validAccess,
 				},
+				SMTP: SMTPConfig{
+					Host: "smtp.example.com",
+				},
 			},
 			wantErr: "must be different",
+		},
+		{
+			name: "rejects missing SMTP host",
+			cfg: &Config{
+				JWT: JWTConfig{
+					AccessSecret:  validAccess,
+					RefreshSecret: validRefresh,
+				},
+			},
+			wantErr: "SMTP_HOST",
 		},
 	}
 

--- a/services/api/internal/services/mailer.go
+++ b/services/api/internal/services/mailer.go
@@ -125,12 +125,11 @@ func (m *SMTPMailer) Send(ctx context.Context, to, subject, htmlBody string) err
 }
 
 // NoOpMailer is used when SMTP is not configured.
-// It logs the email to stdout instead of sending it, which is useful during development.
+// It logs delivery metadata without the body so token-bearing links never reach logs.
 type NoOpMailer struct{}
 
 func (n *NoOpMailer) Send(_ context.Context, to, subject, htmlBody string) error {
-	log.Printf("[mailer] no-op send | to=%s | subject=%s", to, subject)
-	fmt.Printf("--- email ---\nTo: %s\nSubject: %s\n%s\n-------------\n", to, subject, htmlBody)
+	log.Printf("[mailer] no-op send | to=%s | subject=%s | body_bytes=%d | body=redacted", to, subject, len(htmlBody))
 	return nil
 }
 

--- a/services/api/internal/services/mailer_test.go
+++ b/services/api/internal/services/mailer_test.go
@@ -1,0 +1,46 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNoOpMailer_DoesNotPrintEmailBody(t *testing.T) {
+	originalStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = writePipe
+	defer func() {
+		os.Stdout = originalStdout
+	}()
+
+	var logOutput bytes.Buffer
+	originalLogOutput := log.Writer()
+	log.SetOutput(&logOutput)
+	defer log.SetOutput(originalLogOutput)
+
+	body := `<a href="https://app.example/reset?token=secret-token">reset</a>`
+	if err := (&NoOpMailer{}).Send(context.Background(), "user@example.com", "Reset password", body); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	if err := writePipe.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+	outputBytes, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+
+	combined := string(outputBytes) + logOutput.String()
+	if strings.Contains(combined, "secret-token") || strings.Contains(combined, body) {
+		t.Fatalf("no-op mailer leaked email body: %q", combined)
+	}
+}


### PR DESCRIPTION
## 什麼改動
Production secrets validation 現在要求 `SMTP_HOST`，避免 production 缺 SMTP 時 fallback 到 no-op mailer；`NoOpMailer` 也改成只記錄收件人、主旨與 body 長度，不輸出 email body。

## 為什麼
closes #574

驗證信、密碼重設、agency setup 與 raffle claim email 都可能包含一次性 token link。Production 若誤用 `NoOpMailer`，原本會把完整信件 body 寫進 stdout/log。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#574
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 SMTP provider 設定
  - 不改 email token 產生或儲存邏輯

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 防止 production 缺 SMTP 時將 token-bearing email body 寫入 log。
- Approx changed lines：~85
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接驗證 production config validation 與 no-op mailer redaction 行為。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `APP_ENV=production` 路徑缺 `SMTP_HOST` 時會 fail fast
- [x] `NoOpMailer` 不輸出 raw verify/reset/claim links 或完整 body
- [x] Development/test 仍可使用 safe redacted no-op mailer

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk go test ./internal/config -run TestValidateProductionSecrets
Go test: 10 passed in 1 packages

rtk go test ./internal/services -run TestNoOpMailer_DoesNotPrintEmailBody
Go test: 1 passed in 1 packages

rtk go test ./...
Go test: 580 passed in 13 packages
```

## 備註
Production startup 原本已透過 `ShouldValidateProductionSecrets` 呼叫 validation；本 PR 把 SMTP 缺漏納入同一條 fail-fast 路徑。

## Notes for Claude Code Review
- 請確認 production 是否一定應啟用 mail-dependent flows；本 PR 依 issue scope 選擇 fail fast，而不是動態關閉 email flows。
