### PR TITLE
[backend] Gate Swagger outside development

### DIFF
--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -49,9 +50,11 @@ type AppConfig struct {
 }
 
 type ServerConfig struct {
-	Port   string
-	Env    string
-	EnvSet bool
+	Port             string
+	Env              string
+	EnvSet           bool
+	EnableSwagger    bool
+	EnableSwaggerSet bool
 }
 
 type DatabaseConfig struct {
@@ -88,12 +91,15 @@ func Load() *Config {
 	refreshTTL, _ := strconv.Atoi(getEnv("JWT_REFRESH_TTL_DAYS", "30"))
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "587"))
 	appEnv, appEnvSet := getEnvWithPresence("APP_ENV", "development")
+	enableSwagger, enableSwaggerSet := getBoolEnvWithPresence("ENABLE_SWAGGER", false)
 
 	return &Config{
 		Server: ServerConfig{
-			Port:   getEnv("PORT", "8080"),
-			Env:    appEnv,
-			EnvSet: appEnvSet,
+			Port:             getEnv("PORT", "8080"),
+			Env:              appEnv,
+			EnvSet:           appEnvSet,
+			EnableSwagger:    enableSwagger,
+			EnableSwaggerSet: enableSwaggerSet,
 		},
 		Database: DatabaseConfig{
 			DSN: getEnv("DATABASE_URL", "host=localhost user=postgres password=postgres dbname=tachigo port=5432 sslmode=disable"),
@@ -151,11 +157,39 @@ func getEnvWithPresence(key, fallback string) (string, bool) {
 	return fallback, false
 }
 
+func getBoolEnvWithPresence(key string, fallback bool) (bool, bool) {
+	raw, ok := getEnvWithPresence(key, "")
+	if !ok {
+		return fallback, false
+	}
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return fallback, true
+	}
+	return value, true
+}
+
 func ShouldValidateProductionSecrets(cfg *Config) bool {
 	if cfg == nil {
 		return true
 	}
 	return !cfg.Server.EnvSet || cfg.Server.Env != "development"
+}
+
+func ShouldEnableSwagger(cfg *Config) bool {
+	if cfg == nil {
+		return true
+	}
+	if cfg.Server.EnableSwaggerSet {
+		return cfg.Server.EnableSwagger
+	}
+
+	switch strings.ToLower(cfg.Server.Env) {
+	case "", "development", "dev", "local":
+		return true
+	default:
+		return false
+	}
 }
 
 func ValidateProductionSecrets(cfg *Config) error {

--- a/services/api/internal/config/config_test.go
+++ b/services/api/internal/config/config_test.go
@@ -162,6 +162,82 @@ func TestShouldValidateProductionSecrets(t *testing.T) {
 	}
 }
 
+func TestShouldEnableSwagger(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{
+			name: "defaults to enabled when config is missing",
+			want: true,
+		},
+		{
+			name: "enabled by default in development",
+			cfg: &Config{
+				Server: ServerConfig{Env: "development"},
+			},
+			want: true,
+		},
+		{
+			name: "disabled by default in production",
+			cfg: &Config{
+				Server: ServerConfig{Env: "production"},
+			},
+			want: false,
+		},
+		{
+			name: "explicit flag enables production",
+			cfg: &Config{
+				Server: ServerConfig{Env: "production", EnableSwagger: true, EnableSwaggerSet: true},
+			},
+			want: true,
+		},
+		{
+			name: "explicit flag disables development",
+			cfg: &Config{
+				Server: ServerConfig{Env: "development", EnableSwagger: false, EnableSwaggerSet: true},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShouldEnableSwagger(tc.cfg)
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestLoad_EnableSwagger(t *testing.T) {
+	t.Run("records explicit true", func(t *testing.T) {
+		t.Setenv("ENABLE_SWAGGER", "true")
+
+		cfg := Load()
+		if !cfg.Server.EnableSwaggerSet {
+			t.Fatal("expected EnableSwaggerSet=true")
+		}
+		if !cfg.Server.EnableSwagger {
+			t.Fatal("expected EnableSwagger=true")
+		}
+	})
+
+	t.Run("records explicit false", func(t *testing.T) {
+		t.Setenv("ENABLE_SWAGGER", "false")
+
+		cfg := Load()
+		if !cfg.Server.EnableSwaggerSet {
+			t.Fatal("expected EnableSwaggerSet=true")
+		}
+		if cfg.Server.EnableSwagger {
+			t.Fatal("expected EnableSwagger=false")
+		}
+	})
+}
+
 func TestLoad_ContractRPCEndpoint(t *testing.T) {
 	t.Run("defaults to public Sepolia endpoint", func(t *testing.T) {
 		t.Setenv("SEPOLIA_RPC_URL", "")

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -63,7 +63,9 @@ func New(
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})
 	})
-	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	if config.ShouldEnableSwagger(cfg) {
+		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	}
 
 	v1 := r.Group("/api/v1")
 

--- a/services/api/internal/router/router_test.go
+++ b/services/api/internal/router/router_test.go
@@ -37,7 +37,7 @@ type routerTestEnv struct {
 	router  *gin.Engine
 }
 
-func newRouterTestEnv(t *testing.T) *routerTestEnv {
+func newRouterTestEnv(t *testing.T, routerConfigs ...*config.Config) *routerTestEnv {
 	t.Helper()
 
 	dbName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
@@ -74,6 +74,9 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 			FrontendURL: "http://localhost:3000",
 		},
 	}
+	if len(routerConfigs) > 0 {
+		cfg = routerConfigs[0]
+	}
 	authSvc := services.NewAuthService(db, cfg)
 	userSvc := services.NewUserService(db)
 	addrSvc := services.NewAddressService(db)
@@ -89,6 +92,11 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 	spendSvc := services.NewSpendService(db, config.ContractConfig{}, nil, nil)
 	raffleSvc := services.NewRaffleService(db, "", "", nil)
 	agencyHandler := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
+
+	internalRouterConfigs := []router.InternalRouterConfig{}
+	if len(routerConfigs) > 0 {
+		internalRouterConfigs = append(internalRouterConfigs, router.InternalRouterConfig{DB: db, Config: cfg})
+	}
 
 	engine := router.New(
 		authSvc,
@@ -107,12 +115,74 @@ func newRouterTestEnv(t *testing.T) *routerTestEnv {
 		raffleSvc,
 		agencyHandler,
 		[]string{"http://localhost:3000"},
+		internalRouterConfigs...,
 	)
 
 	return &routerTestEnv{
 		db:      db,
 		authSvc: authSvc,
 		router:  engine,
+	}
+}
+
+func TestSwaggerRoute_DevelopmentDefaultExposesSwagger(t *testing.T) {
+	env := newRouterTestEnv(t, routerTestConfig("development", false, false))
+
+	assertSwaggerExposed(t, env.router)
+}
+
+func TestSwaggerRoute_ProductionDefaultHidesSwagger(t *testing.T) {
+	env := newRouterTestEnv(t, routerTestConfig("production", false, false))
+
+	assertSwaggerHidden(t, env.router)
+}
+
+func TestSwaggerRoute_ProductionExplicitFlagExposesSwagger(t *testing.T) {
+	env := newRouterTestEnv(t, routerTestConfig("production", true, true))
+
+	assertSwaggerExposed(t, env.router)
+}
+
+func routerTestConfig(serverEnv string, enableSwagger, enableSwaggerSet bool) *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{
+			Env:              serverEnv,
+			EnableSwagger:    enableSwagger,
+			EnableSwaggerSet: enableSwaggerSet,
+		},
+		JWT: config.JWTConfig{
+			AccessSecret:  "test-access-secret-at-least-32-chars!",
+			RefreshSecret: "test-refresh-secret",
+			AccessTTL:     15 * time.Minute,
+			RefreshTTL:    30 * 24 * time.Hour,
+		},
+		App: config.AppConfig{
+			FrontendURL: "http://localhost:3000",
+		},
+	}
+}
+
+func assertSwaggerExposed(t *testing.T, engine *gin.Engine) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/swagger/index.html", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("expected swagger route to be exposed, got 404: %s", rec.Body.String())
+	}
+}
+
+func assertSwaggerHidden(t *testing.T, engine *gin.Engine) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/swagger/index.html", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected swagger route to be hidden with 404, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
新增 `ENABLE_SWAGGER` 設定與 `ShouldEnableSwagger` 判斷，讓 Swagger endpoint 只在 development/local 預設開啟；production/prod 預設不註冊 `/swagger/*any`，但可用 `ENABLE_SWAGGER=true` 明確開啟。

## 為什麼
closes #580

Production 公開 Swagger docs 會增加 API surface discovery；本 PR 讓 production default 更保守，同時保留本機開發便利性。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#580
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 Swagger 文件內容或重新產生 docs artifact
  - 不調整其他 debug/admin endpoints

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Production 預設隱藏 Swagger endpoint，並提供明確 opt-in flag。
- Approx changed lines：~190
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - router gate 需要 config 判斷與對應測試一起驗證。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Production default does not expose `/swagger/*any`
- [x] Development still exposes Swagger by default
- [x] `ENABLE_SWAGGER=true` can explicitly enable Swagger outside development

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk go test ./internal/config -run 'Test(ShouldEnableSwagger|Load_EnableSwagger)'
Go test: 9 passed in 1 packages

rtk go test ./internal/router -run TestSwaggerRoute
Go test: 3 passed in 1 packages

rtk go test ./...
Go test: 590 passed in 13 packages
```

## 備註
`ENABLE_SWAGGER=false` 也可明確關閉 development Swagger；未設定時 development/local/dev 預設開啟，其餘環境預設關閉。

## Notes for Claude Code Review
- 請確認新 env var 名稱 `ENABLE_SWAGGER` 符合部署設定慣例。
