### PR TITLE
[backend] Limit raffle CSV uploads

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -17,6 +17,11 @@ type RaffleHandler struct {
 	raffleSvc *services.RaffleService
 }
 
+const (
+	maxRaffleCSVFileBytes          = 1 << 20
+	maxRaffleCSVImportRequestBytes = maxRaffleCSVFileBytes + 64*1024
+)
+
 func NewRaffleHandler(svc *services.RaffleService) *RaffleHandler {
 	return &RaffleHandler{raffleSvc: svc}
 }
@@ -147,12 +152,22 @@ func (h *RaffleHandler) ImportCSV(c *gin.Context) {
 		return
 	}
 
-	file, _, err := c.Request.FormFile("file")
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRaffleCSVImportRequestBytes)
+	file, header, err := c.Request.FormFile("file")
 	if err != nil {
+		if isRequestBodyTooLarge(err) {
+			raffleCSVTooLarge(c)
+			return
+		}
 		badRequest(c, "file is required")
 		return
 	}
 	defer file.Close()
+
+	if header != nil && header.Size > maxRaffleCSVFileBytes {
+		raffleCSVTooLarge(c)
+		return
+	}
 
 	result, err := h.raffleSvc.ImportCSV(raffleID, userID, file)
 	if err != nil {
@@ -169,6 +184,15 @@ func (h *RaffleHandler) ImportCSV(c *gin.Context) {
 		return
 	}
 	ok(c, result)
+}
+
+func isRequestBodyTooLarge(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+	return errors.As(err, &maxBytesErr)
+}
+
+func raffleCSVTooLarge(c *gin.Context) {
+	c.JSON(http.StatusRequestEntityTooLarge, Response{Success: false, Error: "csv upload is too large"})
 }
 
 // DrawNext godoc

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -744,6 +744,81 @@ func TestRaffle_CSVDuplicateSkipped(t *testing.T) {
 	}
 }
 
+func TestRaffle_ImportCSV_ValidUploadStillWorks(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "csvvalid", "csvvalid@test.com", "pass1234")
+	raffleID := env.createRaffle(t, token, "valid csv")
+	env.createTwitchLinkedUser(t, "csv_valid_user")
+
+	w := env.uploadCSV(t, token, raffleID, "csv_valid_user,CSV Valid User\n")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	data := resp["data"].(map[string]interface{})
+	if int(data["imported"].(float64)) != 1 {
+		t.Fatalf("want imported=1, got %v", data["imported"])
+	}
+}
+
+func TestRaffle_ImportCSV_OversizedUploadReturns413(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "csvlarge", "csvlarge@test.com", "pass1234")
+	raffleID := env.createRaffle(t, token, "large csv")
+
+	oversizedCSV := strings.Repeat("large_user,Large User\n", 70000)
+	w := env.uploadCSV(t, token, raffleID, oversizedCSV)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("want 413, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if resp["error"] != "csv upload is too large" {
+		t.Fatalf("want deterministic too-large error, got %#v", resp["error"])
+	}
+}
+
+func (e *raffleTestEnv) createRaffle(t *testing.T, token, title string) string {
+	t.Helper()
+
+	body, _ := json.Marshal(map[string]string{"title": title})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	e.router.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create raffle: want 201, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	return resp["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+}
+
+func (e *raffleTestEnv) uploadCSV(t *testing.T, token, raffleID, csvBody string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "entries.csv")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := fw.Write([]byte(csvBody)); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/entries/import-csv", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", bearer(token))
+	e.router.ServeHTTP(w, req)
+	return w
+}
+
 // testConfig returns minimal config for tests.
 func testConfig() *config.Config {
 	return &config.Config{


### PR DESCRIPTION
## 什麼改動
Raffle CSV import endpoint 現在會限制整個 multipart request 大小與 CSV file 大小；超限時固定回 `413` 與 `csv upload is too large`，不進入 CSV parsing/service import。

## 為什麼
closes #581

避免 authenticated streamer 上傳過大的 CSV/multipart request 造成記憶體或處理資源消耗。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#581
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 CSV 欄位格式或匯入規則
  - 不改 raffle service 的去重/linked-account 行為

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 限制 raffle CSV upload 大小並提供 deterministic error。
- Approx changed lines：~100
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - handler guard 與 endpoint tests 是同一個 upload safety behavior。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Oversized CSV/multipart upload is rejected before CSV parsing
- [x] Valid CSV import still works
- [x] Error response is deterministic and does not expose internals

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk go test ./internal/handlers -run 'TestRaffle_ImportCSV_(ValidUploadStillWorks|OversizedUploadReturns413)'
Go test: 2 passed in 1 packages

rtk go test ./...
Go test: 580 passed in 13 packages
```

## 備註
目前限制為 1 MiB CSV file、1 MiB + 64 KiB multipart request overhead；之後若產品需要更大匯入量，可以獨立調整成 config。

## Notes for Claude Code Review
- 請確認 1 MiB CSV file limit 對 launch 前 streamer 匯入量足夠。
