### PR TITLE
[backend] Upgrade Go toolchain patch

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -925,7 +925,7 @@ test('backend security scanner job installs pinned staticcheck and govulncheck',
   assert.equal(job.name, 'Backend security scanners')
   assert.equal(job.env.STATICCHECK_VERSION, 'v0.7.0')
   assert.equal(job.env.GOVULNCHECK_VERSION, 'v1.3.0')
-  assert.match(jobBlock, /go-version: 1\.25\.10/)
+  assert.match(jobBlock, /go-version: 1\.26\.3/)
   assert.match(jobBlock, /go install honnef\.co\/go\/tools\/cmd\/staticcheck@\$STATICCHECK_VERSION/)
   assert.match(jobBlock, /go install golang\.org\/x\/vuln\/cmd\/govulncheck@\$GOVULNCHECK_VERSION/)
   assert.match(jobBlock, /working-directory: services\/api\n\s+run: staticcheck \.\/\.\.\./)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.25.10
+          go-version: 1.26.3
 
       - name: Install scanner tools
         run: |

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,5 +1,5 @@
 # ── Dev stage ─────────────────────────────────────────────────────────────────
-FROM golang:1.25-alpine AS dev
+FROM golang:1.26.3-alpine AS dev
 
 RUN apk add --no-cache git build-base && \
     go install github.com/air-verse/air@latest && \
@@ -15,7 +15,7 @@ EXPOSE 8080
 CMD ["air"]
 
 # ── Build stage ───────────────────────────────────────────────────────────────
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 RUN apk add --no-cache git tzdata
 

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/tachigo/tachigo
 
-go 1.25.0
+go 1.26.3
 
 require (
 	ariga.io/atlas-provider-gorm v0.6.0


### PR DESCRIPTION
## 什麼改動
將 backend Go toolchain pin 到 Go 1.26.3：更新 `services/api/go.mod`、Docker dev/build base image、CI backend security scanner job，以及 workflow self-test 的版本斷言。

## 為什麼
closes #575

`govulncheck` 在較舊 Go patch toolchain 下回報多個 reachable stdlib findings。官方 Go release history 顯示 go1.26.3（2026-05-07）包含 `html/template`、`net/http`、`net/mail` 等 security fixes。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#575
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不更新 Go module dependencies
  - 不調整 application code
  - 不改 staticcheck/govulncheck tool versions

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 將 backend local/CI/Docker Go patch 版本升到 1.26.3 以清除 reachable stdlib govulncheck findings。
- Approx changed lines：~10
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - CI self-test 需要跟 workflow pin 同步更新。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `govulncheck ./...` reports no reachable affected vulnerabilities
- [x] Backend test suite passes under Go 1.26.3
- [x] Dockerfile no longer relies on floating/vulnerable Go patch image

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOTOOLCHAIN=go1.26.3 rtk go version
go version go1.26.3 darwin/arm64

GOTOOLCHAIN=go1.26.3 rtk go test ./...
Go test: 578 passed in 13 packages

GOTOOLCHAIN=go1.26.3 rtk go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.

rtk node --test .github/workflows/ci.test.mjs
tests 60, pass 60, fail 0
```

## 備註
官方來源：https://go.dev/doc/devel/release

## Notes for Claude Code Review
- 請確認部署環境支援 `golang:1.26.3-alpine` image；本 PR 未改 runtime Alpine stage。
