### PR TITLE
[chore] Add Codex session index tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev up down logs pr-meta-check pr-open
+.PHONY: setup dev up down logs pr-meta-check pr-open session-index session-find session-index-test
 
 # ── Setup (run once after cloning) ────────────────────────────────────────────
 setup:
@@ -31,3 +31,15 @@ pr-open:
 	@test -n "$(TITLE)" || (echo "TITLE is required"; exit 2)
 	@test -n "$(BODY_FILE)" || (echo "BODY_FILE is required"; exit 2)
 	@./infra/scripts/pr-open.sh --title "$(TITLE)" --body-file "$(BODY_FILE)" --base "$(or $(BASE),develop)" $(if $(HEAD),--head "$(HEAD)",) $(if $(filter 1,$(DRAFT)),--draft,) $(if $(filter 1,$(AUTO_READY)),--auto-ready,)
+
+# ── Local Codex session lookup ───────────────────────────────────────────────
+session-index:
+	@test -n "$(PR)" || (echo "PR is required"; exit 2)
+	@./infra/scripts/session-index.sh add --pr "$(PR)" $(if $(ISSUE),--issue "$(ISSUE)",) $(if $(WORKTREE),--worktree "$(WORKTREE)",) $(if $(INDEX_FILE),--index-file "$(INDEX_FILE)",)
+
+session-find:
+	@test -n "$(PR)" || (echo "PR is required"; exit 2)
+	@./infra/scripts/session-index.sh find --pr "$(PR)" $(if $(INDEX_FILE),--index-file "$(INDEX_FILE)",)
+
+session-index-test:
+	@./infra/scripts/session-index.test.sh

--- a/infra/scripts/pr-open.sh
+++ b/infra/scripts/pr-open.sh
@@ -11,6 +11,38 @@ Runs local PR metadata checks, then opens a PR with gh.
 EOF
 }
 
+extract_issue_number() {
+  local body_file="$1"
+
+  grep -Eio '(refs|closes|fixes|resolves)[[:space:]]+#[0-9]+' "$body_file" 2>/dev/null \
+    | head -n 1 \
+    | grep -Eo '[0-9]+' \
+    || true
+}
+
+extract_pr_number() {
+  sed -n -E 's#.*github\.com/.*/pull/([0-9]+).*#\1#p' | tail -n 1
+}
+
+update_session_index() {
+  local root_dir="$1"
+  local pr_number="$2"
+  local issue_number="$3"
+  local session_index="$root_dir/infra/scripts/session-index.sh"
+  local cmd=("$session_index" add --pr "$pr_number" --worktree "$root_dir")
+
+  [ -x "$session_index" ] || return 0
+  if [ -n "$issue_number" ]; then
+    cmd+=(--issue "$issue_number")
+  fi
+
+  if "${cmd[@]}" >/dev/null; then
+    echo "Updated local Codex session index for PR #$pr_number."
+  else
+    echo "warning: failed to update local Codex session index for PR #$pr_number" >&2
+  fi
+}
+
 main() {
   local title=""
   local body_file=""
@@ -18,6 +50,9 @@ main() {
   local head_branch=""
   local draft=0
   local auto_ready=0
+  local pr_output=""
+  local pr_number=""
+  local issue_number=""
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -87,7 +122,14 @@ main() {
   fi
 
   echo "Opening PR with gh..."
-  "${cmd[@]}"
+  pr_output="$("${cmd[@]}")"
+  printf '%s\n' "$pr_output"
+
+  pr_number="$(printf '%s\n' "$pr_output" | extract_pr_number)"
+  if [ -n "$pr_number" ]; then
+    issue_number="$(extract_issue_number "$body_file")"
+    update_session_index "$root_dir" "$pr_number" "$issue_number"
+  fi
 }
 
 main "$@"

--- a/infra/scripts/pr-open.test.sh
+++ b/infra/scripts/pr-open.test.sh
@@ -16,6 +16,14 @@ printf '%s\n' "$*" > "$PR_METADATA_CHECK_LOG"
 STUB
 chmod +x "$tmp_dir/infra/scripts/pr-metadata-check.sh"
 
+cat > "$tmp_dir/infra/scripts/session-index.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$SESSION_INDEX_LOG"
+exit "${SESSION_INDEX_EXIT:-0}"
+STUB
+chmod +x "$tmp_dir/infra/scripts/session-index.sh"
+
 cat > "$tmp_dir/fakebin/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -26,6 +34,7 @@ fi
 
 if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then
   printf '%s\n' "$*" > "$GH_PR_CREATE_LOG"
+  printf '%s\n' "https://github.com/nurockplayer/tachigo/pull/566"
   exit 0
 fi
 
@@ -38,11 +47,12 @@ chmod +x "$tmp_dir/fakebin/gh"
   cd "$tmp_dir"
   git init -q
   git checkout -q -b test/pr-open
-  touch body.md
+  printf '%s\n' "refs #420" > body.md
 
   PATH="$tmp_dir/fakebin:$PATH" \
     GH_PR_CREATE_LOG="$tmp_dir/gh-pr-create.log" \
     PR_METADATA_CHECK_LOG="$tmp_dir/pr-metadata-check.log" \
+    SESSION_INDEX_LOG="$tmp_dir/session-index.log" \
     "$tmp_dir/infra/scripts/pr-open.sh" \
       --title "[chore] Test auto-ready PR" \
       --body-file body.md \
@@ -52,6 +62,9 @@ chmod +x "$tmp_dir/fakebin/gh"
 grep -q -- '--draft' "$tmp_dir/gh-pr-create.log"
 grep -q -- '--label auto-ready' "$tmp_dir/gh-pr-create.log"
 grep -q -- '--title \[chore\] Test auto-ready PR' "$tmp_dir/pr-metadata-check.log"
+grep -q -- 'add --pr 566' "$tmp_dir/session-index.log"
+grep -q -- '--issue 420' "$tmp_dir/session-index.log"
+grep -q -- '--worktree '"$tmp_dir" "$tmp_dir/session-index.log"
 
 (
   cd "$tmp_dir"
@@ -59,6 +72,7 @@ grep -q -- '--title \[chore\] Test auto-ready PR' "$tmp_dir/pr-metadata-check.lo
   PATH="$tmp_dir/fakebin:$PATH" \
     GH_PR_CREATE_LOG="$tmp_dir/gh-pr-create-default.log" \
     PR_METADATA_CHECK_LOG="$tmp_dir/pr-metadata-check-default.log" \
+    SESSION_INDEX_LOG="$tmp_dir/session-index-default.log" \
     "$tmp_dir/infra/scripts/pr-open.sh" \
       --title "[chore] Test default PR" \
       --body-file body.md
@@ -67,5 +81,24 @@ grep -q -- '--title \[chore\] Test auto-ready PR' "$tmp_dir/pr-metadata-check.lo
 ! grep -q -- '--draft' "$tmp_dir/gh-pr-create-default.log"
 ! grep -q -- '--label auto-ready' "$tmp_dir/gh-pr-create-default.log"
 grep -q -- '--title \[chore\] Test default PR' "$tmp_dir/pr-metadata-check-default.log"
+grep -q -- 'add --pr 566' "$tmp_dir/session-index-default.log"
+grep -q -- '--issue 420' "$tmp_dir/session-index-default.log"
+grep -q -- '--worktree '"$tmp_dir" "$tmp_dir/session-index-default.log"
+
+(
+  cd "$tmp_dir"
+
+  PATH="$tmp_dir/fakebin:$PATH" \
+    GH_PR_CREATE_LOG="$tmp_dir/gh-pr-create-index-fail.log" \
+    PR_METADATA_CHECK_LOG="$tmp_dir/pr-metadata-check-index-fail.log" \
+    SESSION_INDEX_LOG="$tmp_dir/session-index-fail.log" \
+    SESSION_INDEX_EXIT=1 \
+    "$tmp_dir/infra/scripts/pr-open.sh" \
+      --title "[chore] Test index failure is non-fatal" \
+      --body-file body.md \
+      2>"$tmp_dir/index-fail.stderr"
+)
+
+grep -q -- 'warning: failed to update local Codex session index' "$tmp_dir/index-fail.stderr"
 
 echo "pr-open regression tests passed"

--- a/infra/scripts/session-index.sh
+++ b/infra/scripts/session-index.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  infra/scripts/session-index.sh add --pr <number> [--issue <number>] [--worktree <path>] [--index-file <path>]
+  infra/scripts/session-index.sh find --pr <number> [--index-file <path>]
+
+Maintains a private local Codex session index for mapping PRs back to the
+Codex IDE session title/id that produced them.
+EOF
+}
+
+codex_home() {
+  printf '%s\n' "${CODEX_HOME:-$HOME/.codex}"
+}
+
+default_index_file() {
+  printf '%s/tachigo-session-index.tsv\n' "$(codex_home)"
+}
+
+clean_tsv_field() {
+  printf '%s' "${1:-}" | tr '\t\r\n' '   '
+}
+
+pr_metadata() {
+  local pr="$1"
+
+  command -v gh >/dev/null 2>&1 || return 1
+  gh pr view "$pr" \
+    --json headRefName,commits,title,url,createdAt \
+    --jq '[.headRefName, (.commits[-1].oid // ""), .title, .url, .createdAt] | @tsv'
+}
+
+session_title_for_id() {
+  local id="$1"
+  local index_json
+  index_json="$(codex_home)/session_index.jsonl"
+
+  [ -f "$index_json" ] || return 1
+  grep -F "\"id\":\"$id\"" "$index_json" \
+    | tail -n 1 \
+    | sed -E 's/.*"thread_name":"([^"]*)".*/\1/'
+}
+
+session_id_from_file() {
+  local file="$1"
+  local base
+  base="$(basename "$file")"
+
+  printf '%s\n' "$base" \
+    | sed -E 's/^.*-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/\1/'
+}
+
+search_files() {
+  local needle="$1"
+  shift
+
+  [ -n "$needle" ] || return 0
+  if command -v rg >/dev/null 2>&1; then
+    rg -l -F "$needle" "$@" 2>/dev/null || true
+  else
+    grep -R -l -F "$needle" "$@" 2>/dev/null || true
+  fi
+}
+
+session_started_at() {
+  local file="$1"
+
+  sed -n -E '/"timestamp":/ { s/.*"timestamp":"([^"]+)".*/\1/; p; q; }' "$file"
+}
+
+score_session_file() {
+  local file="$1"
+  local branch="$2"
+  local commit="$3"
+  local pr_url="$4"
+  local pr_created_at="$5"
+  local score=0
+  local started_at=""
+
+  [ -n "$commit" ] && grep -q -F "$commit" "$file" && score=$((score + 20))
+  [ -n "$branch" ] && grep -q -F "$branch" "$file" && score=$((score + 10))
+  [ -n "$pr_url" ] && grep -q -F "$pr_url" "$file" && score=$((score + 10))
+  grep -q -F "git commit" "$file" && score=$((score + 5))
+  grep -q -F "git push" "$file" && score=$((score + 5))
+  grep -q -F "make pr-open" "$file" && score=$((score + 8))
+  grep -q -F "::git-create-pr" "$file" && score=$((score + 12))
+  grep -q -F "::git-create-branch" "$file" && score=$((score + 4))
+
+  if [ -n "$pr_created_at" ]; then
+    started_at="$(session_started_at "$file" || true)"
+    if [ -n "$started_at" ] && [[ "$started_at" > "$pr_created_at" ]]; then
+      score=$((score - 1000))
+    fi
+  fi
+
+  printf '%s\t%s\n' "$score" "$file"
+}
+
+detect_session() {
+  local branch="$1"
+  local commit="$2"
+  local pr_url="$3"
+  local pr_created_at="$4"
+  local home
+  local roots=()
+  local candidates
+  local best
+  local score
+  local file
+  local id
+  local title
+
+  home="$(codex_home)"
+  [ -d "$home/sessions" ] && roots+=("$home/sessions")
+  [ -d "$home/archived_sessions" ] && roots+=("$home/archived_sessions")
+  [ "${#roots[@]}" -gt 0 ] || return 1
+
+  candidates="$(
+    {
+      search_files "$commit" "${roots[@]}"
+      search_files "$branch" "${roots[@]}"
+      search_files "$pr_url" "${roots[@]}"
+    } | sort -u
+  )"
+  [ -n "$candidates" ] || return 1
+
+  best="$(
+    printf '%s\n' "$candidates" | while IFS= read -r file; do
+      [ -n "$file" ] || continue
+      score_session_file "$file" "$branch" "$commit" "$pr_url" "$pr_created_at"
+    done | sort -nr | head -n 1
+  )"
+
+  [ -n "$best" ] || return 1
+  score="${best%%	*}"
+  file="${best#*	}"
+  [ "$score" -gt 0 ] || return 1
+
+  id="$(session_id_from_file "$file")"
+  title="$(session_title_for_id "$id" || true)"
+  [ -n "$title" ] || title="$(basename "$file")"
+
+  printf '%s\t%s\t%s\t%s\n' "$id" "$title" "$file" "$score"
+}
+
+print_entry() {
+  local line="$1"
+  local pr issue branch commit session_id session_title session_file worktree pr_url pr_created_at indexed_at
+
+  IFS=$'\t' read -r pr issue branch commit session_id session_title session_file worktree pr_url pr_created_at indexed_at <<EOF
+$line
+EOF
+
+  printf 'PR #%s\n' "$pr"
+  [ -n "$issue" ] && printf 'Issue: #%s\n' "$issue"
+  printf 'Session title: %s\n' "$session_title"
+  printf 'Session id: %s\n' "$session_id"
+  printf 'Left nav search: %s\n' "$session_title"
+  printf 'Branch: %s\n' "$branch"
+  printf 'Commit: %s\n' "$commit"
+  printf 'Worktree: %s\n' "$worktree"
+  printf 'Session file: %s\n' "$session_file"
+  printf 'PR URL: %s\n' "$pr_url"
+  [ -n "$pr_created_at" ] && printf 'PR created at: %s\n' "$pr_created_at"
+  printf 'Indexed at: %s\n' "$indexed_at"
+}
+
+find_index_line() {
+  local pr="$1"
+  local index_file="$2"
+
+  [ -f "$index_file" ] || return 1
+  awk -F '\t' -v pr="$pr" '$1 == pr { line = $0 } END { if (line != "") print line; else exit 1 }' "$index_file"
+}
+
+cmd_add() {
+  local pr=""
+  local issue=""
+  local worktree=""
+  local index_file=""
+  local branch=""
+  local commit=""
+  local title=""
+  local pr_url=""
+  local pr_created_at=""
+  local metadata=""
+  local detected=""
+  local session_id=""
+  local session_title=""
+  local session_file=""
+  local score=""
+  local tmp_file
+  local indexed_at
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --pr) pr="${2:-}"; shift 2 ;;
+      --issue) issue="${2:-}"; shift 2 ;;
+      --worktree) worktree="${2:-}"; shift 2 ;;
+      --index-file) index_file="${2:-}"; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *) usage >&2; echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+  done
+
+  [ -n "$pr" ] || { echo "--pr is required" >&2; exit 2; }
+  [ -n "$index_file" ] || index_file="$(default_index_file)"
+  [ -n "$worktree" ] || worktree="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+  metadata="$(pr_metadata "$pr" || true)"
+  if [ -n "$metadata" ]; then
+    IFS=$'\t' read -r branch commit title pr_url pr_created_at <<EOF
+$metadata
+EOF
+  fi
+
+  detected="$(detect_session "$branch" "$commit" "$pr_url" "$pr_created_at" || true)"
+  if [ -n "$detected" ]; then
+    IFS=$'\t' read -r session_id session_title session_file score <<EOF
+$detected
+EOF
+  fi
+
+  indexed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "$(dirname "$index_file")"
+  tmp_file="$(mktemp)"
+  if [ -f "$index_file" ]; then
+    awk -F '\t' -v pr="$pr" '$1 != pr { print }' "$index_file" > "$tmp_file"
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$(clean_tsv_field "$pr")" \
+    "$(clean_tsv_field "$issue")" \
+    "$(clean_tsv_field "$branch")" \
+    "$(clean_tsv_field "$commit")" \
+    "$(clean_tsv_field "$session_id")" \
+    "$(clean_tsv_field "$session_title")" \
+    "$(clean_tsv_field "$session_file")" \
+    "$(clean_tsv_field "$worktree")" \
+    "$(clean_tsv_field "$pr_url")" \
+    "$(clean_tsv_field "$pr_created_at")" \
+    "$indexed_at" >> "$tmp_file"
+  mv "$tmp_file" "$index_file"
+
+  echo "PR #$pr indexed at $index_file"
+  if [ -n "$session_title" ]; then
+    echo "Left nav search: $session_title"
+  else
+    echo "Warning: no matching Codex session detected; try running session-find later." >&2
+  fi
+}
+
+cmd_find() {
+  local pr=""
+  local index_file=""
+  local line=""
+  local branch=""
+  local commit=""
+  local title=""
+  local pr_url=""
+  local pr_created_at=""
+  local metadata=""
+  local detected=""
+  local session_id=""
+  local session_title=""
+  local session_file=""
+  local score=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --pr) pr="${2:-}"; shift 2 ;;
+      --index-file) index_file="${2:-}"; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *) usage >&2; echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+  done
+
+  [ -n "$pr" ] || { echo "--pr is required" >&2; exit 2; }
+  [ -n "$index_file" ] || index_file="$(default_index_file)"
+
+  line="$(find_index_line "$pr" "$index_file" || true)"
+  if [ -n "$line" ]; then
+    print_entry "$line"
+    return 0
+  fi
+
+  echo "No index entry found for PR #$pr; searching Codex sessions by branch/commit..."
+  metadata="$(pr_metadata "$pr" || true)"
+  if [ -z "$metadata" ]; then
+    echo "Unable to load PR metadata with gh; cannot fallback search." >&2
+    exit 1
+  fi
+  IFS=$'\t' read -r branch commit title pr_url pr_created_at <<EOF
+$metadata
+EOF
+
+  detected="$(detect_session "$branch" "$commit" "$pr_url" "$pr_created_at" || true)"
+  if [ -z "$detected" ]; then
+    echo "No matching Codex session found." >&2
+    echo "Search keys: PR #$pr, branch '$branch', commit '$commit'"
+    exit 1
+  fi
+
+  IFS=$'\t' read -r session_id session_title session_file score <<EOF
+$detected
+EOF
+
+  printf 'PR #%s\n' "$pr"
+  printf 'Session title: %s\n' "$session_title"
+  printf 'Session id: %s\n' "$session_id"
+  printf 'Left nav search: %s\n' "$session_title"
+  printf 'Branch: %s\n' "$branch"
+  printf 'Commit: %s\n' "$commit"
+  printf 'Session file: %s\n' "$session_file"
+  printf 'PR URL: %s\n' "$pr_url"
+  printf 'PR created at: %s\n' "$pr_created_at"
+  printf 'Fallback score: %s\n' "$score"
+}
+
+main() {
+  local command="${1:-}"
+
+  case "$command" in
+    add)
+      shift
+      cmd_add "$@"
+      ;;
+    find)
+      shift
+      cmd_find "$@"
+      ;;
+    -h|--help|"")
+      usage
+      ;;
+    *)
+      usage >&2
+      echo "unknown command: $command" >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/infra/scripts/session-index.test.sh
+++ b/infra/scripts/session-index.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "$0")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+codex_home="$tmp_dir/codex"
+sessions_dir="$codex_home/sessions/2026/05/10"
+mkdir -p "$sessions_dir" "$tmp_dir/fakebin"
+
+session_id="019e07df-3d46-7913-9f70-28c1488562e7"
+session_title="檢查專案測試完整性"
+session_file="$sessions_dir/rollout-2026-05-08T22-55-31-$session_id.jsonl"
+finder_session_id="019e10ea-df65-7501-9e29-de343fbda8b4"
+finder_session_title="找出 PR #566 的 session"
+finder_session_file="$sessions_dir/rollout-2026-05-10T17-04-48-$finder_session_id.jsonl"
+branch="test/auth-persistence-failure-coverage"
+commit="418ad9175bcf5c5c2ea5edcad53b253ab44596f8"
+pr_url="https://github.com/nurockplayer/tachigo/pull/566"
+pr_created_at="2026-05-10T04:48:25Z"
+
+cat > "$codex_home/session_index.jsonl" <<EOF
+{"id":"$session_id","thread_name":"$session_title","updated_at":"2026-05-10T04:48:50Z"}
+{"id":"$finder_session_id","thread_name":"$finder_session_title","updated_at":"2026-05-10T08:05:15Z"}
+EOF
+
+cat > "$session_file" <<EOF
+{"timestamp":"2026-05-10T04:39:18Z","type":"event_msg","payload":{"type":"agent_message","message":"建立 $branch worktree"}}
+{"timestamp":"2026-05-10T04:47:03Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"git commit -m fix"}}
+{"timestamp":"2026-05-10T04:48:22Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"make pr-open TITLE=\"[backend] fix: propagate auth persistence errors\""}}
+{"timestamp":"2026-05-10T04:48:50Z","type":"event_msg","payload":{"type":"agent_message","message":"PR $pr_url commit $commit branch $branch ::git-create-pr"}}
+EOF
+
+cat > "$finder_session_file" <<EOF
+{"timestamp":"2026-05-10T08:04:48Z","type":"session_meta","payload":{"id":"$finder_session_id"}}
+{"timestamp":"2026-05-10T08:05:15Z","type":"event_msg","payload":{"type":"agent_message","message":"找出 $pr_url $commit $branch git commit git push make pr-open ::git-create-pr"}}
+EOF
+
+cat > "$tmp_dir/fakebin/gh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "\${1:-}" = "pr" ] && [ "\${2:-}" = "view" ]; then
+  printf '%s\t%s\t%s\t%s\t%s\n' "$branch" "$commit" "[backend] fix: propagate auth persistence errors" "$pr_url" "$pr_created_at"
+  exit 0
+fi
+
+echo "unexpected gh invocation: \$*" >&2
+exit 1
+EOF
+chmod +x "$tmp_dir/fakebin/gh"
+
+index_file="$tmp_dir/tachigo-session-index.tsv"
+
+PATH="$tmp_dir/fakebin:$PATH" \
+CODEX_HOME="$codex_home" \
+  "$root_dir/infra/scripts/session-index.sh" add \
+    --pr 566 \
+    --issue 420 \
+    --worktree /tmp/worktree \
+    --index-file "$index_file" \
+    > "$tmp_dir/add.out"
+
+grep -q "PR #566 indexed" "$tmp_dir/add.out"
+grep -q "$session_id" "$index_file"
+grep -q "$session_title" "$index_file"
+grep -q "$commit" "$index_file"
+
+CODEX_HOME="$codex_home" \
+  "$root_dir/infra/scripts/session-index.sh" find \
+    --pr 566 \
+    --index-file "$index_file" \
+    > "$tmp_dir/find-index.out"
+
+grep -q "Session title: $session_title" "$tmp_dir/find-index.out"
+grep -q "Session id: $session_id" "$tmp_dir/find-index.out"
+grep -q "Left nav search: $session_title" "$tmp_dir/find-index.out"
+
+rm -f "$index_file"
+
+PATH="$tmp_dir/fakebin:$PATH" \
+CODEX_HOME="$codex_home" \
+  "$root_dir/infra/scripts/session-index.sh" find \
+    --pr 566 \
+    --index-file "$index_file" \
+    > "$tmp_dir/find-fallback.out"
+
+grep -q "No index entry found" "$tmp_dir/find-fallback.out"
+grep -q "Session title: $session_title" "$tmp_dir/find-fallback.out"
+grep -q "Session id: $session_id" "$tmp_dir/find-fallback.out"
+
+echo "session-index regression tests passed"


### PR DESCRIPTION
## 什麼改動
新增本機 private Codex session index tooling，讓 PR 可以反查到對應的 Codex IDE session title / session id。

## 為什麼
closes #595

同一個 Codex session 可能後續接著完成多個任務或 PR，Codex IDE 左側 session title 不一定包含 PR number。這包提供 `make session-find PR=...`，並讓 `make pr-open` 成功後 best-effort 寫入本機索引，降低之後找不到實作 session 的機率。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#595
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 Codex IDE session title
  - 不把 session id / 本機路徑寫進公開 PR body
  - 不碰產品程式碼、backend migration、frontend UI

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 `make pr-open` 自動維護本機 private Codex session index，並提供 `make session-find PR=...` 查詢入口。
- Approx changed lines：~530
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a；這包只有 infra workflow script 與對應 regression tests。雖然行數超過 400，但 script、Makefile entrypoints、`pr-open` integration、tests 是同一個可獨立驗證的 workflow 行為，拆開會讓部分 PR 無法單獨使用。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `make session-find PR=<number>` can show which Codex IDE session title to search.
- [x] `make pr-open` best-effort writes a private local session index after PR creation.
- [x] Session indexing failure does not block PR creation.
- [x] Session metadata stays local and is not written to public PR bodies.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
bash -n infra/scripts/pr-open.sh infra/scripts/pr-open.test.sh infra/scripts/session-index.sh infra/scripts/session-index.test.sh
PASS

bash infra/scripts/session-index.test.sh
PASS: session-index regression tests passed

bash infra/scripts/pr-open.test.sh
PASS: pr-open regression tests passed
```

## 備註
`session-index.sh` 寫入的是本機 private index：`~/.codex/tachigo-session-index.tsv`。找不到 index entry 時，會用 PR branch / commit / PR URL fallback 搜本機 Codex session logs。

## Notes for Claude Code Review
- 請特別看 `pr-open.sh` 的 session-index 呼叫是否保持 best-effort，不會因本機 Codex log 或 `gh pr view` 查詢失敗而阻斷 PR 建立。
- 請確認 PR body 沒有公開寫入 session id 或本機絕對路徑。
