### PR TITLE
[backend] Rate limit public auth and receipt endpoints

### DIFF
--- a/services/api/internal/middleware/rate_limit.go
+++ b/services/api/internal/middleware/rate_limit.go
@@ -1,0 +1,121 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type RateLimitKeyFunc func(*gin.Context) string
+
+type RateLimitConfig struct {
+	Name    string
+	Limit   int
+	Window  time.Duration
+	KeyFunc RateLimitKeyFunc
+}
+
+type RateLimiter struct {
+	mu      sync.Mutex
+	now     func() time.Time
+	entries map[string]rateLimitEntry
+}
+
+type rateLimitEntry struct {
+	windowStart time.Time
+	count       int
+}
+
+func NewRateLimiter() *RateLimiter {
+	return &RateLimiter{
+		now:     time.Now,
+		entries: make(map[string]rateLimitEntry),
+	}
+}
+
+func (l *RateLimiter) Limit(cfg RateLimitConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if l == nil || cfg.Limit <= 0 || cfg.Window <= 0 {
+			c.Next()
+			return
+		}
+
+		key := cfg.Name + "|" + ClientIPRateLimitKey(c)
+		if cfg.KeyFunc != nil {
+			key = cfg.Name + "|" + cfg.KeyFunc(c)
+		}
+
+		allowed, retryAfter := l.allow(key, cfg.Limit, cfg.Window)
+		if !allowed {
+			c.Header("Retry-After", retryAfterSeconds(retryAfter))
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"success": false,
+				"error":   "rate limit exceeded",
+			})
+			return
+		}
+
+		c.Next()
+	}
+}
+
+func (l *RateLimiter) allow(key string, limit int, window time.Duration) (bool, time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	entry, ok := l.entries[key]
+	if !ok || now.Sub(entry.windowStart) >= window {
+		l.entries[key] = rateLimitEntry{windowStart: now, count: 1}
+		l.cleanupLocked(now, window)
+		return true, 0
+	}
+
+	if entry.count >= limit {
+		return false, entry.windowStart.Add(window).Sub(now)
+	}
+
+	entry.count++
+	l.entries[key] = entry
+	return true, 0
+}
+
+func retryAfterSeconds(d time.Duration) string {
+	seconds := int((d + time.Second - 1) / time.Second)
+	if seconds < 1 {
+		seconds = 1
+	}
+	return strconv.Itoa(seconds)
+}
+
+func (l *RateLimiter) cleanupLocked(now time.Time, window time.Duration) {
+	if len(l.entries) < 10000 {
+		return
+	}
+	for key, entry := range l.entries {
+		if now.Sub(entry.windowStart) >= window {
+			delete(l.entries, key)
+		}
+	}
+}
+
+func ClientIPRateLimitKey(c *gin.Context) string {
+	if ip := c.ClientIP(); ip != "" {
+		return ip
+	}
+	if c.Request == nil {
+		return "unknown"
+	}
+	host, _, err := net.SplitHostPort(c.Request.RemoteAddr)
+	if err == nil && host != "" {
+		return host
+	}
+	if c.Request.RemoteAddr != "" {
+		return c.Request.RemoteAddr
+	}
+	return "unknown"
+}

--- a/services/api/internal/middleware/rate_limit_test.go
+++ b/services/api/internal/middleware/rate_limit_test.go
@@ -1,0 +1,42 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tachigo/tachigo/internal/middleware"
+)
+
+func TestRateLimiter_Returns429AfterLimit(t *testing.T) {
+	limiter := middleware.NewRateLimiter()
+	router := gin.New()
+	router.GET("/limited", limiter.Limit(middleware.RateLimitConfig{
+		Name:    "test",
+		Limit:   2,
+		Window:  time.Minute,
+		KeyFunc: middleware.ClientIPRateLimitKey,
+	}), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	for i := 0; i < 2; i++ {
+		if got := doLimitedRequest(router); got != http.StatusOK {
+			t.Fatalf("request %d: want 200, got %d", i+1, got)
+		}
+	}
+
+	if got := doLimitedRequest(router); got != http.StatusTooManyRequests {
+		t.Fatalf("want 429 after limit, got %d", got)
+	}
+}
+
+func doLimitedRequest(router *gin.Engine) int {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/limited", nil)
+	router.ServeHTTP(rec, req)
+	return rec.Code
+}

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"time"
+
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -45,6 +47,15 @@ func New(
 	if len(internalRouterConfig) > 0 {
 		cfg = internalRouterConfig[0].Config
 	}
+	rateLimiter := middleware.NewRateLimiter()
+	publicRateLimit := func(name string) gin.HandlerFunc {
+		return rateLimiter.Limit(middleware.RateLimitConfig{
+			Name:    name,
+			Limit:   60,
+			Window:  time.Minute,
+			KeyFunc: middleware.ClientIPRateLimitKey,
+		})
+	}
 
 	authH := handlers.NewAuthHandler(authSvc, cfg).WithEmailAuth(emailAuthSvc)
 	userH := handlers.NewUserHandler(userSvc)
@@ -70,8 +81,8 @@ func New(
 	// ── Public auth endpoints ─────────────────────────────────────────────
 	auth := v1.Group("/auth")
 	{
-		auth.POST("/register", authH.Register)
-		auth.POST("/login", authH.Login)
+		auth.POST("/register", publicRateLimit("auth_register"), authH.Register)
+		auth.POST("/login", publicRateLimit("auth_login"), authH.Login)
 		auth.POST("/refresh", authH.Refresh)
 		auth.POST("/logout", authH.Logout)
 
@@ -84,15 +95,15 @@ func New(
 		auth.GET("/google/callback", authH.GoogleCallback)
 
 		// Web3 / SIWE
-		auth.POST("/web3/nonce", authH.Web3Nonce)
-		auth.POST("/web3/verify", authH.Web3Verify)
+		auth.POST("/web3/nonce", publicRateLimit("auth_web3_nonce"), authH.Web3Nonce)
+		auth.POST("/web3/verify", publicRateLimit("auth_web3_verify"), authH.Web3Verify)
 
 		// Email verification (confirm is public so users can click link without login)
 		auth.POST("/verify-email/confirm", emailH.ConfirmVerification)
 
 		// Password reset (public)
-		auth.POST("/forgot-password", emailH.ForgotPassword)
-		auth.POST("/reset-password", emailH.ResetPassword)
+		auth.POST("/forgot-password", publicRateLimit("auth_forgot_password"), emailH.ForgotPassword)
+		auth.POST("/reset-password", publicRateLimit("auth_reset_password"), emailH.ResetPassword)
 	}
 
 	// ── Claim endpoints ───────────────────────────────────────────────────
@@ -108,8 +119,8 @@ func New(
 	ext := v1.Group("/extension")
 	{
 		ext.POST("/auth/login", extH.Login)
-		ext.POST("/t-point/complete", extH.TPointComplete)
-		ext.POST("/bits/complete", extH.BitsComplete) // deprecated alias
+		ext.POST("/t-point/complete", publicRateLimit("extension_t_point_complete"), extH.TPointComplete)
+		ext.POST("/bits/complete", publicRateLimit("extension_bits_complete"), extH.BitsComplete) // deprecated alias
 
 		// Raffle result — public read (no auth required)
 		ext.GET("/raffles/:id/result", raffleH.GetResult)

--- a/services/api/internal/router/router_test.go
+++ b/services/api/internal/router/router_test.go
@@ -346,6 +346,77 @@ func migrateTestDB(db *gorm.DB) error {
 	return nil
 }
 
+func TestPublicEndpointRateLimits(t *testing.T) {
+	env := newRouterTestEnv(t)
+
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "register",
+			path: "/api/v1/auth/register",
+			body: `{}`,
+		},
+		{
+			name: "login",
+			path: "/api/v1/auth/login",
+			body: `{}`,
+		},
+		{
+			name: "forgot password",
+			path: "/api/v1/auth/forgot-password",
+			body: `{}`,
+		},
+		{
+			name: "reset password",
+			path: "/api/v1/auth/reset-password",
+			body: `{}`,
+		},
+		{
+			name: "web3 nonce",
+			path: "/api/v1/auth/web3/nonce",
+			body: `{}`,
+		},
+		{
+			name: "web3 verify",
+			path: "/api/v1/auth/web3/verify",
+			body: `{}`,
+		},
+		{
+			name: "receipt completion",
+			path: "/api/v1/extension/t-point/complete",
+			body: `{}`,
+		},
+		{
+			name: "bits receipt completion",
+			path: "/api/v1/extension/bits/complete",
+			body: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := 0; i < 70; i++ {
+				req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+				req.Header.Set("Content-Type", "application/json")
+				rec := httptest.NewRecorder()
+				env.router.ServeHTTP(rec, req)
+
+				if rec.Code == http.StatusTooManyRequests {
+					if !strings.Contains(rec.Body.String(), "rate limit exceeded") {
+						t.Fatalf("want deterministic rate limit error, got %s", rec.Body.String())
+					}
+					return
+				}
+			}
+
+			t.Fatal("expected endpoint to return 429 after repeated requests")
+		})
+	}
+}
+
 func (e *routerTestEnv) tokenForRole(t *testing.T, role models.UserRole, prefix string) (string, string) {
 	t.Helper()
 


### PR DESCRIPTION
## 什麼改動
新增 in-memory fixed-window rate limit middleware，並套用到高風險 public endpoints：

- `POST /api/v1/auth/register`
- `POST /api/v1/auth/login`
- `POST /api/v1/auth/forgot-password`
- `POST /api/v1/auth/reset-password`
- `POST /api/v1/auth/web3/nonce`
- `POST /api/v1/auth/web3/verify`
- `POST /api/v1/extension/t-point/complete`
- `POST /api/v1/extension/bits/complete`

超限時固定回 `429`、`Retry-After` header、以及 `{"success":false,"error":"rate limit exceeded"}`。

## 為什麼
closes #576

這些 public endpoints 可被用來暴力嘗試登入、觸發 email flows、探測 wallet/receipt verification 路徑，launch 前需要基本應用層防線。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#576
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不引入 Redis / distributed rate limiter
  - 不在 middleware 讀 request body 產生 secondary keys，避免 rate-limit 層引入大 body parsing 風險
  - 不限制 authenticated dashboard / extension watch endpoints

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 對 public auth 與 receipt completion endpoints 加上基本 IP-based rate limit。
- Approx changed lines：~253
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - middleware、route binding、router behavior tests 是同一個 rate limit behavior。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Repeated requests beyond configured limits return 429
- [x] Happy-path auth and receipt flows remain unaffected below the limit
- [x] Tests cover login, forgot-password, web3 verify, and receipt completion limits
- [x] Tests also cover register, reset-password, web3 nonce, and deprecated bits completion alias

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk go test ./internal/middleware -run TestRateLimiter_Returns429AfterLimit
Go test: 1 passed in 1 packages

rtk go test ./internal/router -run TestPublicEndpointRateLimits
Go test: 9 passed in 1 packages

rtk go test ./...
Go test: 588 passed in 13 packages
```

## 備註
目前每個 route + client IP 的限制是 60 requests / minute；若未來部署多 replica，需要用 gateway 或 Redis-backed limiter 取代 in-memory store。

## Notes for Claude Code Review
- 請確認 launch 前 60/min/IP 的預設是否符合產品預期；這是保守的 first-pass application-level 防線。

