### PR TITLE
[backend] Stop returning refresh tokens in auth JSON

### DIFF
--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -2361,10 +2361,18 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "tokens": {
-                    "$ref": "#/definitions/services.TokenPair"
+                    "$ref": "#/definitions/handlers.BrowserTokenPair"
                 },
                 "user": {
                     "$ref": "#/definitions/models.User"
+                }
+            }
+        },
+        "handlers.BrowserTokenPair": {
+            "type": "object",
+            "properties": {
+                "access_token": {
+                    "type": "string"
                 }
             }
         },
@@ -2461,7 +2469,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "tokens": {
-                    "$ref": "#/definitions/services.TokenPair"
+                    "$ref": "#/definitions/handlers.BrowserTokenPair"
                 }
             }
         },
@@ -2790,21 +2798,6 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 50,
                     "minLength": 3
-                }
-            }
-        },
-        "services.TokenPair": {
-            "type": "object",
-            "properties": {
-                "access_token": {
-                    "type": "string"
-                },
-                "expires_in": {
-                    "description": "seconds",
-                    "type": "integer"
-                },
-                "refresh_token": {
-                    "type": "string"
                 }
             }
         },

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -2370,9 +2370,16 @@ const docTemplate = `{
         },
         "handlers.BrowserTokenPair": {
             "type": "object",
+            "required": [
+                "access_token",
+                "expires_in"
+            ],
             "properties": {
                 "access_token": {
                     "type": "string"
+                },
+                "expires_in": {
+                    "type": "integer"
                 }
             }
         },

--- a/services/api/docs/docs_test.go
+++ b/services/api/docs/docs_test.go
@@ -130,6 +130,55 @@ func TestSwaggerDoc_NoGlobalSecurity_ProtectedOpsRequireBearerAuth(t *testing.T)
 	}
 }
 
+func TestSwaggerDoc_BrowserTokenPairDocumentsRequiredMetadata(t *testing.T) {
+	raw := SwaggerInfo.ReadDoc()
+
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal doc: %v", err)
+	}
+
+	definitions, ok := doc["definitions"].(map[string]any)
+	if !ok {
+		t.Fatalf("definitions: got %#v", doc["definitions"])
+	}
+	schema, ok := definitions["handlers.BrowserTokenPair"].(map[string]any)
+	if !ok {
+		t.Fatalf("handlers.BrowserTokenPair definition missing, got %#v", definitions["handlers.BrowserTokenPair"])
+	}
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("BrowserTokenPair properties invalid, got %#v", schema["properties"])
+	}
+	if _, ok := properties["access_token"]; !ok {
+		t.Fatalf("BrowserTokenPair must document access_token, got %#v", properties)
+	}
+	if _, ok := properties["expires_in"]; !ok {
+		t.Fatalf("BrowserTokenPair must document expires_in metadata, got %#v", properties)
+	}
+	if _, ok := properties["refresh_token"]; ok {
+		t.Fatalf("BrowserTokenPair must not document refresh_token, got %#v", properties)
+	}
+
+	required, ok := schema["required"].([]any)
+	if !ok {
+		t.Fatalf("BrowserTokenPair must declare required fields, got %#v", schema["required"])
+	}
+	requiredSet := make(map[string]bool, len(required))
+	for _, field := range required {
+		name, ok := field.(string)
+		if !ok {
+			t.Fatalf("BrowserTokenPair required field has invalid shape: %#v", field)
+		}
+		requiredSet[name] = true
+	}
+	for _, field := range []string{"access_token", "expires_in"} {
+		if !requiredSet[field] {
+			t.Fatalf("BrowserTokenPair required fields must include %s, got %#v", field, required)
+		}
+	}
+}
+
 func TestSwaggerDoc_ClaimSubmitDocumentsBadRequest(t *testing.T) {
 	raw := SwaggerInfo.ReadDoc()
 

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -2355,10 +2355,18 @@
             "type": "object",
             "properties": {
                 "tokens": {
-                    "$ref": "#/definitions/services.TokenPair"
+                    "$ref": "#/definitions/handlers.BrowserTokenPair"
                 },
                 "user": {
                     "$ref": "#/definitions/models.User"
+                }
+            }
+        },
+        "handlers.BrowserTokenPair": {
+            "type": "object",
+            "properties": {
+                "access_token": {
+                    "type": "string"
                 }
             }
         },
@@ -2455,7 +2463,7 @@
             "type": "object",
             "properties": {
                 "tokens": {
-                    "$ref": "#/definitions/services.TokenPair"
+                    "$ref": "#/definitions/handlers.BrowserTokenPair"
                 }
             }
         },
@@ -2784,21 +2792,6 @@
                     "type": "string",
                     "maxLength": 50,
                     "minLength": 3
-                }
-            }
-        },
-        "services.TokenPair": {
-            "type": "object",
-            "properties": {
-                "access_token": {
-                    "type": "string"
-                },
-                "expires_in": {
-                    "description": "seconds",
-                    "type": "integer"
-                },
-                "refresh_token": {
-                    "type": "string"
                 }
             }
         },

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -2364,9 +2364,16 @@
         },
         "handlers.BrowserTokenPair": {
             "type": "object",
+            "required": [
+                "access_token",
+                "expires_in"
+            ],
             "properties": {
                 "access_token": {
                     "type": "string"
+                },
+                "expires_in": {
+                    "type": "integer"
                 }
             }
         },

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -15,9 +15,14 @@ definitions:
   handlers.AuthResponse:
     properties:
       tokens:
-        $ref: '#/definitions/services.TokenPair'
+        $ref: '#/definitions/handlers.BrowserTokenPair'
       user:
         $ref: '#/definitions/models.User'
+    type: object
+  handlers.BrowserTokenPair:
+    properties:
+      access_token:
+        type: string
     type: object
   handlers.MessageResponse:
     properties:
@@ -80,7 +85,7 @@ definitions:
   handlers.TokensResponse:
     properties:
       tokens:
-        $ref: '#/definitions/services.TokenPair'
+        $ref: '#/definitions/handlers.BrowserTokenPair'
     type: object
   handlers.UserResponse:
     properties:
@@ -304,16 +309,6 @@ definitions:
     - email
     - password
     - username
-    type: object
-  services.TokenPair:
-    properties:
-      access_token:
-        type: string
-      expires_in:
-        description: seconds
-        type: integer
-      refresh_token:
-        type: string
     type: object
   services.UpdateProfileInput:
     properties:

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -23,6 +23,11 @@ definitions:
     properties:
       access_token:
         type: string
+      expires_in:
+        type: integer
+    required:
+    - access_token
+    - expires_in
     type: object
   handlers.MessageResponse:
     properties:

--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -85,7 +85,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	}
 
 	h.setRefreshCookie(c, tokens.RefreshToken)
-	created(c, gin.H{"user": user, "tokens": tokens})
+	created(c, gin.H{"user": user, "tokens": browserTokenPair(tokens)})
 }
 
 // Login godoc
@@ -116,7 +116,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	}
 
 	h.setRefreshCookie(c, tokens.RefreshToken)
-	ok(c, gin.H{"user": user, "tokens": tokens})
+	ok(c, gin.H{"user": user, "tokens": browserTokenPair(tokens)})
 }
 
 // Refresh godoc
@@ -147,7 +147,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 	}
 
 	h.setRefreshCookie(c, tokens.RefreshToken)
-	ok(c, gin.H{"tokens": tokens})
+	ok(c, gin.H{"tokens": browserTokenPair(tokens)})
 }
 
 // Logout godoc
@@ -207,7 +207,7 @@ func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 	}
 
 	h.setRefreshCookie(c, tokens.RefreshToken)
-	ok(c, gin.H{"user": user, "tokens": tokens})
+	ok(c, gin.H{"user": user, "tokens": browserTokenPair(tokens)})
 }
 
 // GoogleLogin godoc
@@ -246,7 +246,7 @@ func (h *AuthHandler) GoogleCallback(c *gin.Context) {
 	}
 
 	h.setRefreshCookie(c, tokens.RefreshToken)
-	ok(c, gin.H{"user": user, "tokens": tokens})
+	ok(c, gin.H{"user": user, "tokens": browserTokenPair(tokens)})
 }
 
 // Web3Nonce godoc
@@ -311,7 +311,7 @@ func (h *AuthHandler) Web3Verify(c *gin.Context) {
 	}
 
 	h.setRefreshCookie(c, tokens.RefreshToken)
-	ok(c, gin.H{"user": user, "tokens": tokens})
+	ok(c, gin.H{"user": user, "tokens": browserTokenPair(tokens)})
 }
 
 // UnlinkProvider godoc

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -32,6 +32,7 @@ func TestRegisterHandler_Success(t *testing.T) {
 		t.Error("want success: true")
 	}
 	assertRefreshCookieSet(t, w, "", http.SameSiteLaxMode, false)
+	assertTokenPayloadHasAccessOnly(t, resp)
 }
 
 func TestRegisterHandler_DuplicateEmail(t *testing.T) {
@@ -107,6 +108,7 @@ func TestLoginHandler_Success(t *testing.T) {
 		t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 	assertRefreshCookieSet(t, w, "", http.SameSiteLaxMode, false)
+	assertTokenPayloadHasAccessOnly(t, parseBody(t, w.Body.Bytes()))
 }
 
 func TestLoginHandler_SetsSecureRefreshCookieInProduction(t *testing.T) {
@@ -201,6 +203,7 @@ func TestRefreshHandler_Success(t *testing.T) {
 		t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 	assertRefreshCookieSet(t, w, refreshToken, http.SameSiteLaxMode, false)
+	assertTokenPayloadHasAccessOnly(t, parseBody(t, w.Body.Bytes()))
 }
 
 func TestRefreshHandler_SuccessWithCookie(t *testing.T) {
@@ -217,6 +220,7 @@ func TestRefreshHandler_SuccessWithCookie(t *testing.T) {
 		t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 	assertRefreshCookieSet(t, w, refreshToken, http.SameSiteLaxMode, false)
+	assertTokenPayloadHasAccessOnly(t, parseBody(t, w.Body.Bytes()))
 }
 
 func TestRefreshHandler_PrefersCookieOverBodyToken(t *testing.T) {
@@ -491,9 +495,8 @@ func TestWeb3VerifyHandler_SuccessSetsRefreshCookieAndConsumesNonce(t *testing.T
 	if !ok || accessToken == "" {
 		t.Fatalf("expected non-empty access_token in response: %#v", tokens)
 	}
-	refreshToken, ok := tokens["refresh_token"].(string)
-	if !ok || refreshToken == "" {
-		t.Fatalf("expected non-empty refresh_token in response: %#v", tokens)
+	if _, ok := tokens["refresh_token"]; ok {
+		t.Fatalf("refresh_token must not be returned in JSON response: %#v", tokens)
 	}
 
 	var provider models.AuthProvider
@@ -505,6 +508,26 @@ func TestWeb3VerifyHandler_SuccessSetsRefreshCookieAndConsumesNonce(t *testing.T
 	env.db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
 	if nonceCount != 0 {
 		t.Fatalf("nonce should be consumed, got %d rows", nonceCount)
+	}
+}
+
+func assertTokenPayloadHasAccessOnly(t *testing.T, resp map[string]interface{}) {
+	t.Helper()
+
+	data, ok := resp["data"].(map[string]interface{})
+	if !ok || data == nil {
+		t.Fatalf("expected data map in response, resp=%#v", resp)
+	}
+	tokens, ok := data["tokens"].(map[string]interface{})
+	if !ok || tokens == nil {
+		t.Fatalf("expected tokens map in response, data=%#v", data)
+	}
+	accessToken, ok := tokens["access_token"].(string)
+	if !ok || accessToken == "" {
+		t.Fatalf("expected non-empty access_token in response: %#v", tokens)
+	}
+	if _, ok := tokens["refresh_token"]; ok {
+		t.Fatalf("refresh_token must not be returned in JSON response: %#v", tokens)
 	}
 }
 

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -32,7 +32,7 @@ func TestRegisterHandler_Success(t *testing.T) {
 		t.Error("want success: true")
 	}
 	assertRefreshCookieSet(t, w, "", http.SameSiteLaxMode, false)
-	assertTokenPayloadHasAccessOnly(t, resp)
+	assertTokenPayloadHasBrowserTokens(t, resp)
 }
 
 func TestRegisterHandler_DuplicateEmail(t *testing.T) {
@@ -108,7 +108,7 @@ func TestLoginHandler_Success(t *testing.T) {
 		t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 	assertRefreshCookieSet(t, w, "", http.SameSiteLaxMode, false)
-	assertTokenPayloadHasAccessOnly(t, parseBody(t, w.Body.Bytes()))
+	assertTokenPayloadHasBrowserTokens(t, parseBody(t, w.Body.Bytes()))
 }
 
 func TestLoginHandler_SetsSecureRefreshCookieInProduction(t *testing.T) {
@@ -203,7 +203,7 @@ func TestRefreshHandler_Success(t *testing.T) {
 		t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 	assertRefreshCookieSet(t, w, refreshToken, http.SameSiteLaxMode, false)
-	assertTokenPayloadHasAccessOnly(t, parseBody(t, w.Body.Bytes()))
+	assertTokenPayloadHasBrowserTokens(t, parseBody(t, w.Body.Bytes()))
 }
 
 func TestRefreshHandler_SuccessWithCookie(t *testing.T) {
@@ -220,7 +220,7 @@ func TestRefreshHandler_SuccessWithCookie(t *testing.T) {
 		t.Errorf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 	assertRefreshCookieSet(t, w, refreshToken, http.SameSiteLaxMode, false)
-	assertTokenPayloadHasAccessOnly(t, parseBody(t, w.Body.Bytes()))
+	assertTokenPayloadHasBrowserTokens(t, parseBody(t, w.Body.Bytes()))
 }
 
 func TestRefreshHandler_PrefersCookieOverBodyToken(t *testing.T) {
@@ -498,6 +498,10 @@ func TestWeb3VerifyHandler_SuccessSetsRefreshCookieAndConsumesNonce(t *testing.T
 	if _, ok := tokens["refresh_token"]; ok {
 		t.Fatalf("refresh_token must not be returned in JSON response: %#v", tokens)
 	}
+	expiresIn, ok := tokens["expires_in"].(float64)
+	if !ok || expiresIn <= 0 {
+		t.Fatalf("expected positive expires_in in response: %#v", tokens)
+	}
 
 	var provider models.AuthProvider
 	if err := env.db.Where("provider = ? AND provider_id = ?", models.ProviderWeb3, addr).First(&provider).Error; err != nil {
@@ -511,7 +515,7 @@ func TestWeb3VerifyHandler_SuccessSetsRefreshCookieAndConsumesNonce(t *testing.T
 	}
 }
 
-func assertTokenPayloadHasAccessOnly(t *testing.T, resp map[string]interface{}) {
+func assertTokenPayloadHasBrowserTokens(t *testing.T, resp map[string]interface{}) {
 	t.Helper()
 
 	data, ok := resp["data"].(map[string]interface{})
@@ -529,6 +533,15 @@ func assertTokenPayloadHasAccessOnly(t *testing.T, resp map[string]interface{}) 
 	if _, ok := tokens["refresh_token"]; ok {
 		t.Fatalf("refresh_token must not be returned in JSON response: %#v", tokens)
 	}
+	expiresIn, ok := tokens["expires_in"].(float64)
+	if !ok || expiresIn <= 0 {
+		t.Fatalf("expected positive expires_in in response: %#v", tokens)
+	}
+}
+
+func assertTokenPayloadHasAccessOnly(t *testing.T, resp map[string]interface{}) {
+	t.Helper()
+	assertTokenPayloadHasBrowserTokens(t, resp)
 }
 
 func TestWeb3VerifyHandler_InvalidSignatureReturns401AndKeepsNonce(t *testing.T) {

--- a/services/api/internal/handlers/extension_handler.go
+++ b/services/api/internal/handlers/extension_handler.go
@@ -48,7 +48,7 @@ func (h *ExtensionHandler) Login(c *gin.Context) {
 		return
 	}
 
-	ok(c, gin.H{"user": user, "tokens": tokens})
+	ok(c, gin.H{"user": user, "tokens": browserTokenPair(tokens)})
 }
 
 // TPointComplete godoc
@@ -91,7 +91,7 @@ func (h *ExtensionHandler) TPointComplete(c *gin.Context) {
 		return
 	}
 
-	ok(c, gin.H{"user": user, "tokens": tokens})
+	ok(c, gin.H{"user": user, "tokens": browserTokenPair(tokens)})
 }
 
 // BitsComplete godoc

--- a/services/api/internal/handlers/extension_handler_test.go
+++ b/services/api/internal/handlers/extension_handler_test.go
@@ -165,6 +165,7 @@ func TestTPointComplete_DuplicateTransactionID_Returns409(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("first request: want 200, got %d: %s", w.Code, w.Body.String())
 	}
+	assertTokenPayloadHasAccessOnly(t, parseBody(t, w.Body.Bytes()))
 
 	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/extension/t-point/complete",
 		tpointBody(t, extJWT, receipt, "TPOINT100"))

--- a/services/api/internal/handlers/swagger_types.go
+++ b/services/api/internal/handlers/swagger_types.go
@@ -4,18 +4,17 @@ import (
 	"time"
 
 	"github.com/tachigo/tachigo/internal/models"
-	"github.com/tachigo/tachigo/internal/services"
 )
 
 // AuthResponse is the data payload returned on successful auth.
 type AuthResponse struct {
-	User   models.User        `json:"user"`
-	Tokens services.TokenPair `json:"tokens"`
+	User   models.User      `json:"user"`
+	Tokens BrowserTokenPair `json:"tokens"`
 }
 
 // TokensResponse is the data payload returned on token refresh.
 type TokensResponse struct {
-	Tokens services.TokenPair `json:"tokens"`
+	Tokens BrowserTokenPair `json:"tokens"`
 }
 
 // MessageResponse is a generic message payload.

--- a/services/api/internal/handlers/token_response.go
+++ b/services/api/internal/handlers/token_response.go
@@ -3,12 +3,16 @@ package handlers
 import "github.com/tachigo/tachigo/internal/services"
 
 type BrowserTokenPair struct {
-	AccessToken string `json:"access_token"`
+	AccessToken string `json:"access_token" binding:"required"`
+	ExpiresIn   int    `json:"expires_in" binding:"required"`
 }
 
 func browserTokenPair(tokens *services.TokenPair) BrowserTokenPair {
 	if tokens == nil {
 		return BrowserTokenPair{}
 	}
-	return BrowserTokenPair{AccessToken: tokens.AccessToken}
+	return BrowserTokenPair{
+		AccessToken: tokens.AccessToken,
+		ExpiresIn:   tokens.ExpiresIn,
+	}
 }

--- a/services/api/internal/handlers/token_response.go
+++ b/services/api/internal/handlers/token_response.go
@@ -1,0 +1,14 @@
+package handlers
+
+import "github.com/tachigo/tachigo/internal/services"
+
+type BrowserTokenPair struct {
+	AccessToken string `json:"access_token"`
+}
+
+func browserTokenPair(tokens *services.TokenPair) BrowserTokenPair {
+	if tokens == nil {
+		return BrowserTokenPair{}
+	}
+	return BrowserTokenPair{AccessToken: tokens.AccessToken}
+}


### PR DESCRIPTION
## 什麼改動
Auth/browser JSON responses 現在只回傳 `tokens.access_token`，不再包含 long-lived `refresh_token`；refresh token 仍會照原本流程寫入 / 輪替 httpOnly cookie。Swagger response schema 也改成 `BrowserTokenPair`。

套用範圍：
- register / login / refresh
- Twitch OAuth callback
- Google OAuth callback
- Web3 verify
- Twitch Extension login / T-Point completion response

## 為什麼
closes #577

避免前端 XSS 從 JSON payload 讀到長效 refresh token，破壞 httpOnly cookie 的保護。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#577
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不移除 refresh cookie / refresh token rotation
  - 不改 service layer `TokenPair`，因為內部仍需要 refresh token 來 set cookie
  - 不新增 non-browser client token flow

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 停止在 browser JSON response 中返回 refresh token。
- Approx changed lines：~140
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
    - [x] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - API response contract、handler behavior、Swagger docs、tests 必須同步，避免 contract 與 runtime 分岔。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Login/register/refresh responses do not include `refresh_token` in JSON
- [x] Refresh cookie behavior still works
- [x] Existing dashboard restore-session flow remains functional
- [x] API contract and tests reflect the new response shape

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk go test ./internal/handlers -run 'Test(TPointComplete_DuplicateTransactionID_Returns409|RegisterHandler_Success|LoginHandler_Success|RefreshHandler_Success|RefreshHandler_SuccessWithCookie|Web3VerifyHandler_SuccessSetsRefreshCookieAndConsumesNonce)'
Go test: 6 passed in 1 packages

rtk go test ./docs
Go test: 35 passed in 1 packages

rtk go test ./...
Go test: 578 passed in 13 packages

PATH="/Users/tachikoma/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" rtk pnpm test -- src/services/__tests__/auth.test.ts src/services/__tests__/api.interceptor.test.ts
Test Files 13 passed (13)
Tests      90 passed (90)
```

## 備註
Dashboard worktree 首次跑測試前缺 `node_modules`，已用 `pnpm install --frozen-lockfile` 安裝後重跑；沒有 lockfile 變更。

## Notes for Claude Code Review
- 請確認 Extension response 也改成 access-only 是符合預期；目前 frontend extension 只使用 access token，refresh 仍可透過重新取得 Extension JWT 流程刷新 session。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **API 变更**
  * 认证相关端点的令牌响应已改为仅返回浏览器向量（包含 access_token 与 expires_in），不再在响应体中暴露 refresh_token
  * 登录、注册、刷新与第三方回调等相关响应已同步调整

* **文档更新**
  * API 文档/规范已更新以反映新的令牌响应结构

* **测试**
  * 新增/更新测试以验证文档与响应中不包含 refresh_token 且包含必需字段

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/599)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->