### PR TITLE
[backend] Protect persisted OAuth provider tokens

### DIFF
--- a/services/api/cmd/server/main.go
+++ b/services/api/cmd/server/main.go
@@ -150,7 +150,11 @@ func main() {
 	if cfg.Server.Env == "production" && cfg.OAuth.Twitch.ClientID == "" {
 		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
 	}
-	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID, cfg.App.FrontendURL, mailer)
+	oauthTokenSecret := cfg.OAuth.TokenEncryptionKey
+	if oauthTokenSecret == "" {
+		oauthTokenSecret = cfg.JWT.RefreshSecret
+	}
+	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID, cfg.App.FrontendURL, mailer, oauthTokenSecret)
 	// Tie scheduler lifetime to server shutdown signals so the goroutine exits cleanly.
 	serverCtx, serverStop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer serverStop()

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -66,8 +66,9 @@ type JWTConfig struct {
 }
 
 type OAuthConfig struct {
-	Twitch TwitchConfig
-	Google GoogleConfig
+	Twitch             TwitchConfig
+	Google             GoogleConfig
+	TokenEncryptionKey string
 }
 
 type TwitchConfig struct {
@@ -115,6 +116,7 @@ func Load() *Config {
 			FrontendURL: getEnv("FRONTEND_URL", "http://localhost:3000"),
 		},
 		OAuth: OAuthConfig{
+			TokenEncryptionKey: getEnv("OAUTH_TOKEN_ENCRYPTION_KEY", ""),
 			Twitch: TwitchConfig{
 				ClientID:        getEnv("TWITCH_CLIENT_ID", ""),
 				ClientSecret:    getEnv("TWITCH_CLIENT_SECRET", ""),

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -405,12 +405,12 @@ func (s *AuthService) upsertOAuthUser(
 	if err == nil {
 		// Already linked – update tokens, return user
 		if token != nil {
-			at := token.AccessToken
-			rt := token.RefreshToken
-			ap.AccessToken = &at
-			ap.RefreshToken = &rt
-			ap.TokenExpiresAt = &token.Expiry
-			s.db.Save(&ap)
+			if err := s.assignProviderTokens(&ap, provider, token); err != nil {
+				return nil, nil, err
+			}
+			if err := s.db.Save(&ap).Error; err != nil {
+				return nil, nil, err
+			}
 		}
 		var user models.User
 		if err := s.db.First(&user, "id = ?", ap.UserID).Error; err != nil {
@@ -449,11 +449,9 @@ func (s *AuthService) upsertOAuthUser(
 		ProviderID: providerID,
 	}
 	if token != nil {
-		at := token.AccessToken
-		rt := token.RefreshToken
-		newAP.AccessToken = &at
-		newAP.RefreshToken = &rt
-		newAP.TokenExpiresAt = &token.Expiry
+		if err := s.assignProviderTokens(&newAP, provider, token); err != nil {
+			return nil, nil, err
+		}
 	}
 	if err := s.db.Create(&newAP).Error; err != nil {
 		return nil, nil, err
@@ -461,6 +459,37 @@ func (s *AuthService) upsertOAuthUser(
 
 	tokens, err := s.issueTokenPair(&user)
 	return &user, tokens, err
+}
+
+func (s *AuthService) assignProviderTokens(ap *models.AuthProvider, provider models.ProviderType, token *oauth2.Token) error {
+	ap.AccessToken = nil
+	ap.RefreshToken = nil
+	ap.TokenExpiresAt = nil
+
+	if provider != models.ProviderTwitch || token == nil || token.AccessToken == "" {
+		return nil
+	}
+
+	cipher := newOAuthTokenCipher(s.oauthTokenEncryptionSecret())
+	encrypted, err := cipher.encrypt(token.AccessToken)
+	if err != nil {
+		return err
+	}
+	ap.AccessToken = &encrypted
+	if !token.Expiry.IsZero() {
+		ap.TokenExpiresAt = &token.Expiry
+	}
+	return nil
+}
+
+func (s *AuthService) oauthTokenEncryptionSecret() string {
+	if s == nil || s.cfg == nil {
+		return ""
+	}
+	if s.cfg.OAuth.TokenEncryptionKey != "" {
+		return s.cfg.OAuth.TokenEncryptionKey
+	}
+	return s.cfg.JWT.RefreshSecret
 }
 
 // ─── Utility ─────────────────────────────────────────────────────────────────

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -1,12 +1,15 @@
 package services
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/oauth2"
 
 	"github.com/tachigo/tachigo/internal/models"
 )
@@ -39,6 +42,102 @@ func TestRegister_Success(t *testing.T) {
 	}
 	if user.Role != models.RoleViewer {
 		t.Errorf("role: want viewer, got %s", user.Role)
+	}
+}
+
+func TestOAuthUser_PersistsOnlyEncryptedTwitchAccessToken(t *testing.T) {
+	db := newTestDB(t)
+	cfg := testConfig()
+	cfg.OAuth.TokenEncryptionKey = "oauth-token-encryption-secret"
+	svc := NewAuthService(db, cfg)
+
+	expiry := time.Now().Add(time.Hour)
+	_, _, err := svc.upsertOAuthUser(
+		context.Background(),
+		models.ProviderTwitch,
+		"twitch-broadcaster-1",
+		"twitch-user",
+		"twitch-user@example.com",
+		nil,
+		&oauth2.Token{
+			AccessToken:  "plain-access-token",
+			RefreshToken: "plain-refresh-token",
+			Expiry:       expiry,
+		},
+	)
+	if err != nil {
+		t.Fatalf("upsertOAuthUser: %v", err)
+	}
+
+	var ap models.AuthProvider
+	if err := db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, "twitch-broadcaster-1").First(&ap).Error; err != nil {
+		t.Fatalf("load auth provider: %v", err)
+	}
+	if ap.AccessToken == nil {
+		t.Fatal("expected encrypted Twitch access token to be persisted")
+	}
+	if *ap.AccessToken == "plain-access-token" || strings.Contains(*ap.AccessToken, "plain-access-token") {
+		t.Fatalf("access token persisted in plaintext: %q", *ap.AccessToken)
+	}
+	if !strings.HasPrefix(*ap.AccessToken, encryptedOAuthTokenPrefix) {
+		t.Fatalf("expected encrypted token prefix %q, got %q", encryptedOAuthTokenPrefix, *ap.AccessToken)
+	}
+	if ap.RefreshToken != nil {
+		t.Fatalf("provider refresh token should not be persisted, got %q", *ap.RefreshToken)
+	}
+
+	decrypted, err := newOAuthTokenCipher(cfg.OAuth.TokenEncryptionKey).decrypt(*ap.AccessToken)
+	if err != nil {
+		t.Fatalf("decrypt persisted token: %v", err)
+	}
+	if decrypted != "plain-access-token" {
+		t.Fatalf("expected decrypted access token, got %q", decrypted)
+	}
+
+	rawJSON, err := json.Marshal(ap)
+	if err != nil {
+		t.Fatalf("marshal auth provider: %v", err)
+	}
+	if strings.Contains(string(rawJSON), "plain-access-token") || strings.Contains(string(rawJSON), *ap.AccessToken) {
+		t.Fatalf("auth provider JSON exposed token material: %s", rawJSON)
+	}
+}
+
+func TestOAuthUser_DoesNotPersistUnusedGoogleTokens(t *testing.T) {
+	db := newTestDB(t)
+	cfg := testConfig()
+	cfg.OAuth.TokenEncryptionKey = "oauth-token-encryption-secret"
+	svc := NewAuthService(db, cfg)
+
+	_, _, err := svc.upsertOAuthUser(
+		context.Background(),
+		models.ProviderGoogle,
+		"google-user-1",
+		"google-user",
+		"google-user@example.com",
+		nil,
+		&oauth2.Token{
+			AccessToken:  "google-access-token",
+			RefreshToken: "google-refresh-token",
+			Expiry:       time.Now().Add(time.Hour),
+		},
+	)
+	if err != nil {
+		t.Fatalf("upsertOAuthUser: %v", err)
+	}
+
+	var ap models.AuthProvider
+	if err := db.Where("provider = ? AND provider_id = ?", models.ProviderGoogle, "google-user-1").First(&ap).Error; err != nil {
+		t.Fatalf("load auth provider: %v", err)
+	}
+	if ap.AccessToken != nil {
+		t.Fatalf("google access token should not be persisted, got %q", *ap.AccessToken)
+	}
+	if ap.RefreshToken != nil {
+		t.Fatalf("google refresh token should not be persisted, got %q", *ap.RefreshToken)
+	}
+	if ap.TokenExpiresAt != nil {
+		t.Fatalf("google token expiry should not be persisted, got %v", ap.TokenExpiresAt)
 	}
 }
 

--- a/services/api/internal/services/oauth_token_crypto.go
+++ b/services/api/internal/services/oauth_token_crypto.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const encryptedOAuthTokenPrefix = "enc:v1:"
+
+var ErrOAuthTokenEncryptionKeyMissing = errors.New("oauth token encryption key is missing")
+
+type oauthTokenCipher struct {
+	key []byte
+}
+
+func newOAuthTokenCipher(secret string) *oauthTokenCipher {
+	if secret == "" {
+		return &oauthTokenCipher{}
+	}
+	sum := sha256.Sum256([]byte(secret))
+	return &oauthTokenCipher{key: sum[:]}
+}
+
+func (c *oauthTokenCipher) enabled() bool {
+	return c != nil && len(c.key) > 0
+}
+
+func (c *oauthTokenCipher) encrypt(plaintext string) (string, error) {
+	if plaintext == "" {
+		return "", nil
+	}
+	if !c.enabled() {
+		return "", ErrOAuthTokenEncryptionKeyMissing
+	}
+
+	block, err := aes.NewCipher(c.key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return encryptedOAuthTokenPrefix + base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func (c *oauthTokenCipher) decrypt(stored string) (string, error) {
+	if stored == "" {
+		return "", nil
+	}
+	if !strings.HasPrefix(stored, encryptedOAuthTokenPrefix) {
+		return stored, nil
+	}
+	if !c.enabled() {
+		return "", ErrOAuthTokenEncryptionKeyMissing
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(stored, encryptedOAuthTokenPrefix))
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(c.key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) < gcm.NonceSize() {
+		return "", fmt.Errorf("encrypted oauth token is too short")
+	}
+	nonce, ciphertext := raw[:gcm.NonceSize()], raw[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plaintext), nil
+}

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -54,9 +54,14 @@ type RaffleService struct {
 	httpClient     *http.Client
 	mailer         Mailer
 	frontendURL    string
+	tokenCipher    *oauthTokenCipher
 }
 
-func NewRaffleService(db *gorm.DB, twitchClientID, frontendURL string, mailer Mailer) *RaffleService {
+func NewRaffleService(db *gorm.DB, twitchClientID, frontendURL string, mailer Mailer, tokenEncryptionSecret ...string) *RaffleService {
+	secret := ""
+	if len(tokenEncryptionSecret) > 0 {
+		secret = tokenEncryptionSecret[0]
+	}
 	return &RaffleService{
 		db:             db,
 		twitchClientID: twitchClientID,
@@ -64,6 +69,7 @@ func NewRaffleService(db *gorm.DB, twitchClientID, frontendURL string, mailer Ma
 		httpClient:     &http.Client{Timeout: 10 * time.Second},
 		mailer:         mailer,
 		frontendURL:    frontendURL,
+		tokenCipher:    newOAuthTokenCipher(secret),
 	}
 }
 
@@ -551,15 +557,26 @@ func (s *RaffleService) SyncFromTwitchAPI(ctx context.Context, raffleID, userID 
 		}
 		return nil, err
 	}
-	if ap.AccessToken == nil {
+	accessToken, err := s.decryptedProviderAccessToken(&ap)
+	if err != nil {
+		return nil, err
+	}
+	if accessToken == "" {
+		return nil, ErrTwitchTokenMissing
+	}
+	if ap.TokenExpiresAt != nil && time.Now().After(*ap.TokenExpiresAt) {
+		s.clearProviderTokens(ap.ID)
 		return nil, ErrTwitchTokenMissing
 	}
 
 	result := &SyncFromTwitchResult{}
 	cursor := ""
 	for {
-		subs, nextCursor, err := s.fetchTwitchSubsPage(ctx, *ap.AccessToken, ap.ProviderID, cursor)
+		subs, nextCursor, err := s.fetchTwitchSubsPage(ctx, accessToken, ap.ProviderID, cursor)
 		if err != nil {
+			if errors.Is(err, ErrTwitchInsufficientScope) {
+				s.clearProviderTokens(ap.ID)
+			}
 			return nil, err
 		}
 
@@ -604,6 +621,30 @@ func (s *RaffleService) SyncFromTwitchAPI(ctx context.Context, raffleID, userID 
 	}
 
 	return result, nil
+}
+
+func (s *RaffleService) decryptedProviderAccessToken(ap *models.AuthProvider) (string, error) {
+	if ap == nil || ap.AccessToken == nil {
+		return "", nil
+	}
+	cipher := s.tokenCipher
+	if cipher == nil {
+		cipher = newOAuthTokenCipher("")
+	}
+	return cipher.decrypt(*ap.AccessToken)
+}
+
+func (s *RaffleService) clearProviderTokens(providerID uuid.UUID) {
+	if s == nil || s.db == nil || providerID == uuid.Nil {
+		return
+	}
+	_ = s.db.Model(&models.AuthProvider{}).
+		Where("id = ?", providerID).
+		Updates(map[string]interface{}{
+			"access_token":     nil,
+			"refresh_token":    nil,
+			"token_expires_at": nil,
+		}).Error
 }
 
 // ── Scheduled snapshot (cron) ─────────────────────────────────────────────────

--- a/services/api/internal/services/raffle_service_oauth_token_test.go
+++ b/services/api/internal/services/raffle_service_oauth_token_test.go
@@ -1,0 +1,107 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/models"
+	"github.com/tachigo/tachigo/internal/testutil"
+)
+
+func TestSyncFromTwitchAPI_UsesEncryptedStoredAccessToken(t *testing.T) {
+	db := newTestDB(t)
+	secret := "oauth-token-encryption-secret"
+	encryptedToken, err := newOAuthTokenCipher(secret).encrypt("streamer-access-token")
+	if err != nil {
+		t.Fatalf("encrypt token: %v", err)
+	}
+
+	ownerID := seedUserWithEmail(t, db, "streamer@example.com")
+	viewerID := seedUserWithEmail(t, db, "viewer@example.com")
+	raffleID := uuid.New()
+
+	if err := db.Exec(`
+		INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, token_expires_at, created_at, updated_at)
+		VALUES (?, ?, 'twitch', 'broadcaster-1', ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, uuid.New().String(), ownerID.String(), encryptedToken, time.Now().Add(time.Hour)).Error; err != nil {
+		t.Fatalf("insert streamer provider: %v", err)
+	}
+	if err := db.Exec(`
+		INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at)
+		VALUES (?, ?, 'twitch', 'viewer-1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, uuid.New().String(), viewerID.String()).Error; err != nil {
+		t.Fatalf("insert viewer provider: %v", err)
+	}
+	if err := db.Exec(`
+		INSERT INTO raffles (id, user_id, title, status, source, created_at, updated_at)
+		VALUES (?, ?, 'Encrypted Token Raffle', 'draft', 'twitch_api', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, raffleID.String(), ownerID.String()).Error; err != nil {
+		t.Fatalf("insert raffle: %v", err)
+	}
+
+	svc := NewRaffleService(db, "client-id", "", nil, secret)
+	svc.SetTwitchBaseURL("https://twitch.test")
+	svc.SetHTTPClient(testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if got := r.Header.Get("Authorization"); got != "Bearer streamer-access-token" {
+			t.Fatalf("expected decrypted bearer token, got %q", got)
+		}
+		return testutil.NewStringResponse(http.StatusOK, `{"data":[{"user_id":"viewer-1","user_login":"viewer","user_name":"Viewer"}],"pagination":{}}`), nil
+	}))
+
+	result, err := svc.SyncFromTwitchAPI(context.Background(), raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("SyncFromTwitchAPI: %v", err)
+	}
+	if result.Imported != 1 || result.Skipped != 0 {
+		t.Fatalf("expected imported=1 skipped=0, got %#v", result)
+	}
+
+	var entry models.RaffleEntry
+	if err := db.Where("raffle_id = ? AND twitch_login = ?", raffleID, "viewer").First(&entry).Error; err != nil {
+		t.Fatalf("expected imported raffle entry: %v", err)
+	}
+}
+
+func TestSyncFromTwitchAPI_ClearsExpiredStoredAccessToken(t *testing.T) {
+	db := newTestDB(t)
+	secret := "oauth-token-encryption-secret"
+	encryptedToken, err := newOAuthTokenCipher(secret).encrypt("expired-token")
+	if err != nil {
+		t.Fatalf("encrypt token: %v", err)
+	}
+
+	ownerID := seedUserWithEmail(t, db, "expired-streamer@example.com")
+	raffleID := uuid.New()
+	providerID := uuid.New()
+	if err := db.Exec(`
+		INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, token_expires_at, created_at, updated_at)
+		VALUES (?, ?, 'twitch', 'broadcaster-expired', ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, providerID.String(), ownerID.String(), encryptedToken, time.Now().Add(-time.Minute)).Error; err != nil {
+		t.Fatalf("insert provider: %v", err)
+	}
+	if err := db.Exec(`
+		INSERT INTO raffles (id, user_id, title, status, source, created_at, updated_at)
+		VALUES (?, ?, 'Expired Token Raffle', 'draft', 'twitch_api', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, raffleID.String(), ownerID.String()).Error; err != nil {
+		t.Fatalf("insert raffle: %v", err)
+	}
+
+	svc := NewRaffleService(db, "client-id", "", nil, secret)
+	_, err = svc.SyncFromTwitchAPI(context.Background(), raffleID, ownerID)
+	if !errors.Is(err, ErrTwitchTokenMissing) {
+		t.Fatalf("expected ErrTwitchTokenMissing, got %v", err)
+	}
+
+	var ap models.AuthProvider
+	if err := db.First(&ap, "id = ?", providerID).Error; err != nil {
+		t.Fatalf("load provider: %v", err)
+	}
+	if ap.AccessToken != nil || ap.RefreshToken != nil || ap.TokenExpiresAt != nil {
+		t.Fatalf("expected expired token material to be cleared, got access=%v refresh=%v expiry=%v", ap.AccessToken, ap.RefreshToken, ap.TokenExpiresAt)
+	}
+}


### PR DESCRIPTION
## 什麼改動
OAuth provider token persistence is now minimized and protected:

- Google access/refresh tokens are no longer persisted after login.
- Twitch provider refresh tokens are no longer persisted.
- Twitch access tokens needed by raffle subscriber snapshot sync are stored encrypted with AES-GCM using the `enc:v1:` format.
- Raffle snapshot sync decrypts stored Twitch tokens before calling Twitch, keeps legacy plaintext token reads for migration, and clears stored token material when the token is expired or Twitch returns an authorization failure.
- Added `OAUTH_TOKEN_ENCRYPTION_KEY`, falling back to `JWT_REFRESH_SECRET` when unset.

## 為什麼
Closes #578.

OAuth provider access and refresh tokens were persisted as plaintext in `auth_providers`. A database dump or read-only DB compromise could expose Twitch/Google provider credentials directly. This PR avoids storing tokens that are not needed and encrypts the one token still needed for Twitch raffle snapshot sync.

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#578
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Does not add a new DB schema or migration.
  - Does not add external KMS integration.
  - Does not change OAuth login response contracts.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Minimize persisted OAuth provider tokens and encrypt the Twitch token still required for raffle sync.
- Approx changed lines：~390
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The crypto helper, OAuth persistence behavior, raffle token retrieval, and tests are one security behavior change for #578.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Persisted provider tokens are encrypted at rest or no longer stored.
- [x] Raffle Twitch snapshot still works for authorized streamers.
- [x] Tests cover token persistence and retrieval without exposing plaintext values in model JSON/logs.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk go test ./internal/services -run 'Test(OAuthUser_PersistsOnlyEncryptedTwitchAccessToken|OAuthUser_DoesNotPersistUnusedGoogleTokens|SyncFromTwitchAPI_UsesEncryptedStoredAccessToken|SyncFromTwitchAPI_ClearsExpiredStoredAccessToken)'
Go test: 4 passed in 1 packages.

rtk go test ./...
Go test: 582 passed in 13 packages.
```

## 備註
`OAUTH_TOKEN_ENCRYPTION_KEY` should be set in production so token encryption can be rotated independently from JWT signing secrets. Existing legacy plaintext Twitch access tokens remain readable during migration and are replaced with encrypted values on the next OAuth login.

## Notes for Claude Code Review
- Review the fallback secret behavior: `OAUTH_TOKEN_ENCRYPTION_KEY` is preferred, `JWT_REFRESH_SECRET` is used only when the dedicated key is unset.
- Confirm the token-clearing behavior on expired tokens or Twitch 401/403 matches expected streamer re-login UX.
