### PR TITLE
[frontend] Display extension point balance

### DIFF
--- a/apps/extension/src/TwitchApp.tsx
+++ b/apps/extension/src/TwitchApp.tsx
@@ -5,6 +5,7 @@ import { useTPoint } from './hooks/useTPoint'
 import { useHeartbeat } from './hooks/useHeartbeat'
 import { useClickBoost } from './hooks/useClickBoost'
 import { claimPoints, getTachiBalance } from './services/api'
+import { PointsDisplay } from './components/PointsDisplay'
 
 type ClaimErrorKey = 'loadBalanceFailed' | 'claimFailed'
 
@@ -16,7 +17,7 @@ export default function App() {
   const [tachiBalance, setTachiBalance] = useState<number | null>(null)
   const [claimStatus, setClaimStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle')
   const [claimError, setClaimError] = useState<ClaimErrorKey | null>(null)
-  const { balance, gain, isAnimating, syncBalance } = useHeartbeat(context?.channelId, {
+  const { balance, cumulativeTotal, gain, isAnimating, syncBalance } = useHeartbeat(context?.channelId, {
     enabled: isViewer && backendReady,
   })
   const {
@@ -108,15 +109,12 @@ export default function App() {
       </header>
 
       <div className="ext-body">
-        <section className="ext-balance-wrap">
-          <div className={`ext-balance ${isAnimating ? 'ext-balance--bump' : ''}`}>
-            <span className="ext-balance__label">Points</span>
-            <strong className="ext-balance__value">{balance?.toLocaleString() ?? '—'}</strong>
-          </div>
-          {gain !== null && gain > 0 && (
-            <span className="ext-balance-gain">+{gain.toLocaleString()} {t('common.points')}</span>
-          )}
-        </section>
+        <PointsDisplay
+          spendableBalance={balance}
+          cumulativeTotal={cumulativeTotal}
+          gain={gain}
+          isAnimating={isAnimating}
+        />
 
         <section className="ext-claim">
           <div>

--- a/apps/extension/src/components/PointsDisplay.tsx
+++ b/apps/extension/src/components/PointsDisplay.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next'
+
+interface PointsDisplayProps {
+  spendableBalance: number | null
+  cumulativeTotal: number | null
+  gain: number | null
+  isAnimating: boolean
+}
+
+function formatBalance(value: number | null) {
+  return value?.toLocaleString() ?? '...'
+}
+
+export function PointsDisplay({
+  spendableBalance,
+  cumulativeTotal,
+  gain,
+  isAnimating,
+}: PointsDisplayProps) {
+  const { t } = useTranslation()
+
+  return (
+    <section className="ext-balance-wrap" aria-label={t('hud.pointsBalance')}>
+      <div className={`ext-balance ${isAnimating ? 'ext-balance--bump' : ''}`}>
+        <div className="ext-balance__metric">
+          <span className="ext-balance__label">{t('hud.availableBalance')}</span>
+          <strong className="ext-balance__value">{formatBalance(spendableBalance)}</strong>
+        </div>
+        <div className="ext-balance__metric ext-balance__metric--secondary">
+          <span className="ext-balance__label">{t('hud.cumulativeTotal')}</span>
+          <strong className="ext-balance__value">{formatBalance(cumulativeTotal)}</strong>
+        </div>
+      </div>
+      {gain !== null && gain > 0 && (
+        <span className="ext-balance-gain">+{gain.toLocaleString()} {t('common.points')}</span>
+      )}
+    </section>
+  )
+}

--- a/apps/extension/src/hooks/useHeartbeat.ts
+++ b/apps/extension/src/hooks/useHeartbeat.ts
@@ -9,6 +9,7 @@ interface UseHeartbeatOptions {
 export function useHeartbeat(channelId: string | undefined, options: UseHeartbeatOptions = {}) {
   const { enabled = true, intervalMs = 30_000 } = options
   const [balance, setBalance] = useState<number | null>(null)
+  const [cumulativeTotal, setCumulativeTotal] = useState<number | null>(null)
   const [gain, setGain] = useState<number | null>(null)
   const [isAnimating, setIsAnimating] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -26,6 +27,7 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
     clearAnimationTimer()
     lastBalanceRef.current = null
     setBalance(null)
+    setCumulativeTotal(null)
     setGain(null)
     setIsAnimating(false)
     setError(null)
@@ -69,6 +71,7 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
         const nextBalance = data.balance
         const prevBalance = lastBalanceRef.current
         setBalance(nextBalance)
+        setCumulativeTotal(data.cumulativeTotal)
 
         if (prevBalance !== null && nextBalance > prevBalance) {
           setGain(nextBalance - prevBalance)
@@ -121,5 +124,5 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
     setBalance(newBalance)
   }, [])
 
-  return { balance, gain, isAnimating, error, syncBalance }
+  return { balance, cumulativeTotal, gain, isAnimating, error, syncBalance }
 }

--- a/apps/extension/src/i18n/locales/en/common.json
+++ b/apps/extension/src/i18n/locales/en/common.json
@@ -17,6 +17,8 @@
     "bgmOn": "♪ ON",
     "bgmOff": "♪ OFF",
     "tabAudioUnavailable": "TAB AUDIO OFF",
+    "pointsBalance": "Points balance",
+    "availableBalance": "AVAILABLE",
     "cumulativeTotal": "CUMULATIVE TOTAL",
     "nextIn": "NEXT IN {{count}}S",
     "clicksLeft": "{{count}} / 30 CLICKS",

--- a/apps/extension/src/i18n/locales/zh-CN/common.json
+++ b/apps/extension/src/i18n/locales/zh-CN/common.json
@@ -17,6 +17,8 @@
     "bgmOn": "♪ 开",
     "bgmOff": "♪ 关",
     "tabAudioUnavailable": "分页音频不可用",
+    "pointsBalance": "点数余额",
+    "availableBalance": "可用",
     "cumulativeTotal": "累计总计",
     "nextIn": "下次 {{count}} 秒",
     "clicksLeft": "剩 {{count}} 次",

--- a/apps/extension/src/i18n/locales/zh-TW/common.json
+++ b/apps/extension/src/i18n/locales/zh-TW/common.json
@@ -17,6 +17,8 @@
     "bgmOn": "♪ 開",
     "bgmOff": "♪ 關",
     "tabAudioUnavailable": "分頁音訊不可用",
+    "pointsBalance": "點數餘額",
+    "availableBalance": "可用",
     "cumulativeTotal": "累計總計",
     "nextIn": "下次 {{count}} 秒",
     "clicksLeft": "剩 {{count}} 次",

--- a/apps/extension/src/index.css
+++ b/apps/extension/src/index.css
@@ -98,10 +98,10 @@ p  { margin: 0; }
 }
 
 .ext-balance {
-  display: flex;
-  align-items: baseline;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   justify-content: space-between;
-  gap: 8px;
+  gap: 10px;
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -112,15 +112,26 @@ p  { margin: 0; }
   animation: balance-bump 450ms ease;
 }
 
+.ext-balance__metric {
+  min-width: 0;
+}
+
+.ext-balance__metric--secondary {
+  text-align: right;
+}
+
 .ext-balance__label {
+  display: block;
   font-size: 12px;
   color: var(--text);
 }
 
 .ext-balance__value {
+  display: block;
   font-size: 18px;
   color: var(--text-h);
   letter-spacing: -0.2px;
+  overflow-wrap: anywhere;
 }
 
 .ext-balance-gain {

--- a/apps/extension/src/services/api.test.ts
+++ b/apps/extension/src/services/api.test.ts
@@ -140,6 +140,61 @@ test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes poin
   )
 })
 
+test('sendHeartbeat falls back when point balance response is missing cumulative total', async () => {
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/start') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { started: true } }))
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/watch/heartbeat') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { points_earned: 2 } }))
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/users/me/points?channel_id=channel-123') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { spendable_balance: 42 } }))
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl) => {
+      const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+
+      try {
+        vi.resetModules()
+        const api = await import('./api.ts')
+
+        api.setAuthToken('tachigo-access-token')
+        const result = await api.sendHeartbeat('channel-123', 40)
+
+        assert.deepEqual(result, { balance: 42, cumulativeTotal: null })
+      } finally {
+        if (originalBaseUrl === undefined) {
+          delete process.env.VITE_TACHIGO_API_URL
+        } else {
+          process.env.VITE_TACHIGO_API_URL = originalBaseUrl
+        }
+      }
+    },
+  )
+})
+
 test('sendClick ensures the watch session exists before sending click rewards', async () => {
   await withApiServer(
     (requests) => async (req, res) => {

--- a/apps/extension/src/services/api.test.ts
+++ b/apps/extension/src/services/api.test.ts
@@ -52,7 +52,7 @@ async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
   return JSON.parse(Buffer.concat(chunks).toString('utf8'))
 }
 
-test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes balance', async () => {
+test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes point balance', async () => {
   await withApiServer(
     (requests) => async (req, res) => {
       const body = await readJsonBody(req)
@@ -75,12 +75,12 @@ test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes bala
         return
       }
 
-      if (req.method === 'GET' && req.url === '/api/v1/extension/watch/balance?channel_id=channel-123') {
+      if (req.method === 'GET' && req.url === '/api/v1/users/me/points?channel_id=channel-123') {
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(
           JSON.stringify({
             success: true,
-            data: { spendable_balance: 42, cumulative_total: 42 },
+            data: { spendable_balance: 42, cumulative_total: 77 },
           }),
         )
         return
@@ -100,7 +100,7 @@ test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes bala
         api.setAuthToken('tachigo-access-token')
         const result = await api.sendHeartbeat('channel-123')
 
-        assert.equal(result.balance, 42)
+        assert.deepEqual(result, { balance: 42, cumulativeTotal: 77 })
         assert.deepEqual(
           requests.map(({ method, url, authorization, body }) => ({
             method,
@@ -123,7 +123,7 @@ test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes bala
             },
             {
               method: 'GET',
-              url: '/api/v1/extension/watch/balance?channel_id=channel-123',
+              url: '/api/v1/users/me/points?channel_id=channel-123',
               authorization: 'Bearer tachigo-access-token',
               body: null,
             },
@@ -322,7 +322,7 @@ test('sendHeartbeat re-authenticates after 401 and falls back to previous balanc
         return
       }
 
-      if (req.method === 'GET' && req.url === '/api/v1/extension/watch/balance?channel_id=channel-123') {
+      if (req.method === 'GET' && req.url === '/api/v1/users/me/points?channel_id=channel-123') {
         res.writeHead(503, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ success: false, error: 'temporary unavailable' }))
         return
@@ -343,7 +343,7 @@ test('sendHeartbeat re-authenticates after 401 and falls back to previous balanc
         api.setAuthToken('expired-access-token')
         const result = await api.sendHeartbeat('channel-123', 40)
 
-        assert.equal(result.balance, 42)
+        assert.deepEqual(result, { balance: 42, cumulativeTotal: null })
         assert.deepEqual(
           requests.map(({ method, url, authorization, body }) => ({
             method,
@@ -378,7 +378,7 @@ test('sendHeartbeat re-authenticates after 401 and falls back to previous balanc
             },
             {
               method: 'GET',
-              url: '/api/v1/extension/watch/balance?channel_id=channel-123',
+              url: '/api/v1/users/me/points?channel_id=channel-123',
               authorization: 'Bearer refreshed-access-token',
               body: null,
             },

--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -115,10 +115,16 @@ async function runWithAuthRecovery<T>(
 
 interface HeartbeatResponse {
   balance: number
+  cumulativeTotal: number | null
 }
 
 interface TachiBalanceResponse {
   tachiBalance: number
+}
+
+interface PointBalanceResponse {
+  spendableBalance: number
+  cumulativeTotal: number
 }
 
 export interface RedeemCouponResponse {
@@ -139,27 +145,30 @@ function parsePointsEarnedFromPayload(payload: unknown): number | null {
   return value
 }
 
-function parseBalanceFromPayload(payload: unknown): number {
+function parsePointBalanceFromPayload(payload: unknown): PointBalanceResponse {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid balance response')
+    throw new Error('Invalid point balance response')
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const raw = payload as any
-  const direct = raw.balance
-  const nested = raw.data?.balance
   const legacy = raw.points_balance
   const spendable = raw.spendable_balance
   const nestedSpendable = raw.data?.spendable_balance
+  const cumulative = raw.cumulative_total
+  const nestedCumulative = raw.data?.cumulative_total
 
-  const value = [direct, nested, legacy, spendable, nestedSpendable].find(
+  const spendableBalance = [spendable, nestedSpendable, legacy].find(
     (candidate) => typeof candidate === 'number',
   )
-  if (typeof value !== 'number') {
-    throw new Error('Balance response missing balance')
+  const cumulativeTotal = [cumulative, nestedCumulative, spendableBalance].find(
+    (candidate) => typeof candidate === 'number',
+  )
+  if (typeof spendableBalance !== 'number' || typeof cumulativeTotal !== 'number') {
+    throw new Error('Point balance response missing balance')
   }
 
-  return value
+  return { spendableBalance, cumulativeTotal }
 }
 
 function parseTachiBalanceFromPayload(payload: unknown): number {
@@ -188,13 +197,13 @@ async function ensureWatchSession(channelId: string) {
   await runWithAuthRecovery((config) => client.post('/api/v1/extension/watch/start', { channel_id: channelId }, config))
 }
 
-async function getWatchBalance(channelId: string): Promise<number> {
-  const { data } = await runWithAuthRecovery((config) => client.get('/api/v1/extension/watch/balance', {
+export async function getPointBalance(channelId: string): Promise<PointBalanceResponse> {
+  const { data } = await runWithAuthRecovery((config) => client.get('/api/v1/users/me/points', {
     ...config,
     params: { channel_id: channelId },
   }))
 
-  return parseBalanceFromPayload(data)
+  return parsePointBalanceFromPayload(data)
 }
 
 export async function sendClick(channelId: string): Promise<ClickResponse> {
@@ -266,19 +275,23 @@ export async function sendHeartbeat(
     }, config))
 
   try {
+    const pointBalance = await getPointBalance(channelId)
     return {
-      balance: await getWatchBalance(channelId),
+      balance: pointBalance.spendableBalance,
+      cumulativeTotal: pointBalance.cumulativeTotal,
     }
   } catch {
     const pointsEarned = parsePointsEarnedFromPayload(heartbeatResponse.data)
     if (typeof previousBalance === 'number') {
       return {
         balance: previousBalance + Math.max(pointsEarned ?? 0, 0),
+        cumulativeTotal: null,
       }
     }
 
     return {
       balance: Math.max(pointsEarned ?? 0, 0),
+      cumulativeTotal: null,
     }
   }
 }

--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -161,11 +161,11 @@ function parsePointBalanceFromPayload(payload: unknown): PointBalanceResponse {
   const spendableBalance = [spendable, nestedSpendable, legacy].find(
     (candidate) => typeof candidate === 'number',
   )
-  const cumulativeTotal = [cumulative, nestedCumulative, spendableBalance].find(
+  const cumulativeTotal = [cumulative, nestedCumulative].find(
     (candidate) => typeof candidate === 'number',
   )
   if (typeof spendableBalance !== 'number' || typeof cumulativeTotal !== 'number') {
-    throw new Error('Point balance response missing balance')
+    throw new Error('Point balance response missing cumulative_total or spendable_balance')
   }
 
   return { spendableBalance, cumulativeTotal }


### PR DESCRIPTION
## 什麼改動
Extension viewer 面板新增點數餘額顯示元件，會顯示可用點數與累積點數。

## 為什麼
補齊 viewer 登入後可看到目前點數餘額的需求。

closes #31

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#31
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 backend points API
  - 不改 dashboard UI
  - 不重做 Extension 整體版面

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 在 Extension viewer view 顯示可用與累積點數餘額。
- Approx changed lines：~140
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試鎖定同一個 frontend API integration 行為。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 顯示可用餘額與累積總量
- [x] 載入中顯示 `...`
- [x] API 失敗時不 crash，沿用 heartbeat fallback
- [x] PR 指向 `develop`

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
PASS rtk node --experimental-strip-types apps/extension/scripts/check-i18n.ts
PASS rtk git --no-optional-locks diff --check
PASS rtk git --no-optional-locks diff --cached --check

BLOCKED rtk pnpm --filter ./apps/extension test -- src/services/api.test.ts
原因：apps/extension 缺 node_modules，且 rtk pnpm install --frozen-lockfile 無法解析 registry.npmjs.org（ENOTFOUND），所以 vitest 不存在。
```

## 備註
本 PR 改用既有 `/api/v1/users/me/points?channel_id=...` contract 讀取點數餘額。

## Notes for Claude Code Review
- 請留意 `sendHeartbeat` 現在同步 points balance endpoint，而不是舊的 watch balance endpoint。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增积分显示组件，展示可用余额、增量提示与累计积分指标，并支持本地化文案。

* **样式**
  * 优化积分显示区域为两栏布局，改善对齐与换行表现。

* **重构**
  * 积分心跳/同步流程返回并保留累计总计信息，平滑接入新指标显示。

* **测试**
  * 更新并新增积分相关接口与心跳流程测试，覆盖缺失累计数据的降级场景。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/601)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->