### PR TITLE
[chore] Update dashboard auth architecture

### DIFF
--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -51,10 +51,10 @@ Provider support is part of the shared identity layer, but client auth contracts
 Observed behavior in the current repo:
 
 - access token is kept in memory only
-- refresh token is persisted in `localStorage` under key `refresh_token`
-- `login()` calls `POST /api/v1/auth/login`; login stores the returned refresh token in `localStorage`
-- logout sends `refresh_token` in the request body when present
-- session restore on page reload is not implemented
+- refresh token is owned by the backend-managed httpOnly cookie; dashboard does not persist it in `localStorage`
+- `login()` calls `POST /api/v1/auth/login`; login stores only the returned access token in memory
+- logout calls `POST /api/v1/auth/logout` without a `refresh_token` request body
+- session restore on page reload is implemented by calling `restoreSession()` before rendering the app
 - axios client sends `withCredentials: true`; 401 responses trigger a single silent refresh (deduped across concurrent requests) and retry
 - dashboard does not currently persist a separate `current_user` payload
 
@@ -64,9 +64,9 @@ Observed behavior in the current repo:
 |---|---|---|
 | Phase 1 — Backend | httpOnly cookie set on login/refresh/logout; refresh and logout prefer cookie with body fallback | ✅ Done (PR #220) |
 | Phase 2a — Dashboard axios layer | `withCredentials: true`; `hasAuthToken()`; 401 dedupe interceptor | ✅ Done (PR #338) |
-| Phase 2b — Dashboard auth contract | Remove `localStorage`; cookie-based session restore; update `auth.ts` and `main.tsx` | ⏳ Pending |
+| Phase 2b — Dashboard auth contract | Remove `localStorage`; cookie-based session restore; update `auth.ts` and `main.tsx` | ✅ Done (PR #340) |
 
-Body fallback (sending `refresh_token` in request body) remains active in the backend during the transition period. It will be removed in a dedicated follow-up once all clients are confirmed to be on the cookie-based contract.
+Body fallback (sending `refresh_token` in request body) remains active in the backend during the transition period, but dashboard no longer uses it. The backend fallback should be removed in a dedicated follow-up once all clients are confirmed to be on the cookie-based contract.
 
 ## Current Extension State
 

--- a/plans/dashboard-auth.md
+++ b/plans/dashboard-auth.md
@@ -1,5 +1,12 @@
 # 任務：Dashboard 登入與 JWT 管理
 
+> Status: superseded by the dashboard refresh-token migration tracked in #217
+> and implemented by #338/#340. This plan records the original dashboard auth
+> implementation shape and must not be used as the current token-storage
+> contract. Current dashboard auth keeps access tokens in memory, relies on the
+> backend-managed httpOnly refresh cookie, and does not persist
+> `refresh_token` in `localStorage`; see `docs/auth-architecture.md`.
+
 ## 專案背景
 
 這是 tachigo 專案的 Dashboard 前端，位於 `dashboard/` 資料夾。


### PR DESCRIPTION
## 什麼改動
同步 Dashboard auth 文件的 current-state 描述，並在舊 dashboard auth plan 標示 superseded。

## 為什麼
`origin/develop` 已經透過 #338/#340 完成 dashboard cookie-based refresh、session restore，以及移除 `refresh_token` localStorage 持久化；文件仍標示 Phase 2b pending，舊 plan 也仍以 localStorage 作為實作策略，容易誤導後續 auth 工作。

refs #217

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#217
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不變更 runtime auth 行為
  - 不移除 backend refresh_token body fallback
  - 不決定未來 extension 或其他 client auth contract

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 Dashboard auth 文件反映 develop 已落地的 cookie-based session restore 狀態。
- Approx changed lines：~19
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Dashboard current-state 不再描述 refresh token 存入 `localStorage`
- [x] Dashboard current-state 描述 `restoreSession()` 在 render 前執行
- [x] Refresh Token Migration Status 將 Phase 2b 標示為已由 #340 完成
- [x] 舊 dashboard auth plan 明確標示為 superseded，避免被當成 current contract

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
rtk rg -n "superseded|localStorage|Phase 2b|restoreSession" docs/auth-architecture.md plans/dashboard-auth.md
PASS: current-state docs and superseded banner are present.

rtk git --no-optional-locks diff --check
PASS
```

## 備註
Docs-only PR；不改變程式碼與部署行為。

## Notes for Claude Code Review
- 請確認此文件描述是否符合 #338/#340 後 develop 的實作現況。
