### PR TITLE
[backend] Split server bootstrap and wiring

### DIFF
--- a/services/api/cmd/server/bootstrap.go
+++ b/services/api/cmd/server/bootstrap.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/tachigo/tachigo/internal/config"
+	"github.com/tachigo/tachigo/internal/database"
+	"gorm.io/gorm"
+)
+
+func bootstrap(cfg *config.Config) *gorm.DB {
+	db := database.Connect(cfg.Database.DSN)
+
+	hashCtx, hashCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	hashErr := hashLegacyRaffleClaimTokens(hashCtx, db)
+	hashCancel()
+	if hashErr != nil {
+		log.Fatalf("failed to hash existing claim tokens: %v", hashErr)
+	}
+
+	return db
+}
+
+func hashLegacyRaffleClaimTokens(ctx context.Context, db *gorm.DB) error {
+	// claim_token was previously a raw UUIDv7 (36 chars); it now stores the
+	// SHA-256 hex digest (64 chars). This idempotent repair is data-only.
+	return db.WithContext(ctx).Exec(`
+		UPDATE raffle_draws
+		SET claim_token = encode(sha256(claim_token::bytea), 'hex')
+		WHERE length(claim_token) = 36
+	`).Error
+}

--- a/services/api/cmd/server/main.go
+++ b/services/api/cmd/server/main.go
@@ -14,18 +14,11 @@ import (
 	"log"
 	"os/signal"
 	"syscall"
-	"time"
 
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/joho/godotenv"
 
 	_ "github.com/tachigo/tachigo/docs"
 	"github.com/tachigo/tachigo/internal/config"
-	"github.com/tachigo/tachigo/internal/database"
-	"github.com/tachigo/tachigo/internal/handlers"
-	"github.com/tachigo/tachigo/internal/router"
-	"github.com/tachigo/tachigo/internal/services"
-	"gorm.io/gorm"
 )
 
 func main() {
@@ -39,89 +32,14 @@ func main() {
 		}
 	}
 
-	db := database.Connect(cfg.Database.DSN)
-
-	hashCtx, hashCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	hashErr := hashLegacyRaffleClaimTokens(hashCtx, db)
-	hashCancel()
-	if hashErr != nil {
-		log.Fatalf("failed to hash existing claim tokens: %v", hashErr)
-	}
-
-	// Wire services
-	authSvc := services.NewAuthService(db, cfg)
-	userSvc := services.NewUserService(db)
-	addrSvc := services.NewAddressService(db)
-	mailer := services.NewMailer(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.Username, cfg.SMTP.Password, cfg.SMTP.From)
-	emailAuthSvc := services.NewEmailAuthService(db, cfg, mailer)
-	watchSvc := services.NewWatchService(db)
-	channelConfigSvc := services.NewChannelConfigService(db)
-	pointsSvc := services.NewPointsService(db, watchSvc)
-	extSvc := services.NewExtensionService(db, cfg, authSvc, pointsSvc)
-	streamerSvc := services.NewStreamerService(db, pointsSvc)
-	agencySvc := services.NewAgencyService(db)
-	airdropSvc := services.NewAirdropService(db, pointsSvc, channelConfigSvc)
-	var ethClient *ethclient.Client
-	if cfg.Contract.TachiContractAddress != "" && cfg.Contract.SepoliaSignerKey != "" {
-		var err error
-		dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer dialCancel()
-		ethClient, err = ethclient.DialContext(dialCtx, cfg.Contract.RPCEndpoint)
-		if err != nil {
-			log.Printf("warning: failed to connect Sepolia RPC: %v", err)
-			ethClient = nil
-		}
-	}
-	claimSvc := services.NewClaimService(db, cfg.Contract, ethClient)
-	tachiyaClient := services.NewTachiyaHTTPClient(cfg.Internal.TachiyaBaseURL, cfg.Internal.TachiyaSharedSecret)
-	spendSvc := services.NewSpendService(db, cfg.Contract, ethClient, tachiyaClient)
-	if cfg.Server.Env == "production" && cfg.OAuth.Twitch.ClientID == "" {
-		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
-	}
-	oauthTokenSecret := cfg.OAuth.TokenEncryptionKey
-	if oauthTokenSecret == "" {
-		oauthTokenSecret = cfg.JWT.RefreshSecret
-	}
-	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID, cfg.App.FrontendURL, mailer, oauthTokenSecret)
-	// Tie scheduler lifetime to server shutdown signals so the goroutine exits cleanly.
+	db := bootstrap(cfg)
 	serverCtx, serverStop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer serverStop()
-	services.NewRaffleScheduler(raffleSvc).Start(serverCtx)
-	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
-
-	r := router.New(
-		authSvc,
-		userSvc,
-		addrSvc,
-		extSvc,
-		emailAuthSvc,
-		watchSvc,
-		channelConfigSvc,
-		pointsSvc,
-		airdropSvc,
-		streamerSvc,
-		agencySvc,
-		claimSvc,
-		spendSvc,
-		raffleSvc,
-		agencyH,
-		cfg.Server.AllowedOrigins,
-		router.InternalRouterConfig{DB: db, Config: cfg},
-	)
+	r := wire(db, cfg, serverCtx)
 
 	addr := ":" + cfg.Server.Port
 	log.Printf("server starting on %s (env=%s)", addr, cfg.Server.Env)
 	if err := r.Run(addr); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
-}
-
-func hashLegacyRaffleClaimTokens(ctx context.Context, db *gorm.DB) error {
-	// claim_token was previously a raw UUIDv7 (36 chars); it now stores the
-	// SHA-256 hex digest (64 chars). This idempotent repair is data-only.
-	return db.WithContext(ctx).Exec(`
-		UPDATE raffle_draws
-		SET claim_token = encode(sha256(claim_token::bytea), 'hex')
-		WHERE length(claim_token) = 36
-	`).Error
 }

--- a/services/api/cmd/server/main_test.go
+++ b/services/api/cmd/server/main_test.go
@@ -14,12 +14,15 @@ func TestServerStartupDoesNotRunSchemaDDL(t *testing.T) {
 		t.Fatal("resolve current test file")
 	}
 
-	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "main.go"))
-	if err != nil {
-		t.Fatalf("read main.go: %v", err)
+	dir := filepath.Dir(file)
+	var source strings.Builder
+	for _, name := range []string{"main.go", "bootstrap.go", "wiring.go"} {
+		body, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		source.Write(body)
 	}
-
-	source := string(body)
 	for _, forbidden := range []string{
 		"AutoMigrate(",
 		"initializeUserRoleEnum(",
@@ -28,14 +31,74 @@ func TestServerStartupDoesNotRunSchemaDDL(t *testing.T) {
 		"ALTER TABLE tachi_balances ADD CONSTRAINT",
 		"applyStreamerAgencyMigration(db)",
 	} {
-		if strings.Contains(source, forbidden) {
+		if strings.Contains(source.String(), forbidden) {
 			t.Fatalf("server startup must not run schema DDL %q after Atlas owns migrations", forbidden)
 		}
 	}
-	if !strings.Contains(source, "hashLegacyRaffleClaimTokens(hashCtx, db)") {
-		t.Fatalf("server startup should keep the non-schema raffle claim token data repair")
+	bootstrapBody, err := os.ReadFile(filepath.Join(dir, "bootstrap.go"))
+	if err != nil {
+		t.Fatalf("read bootstrap.go: %v", err)
 	}
-	if !strings.Contains(source, "db.WithContext(ctx).Exec") {
+	bootstrapSource := string(bootstrapBody)
+	if !strings.Contains(bootstrapSource, "hashLegacyRaffleClaimTokens(hashCtx, db)") {
+		t.Fatalf("bootstrap should keep the non-schema raffle claim token data repair")
+	}
+	if !strings.Contains(bootstrapSource, "db.WithContext(ctx).Exec") {
 		t.Fatalf("legacy raffle claim token repair must respect startup timeout context")
+	}
+}
+
+func TestServerStartupIsSplitByResponsibility(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+	dir := filepath.Dir(file)
+
+	mainBody, err := os.ReadFile(filepath.Join(dir, "main.go"))
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	if lines := strings.Count(string(mainBody), "\n"); lines > 50 {
+		t.Fatalf("main.go should stay at 50 lines or fewer after bootstrap/wiring split, got %d", lines)
+	}
+	for _, want := range []string{
+		"bootstrap(cfg)",
+		"wire(db, cfg, serverCtx)",
+	} {
+		if !strings.Contains(string(mainBody), want) {
+			t.Fatalf("main.go should delegate startup with %q", want)
+		}
+	}
+
+	bootstrapBody, err := os.ReadFile(filepath.Join(dir, "bootstrap.go"))
+	if err != nil {
+		t.Fatalf("read bootstrap.go: %v", err)
+	}
+	bootstrapSource := string(bootstrapBody)
+	for _, want := range []string{
+		"func bootstrap(cfg *config.Config) *gorm.DB",
+		"database.Connect(cfg.Database.DSN)",
+		"hashLegacyRaffleClaimTokens(hashCtx, db)",
+	} {
+		if !strings.Contains(bootstrapSource, want) {
+			t.Fatalf("bootstrap.go should own %q", want)
+		}
+	}
+
+	wiringBody, err := os.ReadFile(filepath.Join(dir, "wiring.go"))
+	if err != nil {
+		t.Fatalf("read wiring.go: %v", err)
+	}
+	wiringSource := string(wiringBody)
+	for _, want := range []string{
+		"func wire(db *gorm.DB, cfg *config.Config, ctx context.Context) *gin.Engine",
+		"services.NewAuthService(db, cfg)",
+		"services.NewRaffleScheduler(raffleSvc).Start(ctx)",
+		"router.New(",
+	} {
+		if !strings.Contains(wiringSource, want) {
+			t.Fatalf("wiring.go should own %q", want)
+		}
 	}
 }

--- a/services/api/cmd/server/wiring.go
+++ b/services/api/cmd/server/wiring.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/gin-gonic/gin"
+	"github.com/tachigo/tachigo/internal/config"
+	"github.com/tachigo/tachigo/internal/handlers"
+	"github.com/tachigo/tachigo/internal/router"
+	"github.com/tachigo/tachigo/internal/services"
+	"gorm.io/gorm"
+)
+
+func wire(db *gorm.DB, cfg *config.Config, ctx context.Context) *gin.Engine {
+	authSvc := services.NewAuthService(db, cfg)
+	userSvc := services.NewUserService(db)
+	addrSvc := services.NewAddressService(db)
+	mailer := services.NewMailer(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.Username, cfg.SMTP.Password, cfg.SMTP.From)
+	emailAuthSvc := services.NewEmailAuthService(db, cfg, mailer)
+	watchSvc := services.NewWatchService(db)
+	channelConfigSvc := services.NewChannelConfigService(db)
+	pointsSvc := services.NewPointsService(db, watchSvc)
+	extSvc := services.NewExtensionService(db, cfg, authSvc, pointsSvc)
+	streamerSvc := services.NewStreamerService(db, pointsSvc)
+	agencySvc := services.NewAgencyService(db)
+	airdropSvc := services.NewAirdropService(db, pointsSvc, channelConfigSvc)
+	var ethClient *ethclient.Client
+	if cfg.Contract.TachiContractAddress != "" && cfg.Contract.SepoliaSignerKey != "" {
+		var err error
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer dialCancel()
+		ethClient, err = ethclient.DialContext(dialCtx, cfg.Contract.RPCEndpoint)
+		if err != nil {
+			log.Printf("warning: failed to connect Sepolia RPC: %v", err)
+			ethClient = nil
+		}
+	}
+	claimSvc := services.NewClaimService(db, cfg.Contract, ethClient)
+	tachiyaClient := services.NewTachiyaHTTPClient(cfg.Internal.TachiyaBaseURL, cfg.Internal.TachiyaSharedSecret)
+	spendSvc := services.NewSpendService(db, cfg.Contract, ethClient, tachiyaClient)
+	if cfg.Server.Env == "production" && cfg.OAuth.Twitch.ClientID == "" {
+		log.Fatal("TWITCH_CLIENT_ID is required in production for raffle snapshot sync")
+	}
+	oauthTokenSecret := cfg.OAuth.TokenEncryptionKey
+	if oauthTokenSecret == "" {
+		oauthTokenSecret = cfg.JWT.RefreshSecret
+	}
+	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID, cfg.App.FrontendURL, mailer, oauthTokenSecret)
+	services.NewRaffleScheduler(raffleSvc).Start(ctx)
+	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
+
+	return router.New(
+		authSvc,
+		userSvc,
+		addrSvc,
+		extSvc,
+		emailAuthSvc,
+		watchSvc,
+		channelConfigSvc,
+		pointsSvc,
+		airdropSvc,
+		streamerSvc,
+		agencySvc,
+		claimSvc,
+		spendSvc,
+		raffleSvc,
+		agencyH,
+		cfg.Server.AllowedOrigins,
+		router.InternalRouterConfig{DB: db, Config: cfg},
+	)
+}


### PR DESCRIPTION
## 什麼改動
將 `cmd/server/main.go` 的啟動流程拆成 `bootstrap.go` 與 `wiring.go`，讓 `main.go` 只保留 env/config、signal context、router 啟動。

## 為什麼
closes #570。`main.go` 原本同時負責 DB bootstrap、service wiring、scheduler 與 server run；此 PR 純搬移職責，讓後續新增 service 或調整啟動流程有明確落點。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#570
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 service 初始化參數、router 內部實作、DB 連線池設定或 schema migration 行為。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 純搬移 server bootstrap 與 wiring，讓 `main.go` 降到 50 行以內。
- Approx changed lines：~275
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試只鎖定本次 refactor 的 acceptance criteria，避免後續把 wiring 搬回 `main.go`。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `go build ./...` 通過
- [x] `go test ./...` 通過
- [x] `main.go` ≤ 50 行
- [x] 純搬移：service 初始化參數、順序維持不變
- [x] `bootstrap.go` 與 `wiring.go` 職責單一

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED: go test ./cmd/server -run TestServerStartupIsSplitByResponsibility -count=1
FAIL: main.go should stay at 50 lines or fewer after bootstrap/wiring split, got 127

GREEN: go test ./cmd/server -run TestServerStartupIsSplitByResponsibility -count=1
PASS

go test ./cmd/server -count=1
PASS

go build ./...
PASS

go test ./... -count=1
PASS

git diff --check
PASS
```

## 備註
`main.go` 目前為 45 行；Swagger package import 仍留在 `main.go` 以維持既有 docs registration。

## Notes for Claude Code Review
- 請特別確認 `wiring.go` 內 service/handler 建立順序與原本 `main.go` 一致；本 PR 目標是純搬移，不改 runtime behavior。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化了服务器启动流程，改进了代码组织结构
  * 增强了数据库初始化逻辑，确保遗留数据迁移流程的稳定性和可靠性
  * 改进了测试覆盖率，加强了系统架构责任分离的验证

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/604)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->