### PR TITLE
[infra] Expand destructive migration guard

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
@@ -91,6 +92,14 @@ function workflowJobBlock(workflow, jobName) {
   const match = workflow.match(pattern)
   assert.ok(match, `expected workflow to include ${jobName} job`)
   return match[0]
+}
+
+function workflowJobStep(parsedWorkflow, jobName, stepName) {
+  const job = parsedWorkflow.jobs[jobName]
+  assert.ok(job, `expected workflow to include ${jobName} job`)
+  const step = job.steps.find((candidate) => candidate.name === stepName)
+  assert.ok(step, `expected ${jobName} to include ${stepName} step`)
+  return step
 }
 
 function escapeRegExp(value) {
@@ -691,6 +700,46 @@ test('CI workflow validates Atlas migrations against ephemeral PostgreSQL', asyn
   assert.doesNotMatch(atlasJob, /--community|\/tmp\/atlas-community|migrate lint|--git-base|docker:\/\/postgres\/15/)
   assert.doesNotMatch(atlasJob, /version: v0\.37\.0|version: v1\.2\.0/)
   assert.doesNotMatch(atlasJob, /atlas schema apply|docker compose up/)
+})
+
+test('Atlas destructive migration guard blocks high-risk schema rewrites without nolint', async () => {
+  const parsedWorkflow = parseYaml(workflowPath)
+  const step = workflowJobStep(parsedWorkflow, 'atlas-migration-tooling', 'Reject destructive migration statements without nolint')
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'tachigo-atlas-guard-'))
+  const migrationsDir = path.join(tempDir, 'migrations')
+
+  await mkdir(migrationsDir)
+  try {
+    const cases = [
+      ['drop_index', 'DROP INDEX idx_users_email;'],
+      ['rename_column', 'ALTER TABLE users RENAME COLUMN email TO login_email;'],
+      ['rename_table', 'ALTER TABLE users RENAME TO app_users;'],
+      ['alter_column_type', 'ALTER TABLE users ALTER COLUMN score TYPE bigint;'],
+      ['alter_column_set_data_type', 'ALTER TABLE users ALTER COLUMN score SET DATA TYPE bigint;'],
+    ]
+
+    for (const [name, sql] of cases) {
+      const migrationPath = path.join(migrationsDir, `${name}.sql`)
+      await writeFile(migrationPath, `${sql}\n`)
+
+      let failure
+      try {
+        execFileSync('sh', ['-c', step.run], { cwd: tempDir, encoding: 'utf8' })
+      } catch (error) {
+        failure = error
+      }
+
+      assert.ok(failure, `${name} should require -- atlas:nolint`)
+      assert.match(failure.stdout, /destructive migration requires -- atlas:nolint/)
+
+      await writeFile(migrationPath, `-- atlas:nolint\n${sql}\n`)
+      assert.doesNotThrow(() => {
+        execFileSync('sh', ['-c', step.run], { cwd: tempDir, encoding: 'utf8' })
+      })
+    }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
 })
 
 test('backend Docker runtime applies Atlas migrations before starting the API', async () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,11 @@ jobs:
               upper = toupper($0)
               destructive = upper ~ /(^|[^A-Z_])DROP[[:space:]]+TABLE([^A-Z_]|$)/ ||
                 upper ~ /(^|[^A-Z_])TRUNCATE[[:space:]]+TABLE([^A-Z_]|$)/ ||
-                upper ~ /(^|[^A-Z_])DROP[[:space:]]+COLUMN([^A-Z_]|$)/
+                upper ~ /(^|[^A-Z_])DROP[[:space:]]+COLUMN([^A-Z_]|$)/ ||
+                upper ~ /(^|[^A-Z_])DROP[[:space:]]+INDEX([^A-Z_]|$)/ ||
+                upper ~ /(^|[^A-Z_])RENAME[[:space:]]+COLUMN([^A-Z_]|$)/ ||
+                upper ~ /(^|[^A-Z_])RENAME[[:space:]]+TO([^A-Z_]|$)/ ||
+                upper ~ /ALTER[[:space:]]+COLUMN[[:space:]].*[[:space:]]TYPE([[:space:]]|$)/
               allowed = $0 ~ /--[[:space:]]*atlas:nolint/ || previous ~ /--[[:space:]]*atlas:nolint/
               if (destructive && !allowed) {
                 printf "%s:%d: destructive migration requires -- atlas:nolint on the same or previous line\n", FILENAME, FNR


### PR DESCRIPTION
## 什麼改動
- 擴充 Atlas destructive migration guard，未加 `-- atlas:nolint` 時會拒絕 `DROP INDEX`、`RENAME COLUMN`、`RENAME TO`、`ALTER COLUMN ... TYPE` / `SET DATA TYPE`。
- 新增 workflow regression test，直接執行 CI 裡的 awk guard 驗證 fail/pass 行為。

## 為什麼
closes #606

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#606
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 optional `DROP CONSTRAINT` allowlist / `atlas.sum` 更新
  - 不做 #605 的 GORM-shape baseline apply CI job
  - 不改既有 migration 內容

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 CI destructive-DDL guard 擋下更多高風險 schema rewrite pattern。
- Approx changed lines：~57
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `DROP INDEX` 加進 destructive guard
- [x] `RENAME COLUMN` 加進 destructive guard
- [x] `RENAME TO` 加進 destructive guard
- [x] `ALTER COLUMN ... TYPE` / `SET DATA TYPE` 加進 destructive guard
- [x] 新增 `ci.test.mjs` regression，驗證新 patterns fail 且 `-- atlas:nolint` pass
- [x] 確認既有 migration 沒有誤觸發新 patterns

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED: rtk node --test .github/workflows/ci.test.mjs
- FAIL 1/64: drop_index should require -- atlas:nolint

GREEN: rtk node --test .github/workflows/ci.test.mjs
- PASS 64/64

rtk git --no-optional-locks diff --check
- PASS

rtk rg -n "DROP[[:space:]]+INDEX|RENAME[[:space:]]+COLUMN|RENAME[[:space:]]+TO|ALTER[[:space:]]+COLUMN.*[[:space:]]TYPE|ALTER[[:space:]]+COLUMN.*SET[[:space:]]+DATA[[:space:]]+TYPE" services/api/migrations
- no matches
```

## 備註
#606 的 optional `DROP CONSTRAINT` 子任務刻意不納入，避免修改既有 migration 與 `atlas.sum`。

## Notes for Claude Code Review
- 主要 review 點是 awk regex 是否剛好覆蓋 #606 必做四類 pattern，且沒有擴張到 optional `DROP CONSTRAINT`。
