### PR TITLE
[infra] Add GORM baseline Atlas CI verification

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -697,6 +697,26 @@ test('CI workflow validates Atlas migrations against ephemeral PostgreSQL', asyn
     atlasJob,
     /atlas migrate apply --dir file:\/\/migrations --url "postgres:\/\/postgres:postgres@localhost:5432\/tachigo\?sslmode=disable"/,
   )
+  assert.match(
+    atlasJob,
+    /Apply migrations to GORM-shape baseline/,
+  )
+  assert.match(
+    atlasJob,
+    /GORM_BASELINE_DATABASE_URL: postgres:\/\/postgres:postgres@localhost:5432\/tachigo_gorm_baseline\?sslmode=disable/,
+  )
+  assert.match(
+    atlasJob,
+    /psql "postgres:\/\/postgres:postgres@localhost:5432\/postgres\?sslmode=disable" -v ON_ERROR_STOP=1 -c "CREATE DATABASE tachigo_gorm_baseline"/,
+  )
+  assert.match(
+    atlasJob,
+    /psql "\$GORM_BASELINE_DATABASE_URL" -v ON_ERROR_STOP=1 -f \/tmp\/tachigo-gorm-schema\.sql/,
+  )
+  assert.match(
+    atlasJob,
+    /atlas migrate apply --dir file:\/\/migrations --url "\$GORM_BASELINE_DATABASE_URL"/,
+  )
   assert.doesNotMatch(atlasJob, /--community|\/tmp\/atlas-community|migrate lint|--git-base|docker:\/\/postgres\/15/)
   assert.doesNotMatch(atlasJob, /version: v0\.37\.0|version: v1\.2\.0/)
   assert.doesNotMatch(atlasJob, /atlas schema apply|docker compose up/)

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -715,7 +715,7 @@ test('CI workflow validates Atlas migrations against ephemeral PostgreSQL', asyn
   )
   assert.match(
     atlasJob,
-    /atlas migrate apply --dir file:\/\/migrations --url "\$GORM_BASELINE_DATABASE_URL"/,
+    /atlas migrate apply --dir file:\/\/migrations --url "\$GORM_BASELINE_DATABASE_URL" --baseline 019/,
   )
   assert.doesNotMatch(atlasJob, /--community|\/tmp\/atlas-community|migrate lint|--git-base|docker:\/\/postgres\/15/)
   assert.doesNotMatch(atlasJob, /version: v0\.37\.0|version: v1\.2\.0/)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
           psql "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" -v ON_ERROR_STOP=1 -c "CREATE DATABASE tachigo_gorm_baseline"
           go run ./cmd/loader/main.go > /tmp/tachigo-gorm-schema.sql
           psql "$GORM_BASELINE_DATABASE_URL" -v ON_ERROR_STOP=1 -f /tmp/tachigo-gorm-schema.sql
-          atlas migrate apply --dir file://migrations --url "$GORM_BASELINE_DATABASE_URL"
+          atlas migrate apply --dir file://migrations --url "$GORM_BASELINE_DATABASE_URL" --baseline 019
 
   backend-integration:
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,6 +487,16 @@ jobs:
         working-directory: services/api
         run: atlas migrate apply --dir file://migrations --url "postgres://postgres:postgres@localhost:5432/tachigo?sslmode=disable"
 
+      - name: Apply migrations to GORM-shape baseline
+        working-directory: services/api
+        env:
+          GORM_BASELINE_DATABASE_URL: postgres://postgres:postgres@localhost:5432/tachigo_gorm_baseline?sslmode=disable
+        run: |
+          psql "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" -v ON_ERROR_STOP=1 -c "CREATE DATABASE tachigo_gorm_baseline"
+          go run ./cmd/loader/main.go > /tmp/tachigo-gorm-schema.sql
+          psql "$GORM_BASELINE_DATABASE_URL" -v ON_ERROR_STOP=1 -f /tmp/tachigo-gorm-schema.sql
+          atlas migrate apply --dir file://migrations --url "$GORM_BASELINE_DATABASE_URL"
+
   backend-integration:
     timeout-minutes: 20
     name: Backend integration tests


### PR DESCRIPTION
## 什麼改動
- 在 `atlas-migration-tooling` job 追加 GORM-shape baseline 驗證路徑。
- CI 會先建立 `tachigo_gorm_baseline` ephemeral DB，套入 `cmd/loader` 產出的 schema，再對同一 DB 執行 `atlas migrate apply --baseline 019`。
- 補 `.github/workflows/ci.test.mjs` regression assertion，鎖住新 step 與關鍵命令。

## 為什麼
closes #605

PR #588 上線 Atlas runtime 後，CI 已驗證 clean PostgreSQL apply，但還沒有驗證 migration 020 可套到既有 AutoMigrate/GORM-shape baseline。這個 PR 補上該條 CI 路徑，讓 dirty-data guards 與 schema reconciliation 在 PR gate 內被檢查。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#605
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 migration 020 內容
  - 不改 docker-entrypoint.sh / runtime migration path
  - 不引入 production DB snapshot fixture
  - 不新增其他 migration 驗證範圍

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 CI 同時驗證 Atlas migrations 可套用到 clean PostgreSQL 與 GORM-shape baseline。
- Approx changed lines：~30
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] CI 同時驗證 clean PG apply + GORM-shape PG apply 兩條路徑
- [x] GORM-shape PG 上跑 020 不觸發 dirty-data RAISE EXCEPTION 的路徑已加入 CI gate
- [x] CI 失敗時會由 `Apply migrations to GORM-shape baseline` step 指出 baseline 路徑斷點
- [x] `ci.test.mjs` 對應 regression test 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED: rtk node --test .github/workflows/ci.test.mjs --test-name-pattern 'CI workflow validates Atlas migrations against ephemeral PostgreSQL'
=> fail 1/64, missing "Apply migrations to GORM-shape baseline"

GREEN: rtk node --test .github/workflows/ci.test.mjs
=> pass 64/64

rtk git --no-optional-locks diff --check
=> pass
rtk git --no-optional-locks diff --cached --check
=> pass

CI RED: Atlas migration tooling failed before the follow-up fix because Atlas refused to apply on a non-clean GORM-shape DB without a baseline version.
```

## 備註
本機 sandbox 無權連 Docker daemon，且 host 沒有 `psql`；實際 ephemeral PostgreSQL apply 由新增的 GitHub CI step 驗證。

## Notes for Claude Code Review
- 重點請看 `.github/workflows/ci.yml` 新 step 的 `--baseline 019`；這讓 CI 驗證 AutoMigrate/GORM-shape baseline 上真正需要套用的 020 reconciliation migration。
