### PR TITLE
[backend] Propagate server context to RPC dial

### DIFF
--- a/services/api/cmd/server/main_test.go
+++ b/services/api/cmd/server/main_test.go
@@ -94,11 +94,15 @@ func TestServerStartupIsSplitByResponsibility(t *testing.T) {
 	for _, want := range []string{
 		"func wire(db *gorm.DB, cfg *config.Config, ctx context.Context) *gin.Engine",
 		"services.NewAuthService(db, cfg)",
+		"context.WithTimeout(ctx, 10*time.Second)",
 		"services.NewRaffleScheduler(raffleSvc).Start(ctx)",
 		"router.New(",
 	} {
 		if !strings.Contains(wiringSource, want) {
 			t.Fatalf("wiring.go should own %q", want)
 		}
+	}
+	if strings.Contains(wiringSource, "context.WithTimeout(context.Background(), 10*time.Second)") {
+		t.Fatalf("Sepolia RPC dial timeout should inherit the server context")
 	}
 }

--- a/services/api/cmd/server/wiring.go
+++ b/services/api/cmd/server/wiring.go
@@ -30,9 +30,9 @@ func wire(db *gorm.DB, cfg *config.Config, ctx context.Context) *gin.Engine {
 	var ethClient *ethclient.Client
 	if cfg.Contract.TachiContractAddress != "" && cfg.Contract.SepoliaSignerKey != "" {
 		var err error
-		dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer dialCancel()
+		dialCtx, dialCancel := context.WithTimeout(ctx, 10*time.Second)
 		ethClient, err = ethclient.DialContext(dialCtx, cfg.Contract.RPCEndpoint)
+		dialCancel()
 		if err != nil {
 			log.Printf("warning: failed to connect Sepolia RPC: %v", err)
 			ethClient = nil


### PR DESCRIPTION
## 什麼改動
讓 server wiring 建立 Sepolia RPC dial timeout 時，以傳入的 server context 作為 parent，並在 `DialContext` 回傳後立即釋放 timeout context。

## 為什麼
Follow-up to #604 / refs #570。#604 已在舊 head merge；CodeRabbit review 指出 RPC dial 仍使用 `context.Background()`，因此 server 啟動階段若收到 shutdown signal，RPC dial 不會跟著取消。這張 PR 只補同 scope 內的 context propagation 修正。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#604 review feedback / #570 server bootstrap split follow-up
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 `ethClient.Close()` ownership / shutdown lifecycle；那是 pre-existing 行為，需另行設計 owner 與 shutdown path。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 Sepolia RPC dial timeout 繼承 server context，避免 shutdown 時 dial 仍以 background context 繼續等待。
- Approx changed lines：~8
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試只作為同一個 context propagation 修正的 regression guard。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Sepolia RPC dial timeout 使用傳入的 server context 作為 parent。
- [x] `DialContext` 回傳後立即呼叫 `dialCancel()`。
- [x] 補上 regression guard，避免 wiring 回到 `context.Background()`。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
ok github.com/tachigo/tachigo/cmd/server 0.401s
ok github.com/tachigo/tachigo/cmd/server 0.740s
git diff --check origin/develop..HEAD: pass
```

## 備註
#604 已 merge，這張 PR 是把同一個 review feedback 修正重新落到 `develop` 基底上。

## Notes for Claude Code Review
- 請特別確認這張 PR 沒有把 `ethClient.Close()` lifecycle 納入；該議題會牽涉 server shutdown owner，不適合混進這個小修正。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 改进了 RPC 连接的超时管理机制，确保服务器资源的正确分配和回收。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/610)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->