### PR TITLE
[backend] Add graceful server shutdown

### DIFF
--- a/services/api/cmd/server/main.go
+++ b/services/api/cmd/server/main.go
@@ -39,7 +39,10 @@ func main() {
 
 	addr := ":" + cfg.Server.Port
 	log.Printf("server starting on %s (env=%s)", addr, cfg.Server.Env)
-	if err := r.Run(addr); err != nil {
+	srv := newHTTPServer(addr, r)
+	if err := runHTTPServer(serverCtx, srv, func() error {
+		return closeDatabase(db)
+	}); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
 }

--- a/services/api/cmd/server/main_test.go
+++ b/services/api/cmd/server/main_test.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestServerStartupDoesNotRunSchemaDDL(t *testing.T) {
@@ -105,4 +111,179 @@ func TestServerStartupIsSplitByResponsibility(t *testing.T) {
 	if strings.Contains(wiringSource, "context.WithTimeout(context.Background(), 10*time.Second)") {
 		t.Fatalf("Sepolia RPC dial timeout should inherit the server context")
 	}
+}
+
+func TestHTTPServerConfiguresProductionTimeouts(t *testing.T) {
+	handler := http.NewServeMux()
+
+	srv := newHTTPServer(":8080", handler)
+
+	if srv.Addr != ":8080" {
+		t.Fatalf("Addr: want :8080, got %q", srv.Addr)
+	}
+	if srv.Handler != handler {
+		t.Fatalf("Handler: want configured handler")
+	}
+	if srv.ReadTimeout <= 0 {
+		t.Fatalf("ReadTimeout should be set")
+	}
+	if srv.WriteTimeout <= 0 {
+		t.Fatalf("WriteTimeout should be set")
+	}
+	if srv.IdleTimeout <= 0 {
+		t.Fatalf("IdleTimeout should be set")
+	}
+}
+
+func TestRunHTTPServerShutsDownOnContextCancelAndClosesDatabase(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fake := newFakeGracefulServer()
+	var closeCalls atomic.Int32
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runHTTPServer(ctx, fake, func() error {
+			closeCalls.Add(1)
+			return nil
+		})
+	}()
+
+	<-fake.listenStarted
+	cancel()
+	<-fake.shutdownCalled
+	fake.finish(http.ErrServerClosed)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runHTTPServer returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runHTTPServer did not return after shutdown")
+	}
+	if closeCalls.Load() != 1 {
+		t.Fatalf("close hook calls: want 1, got %d", closeCalls.Load())
+	}
+}
+
+func TestRunHTTPServerReturnsListenErrorAndClosesDatabase(t *testing.T) {
+	ctx := context.Background()
+	fake := newFakeGracefulServer()
+	listenErr := errors.New("bind failed")
+	var closeCalls atomic.Int32
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runHTTPServer(ctx, fake, func() error {
+			closeCalls.Add(1)
+			return nil
+		})
+	}()
+
+	<-fake.listenStarted
+	fake.finish(listenErr)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, listenErr) {
+			t.Fatalf("runHTTPServer error: want %v, got %v", listenErr, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runHTTPServer did not return after listen error")
+	}
+	if closeCalls.Load() != 1 {
+		t.Fatalf("close hook calls: want 1, got %d", closeCalls.Load())
+	}
+}
+
+func TestRunHTTPServerReturnsShutdownErrorAndClosesDatabase(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	shutdownErr := errors.New("shutdown failed")
+	fake := newFakeGracefulServer()
+	fake.shutdownErr = shutdownErr
+	var closeCalls atomic.Int32
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runHTTPServer(ctx, fake, func() error {
+			closeCalls.Add(1)
+			return nil
+		})
+	}()
+
+	<-fake.listenStarted
+	cancel()
+	<-fake.shutdownCalled
+	fake.finish(http.ErrServerClosed)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, shutdownErr) {
+			t.Fatalf("runHTTPServer error: want shutdown error %v, got %v", shutdownErr, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runHTTPServer did not return after shutdown error")
+	}
+	if closeCalls.Load() != 1 {
+		t.Fatalf("close hook calls: want 1, got %d", closeCalls.Load())
+	}
+}
+
+func TestMainUsesHTTPServerGracefulShutdown(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+	dir := filepath.Dir(file)
+
+	mainBody, err := os.ReadFile(filepath.Join(dir, "main.go"))
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	mainSource := string(mainBody)
+	if strings.Contains(mainSource, ".Run(") {
+		t.Fatalf("main.go should not start Gin with Run after graceful shutdown support is added")
+	}
+	for _, want := range []string{
+		"newHTTPServer(addr, r)",
+		"runHTTPServer(serverCtx, srv,",
+		"closeDatabase(db)",
+	} {
+		if !strings.Contains(mainSource, want) {
+			t.Fatalf("main.go should use graceful HTTP server wiring %q", want)
+		}
+	}
+}
+
+type fakeGracefulServer struct {
+	listenStarted  chan struct{}
+	shutdownCalled chan struct{}
+	done           chan error
+	shutdownErr    error
+	closeStarted   sync.Once
+	closeShutdown  sync.Once
+}
+
+func newFakeGracefulServer() *fakeGracefulServer {
+	return &fakeGracefulServer{
+		listenStarted:  make(chan struct{}),
+		shutdownCalled: make(chan struct{}),
+		done:           make(chan error, 1),
+	}
+}
+
+func (f *fakeGracefulServer) ListenAndServe() error {
+	f.closeStarted.Do(func() { close(f.listenStarted) })
+	return <-f.done
+}
+
+func (f *fakeGracefulServer) Shutdown(context.Context) error {
+	f.closeShutdown.Do(func() { close(f.shutdownCalled) })
+	return f.shutdownErr
+}
+
+func (f *fakeGracefulServer) finish(err error) {
+	f.done <- err
 }

--- a/services/api/cmd/server/server.go
+++ b/services/api/cmd/server/server.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	serverReadTimeout     = 15 * time.Second
+	serverWriteTimeout    = 120 * time.Second
+	serverIdleTimeout     = 60 * time.Second
+	serverShutdownTimeout = 10 * time.Second
+)
+
+type gracefulHTTPServer interface {
+	ListenAndServe() error
+	Shutdown(context.Context) error
+}
+
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:         addr,
+		Handler:      handler,
+		ReadTimeout:  serverReadTimeout,
+		WriteTimeout: serverWriteTimeout,
+		IdleTimeout:  serverIdleTimeout,
+	}
+}
+
+func runHTTPServer(ctx context.Context, srv gracefulHTTPServer, closeDB func() error) error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe()
+	}()
+
+	select {
+	case err := <-errCh:
+		return finishHTTPServer(err, closeDB)
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
+		defer cancel()
+
+		shutdownErr := srv.Shutdown(shutdownCtx)
+		var serveErr error
+		select {
+		case serveErr = <-errCh:
+		case <-shutdownCtx.Done():
+			serveErr = shutdownCtx.Err()
+		}
+
+		if errors.Is(serveErr, http.ErrServerClosed) {
+			serveErr = nil
+		}
+		return finishHTTPServer(errors.Join(shutdownErr, serveErr), closeDB)
+	}
+}
+
+func finishHTTPServer(serverErr error, closeDB func() error) error {
+	closeErr := runCloseHook(closeDB)
+	if errors.Is(serverErr, http.ErrServerClosed) {
+		serverErr = nil
+	}
+	return errors.Join(serverErr, closeErr)
+}
+
+func runCloseHook(closeDB func() error) error {
+	if closeDB == nil {
+		return nil
+	}
+	return closeDB()
+}
+
+func closeDatabase(db *gorm.DB) error {
+	if db == nil {
+		return nil
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Close()
+}


### PR DESCRIPTION
## 什麼改動
將 API server 啟動從 Gin `Run()` 改成 `http.Server`，集中設定 Read/Write/Idle timeout，並在收到 signal context cancel 時呼叫 `Shutdown()`。

新增 server lifecycle helper，讓 server 結束後一定執行 DB close hook，並補測試覆蓋 timeout、graceful shutdown、listen error、shutdown error 與 main.go 不回退到 `r.Run()`。

## 為什麼
refs #455

#455 B2 指出 backend 已有 signal context，但缺少 Gin server-level graceful shutdown、server timeout 與 DB close hook。這個 PR 只補啟動/關閉 lifecycle，不改 router、service wiring 或業務邏輯。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#455 B2 `[backend] Gin graceful shutdown`
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 DB query context timeout 傳遞（#455 B3）
  - 不改 service/router API behavior
  - 不引入 timeout env var 或 config schema
  - 不改 scheduler enable/disable wiring

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 API server 使用 `http.Server` timeout 與 signal-driven graceful shutdown，並在 server 結束時關閉 DB connection pool。
- Approx changed lines：~272
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試是同一個 server lifecycle change 的 regression guard，避免後續回退到 `r.Run()` 或漏掉 close hook。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] API server 改用 `http.Server` 啟動。
- [x] `ReadTimeout` / `WriteTimeout` / `IdleTimeout` 已設定。
- [x] signal context cancel 時呼叫 `Shutdown()`。
- [x] server 結束時執行 DB close hook。
- [x] 補測試覆蓋正常 shutdown、listen error、shutdown error 與 main.go wiring。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
RED: rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./cmd/server -run 'TestHTTPServerConfiguresProductionTimeouts|TestRunHTTPServer|TestMainUsesHTTPServerGracefulShutdown' -count=1
=> build failed: undefined newHTTPServer / runHTTPServer

RED: rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./cmd/server -run TestRunHTTPServerReturnsShutdownErrorAndClosesDatabase -count=1
=> failed because shutdown error was swallowed

GREEN: rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./cmd/server -run 'TestRunHTTPServerReturnsShutdownErrorAndClosesDatabase|TestRunHTTPServerShutsDownOnContextCancelAndClosesDatabase|TestRunHTTPServerReturnsListenErrorAndClosesDatabase' -count=1
=> ok github.com/tachigo/tachigo/cmd/server 0.406s

GREEN: rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./cmd/server -count=1
=> ok github.com/tachigo/tachigo/cmd/server 0.393s

GREEN: rtk env GOCACHE=/private/tmp/tachigo-go-cache go build ./...
=> pass

GREEN: rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./... -count=1
=> all services/api packages pass

GREEN: rtk env GOCACHE=/private/tmp/tachigo-go-cache go vet ./...
=> pass

GREEN: rtk git --no-optional-locks diff --check
GREEN: rtk git --no-optional-locks diff --cached --check
```

## 備註
Timeout values are intentionally fixed constants in `cmd/server` for this PR. Making them configurable would be a separate config-surface change.

## Notes for Claude Code Review
- 請特別確認 `serverWriteTimeout = 120s` 是否符合目前 spend/claim paths 可能等待外部 RPC/Tachiya 的最小風險設定。
- 這個 PR 不處理 B3 service-layer `WithContext(ctx)` 傳遞；只建立 server lifecycle boundary。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了服务器启动和关闭流程，实现优雅关闭机制
  * 添加了请求读写和空闲超时配置，提升生产环境稳定性
  * 确保服务器关闭时数据库连接被正确关闭

* **Tests**
  * 增加了服务器超时配置、优雅关闭行为及数据库清理的全面测试覆盖

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/611)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->