### PR TITLE
[backend] Add request timeout middleware

### DIFF
--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -13,6 +13,7 @@ const (
 	defaultJWTRefreshSecret   = "change-me-refresh-secret"
 	minJWTSecretLength        = 32
 	defaultSepoliaRPCEndpoint = "https://ethereum-sepolia-rpc.publicnode.com"
+	defaultRequestTimeoutSec  = 30
 )
 
 type Config struct {
@@ -98,7 +99,7 @@ func Load() *Config {
 	accessTTL, _ := strconv.Atoi(getEnv("JWT_ACCESS_TTL_MINUTES", "15"))
 	refreshTTL, _ := strconv.Atoi(getEnv("JWT_REFRESH_TTL_DAYS", "30"))
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "587"))
-	requestTimeoutSeconds, _ := strconv.Atoi(getEnv("REQUEST_TIMEOUT_SECONDS", "30"))
+	requestTimeoutSeconds := getPositiveIntEnv("REQUEST_TIMEOUT_SECONDS", defaultRequestTimeoutSec)
 	appEnv, appEnvSet := getEnvWithPresence("APP_ENV", "development")
 	isProduction := appEnvSet && appEnv == "production"
 
@@ -261,6 +262,18 @@ func getBoolEnv(key string, fallback bool) bool {
 		return fallback
 	}
 	return b
+}
+
+func getPositiveIntEnv(key string, fallback int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
 }
 
 func getCommaEnv(key string, fallback []string) []string {

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -61,6 +61,7 @@ type ServerConfig struct {
 	AllowedOrigins    []string
 	GinMode           string
 	TrustedProxies    []string
+	RequestTimeout    time.Duration
 }
 
 type DatabaseConfig struct {
@@ -97,6 +98,7 @@ func Load() *Config {
 	accessTTL, _ := strconv.Atoi(getEnv("JWT_ACCESS_TTL_MINUTES", "15"))
 	refreshTTL, _ := strconv.Atoi(getEnv("JWT_REFRESH_TTL_DAYS", "30"))
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "587"))
+	requestTimeoutSeconds, _ := strconv.Atoi(getEnv("REQUEST_TIMEOUT_SECONDS", "30"))
 	appEnv, appEnvSet := getEnvWithPresence("APP_ENV", "development")
 	isProduction := appEnvSet && appEnv == "production"
 
@@ -121,6 +123,7 @@ func Load() *Config {
 			AllowedOrigins:    getCommaEnv("ALLOWED_ORIGINS", defaultAllowedOrigins),
 			GinMode:           getEnv("GIN_MODE", defaultGinMode),
 			TrustedProxies:    getCommaEnv("TRUSTED_PROXIES", nil),
+			RequestTimeout:    time.Duration(requestTimeoutSeconds) * time.Second,
 		},
 		Database: DatabaseConfig{
 			DSN: getEnv("DATABASE_URL", "host=localhost user=postgres password=postgres dbname=tachigo port=5432 sslmode=disable"),

--- a/services/api/internal/config/config_test.go
+++ b/services/api/internal/config/config_test.go
@@ -300,6 +300,47 @@ func TestLoad_ContractRPCEndpoint(t *testing.T) {
 	})
 }
 
+func TestLoad_RequestTimeoutSecondsValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     time.Duration
+	}{
+		{
+			name:     "falls back to default when invalid",
+			envValue: "invalid",
+			want:     30 * time.Second,
+		},
+		{
+			name:     "falls back to default when zero",
+			envValue: "0",
+			want:     30 * time.Second,
+		},
+		{
+			name:     "falls back to default when negative",
+			envValue: "-1",
+			want:     30 * time.Second,
+		},
+		{
+			name:     "uses positive override",
+			envValue: "45",
+			want:     45 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("REQUEST_TIMEOUT_SECONDS", tc.envValue)
+
+			cfg := Load()
+
+			if cfg.Server.RequestTimeout != tc.want {
+				t.Fatalf("RequestTimeout: want %v, got %v", tc.want, cfg.Server.RequestTimeout)
+			}
+		})
+	}
+}
+
 func TestGetBoolEnv(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/services/api/internal/config/config_test.go
+++ b/services/api/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateProductionSecrets(t *testing.T) {
@@ -374,6 +375,7 @@ func TestLoad_ServerConfig_Defaults(t *testing.T) {
 		"APP_ENV", "LOG_LEVEL", "ENABLE_SWAGGER",
 		"ENABLE_AUTOMIGRATE", "ENABLE_SCHEDULER",
 		"ALLOWED_ORIGINS", "GIN_MODE", "TRUSTED_PROXIES",
+		"REQUEST_TIMEOUT_SECONDS",
 	}
 	for _, k := range envVars {
 		t.Setenv(k, "")
@@ -405,6 +407,9 @@ func TestLoad_ServerConfig_Defaults(t *testing.T) {
 	if cfg.Server.TrustedProxies != nil {
 		t.Errorf("TrustedProxies: want nil, got %v", cfg.Server.TrustedProxies)
 	}
+	if cfg.Server.RequestTimeout != 30*time.Second {
+		t.Errorf("RequestTimeout: want 30s, got %v", cfg.Server.RequestTimeout)
+	}
 }
 
 func TestLoad_ServerConfig_ProductionDefaults(t *testing.T) {
@@ -432,6 +437,7 @@ func TestLoad_ServerConfig_EnvOverrides(t *testing.T) {
 	t.Setenv("ALLOWED_ORIGINS", "https://app.tachigo.io,https://admin.tachigo.io")
 	t.Setenv("GIN_MODE", "debug")
 	t.Setenv("TRUSTED_PROXIES", "10.0.0.1,10.0.0.2")
+	t.Setenv("REQUEST_TIMEOUT_SECONDS", "45")
 
 	cfg := Load()
 
@@ -455,5 +461,8 @@ func TestLoad_ServerConfig_EnvOverrides(t *testing.T) {
 	}
 	if len(cfg.Server.TrustedProxies) != 2 || cfg.Server.TrustedProxies[0] != "10.0.0.1" {
 		t.Errorf("TrustedProxies: got %v", cfg.Server.TrustedProxies)
+	}
+	if cfg.Server.RequestTimeout != 45*time.Second {
+		t.Errorf("RequestTimeout: want 45s, got %v", cfg.Server.RequestTimeout)
 	}
 }

--- a/services/api/internal/middleware/rate_limit_test.go
+++ b/services/api/internal/middleware/rate_limit_test.go
@@ -2,6 +2,7 @@ package middleware_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -74,6 +75,20 @@ func TestRequestTimeout_Returns504WhenHandlerStopsOnDeadline(t *testing.T) {
 
 	if rec.Code != http.StatusGatewayTimeout {
 		t.Fatalf("want 504, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if body.Success {
+		t.Fatal("expected success=false")
+	}
+	if body.Error != "request timeout" {
+		t.Fatalf("want error %q, got %q", "request timeout", body.Error)
 	}
 }
 

--- a/services/api/internal/middleware/rate_limit_test.go
+++ b/services/api/internal/middleware/rate_limit_test.go
@@ -1,6 +1,7 @@
 package middleware_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -39,4 +40,58 @@ func doLimitedRequest(router *gin.Engine) int {
 	req := httptest.NewRequest(http.MethodGet, "/limited", nil)
 	router.ServeHTTP(rec, req)
 	return rec.Code
+}
+
+func TestRequestTimeout_AddsDeadlineToRequestContext(t *testing.T) {
+	router := gin.New()
+	router.Use(middleware.RequestTimeout(50 * time.Millisecond))
+	router.GET("/deadline", func(c *gin.Context) {
+		if _, ok := c.Request.Context().Deadline(); !ok {
+			t.Fatal("expected request context deadline")
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deadline", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequestTimeout_Returns504WhenHandlerStopsOnDeadline(t *testing.T) {
+	router := gin.New()
+	router.Use(middleware.RequestTimeout(time.Millisecond))
+	router.GET("/slow", func(c *gin.Context) {
+		<-c.Request.Context().Done()
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/slow", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("want 504, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequestTimeout_DisabledForNonPositiveDuration(t *testing.T) {
+	router := gin.New()
+	router.Use(middleware.RequestTimeout(0))
+	router.GET("/disabled", func(c *gin.Context) {
+		if _, ok := c.Request.Context().Deadline(); ok {
+			t.Fatal("expected request context without deadline")
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/disabled", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
 }

--- a/services/api/internal/middleware/request_timeout.go
+++ b/services/api/internal/middleware/request_timeout.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RequestTimeout(timeout time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if timeout <= 0 || c.Request == nil {
+			c.Next()
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
+		defer cancel()
+		c.Request = c.Request.WithContext(ctx)
+
+		c.Next()
+
+		if ctx.Err() == context.DeadlineExceeded && !c.Writer.Written() {
+			c.AbortWithStatusJSON(http.StatusGatewayTimeout, gin.H{
+				"success": false,
+				"error":   "request timeout",
+			})
+		}
+	}
+}

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -51,6 +51,9 @@ func New(
 
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
+	if cfg != nil {
+		r.Use(middleware.RequestTimeout(cfg.Server.RequestTimeout))
+	}
 	r.Use(middleware.CORS(allowedOrigins))
 
 	if cfg != nil && len(cfg.Server.TrustedProxies) > 0 {

--- a/services/api/internal/router/router_test.go
+++ b/services/api/internal/router/router_test.go
@@ -143,6 +143,29 @@ func TestSwaggerRoute_ProductionExplicitFlagExposesSwagger(t *testing.T) {
 	assertSwaggerExposed(t, env.router)
 }
 
+func TestRouter_AppliesRequestTimeoutMiddleware(t *testing.T) {
+	cfg := routerTestConfig("development", false, false)
+	cfg.Server.RequestTimeout = 50 * time.Millisecond
+	env := newRouterTestEnv(t, cfg)
+
+	var sawDeadline bool
+	env.router.GET("/test-timeout-deadline", func(c *gin.Context) {
+		_, sawDeadline = c.Request.Context().Deadline()
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test-timeout-deadline", nil)
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !sawDeadline {
+		t.Fatal("expected router to attach request context deadline")
+	}
+}
+
 func routerTestConfig(serverEnv string, enableSwagger, enableSwaggerSet bool) *config.Config {
 	return &config.Config{
 		Server: config.ServerConfig{


### PR DESCRIPTION
## 什麼改動
新增 request timeout middleware，讓 backend request context 依設定帶 deadline；若 handler 在 deadline 後未寫入回應，回傳 504 JSON。

## 為什麼
#455 Backend Production-Grade 路線圖 B6：補 request timeout middleware，避免 backend request 缺少統一 deadline，也替後續 DB query context timeout 工作提供 request context 基礎。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#455 B6
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 #455 B3 的 service-layer DB query WithContext 全面盤點
  - 不改 server graceful shutdown / http.Server timeout 設定
  - 不改 rate limit policy 或 endpoint behavior

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 為 backend router 加上可設定的 request context timeout middleware。
- Approx changed lines：~124
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - middleware/config/router 掛載與 tests 是同一個 request timeout behavior 的最小可驗證切片。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] request middleware 會替 request context 加上 deadline
- [x] handler 在 deadline 後未寫入回應時回傳 504 JSON
- [x] `REQUEST_TIMEOUT_SECONDS` 載入到 server config，預設 30 秒
- [x] router 會依 config 掛上 request timeout middleware

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./internal/middleware ./internal/config ./internal/router -run 'TestRequestTimeout|TestLoad_ServerConfig|TestRouter_AppliesRequestTimeout' -count=1
PASS: middleware, config, router focused tests

rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./internal/middleware ./internal/config ./internal/router -count=1
PASS: middleware, config, router packages

rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./... -count=1
PASS: all services/api packages

rtk env GOCACHE=/private/tmp/tachigo-go-cache go vet ./...
PASS

rtk git --no-optional-locks diff --check
PASS
```

## 備註
n/a

## Notes for Claude Code Review
- 這個 middleware 主要提供 request context deadline；實際 DB cancellation 仍需後續 #455 B3 將 service queries 接到 request context。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 可配置的请求超时机制，默认 30 秒，可通过环境变量调整；超时时 API 返回 HTTP 504 与错误信息。
* **测试**
  * 增加多项测试，覆盖超时配置的默认与覆盖行为、超时中间件在请求上下文与超时响应的行为，以及路由上超时中间件的应用验证。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/612)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->