### PR TITLE
[chore] Document backend permission rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ tachigo/
 |------|------|
 | System architecture | [docs/architecture.md](docs/architecture.md) |
 | Auth baseline | [docs/auth-architecture.md](docs/auth-architecture.md) |
+| Backend permissions | [docs/backend-permissions.md](docs/backend-permissions.md) |
 | Chrome sidepanel migration | [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md) |
 | PR scope policy | [docs/pr-scope-policy.md](docs/pr-scope-policy.md) |
 | Dependency update policy | [docs/dependabot-update-policy.md](docs/dependabot-update-policy.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 |---|---|
 | [`architecture.md`](architecture.md) | 系統整體架構與主要資料流 |
 | [`auth-architecture.md`](auth-architecture.md) | Auth 現況與 migration guardrails |
+| [`backend-permissions.md`](backend-permissions.md) | Backend role / permission 現況與變更 guardrails |
 | [`auto-merge-policy.md`](auto-merge-policy.md) | Auto-merge 與 approve 語義 |
 | [`dependabot-update-policy.md`](dependabot-update-policy.md) | Dependabot 更新政策 |
 | [`draft-pr-auto-ready.md`](draft-pr-auto-ready.md) | Draft PR auto-ready 現行流程 |

--- a/docs/backend-permissions.md
+++ b/docs/backend-permissions.md
@@ -1,0 +1,140 @@
+# Backend Permission Rules
+
+## Purpose
+
+This document records the backend permission rules that are currently enforced
+by the Go API. It is a current-state reference for dashboard, agency, streamer,
+viewer, and internal service access.
+
+It does not introduce new product policy. When this document conflicts with
+code, the code is the source of truth and this document should be updated in the
+same PR that changes the permission behavior.
+
+## Role Model
+
+Backend user roles are stored on `models.User.Role` and carried in access token
+claims.
+
+| Role | Current meaning |
+|---|---|
+| `viewer` | Default account role for viewers and regular users. |
+| `streamer` | Channel operator role for dashboard channel, raffle, and airdrop work. |
+| `agency` | Agency operator role for agency-owned streamer/channel work. |
+| `admin` | Global operator role for administrative setup and cross-account access. |
+
+## Enforcement Layers
+
+The API uses two main permission gates:
+
+| Layer | Mechanism | Behavior |
+|---|---|---|
+| Authentication | `middleware.JWTAuth` | Requires `Authorization: Bearer <token>`, validates the access token, and stores claims in Gin context. Missing or invalid tokens return 401. |
+| Role authorization | `middleware.RequireRole(...)` | Allows any listed role. Authenticated callers with a non-matching role return 403. |
+
+Handlers add ownership checks after the route-level role gate when the route is
+scoped to a channel, streamer, agency, or raffle owned by a specific user.
+
+## Public And Viewer Routes
+
+The following surfaces are not dashboard role-gated:
+
+| Surface | Current access |
+|---|---|
+| `/health` | Public liveness check. |
+| `/swagger/*any` | Public only when Swagger is enabled by config. |
+| Public auth routes under `/api/v1/auth` | Public, with rate limits on selected login/registration/reset paths. |
+| `GET /api/v1/claim/:token` | Public claim lookup. |
+| `POST /api/v1/claim/:token` | Requires a valid user JWT for the winner claim submission path. |
+| `/api/v1/extension/auth/login` | Public Twitch Extension login exchange. |
+| `/api/v1/extension/t-point/complete` and `/bits/complete` | Public completion callbacks with public endpoint rate limiting. |
+| `/api/v1/extension/raffles/:id/result` | Public raffle result read. |
+| `/api/v1/extension/watch/*` | Requires a valid tachigo JWT after extension login. |
+| `/api/v1/users/me/*`, `/api/v1/spend/redeem`, provider unlink, email verification send, and address routes | Require a valid user JWT and operate on the authenticated user. |
+
+Viewer JWTs do not pass dashboard, agency management, event, or admin role
+gates unless a route explicitly lists `viewer`, which the current dashboard and
+admin route groups do not.
+
+## Dashboard Routes
+
+All `/api/v1/dashboard/*` routes require a valid JWT and one of
+`admin`, `streamer`, or `agency` before route-specific checks run.
+
+| Route | Allowed roles | Additional ownership behavior |
+|---|---|---|
+| `POST /dashboard/streamers` | `admin` | Creates streamer records for a supplied user/channel. |
+| `GET /dashboard/streamers` | `agency`, `admin` | Admin lists all; agency lists streamers owned by that agency user. |
+| `GET /dashboard/streamers/:streamer_id/stats` | `streamer`, `agency`, `admin` | Streamer must own that streamer record; agency must own the streamer; admin can access any. Non-admin unauthorized streamer IDs return 404 to avoid existence enumeration. |
+| `POST /dashboard/streamers/register` | `streamer` | Registers the caller's own streamer channel. |
+| `GET /dashboard/streamers/channels` | `streamer` | Lists channels owned by the caller. |
+| `GET /dashboard/channels/:channel_id/stats` | `admin`, `streamer` | Non-admin callers must own the channel. Agencies are not route-level allowed here. |
+| `GET /dashboard/channels/:channel_id/config` | `admin`, `streamer`, `agency` | Streamer or agency callers must own the channel. |
+| `PUT /dashboard/channels/:channel_id/config` | `admin`, `streamer` | Streamer callers must own the channel. Agencies are not route-level allowed to update config. |
+| `POST /dashboard/channels/:channel_id/airdrop` | `admin`, `streamer`, `agency` | Streamer or agency callers must own the channel. |
+
+Raffle management routes under `/api/v1/dashboard/raffles` are currently
+streamer-only at the route level. The raffle service then verifies the caller's
+ownership of the target raffle where a raffle ID is supplied.
+
+## Agency Management Routes
+
+Agency management routes use JWT authentication and route-level role checks.
+Agency-scoped routes also check that an `agency` caller is operating on its own
+agency user ID.
+
+| Route | Allowed roles | Additional ownership behavior |
+|---|---|---|
+| `POST /api/v1/agencies` | `admin` | Creates an agency user and attempts setup email delivery. |
+| `GET /api/v1/agencies/:id` | `agency`, `admin` | Agency callers can only read their own agency record. |
+| `PUT /api/v1/agencies/:id/settings` | `agency`, `admin` | Agency callers can only update their own agency record. |
+| `GET /api/v1/agencies/:id/streamers` | `agency`, `admin` | Agency callers can only list streamers for their own agency record. |
+| `POST /api/v1/agencies/:id/resend-setup` | `admin` | Re-sends setup email for agencies that have not completed onboarding. |
+
+## Event And Admin Stubs
+
+The current event and admin groups are permission-gated, but their handlers are
+still placeholders.
+
+| Route group | Allowed roles | Current behavior |
+|---|---|---|
+| `/api/v1/events/*` | `streamer`, `agency`, `admin` | Stub handlers return 501 after authorization succeeds. |
+| `/api/v1/admin/*` | `admin` | Stub handlers return 501 after authorization succeeds. |
+
+These stubs should not be treated as complete product APIs until their handlers
+are implemented and tested.
+
+## Internal Service Route
+
+`/api/v1/internal/tachiya/users/points/balance` is not JWT-authenticated. It is
+registered only when the API has both a database handle and
+`TACHIYA_SHARED_SECRET` configured. Requests must include
+`X-Tachiya-Internal-Secret` matching the configured secret; otherwise the API
+returns 401.
+
+This route is intended for Tachiya-to-tachigo service calls, not browser or
+dashboard traffic.
+
+## Status Code Conventions
+
+| Situation | Current response |
+|---|---|
+| Missing bearer token on JWT route | 401 |
+| Invalid or expired bearer token | 401 |
+| Valid token but route-level role mismatch | 403 |
+| Valid token and route role passes, but handler ownership check fails | 403 or 404 depending on enumeration risk for that handler |
+| Authorized caller reaches not-yet-implemented event/admin stub | 501 |
+
+## Change Guardrails
+
+Permission changes should be handled in dedicated PRs when they do any of the
+following:
+
+- change which roles can access an existing route
+- change ownership checks for channel, streamer, agency, raffle, or user data
+- expose a route that was previously JWT or internal-secret protected
+- turn an event/admin stub into product behavior
+- change 401/403/404 behavior in a way that affects enumeration risk
+
+Small documentation corrections can be made with the code change they describe,
+but this document should not be used to introduce policy that is not yet
+implemented in code.


### PR DESCRIPTION
## 什麼改動
新增 `docs/backend-permissions.md`，記錄目前 backend 已實作的 role / permission 規則，並從 root README 與 docs index 連到該文件。

## 為什麼
refs #455 D3。Production-grade roadmap 要文件化 admin / streamer / agency 權限規則；本 PR 只整理現行程式碼已 enforce 的權限邊界，不引入新 policy。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#455 D3
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 backend permission behavior
  - 不新增或移除 role
  - 不實作 event/admin stub
  - 不改 dashboard / extension UI

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 文件化目前 backend role / permission 規則與變更 guardrails。
- Approx changed lines：~142
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試未修改；只執行既有 RBAC/handler 測試驗證文件內容對照現行 behavior。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Backend admin / streamer / agency permission rules are documented
- [x] Current role gates and ownership checks are documented without changing behavior
- [x] Documentation index links to the permission rules

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
rtk env GOCACHE=/private/tmp/tachigo-go-cache go test ./internal/middleware ./internal/handlers -run 'TestRequireRole|TestRBAC|TestChannelConfig|TestAirdrop|TestAgency' -count=1
PASS: middleware and handlers focused RBAC/permission tests

rtk git --no-optional-locks diff --check
PASS

rtk git --no-optional-locks diff --cached --check
PASS
```

## 備註
n/a

## Notes for Claude Code Review
- 重點請確認 `docs/backend-permissions.md` 是否只描述 current-state code behavior，沒有把未實作的 event/admin stubs 寫成完成 API。
- 本 PR uses `refs #455` intentionally; it should not close the parent roadmap issue.
