### PR TITLE
[infra] Add repository security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are accepted for the currently maintained development branch,
+`develop`, and any actively deployed release branch.
+
+Historical branches, archived experiments, and local development snapshots are
+not supported unless a maintainer explicitly marks them as supported.
+
+## Reporting A Vulnerability
+
+Please report security vulnerabilities privately. Do not create a public issue,
+pull request, discussion, or social media post that includes exploit details,
+proof-of-concept code, secrets, private keys, token abuse paths, or personally
+identifiable information.
+
+Preferred reporting path:
+
+1. Open the repository's Security tab on GitHub.
+2. Choose "Report a vulnerability" if private vulnerability reporting is
+   enabled.
+3. Include a concise description, affected surface, reproduction steps, impact,
+   and any suggested mitigation.
+
+If private vulnerability reporting is not available, open a minimal public issue
+asking for a private security contact. Do not include vulnerability details in
+that issue.
+
+## Scope
+
+Security reports are especially useful for issues involving:
+
+- authentication or authorization bypass
+- Twitch extension or OAuth token exposure
+- wallet signature verification, replay protection, or chain ownership checks
+- TACHI token accounting, mint, burn, claim, spend, balance, reward, raffle, or
+  airdrop logic
+- smart contract vulnerabilities
+- leaked secrets, signer keys, deployment credentials, or production
+  configuration
+- dependency vulnerabilities that are reachable in production behavior
+
+Routine dependency update requests, general bugs without a security impact, and
+feature requests should use the normal issue or pull request process instead.
+
+## Response Expectations
+
+Maintainers will try to acknowledge valid private reports within three business
+days. The timeline for a fix depends on severity, exploitability, affected
+surface, and release coordination needs.
+
+When a report is accepted, maintainers may coordinate a fix privately before
+public disclosure. Please avoid publishing details until a fix or mitigation has
+been released and maintainers have had a reasonable opportunity to notify users.
+
+## Bounty Policy
+
+This project does not currently operate a paid bug bounty program. Reports are
+still welcome and appreciated, but submitting a report does not create an
+entitlement to payment, rewards, tokens, or other compensation.


### PR DESCRIPTION
## 什麼改動
新增 `.github/SECURITY.md`，讓 GitHub 能顯示 repository security policy。

## 為什麼
補上正式漏洞通報入口，讓研究者或使用者知道應透過私密管道回報安全問題，避免把 exploit detail、secret、signer key、token abuse path 等內容公開在 issue 或 PR。

closes #624

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#624
- Depends on PR：none
- Backend contract already in develop:
  - [ ] yes
  - [ ] no
  - n/a：docs-only policy PR，沒有 backend contract 變更。
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
  - n/a：docs-only policy PR。
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不啟用 GitHub Private vulnerability reporting 設定。
  - 不調整 CI、Dependabot、branch protection 或 security scanner policy。
  - 不修改 product code。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 GitHub repository security policy。
- Approx changed lines：~61
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] GitHub can detect a repository security policy.
- [x] The policy includes supported versions or branches.
- [x] The policy includes private reporting guidance.
- [x] The policy avoids promising compensation or an overly strict response SLA.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
rtk sed -n '1,220p' .github/SECURITY.md
# pass: confirmed the security policy content is readable.

rtk git --no-optional-locks diff --cached --stat
# pass before commit: .github/SECURITY.md only, 61 insertions.

rtk make pr-meta-check TITLE="[infra] Add repository security policy" BODY_FILE=/tmp/tachigo-security-policy-pr.md HEAD=docs/security-policy
# pass: PR metadata check passed.
```

## 備註
GitHub Private vulnerability reporting still needs to be enabled by a repository admin in GitHub settings.

## Notes for Claude Code Review
- This is intentionally limited to the public `SECURITY.md` policy file.
- No runtime behavior changes are included.
- The policy does not promise a paid bug bounty or hard SLA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 添加了 GitHub 安全策略文档，明确了漏洞报告流程、信息披露指南和安全修复支持的分支等信息。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/625)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->