### PR TITLE
[backend] Align Atlas runtime ownership paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,16 @@ docker compose logs -f        # tail all logs
 
 - Hot reload via [air](https://github.com/air-verse/air) — save any `.go` file to rebuild
 - Swagger docs regenerated automatically on each build (`swag init`)
-- Tests use SQLite in-memory — no Postgres required
+- Unit tests mostly use SQLite in-memory.
+- Schema/migration validation uses PostgreSQL via Atlas and CI.
+- Changes touching migrations, PostgreSQL constraints, partial indexes, or the Atlas loader must be verified against PostgreSQL.
 
 ```bash
+# Unit tests
 docker compose run --no-deps --rm app go test ./...
+
+# Integration / PostgreSQL-related tests
+docker compose run --rm app go test -tags integration ./...
 ```
 
 ### Frontend (`apps/extension/`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,9 +5,9 @@
 │                           CLIENT LAYER                             │
 │                                                                    │
 │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
-│  │ Chrome Sidepanel │  │  Dashboard [TBD] │  │  Wallet [Phs.2]  │  │
-│  │   (tachimint)    │  │  Agency/Streamer │  │  Claim on-chain  │  │
-│  │ React+TypeScript │  │  Mgmt Interface  │  │                  │  │
+│  │ Chrome Sidepanel │  │  Dashboard [MVP] │  │  Wallet [Phs.2]  │  │
+│  │   (tachimint)    │  │ React+Vite+Refine│  │  Claim on-chain  │  │
+│  │ React+TypeScript │  │ Agency/Strm Mgmt │  │                  │  │
 │  └────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘  │
 └───────────┼─────────────────────┼─────────────────────┼────────────┘
             │ Heartbeat + JWT     │ Admin API           │ Claim
@@ -46,7 +46,7 @@
                                             │  Private stream [Phs2] │
                                             └────────────────────────┘
 
-[done] = 已完成    [TBD] = MVP 待實作    [Phs.2] = Phase 2+
+[done] = 已完成    [MVP] = MVP 已進入實作    [TBD] = MVP 待實作    [Phs.2] = Phase 2+
 ```
 
 ## 主要資料流

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,9 +5,9 @@
 │                           CLIENT LAYER                             │
 │                                                                    │
 │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
-│  │ Chrome Sidepanel │  │  Dashboard [MVP] │  │  Wallet [Phs.2]  │  │
-│  │   (tachimint)    │  │ React+Vite+Refine│  │  Claim on-chain  │  │
-│  │ React+TypeScript │  │ Agency/Strm Mgmt │  │                  │  │
+│  │ Chrome Sidepanel │  │  Dashboard [TBD] │  │  Wallet [Phs.2]  │  │
+│  │   (tachimint)    │  │  Agency/Streamer │  │  Claim on-chain  │  │
+│  │ React+TypeScript │  │  Mgmt Interface  │  │                  │  │
 │  └────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘  │
 └───────────┼─────────────────────┼─────────────────────┼────────────┘
             │ Heartbeat + JWT     │ Admin API           │ Claim
@@ -46,7 +46,7 @@
                                             │  Private stream [Phs2] │
                                             └────────────────────────┘
 
-[done] = 已完成    [MVP] = MVP 已進入實作    [TBD] = MVP 待實作    [Phs.2] = Phase 2+
+[done] = 已完成    [TBD] = MVP 待實作    [Phs.2] = Phase 2+
 ```
 
 ## 主要資料流

--- a/docs/atlas-migration-plan.md
+++ b/docs/atlas-migration-plan.md
@@ -4,22 +4,34 @@
 
 **目標：** 將 `services/api` 的 schema 管理由 GORM `AutoMigrate` 遷移到 Atlas，同時不削弱既有資料庫 invariant，也不送出不安全的 baseline。
 
-**架構：** Atlas 遷移原本規劃拆成多個小型、可獨立 review 的 PR：先導入 tooling 與 CI validation，再盤點現有 schema source，接著決定並驗證 baseline 策略，最後移除 runtime `AutoMigrate` 與手寫 schema patches。2026-05-10 後續決策改為由 PR `#588` 一次交付完整 runtime migration path，因為專案尚未正式上線，保留半套 migration ownership 反而會增加風險。
+**架構：** Atlas 遷移原本規劃拆成多個小型、可獨立 review 的 PR。2026-05-10 後續決策改為由 PR `#588` 一次交付完整 runtime migration path，因為專案尚未正式上線，保留半套 migration ownership 反而會增加風險。下方 PR 1-4 保留為 historical plan，不再作為新的 implementation checklist。
 
 **Tech Stack：** Go、GORM、PostgreSQL、Atlas、`atlas-provider-gorm`、GitHub Actions。
 
 ---
 
-## Source Of Truth
+## Issue And Artifact References
 
 - GitHub issue：`#463` `[backend] Migration 工具遷移：GORM AutoMigrate → Atlas`
 - 前置討論：`#214`
 - Migration 目錄：`services/api/migrations/`
 - Atlas 設定檔：`services/api/atlas.hcl`
-- 目前 runtime schema 入口：`services/api/cmd/server/main.go`
-- 目前 GORM models：`services/api/internal/models/`
+- API server entrypoint：`services/api/cmd/server/main.go`
+- GORM model structs：`services/api/internal/models/`
+- Atlas loader model list：`services/api/internal/schema.AtlasSchemaModels()`
 
-本文件只是執行計劃，不代表 `#463` 已完成，也不得把文件本身當成 implementation source of truth。
+## Current Source Of Truth
+
+目前 `develop` 的實作狀態：
+
+- Atlas migration directory is active at `services/api/migrations/`.
+- Docker entrypoint applies migrations before starting `air`, `/tachigo`, or `tachigo`.
+- Local `make run` depends on `make migrate`; `make run-no-migrate` is the explicit skip path.
+- API binary must not execute schema DDL; startup guard tests enforce this boundary.
+- GORM model structs remain the Atlas loader schema source via `AtlasSchemaModels()`, not a runtime migration owner.
+- Legacy raffle token hash repair remains a data-only startup repair.
+
+本文件記錄 issue `#463` 的遷移背景與現況；future implementation 必須以上方 current source of truth 和 repo code 為準，不得把 historical checklist 當成新的待辦。
 
 ## Guardrails
 
@@ -30,7 +42,9 @@
 - 不得把 production deploy automation 或 rollback automation 混進 `#463`；issue 已明確排除。
 - 任何改變 runtime schema 行為的 PR，都必須在 PR body 補 staging 驗證說明。
 
-## PR 拆分順序
+## Historical Plan
+
+以下 PR 1-4 是原始拆分計畫，已被 PR `#588` 取代，不再作為新的 implementation checklist。保留它們只為了說明 Atlas ownership 遷移時的決策脈絡。
 
 ### PR 1：Atlas Tooling Only
 
@@ -226,6 +240,7 @@ Co-Authored-By: Codex <codex[bot]@openai.com>
 ### 運作邊界
 
 - Fresh DB / 新 Docker volume：API Docker entrypoint 會先套用 `001-020`，再啟動 `air`（dev target）或 `/tachigo`（runtime target）；API binary 本身不再執行 schema DDL。
+- Local Go startup：`make run` 會先執行 `make migrate`；只有明確使用 `make run-no-migrate` 才會跳過 Atlas migration。
 - 既有 dev DB / 舊 volume：若 schema 是早期 `AutoMigrate` 建出來、但沒有 `atlas_schema_revisions`，Atlas 不能自動判斷已套用哪些歷史 migration；本專案尚未正式上線，建議 reset dev volume 或由 operator 手動 baseline。
 - Production deploy automation 仍不屬於 `#463` 範圍；上線前需要在部署 workflow/runbook 中重用同一個 `atlas migrate apply` 流程。
 
@@ -236,7 +251,7 @@ Co-Authored-By: Codex <codex[bot]@openai.com>
 - [x] `services/api/migrations/001-019` 與 GORM model drift 已記錄或修正。
 - [x] Baseline strategy 明確，採 guarded apply-safe reconciliation migration。
 - [x] `AutoMigrate` 已從 server startup 移除；server 不再執行 schema DDL。
-- [x] Migration runner 存在：Docker image entrypoint 與 `make migrate` 都有 `atlas migrate apply` path，確保 fresh DB / 新 volume 可正確 bootstrap schema。
+- [x] Migration runner 存在：Docker image entrypoint 與 `make migrate` 都有 `atlas migrate apply` path；`make run` 依賴 `make migrate`，確保 fresh DB / 新 volume / 本機 Go startup 可正確 bootstrap schema。
 - [x] CI 改成 official/latest Atlas + ephemeral Postgres apply（移除舊版 pin、Community binary 與 migrate lint）。
 
 ## Atlas References

--- a/services/api/Makefile
+++ b/services/api/Makefile
@@ -1,9 +1,12 @@
-.PHONY: run build tidy migrate db-up db-down up down logs lint test
+.PHONY: run run-no-migrate build tidy migrate db-up db-down up down logs lint test
 
 ATLAS_DATABASE_URL ?= postgres://postgres:postgres@localhost:5432/tachigo?sslmode=disable
 
 # ── Dev ───────────────────────────────────────────────────────────────────────
-run:
+run: migrate
+	go run ./cmd/server
+
+run-no-migrate:
 	go run ./cmd/server
 
 build:

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -48,7 +48,7 @@ make run
 常用後端指令：
 
 ```bash
-make run    # go run ./cmd/server
+make run    # atlas migrate apply, then go run ./cmd/server
 make build  # go build -o bin/tachigo ./cmd/server
 make test   # go test ./... -v
 make tidy   # go mod tidy
@@ -119,24 +119,23 @@ swag init -g cmd/server/main.go --output docs --quiet
 
 ## 資料庫與 migrations
 
-目前 server startup 會執行：
+Atlas owns runtime schema changes. Server startup no longer runs schema DDL; schema changes must enter through [`migrations/`](migrations/) and be applied with Atlas.
 
-- 建立 `user_role` enum
-- `db.AutoMigrate(schema.AutoMigrateModels()...)`
-- 需要 PostgreSQL partial index / FK / runtime repair 的 idempotent SQL patch
+Current paths:
 
-[`migrations/`](migrations/) 內的 `001-019` SQL 是現有 schema history / manual setup reference。Atlas 遷移正在 #463 路線中推進；在正式 runner 完成前，不要把這個目錄誤認為 production migration pipeline。
+- Docker entrypoint applies `atlas migrate apply` before starting `air` or `/tachigo`.
+- `make run` depends on `make migrate`; use `make run-no-migrate` only when intentionally reusing an already-migrated database.
+- `cmd/loader` uses `internal/schema.AtlasSchemaModels()` as the GORM schema source for Atlas.
+- Legacy raffle claim token hashing remains a data-only startup repair; do not add schema DDL to server bootstrap.
 
-若需要在乾淨 local PostgreSQL 上重播目前 SQL reference，可以使用：
+若需要在乾淨 local PostgreSQL 上重播目前 migration directory，可以使用：
 
 ```bash
 cd services/api
-for file in migrations/*.sql; do
-  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
-done
+atlas migrate apply --dir file://migrations --url "$ATLAS_DATABASE_URL"
 ```
 
-注意：這個 loop 只適合本機驗證或 schema reconciliation。正式環境變更要依當前 PR / issue 的 migration strategy 執行。
+注意：正式環境變更要依當前 deploy workflow / runbook 的 Atlas migration strategy 執行，不要讓 API binary 重新取得 schema DDL ownership。
 
 ## 分層結構
 
@@ -152,8 +151,8 @@ done
 | `internal/handlers` | HTTP request / response layer |
 | `internal/services` | domain logic 與 transaction boundaries |
 | `internal/models` | GORM models 與 persisted schema shape |
-| `internal/schema` | server AutoMigrate 與 Atlas loader 共用的 model list |
-| `migrations` | historical / manual SQL migration reference |
+| `internal/schema` | Atlas loader 使用的 GORM model list |
+| `migrations` | Atlas-owned SQL migration directory |
 | `docs` | generated Swagger artifacts |
 
 通常修改順序：
@@ -165,7 +164,7 @@ done
 
 ## 測試
 
-後端測試預設使用 SQLite in-memory，少數 PostgreSQL-specific 測試使用 testcontainers 或 `DATABASE_URL`。
+後端 unit tests 預設多數使用 SQLite in-memory；schema / migration validation 以及 PostgreSQL-specific constraints、partial indexes、Atlas loader 相關變更必須走 PostgreSQL path。
 
 常用指令：
 
@@ -179,7 +178,11 @@ go test ./internal/handlers -count=1
 從 repo root 用 Docker 跑：
 
 ```bash
+# SQLite-backed unit tests only
 docker compose run --no-deps --rm app go test ./...
+
+# Integration / PostgreSQL-related tests
+docker compose run --rm app go test -tags integration ./...
 ```
 
 新增 API endpoint 時，請同步檢查 handler tests、router auth / role boundary、Swagger annotation，以及 `services/api/docs/` 產物是否需要更新。

--- a/services/api/cmd/loader/main.go
+++ b/services/api/cmd/loader/main.go
@@ -39,7 +39,7 @@ func atlasDialect() string {
 }
 
 func atlasModels() []any {
-	return schema.AutoMigrateModels()
+	return schema.AtlasSchemaModels()
 }
 
 func atlasCustomPostgresSchema() string {

--- a/services/api/cmd/loader/main_test.go
+++ b/services/api/cmd/loader/main_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/tachigo/tachigo/internal/schema"
 )
 
-func TestAtlasModelsUseSharedAutoMigrateModels(t *testing.T) {
+func TestAtlasModelsUseSharedAtlasSchemaModels(t *testing.T) {
 	got := modelTypeNames(atlasModels())
-	want := modelTypeNames(schema.AutoMigrateModels())
+	want := modelTypeNames(schema.AtlasSchemaModels())
 
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("atlas model list drifted from shared AutoMigrate model list\nwant: %#v\n got: %#v", want, got)
+		t.Fatalf("atlas model list drifted from shared Atlas schema model list\nwant: %#v\n got: %#v", want, got)
 	}
 }
 

--- a/services/api/cmd/server/bootstrap.go
+++ b/services/api/cmd/server/bootstrap.go
@@ -24,6 +24,9 @@ func bootstrap(cfg *config.Config) *gorm.DB {
 }
 
 func hashLegacyRaffleClaimTokens(ctx context.Context, db *gorm.DB) error {
+	// Data repair only. Do not add schema DDL here.
+	// Prefer Atlas migrations for schema changes and explicit data migrations
+	// or ops runbooks for one-time data changes.
 	// claim_token was previously a raw UUIDv7 (36 chars); it now stores the
 	// SHA-256 hex digest (64 chars). This idempotent repair is data-only.
 	return db.WithContext(ctx).Exec(`

--- a/services/api/internal/schema/models.go
+++ b/services/api/internal/schema/models.go
@@ -2,7 +2,8 @@ package schema
 
 import "github.com/tachigo/tachigo/internal/models"
 
-func AutoMigrateModels() []any {
+// AtlasSchemaModels returns the GORM model list used by the Atlas external schema loader.
+func AtlasSchemaModels() []any {
 	return []any{
 		&models.User{},
 		&models.AuthProvider{},


### PR DESCRIPTION
## 什麼改動
- Make `services/api` local `make run` apply Atlas migrations before starting the Go server, with `run-no-migrate` as the explicit skip path.
- Rename the shared GORM model list from `AutoMigrateModels()` to `AtlasSchemaModels()` and update the Atlas loader test.
- Add a no-schema-DDL guardrail comment around the remaining startup data repair.
- Update Atlas, backend, and root README docs so they describe the current migration/test state instead of stale AutoMigrate-era language.
- Scope correction: removed the dashboard architecture status update from this PR; that separate docs task is tracked by #643.

## 為什麼
Refs #463.

Atlas owns runtime schema changes now, but local `make run` could still start the API without applying migrations while Docker entrypoint did apply them. That split made fresh DB state depend on how a developer started the service. The docs and model-list naming also still carried old AutoMigrate-era wording.

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#463 and the Atlas runtime ownership consistency audit in the Codex thread
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Does not add or modify SQL migration files.
  - Does not move the legacy raffle token data repair into a one-shot task.
  - Does not change backend service, handler, router, or API contract behavior.
  - Does not add dashboard UI functionality.
  - Does not update dashboard architecture status; that is tracked separately by #643.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Align local runtime startup, loader naming, and docs with Atlas schema ownership.
- Approx changed lines：~89
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The test/cleanup/docs changes all document or enforce the same ownership boundary: Atlas is the runtime schema owner, while GORM models feed only the Atlas loader. No schema, service, handler, or frontend behavior is included.
- 若已拆分，相關 PR：
  - #643 tracks the separate dashboard architecture status docs update.

## Acceptance Criteria
- [x] Local `make run` applies Atlas migrations before `go run ./cmd/server`.
- [x] Atlas loader uses `AtlasSchemaModels()` instead of AutoMigrate-era naming.
- [x] Startup raffle token repair is documented as data-only and not a place for schema DDL.
- [x] Docs distinguish SQLite-backed unit tests from PostgreSQL/Atlas migration validation.
- [x] Atlas plan distinguishes historical PR 1-4 planning from current source of truth.

## 超出範圍內容
無；dashboard architecture status was removed from this PR and is tracked by #643.

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk env GOCACHE=/private/tmp/tachigo-go-build-cache go test ./cmd/loader -run TestAtlasModelsUseSharedAtlasSchemaModels -count=1
ok  	github.com/tachigo/tachigo/cmd/loader	0.393s

rtk env GOCACHE=/private/tmp/tachigo-go-build-cache go test ./cmd/server -run 'TestServerStartupDoesNotRunSchemaDDL|TestServerStartupIsSplitByResponsibility' -count=1
ok  	github.com/tachigo/tachigo/cmd/server	0.407s

rtk make -n run
atlas migrate apply --dir file://migrations --url "postgres://postgres:postgres@localhost:5432/tachigo?sslmode=disable"
go run ./cmd/server

rtk rg -n 'AutoMigrateModels|Tests use SQLite in-memory|server startup 會執行|manual SQL migration reference|make run\s+# go run|PR 拆分順序' README.md services/api/README.md docs/atlas-migration-plan.md services/api/cmd services/api/internal/schema -g '!services/api/tmp/**'
No matches.

rtk git --no-optional-locks diff --check origin/develop...HEAD
No output.
```

## Delegation Execution Log
- Source issue delegation plan：#463 Atlas runtime ownership consistency cleanup.
- Actual worker profile(s)：controller
- Model strength：GPT-5 controller, self-only execution; no subagent delegation used.
- Verification evidence：focused loader/server tests with writable `GOCACHE`; `rtk make -n run`; stale wording grep; `rtk git --no-optional-locks diff --check origin/develop...HEAD`.
- Self-review / exception reason：small scoped cleanup; dashboard architecture status split out to #643 to avoid scope pollution.
- Worker session closeout：controller implemented, verified, committed, pushed, and updated PR #635 from a clean automation worktree.

## 備註
This PR was prepared and updated in clean worktrees so unrelated dirty files in the original workspace were not included.

## Notes for Claude Code Review
- Please verify the `make run` behavior is the desired local default now that Atlas owns runtime schema migrations.
- The remaining raffle token hashing still runs at startup, but this PR only labels it as data-only and does not move it to a migration/ops task.
