### PR TITLE
[chore] Update UUID v7 migration plan status

### DIFF
--- a/docs/uuid-v7.md
+++ b/docs/uuid-v7.md
@@ -1,12 +1,14 @@
 # UUID 版本策略
 
-> **最後更新：** 2026-04-01
+> **最後更新：** 2026-05-13
 
 ---
 
-## 決策
+## 目標決策
 
-所有 model 的 Primary Key 使用 **UUID v7**，不使用 UUID v4。
+正式環境 model 的 Primary Key 應優先使用 **UUID v7**，避免新資料以 UUID v4 隨機散落在 B-tree index。
+
+目前實作狀態仍是部分完成；剩餘遷移清單維護在 [`plans/uuid-v7-migration.md`](../plans/uuid-v7-migration.md)。本文件只描述技術策略，不追蹤逐檔進度。
 
 ---
 
@@ -24,21 +26,25 @@ UUID v7 前 48 bits 為毫秒時間戳，後接隨機值。新資料永遠插在
 
 ## 實作方式
 
-Go 層在 `BeforeCreate` hook 使用 `uuid.New7()`（`github.com/google/uuid` v1.6+）：
+Go 層在 `BeforeCreate` hook 使用 `uuid.NewV7()`（`github.com/google/uuid` v1.6+）：
 
 ```go
 func (u *User) BeforeCreate(tx *gorm.DB) error {
     if u.ID == uuid.Nil {
-        u.ID = uuid.New7()
+        id, err := uuid.NewV7()
+        if err != nil {
+            id = uuid.New()
+        }
+        u.ID = id
     }
     return nil
 }
 ```
 
-PostgreSQL 的 `default:gen_random_uuid()` GORM tag 維持不變作為 fallback（Go 層永遠先生成，DB default 不會觸發）。PostgreSQL 17 才有原生 `uuidv7()`，不在此版本做 DB 層改動。
+PostgreSQL 的 `default:gen_random_uuid()` GORM tag 維持不變作為資料庫層 fallback；正常路徑由 Go 層先生成 ID，因此 DB default 不會觸發。PostgreSQL 17 才有原生 `uuidv7()`，不在此版本做 DB 層改動。
 
 ---
 
 ## 範圍
 
-所有 model 的 `BeforeCreate` hook，以及 service 層直接賦值 `ID: uuid.New()` 的地方。測試中的 `uuid.New()` 不需更換（測試 ID 無須時序性）。
+正式環境 model 的 `BeforeCreate` hook，以及 service 層直接賦值正式資料列 ID 的地方。測試中的 `uuid.New()` 不需更換（測試 ID 無須時序性）。

--- a/plans/uuid-v7-migration.md
+++ b/plans/uuid-v7-migration.md
@@ -1,44 +1,65 @@
 # UUID v7 Migration
 
-> **狀態：** 待實作
-> **關聯 Issue：** refs #61
-> **最後更新：** 2026-04-01
+> **狀態：** 部分完成，剩餘正式環境 hooks 待遷移
+> **關聯 Issue：** refs #61, refs #354
+> **最後更新：** 2026-05-13
 
 ---
 
 ## 背景
 
-所有 model 的 PK 目前用 `uuid.New()`（UUID v4，完全隨機），導致 B-tree index 隨機插入、page split。改用 `uuid.New7()`（UUID v7，時序）可解決此問題。詳見 [docs/uuid-v7.md](../docs/uuid-v7.md)。
+UUID v7 的技術原理與策略維護在 [docs/uuid-v7.md](../docs/uuid-v7.md)。本文件只追蹤實作狀態，避免與策略文件重複。
+
+目前 `services/api` 已有部分 model 與 service 建立資料列的路徑改用 `uuid.NewV7()`，但仍有正式環境 `BeforeCreate` hook 使用 `uuid.New()`。本 plan 因此保留在 active `plans/`，暫不歸檔。
+
+---
+
+## 已完成項目
+
+### 已使用 UUID v7 的 model BeforeCreate hooks
+
+- [x] `services/api/internal/models/claim.go`（Claim、ClaimItem）
+- [x] `services/api/internal/models/coupon_redemption.go`
+- [x] `services/api/internal/models/points.go`（PointsLedger、PointsTransaction）
+- [x] `services/api/internal/models/raffle.go`（Raffle、RaffleEntry、RaffleDraw、RaffleClaim）
+- [x] `services/api/internal/models/streamer.go`
+- [x] `services/api/internal/models/watch_session.go`
+- [x] `services/api/internal/models/watch_stats.go`（WatchTimeStat、BroadcastTimeStat、BroadcastTimeLog）
+
+### 已使用 UUID v7 的 service 正式資料列 ID 建立路徑
+
+- [x] `services/api/internal/services/watch_service.go` 使用 `newUUID()` 建立 watch session 與 ledger/transaction IDs。
+- [x] `services/api/internal/services/points_service.go` 使用 `newUUID()` 處理直接 SQL insert。
 
 ---
 
 ## 待實作項目
 
-### Model BeforeCreate hooks（改 uuid.New7()）
+### 仍使用 UUID v4 的 model BeforeCreate hooks
 
-- [ ] `backend/internal/models/user.go`
-- [ ] `backend/internal/models/auth_provider.go`
-- [ ] `backend/internal/models/address.go`
-- [ ] `backend/internal/models/refresh_token.go`
-- [ ] `backend/internal/models/email_auth.go`（EmailVerification、PasswordReset）
-- [ ] `backend/internal/models/points.go`（PointsLedger、PointsTransaction）
-- [ ] `backend/internal/models/watch_session.go`
+- [ ] `services/api/internal/models/user.go`
+- [ ] `services/api/internal/models/auth_provider.go`
+- [ ] `services/api/internal/models/address.go`
+- [ ] `services/api/internal/models/refresh_token.go`（RefreshToken、Web3Nonce）
+- [ ] `services/api/internal/models/email_auth.go`（EmailVerification、PasswordReset）
 
-### Service 層直接賦值（改 uuid.New7()）
+### Service 層直接賦值
 
-- [ ] `backend/internal/services/watch_service.go:62` — `ID: uuid.New()` for WatchSession
-- [ ] `backend/internal/services/extension_service.go:125` — `ID: uuid.New()` for User
+- [x] `services/api/internal/services` 底下已無非測試用的 `ID: uuid.New()` 直接賦值。
 
 ### 不需更動
 
-- 測試檔案中的 `uuid.New()` — 測試 ID 無須時序性
+- 測試檔案中的 `uuid.New()`：測試 ID 無須時序性。
+- `uuid.New()` 作為 `uuid.NewV7()` 發生錯誤後的 fallback。
 
 ---
 
 ## 驗證方式
 
 ```bash
-docker compose run --no-deps --rm app go test ./...
+rtk rg -n "ID:\\s*(uuid.New|newUUID)|uuid.NewV7|uuid.New\\(\\)" services/api/internal/services -g '!**/*_test.go'
+rtk rg -n "func .*BeforeCreate|uuid.NewV7|uuid.New\\(\\)" services/api/internal/models -g '!**/*_test.go'
+rtk docker compose run --no-deps --rm app go test ./...
 ```
 
-確認生成的 UUID 為 v7 格式（開頭 8 個 hex chars 反映時間，不是純隨機）。
+後續實作 PR 應補 model-level tests，確認新建 production rows 的 ID 使用 UUID v7（`id.Version() == 7`）。


### PR DESCRIPTION
## 什麼改動
- 更新 `docs/uuid-v7.md`，把 UUID v7 策略文件改成只描述目標策略與技術原理，並修正 `github.com/google/uuid` 的 API 名稱為 `uuid.NewV7()`。
- 更新 `plans/uuid-v7-migration.md`，重新盤點 develop 上已完成與剩餘的 UUID v7 production hooks，改用現行 `services/api/...` 路徑，移除過時的 service TODO。

## 為什麼
Refs #354。

#354 要求整合 `docs/uuid-v7.md` 與 `plans/uuid-v7-migration.md`：技術原理留在 `docs/`，實作進度留在 `plans/`。目前 develop 仍有部分 production `BeforeCreate` hook 使用 `uuid.New()`，所以 migration plan 不能歸檔；本 PR 先把狀態與範圍校正，避免文件誤導 reviewer 或後續 worker。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#354
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 Go 程式碼。
  - 不遷移剩餘 `uuid.New()` production hooks。
  - 不歸檔 `plans/uuid-v7-migration.md`，因為仍有剩餘實作項目。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #354 docs cleanup backlog item。
- Actual worker profile(s)：
  - controller only。
- Model strength：
  - main controller = GPT-5.5 xhigh；未使用 subagent。
- Verification evidence：
  - `rtk git --no-optional-locks diff --check`
  - `rtk rg -n "uuid.New7|backend/internal|extension_service.go:125|watch_service.go:62" docs/uuid-v7.md plans/uuid-v7-migration.md`
  - `rtk rg -n "ID:\\s*(uuid.New|newUUID)|uuid.NewV7|uuid.New\\(\\)" services/api/internal/services -g '!**/*_test.go'`
  - `rtk rg -n "func .*BeforeCreate|uuid.NewV7|uuid.New\\(\\)" services/api/internal/models -g '!**/*_test.go'`
- Self-review / exception reason：
  - 已完成 self-review；docs-only 小 scope，無需 worker 分流。
- Worker session closeout：
  - 無 subagent / worker session。
- Workflow friction / follow-up split：
  - 無；剩餘 UUID v7 code migration 保留在 plan，後續應另開實作 PR。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 校正 UUID v7 策略與 migration plan 的分工及現況。
- Approx changed lines：~77
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] UUID v7 技術原理保留在 `docs/uuid-v7.md`。
- [x] UUID v7 實作進度保留在 `plans/uuid-v7-migration.md`。
- [x] migration plan 使用現行 `services/api/...` 路徑並反映 develop 上已完成 / 待實作狀態。
- [x] 本 PR 不修改任何程式碼。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
rtk git --no-optional-locks diff --check
No output.

rtk rg -n "uuid.New7|backend/internal|extension_service.go:125|watch_service.go:62" docs/uuid-v7.md plans/uuid-v7-migration.md
No matches.

rtk rg -n "ID:\\s*(uuid.New|newUUID)|uuid.NewV7|uuid.New\\(\\)" services/api/internal/services -g '!**/*_test.go'
Confirmed non-test service create paths use newUUID()/uuid.NewV7(); no remaining ID: uuid.New() direct assignment.

rtk rg -n "func .*BeforeCreate|uuid.NewV7|uuid.New\\(\\)" services/api/internal/models -g '!**/*_test.go'
Confirmed remaining production uuid.New() hooks match the pending checklist in plans/uuid-v7-migration.md.
```

## 備註
這是 #354 的 docs-only follow-up；#631/#632 已先歸檔其他 completed plans。

## Notes for Claude Code Review
- 請確認保留 `plans/uuid-v7-migration.md` 為 active plan 是否符合 #354，原因是 develop 仍有剩餘 UUID v7 code migration。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新了 UUID v7 迁移计划的进度追踪，标记为部分完成
  * 优化了实现指南和验证步骤以提高清晰度

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/637)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->