### PR TITLE
[discussion] Document OpenAPI TypeScript codegen flow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@
 | [`atlas-migration-plan.md`](atlas-migration-plan.md) | #463 Atlas migration 拆分實作計畫；不得單獨視為已完成狀態 |
 | [`atlas-schema-reconciliation.md`](atlas-schema-reconciliation.md) | #463 baseline 前 schema reconciliation evidence / procedure |
 | [`non-web3-launch-readiness.md`](non-web3-launch-readiness.md) | 暫時捨棄 Web3 上鏈部分後的上線距離、Codex 自動化能力與真人介入層級 snapshot |
+| [`openapi-codegen-flow.md`](openapi-codegen-flow.md) | #401 OpenAPI → TypeScript contracts / codegen rollout 計畫 |
 
 ## Root Reference / Discussion Notes
 

--- a/docs/openapi-codegen-flow.md
+++ b/docs/openapi-codegen-flow.md
@@ -1,0 +1,101 @@
+# OpenAPI TypeScript Codegen Flow
+
+**Source of truth**: #401
+**Status**: proposed rollout
+**Last reviewed**: 2026-05-13
+
+## 目的
+
+Backend API contract 應該從後端 OpenAPI schema 產生，不應在 Go 與
+TypeScript 兩邊長期手動同步 DTO。
+
+本文件定義 frontend-facing TypeScript contract 的預期 rollout 形狀。這份
+文件尚未引入 generated artifacts，也不改 runtime API 行為。
+
+## 目前來源
+
+後端 Swagger / OpenAPI artifact 由 `swag init` 從 Go handler annotations
+與 API metadata 產生：
+
+```bash
+cd services/api
+swag init -g cmd/server/main.go --output docs --quiet
+```
+
+目前已 commit 的輸出是：
+
+- `services/api/docs/swagger.json`
+- `services/api/docs/swagger.yaml`
+- `services/api/docs/docs.go`
+
+目前這些 artifact 仍是 Swagger 2.0（`"swagger": "2.0"`），不是 OpenAPI
+3.x。這會影響工具選型：目前 `openapi-typescript` 7.x 目標是 OpenAPI
+3.0 / 3.1 schema。後續 implementation PR 必須明確加入 Swagger 2.0 到
+OpenAPI 3.x 的轉換步驟，或先把後端輸出改成 OpenAPI 3.x，再接上 type
+generation。
+
+在 compatibility step 於 CI 被證明可行前，不要直接把最新版本 type generator
+指向 `swagger.json`。
+
+## 目標 packages
+
+用分離 package 維持 generated types 與手寫 client logic 的 ownership 邊界：
+
+| Package | 內容 | 規則 |
+|---|---|---|
+| `packages/shared-types` | 從後端 schema 產生的 TypeScript declarations | Generated files 不手改。 |
+| `packages/api-client` | 給 extension 與 dashboard 使用的薄 typed fetch wrapper | 手寫、runtime-light、framework-agnostic。 |
+
+第一個 package 落地時，workspace 應納入 `packages/*`。
+
+## Regeneration flow
+
+最終實作應提供穩定的 root scripts：
+
+```bash
+pnpm api:types:generate
+pnpm api:types:check
+```
+
+預期行為：
+
+- `api:types:generate` 從已 commit 的後端 schema artifact 重新產生 shared
+  type package。
+- `api:types:check` 重新產生到暫存位置，或以 generator 的 check mode 執行；
+  若 committed generated files 發生 drift，指令應失敗。
+- Schema generation 仍由 backend workflow 擁有：若 handler annotations 改變，
+  同一個 backend PR 必須先 commit `swag init` output，再更新 frontend type
+  generation。
+
+## Client 邊界
+
+第一版 typed client 應刻意維持薄層：
+
+- 預設使用 native Fetch API shape。
+- 明確處理 auth token injection、base URL 選擇與 JSON parsing。
+- 本 issue 不產生 React Query hooks。
+- 不強迫 extension 與 dashboard 共用 UI 或 state management code。
+
+若 dashboard 後續有具體需求，可以在 `packages/api-client` 之上另包
+dashboard-specific hooks。
+
+## CI guardrail
+
+CI drift check 應在 generated artifacts 已 commit 後才加入：
+
+1. 從乾淨 checkout 執行 schema / type generation command。
+2. 若 generated package files 與 committed files 不一致，CI 失敗。
+3. Check 只負責 contract drift；除非 PR 觸碰相關 surface，否則不應順手 rebuild
+   unrelated frontend bundles。
+
+## Rollout slices
+
+1. 先記錄本 flow 與 Swagger 2.0 compatibility constraint。
+2. 新增 `packages/shared-types` 與 pinned generation / conversion command。
+3. 新增 `packages/api-client`，只放最小 typed fetch wrapper。
+4. 一次導入一個 frontend surface。
+5. Generated artifacts 穩定後，再加 CI drift protection。
+
+每個 slice 都應可獨立 review。除非 reviewer 明確同意該 scope，否則不要把
+package scaffolding、frontend migration 與 CI policy changes 合併在同一個 PR。
+

--- a/docs/openapi-codegen-flow.md
+++ b/docs/openapi-codegen-flow.md
@@ -98,4 +98,3 @@ CI drift check 應在 generated artifacts 已 commit 後才加入：
 
 每個 slice 都應可獨立 review。除非 reviewer 明確同意該 scope，否則不要把
 package scaffolding、frontend migration 與 CI policy changes 合併在同一個 PR。
-


### PR DESCRIPTION
## 什麼改動
新增 `docs/openapi-codegen-flow.md`，記錄 #401 的 OpenAPI → TypeScript contracts / codegen rollout 方向，並在 `docs/README.md` 加入索引。

## 為什麼
refs #401。先把 source of truth、package 邊界、regeneration flow、CI drift check 與 rollout slices 收斂成文件，避免後續 codegen PR 一次混入 package scaffold、generated artifacts、frontend adoption 與 CI policy。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Delegation Execution Log
- Source issue delegation plan：
  - #401 無既有 Issue Delegation Plan；本 PR 採 trivial/self-only exception。
- Actual worker profile(s)：
  - controller
- Model strength：
  - controller = GPT-5.5 xhigh
- Verification evidence：
  - `rtk git --no-optional-locks diff --check`
  - `rtk rg -n "openapi-codegen-flow|Swagger 2.0|api:types:generate|packages/shared-types|packages/api-client|openapi-typescript" docs/README.md docs/openapi-codegen-flow.md`
  - `rtk head -n 8 services/api/docs/swagger.json`
- Self-review / exception reason：
  - trivial/self-only exception：本 PR 是 2-file docs-only change，scope 明確且無 batch scan / implementation split / high-risk review 需要；委派 subagent 會增加協調成本而不提高驗證品質。
- Worker session closeout：
  - self-only exception，沒有 spawned worker；無 active worker session 需要 close。
- Workflow friction / follow-up split：
  - 已補齊 autonomous PR metadata；後續 codegen package scaffold / generated artifacts / CI drift check 會拆成獨立 PR。

## Scope 對齊
- Source of truth：#401
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 `packages/shared-types` 或 `packages/api-client`
  - 不產生 TypeScript artifacts
  - 不修改 CI / workflow
  - 不改 extension 或 dashboard runtime code

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 文件化 #401 的 OpenAPI → TypeScript codegen rollout 與 Swagger 2.0 compatibility constraint。
- Approx changed lines：~102
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] OpenAPI/codegen flow is documented
- [ ] generated TS artifacts can be consumed by current frontend apps（後續 PR）
- [ ] backend schema changes can be regenerated repeatably（後續 PR）
- [ ] CI or linting prevents silent contract drift（後續 PR）

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk git --no-optional-locks diff --check
# pass

rtk rg -n "openapi-codegen-flow|Swagger 2.0|api:types:generate|packages/shared-types|packages/api-client|openapi-typescript" docs/README.md docs/openapi-codegen-flow.md
# pass; confirmed README index and rollout constraints are present

rtk head -n 8 services/api/docs/swagger.json
# confirmed current schema artifact is Swagger 2.0
```

## 備註
本 PR 特別標出目前 `services/api/docs/swagger.json` 仍是 Swagger 2.0；後續 codegen implementation 不應直接把 latest `openapi-typescript` 指向該檔，必須先處理 OpenAPI 3.x 相容性或轉換步驟。

## Notes for Claude Code Review
- 請特別看 scope 是否足夠小：這是 #401 的 docs-first 切片，不宣稱完成 package scaffold / generated artifacts / CI guardrail。
- 文件中的 `openapi-typescript` 7.x / OpenAPI 3.x constraint 已依官方文件與目前 repo `swagger.json` 狀態確認。
