### PR TITLE
[chore] Align dashboard architecture state

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,9 +5,9 @@
 │                           CLIENT LAYER                             │
 │                                                                    │
 │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
-│  │ Chrome Sidepanel │  │  Dashboard [TBD] │  │  Wallet [Phs.2]  │  │
-│  │   (tachimint)    │  │  Agency/Streamer │  │  Claim on-chain  │  │
-│  │ React+TypeScript │  │  Mgmt Interface  │  │                  │  │
+│  │ Chrome Sidepanel │  │  Dashboard [MVP] │  │  Wallet [Phs.2]  │  │
+│  │   (tachimint)    │  │ React+Vite+Refine│  │  Claim on-chain  │  │
+│  │ React+TypeScript │  │ Agency/Strm Mgmt │  │                  │  │
 │  └────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘  │
 └───────────┼─────────────────────┼─────────────────────┼────────────┘
             │ Heartbeat + JWT     │ Admin API           │ Claim
@@ -46,12 +46,13 @@
                                             │  Private stream [Phs2] │
                                             └────────────────────────┘
 
-[done] = 已完成    [TBD] = MVP 待實作    [Phs.2] = Phase 2+
+[done] = 已完成    [MVP] = MVP 已進入實作    [TBD] = MVP 待實作    [Phs.2] = Phase 2+
 ```
 
 ## 主要資料流
 
 > 補充：`tachimint` 的前端 runtime 方向已定為 Chrome sidepanel extension；本階段 viewer identity 與既有 API contract 仍沿用 Twitch / extension auth 流程。詳見 [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](history/2026-04-16-tachimint-chrome-sidepanel-migration.md)。
+> Dashboard frontend 已在 `apps/dashboard/` 以 React + Vite + Refine 進入 MVP 實作；上圖後端 `Agency Service [TBD]` 仍表示 agency/management backend maturity，而不是 dashboard app 不存在。
 
 ```
 觀眾觀看直播（定時 Heartbeat）


### PR DESCRIPTION
## 什麼改動
- Update `docs/architecture.md` client layer so Dashboard is marked as `[MVP]` instead of `[TBD]`.
- Document the current dashboard frontend stack as `React + Vite + Refine`.
- Add a note that dashboard frontend existence/status is separate from backend `Agency Service [TBD]` maturity.

## 為什麼
Closes #643.

The architecture diagram still described Dashboard as TBD even though `apps/dashboard/` already exists and has a React + Vite + Refine implementation path. This PR aligns the documentation with the current repository state without changing dashboard UI or backend behavior.

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#643
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - No dashboard rewrite.
  - No frontend framework migration.
  - No backend API redesign.
  - No architecture diagram overhaul outside dashboard state alignment.

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #643 docs-only architecture state alignment.
- Actual worker profile(s)：
  - controller
- Model strength：
  - controller = GPT-5.5 xhigh main agent; no subagents spawned.
- Verification evidence：
  - `rtk git --no-optional-locks diff --check`
  - `rtk rg -n 'Dashboard \[MVP\]|React\+Vite\+Refine|apps/dashboard|Agency Service \[TBD\]' docs/architecture.md`
  - `rtk rg -n 'Dashboard \[TBD\]' docs/architecture.md`
- Self-review / exception reason：
  - Docs-only change split out from #635 to keep Atlas runtime PR scoped.
- Worker session closeout：
  - No worker sessions were opened; controller reviewed the final diff directly.
- Workflow friction / follow-up split：
  - This PR is the follow-up split for dashboard architecture status; no additional split identified.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Align architecture documentation with the implemented dashboard frontend MVP state.
- Approx changed lines：~9
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - Split out from #635 scope review; this PR owns #643.

## Acceptance Criteria
- [x] Architecture diagram no longer marks Dashboard as `[TBD]`.
- [x] Architecture docs mention React + Vite + Refine for the dashboard frontend.
- [x] Docs distinguish dashboard frontend MVP status from backend agency/management service maturity.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk git --no-optional-locks diff --check
No output.

rtk rg -n 'Dashboard \[MVP\]|React\+Vite\+Refine|apps/dashboard|Agency Service \[TBD\]' docs/architecture.md
8:│  │ Chrome Sidepanel │  │  Dashboard [MVP] │  │  Wallet [Phs.2]  │  │
9:│  │   (tachimint)    │  │ React+Vite+Refine│  │  Claim on-chain  │  │
55:> Dashboard frontend 已在 `apps/dashboard/` 以 React + Vite + Refine 進入 MVP 實作；上圖後端 `Agency Service [TBD]` 仍表示 agency/management backend maturity，而不是 dashboard app 不存在。

rtk rg -n 'Dashboard \[TBD\]' docs/architecture.md
No matches.
```

## 備註
This PR was prepared in a clean automation worktree at `/Users/tachikoma/.codex/automations/tachigo-24h-autonomous-sprint/worktrees/dashboard-architecture-state-643`.

## Notes for Claude Code Review
- This intentionally only updates documentation; no frontend code or backend agency service behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文件更新**
  * 架構文檔已更新，確認儀表板組件現已進入 MVP 階段
  * 擴展狀態圖例，新增 [MVP] 標記的明確定義
  * 補充前端運行環境的詳細說明與組件實現位置
  * 調整術語標籤以保持文檔一致性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/648)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->