### PR TITLE
[frontend] Add OpenAPI shared types scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "build:extension": "pnpm --filter ./apps/extension build",
     "build:dashboard": "pnpm --filter ./apps/dashboard build",
+    "api:types:generate": "pnpm --filter @tachigo/shared-types generate",
+    "api:types:check": "pnpm --filter @tachigo/shared-types check",
     "test": "echo \"No root test suite configured\""
   },
   "repository": {

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@tachigo/shared-types",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "generate": "node scripts/generate-swagger-types.mjs generate --input ../../services/api/docs/swagger.json --output src/index.ts",
+    "check": "node scripts/generate-swagger-types.mjs check --input ../../services/api/docs/swagger.json --output src/index.ts",
+    "test": "node --test scripts/*.test.mjs"
+  }
+}

--- a/packages/shared-types/scripts/generate-swagger-types.mjs
+++ b/packages/shared-types/scripts/generate-swagger-types.mjs
@@ -1,0 +1,210 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "options", "head"];
+const GENERATED_HEADER = `/* eslint-disable */\n// Generated from services/api/docs/swagger.json. Do not edit by hand.\n\n`;
+
+export async function generateTypesFromSwaggerFile({ inputFile, outputFile }) {
+  const swagger = JSON.parse(await readFile(inputFile, "utf8"));
+  const source = generateTypes(swagger);
+
+  await mkdir(path.dirname(outputFile), { recursive: true });
+  await writeFile(outputFile, source);
+}
+
+export async function checkTypesFromSwaggerFile({ inputFile, outputFile }) {
+  const swagger = JSON.parse(await readFile(inputFile, "utf8"));
+  const expected = generateTypes(swagger);
+  const current = await readFile(outputFile, "utf8").catch(() => "");
+
+  if (current !== expected) {
+    throw new Error(`${outputFile} is out of date. Run pnpm api:types:generate.`);
+  }
+}
+
+export function generateTypes(swagger) {
+  const definitions = swagger.definitions ?? {};
+  const lines = [GENERATED_HEADER.trimEnd(), ""];
+
+  for (const name of Object.keys(definitions).sort()) {
+    lines.push(renderDefinition(name, definitions[name]), "");
+  }
+
+  lines.push(renderOperations(swagger.paths ?? {}));
+  return `${lines.join("\n")}\n`;
+}
+
+function renderDefinition(name, schema) {
+  const typeName = refName(name);
+
+  if (schema.enum) {
+    return `export type ${typeName} = ${renderEnum(schema.enum)};`;
+  }
+
+  if (schema.type === "object" || schema.properties || schema.allOf) {
+    const objectType = schemaToType(schema, 0);
+    if (objectType.startsWith("{\n")) {
+      return `export interface ${typeName} ${objectType}`;
+    }
+    return `export type ${typeName} = ${objectType};`;
+  }
+
+  return `export type ${typeName} = ${schemaToType(schema, 0)};`;
+}
+
+function renderOperations(paths) {
+  const lines = ["export interface ApiOperations {"];
+
+  for (const route of Object.keys(paths).sort()) {
+    const pathItem = paths[route] ?? {};
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!operation) continue;
+      lines.push(`  "${method.toUpperCase()} ${route}": ${renderOperation(operation, 2)};`);
+    }
+  }
+
+  lines.push("}");
+  return lines.join("\n");
+}
+
+function renderOperation(operation, indent) {
+  const bodyParameter = (operation.parameters ?? []).find((parameter) => parameter.in === "body");
+  const pathParameters = (operation.parameters ?? []).filter((parameter) => parameter.in === "path");
+  const queryParameters = (operation.parameters ?? []).filter((parameter) => parameter.in === "query");
+  const responseType = schemaToType(selectSuccessResponseSchema(operation.responses ?? {}), indent + 2);
+  const lines = ["{"];
+
+  if (bodyParameter?.schema) {
+    const optional = bodyParameter.required ? "" : "?";
+    lines.push(`${spaces(indent + 2)}requestBody${optional}: ${schemaToType(bodyParameter.schema, indent + 2)};`);
+  }
+
+  if (pathParameters.length > 0) {
+    lines.push(`${spaces(indent + 2)}pathParams: ${renderParameterObject(pathParameters, indent + 2)};`);
+  }
+
+  if (queryParameters.length > 0) {
+    lines.push(`${spaces(indent + 2)}queryParams: ${renderParameterObject(queryParameters, indent + 2)};`);
+  }
+
+  lines.push(`${spaces(indent + 2)}response: ${responseType};`);
+  lines.push(`${spaces(indent)}}`);
+
+  return lines.join("\n");
+}
+
+function renderParameterObject(parameters, indent) {
+  const lines = ["{"];
+  for (const parameter of parameters.sort((a, b) => a.name.localeCompare(b.name))) {
+    const optional = parameter.required ? "" : "?";
+    lines.push(`${spaces(indent + 2)}${propertyKey(parameter.name)}${optional}: ${schemaToType(parameter, indent + 2)};`);
+  }
+  lines.push(`${spaces(indent)}}`);
+  return lines.join("\n");
+}
+
+function selectSuccessResponseSchema(responses) {
+  const status = Object.keys(responses)
+    .filter((key) => key.startsWith("2"))
+    .sort()[0];
+
+  return responses[status]?.schema ?? {};
+}
+
+function schemaToType(schema = {}, indent) {
+  if (schema.$ref) return refName(schema.$ref.split("/").at(-1));
+  if (schema.allOf) return schema.allOf.map((item) => schemaToType(item, indent)).join(" & ");
+  if (schema.enum) return renderEnum(schema.enum);
+
+  if (schema.type === "array") {
+    return `Array<${schemaToType(schema.items ?? {}, indent)}>`;
+  }
+
+  if (schema.type === "object" || schema.properties) {
+    return renderObjectType(schema, indent);
+  }
+
+  if (schema.additionalProperties) {
+    return `Record<string, ${schemaToType(schema.additionalProperties, indent)}>`;
+  }
+
+  switch (schema.type) {
+    case "integer":
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "string":
+      return "string";
+    default:
+      return "unknown";
+  }
+}
+
+function renderObjectType(schema, indent) {
+  const properties = schema.properties ?? {};
+  const required = new Set(schema.required ?? []);
+  const names = Object.keys(properties).sort();
+
+  if (names.length === 0) {
+    return "Record<string, unknown>";
+  }
+
+  const lines = ["{"];
+  for (const name of names) {
+    const optional = required.has(name) ? "" : "?";
+    lines.push(`${spaces(indent + 2)}${propertyKey(name)}${optional}: ${schemaToType(properties[name], indent + 2)};`);
+  }
+  lines.push(`${spaces(indent)}}`);
+  return lines.join("\n");
+}
+
+function renderEnum(values) {
+  return values.map((value) => JSON.stringify(value)).join(" | ");
+}
+
+function refName(rawName) {
+  return rawName
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join("");
+}
+
+function propertyKey(name) {
+  return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name) ? name : JSON.stringify(name);
+}
+
+function spaces(count) {
+  return " ".repeat(Math.max(0, count));
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const options = { command };
+
+  for (let index = 0; index < rest.length; index += 2) {
+    options[rest[index].replace(/^--/, "")] = rest[index + 1];
+  }
+
+  if (!["generate", "check"].includes(options.command) || !options.input || !options.output) {
+    throw new Error("Usage: generate-swagger-types.mjs <generate|check> --input <swagger.json> --output <index.ts>");
+  }
+
+  return options;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const options = parseArgs(process.argv.slice(2));
+  const task =
+    options.command === "generate"
+      ? generateTypesFromSwaggerFile({ inputFile: options.input, outputFile: options.output })
+      : checkTypesFromSwaggerFile({ inputFile: options.input, outputFile: options.output });
+
+  task.catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/packages/shared-types/scripts/generate-swagger-types.mjs
+++ b/packages/shared-types/scripts/generate-swagger-types.mjs
@@ -107,8 +107,10 @@ function renderParameterObject(parameters, indent) {
 
 function selectSuccessResponseSchema(responses) {
   const status = Object.keys(responses)
-    .filter((key) => key.startsWith("2"))
-    .sort()[0];
+    .filter((key) => /^\d{3}$/.test(key))
+    .map(Number)
+    .filter((code) => code >= 200 && code < 300)
+    .sort((left, right) => left - right)[0];
 
   return responses[status]?.schema ?? {};
 }

--- a/packages/shared-types/scripts/generate-swagger-types.test.mjs
+++ b/packages/shared-types/scripts/generate-swagger-types.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { generateTypesFromSwaggerFile } from "./generate-swagger-types.mjs";
+
+test("generates deterministic TypeScript contracts from committed Swagger schema", async () => {
+  const repoRoot = path.resolve(import.meta.dirname, "../../..");
+  const outputDir = await mkdir(path.join(tmpdir(), `tachigo-shared-types-${Date.now()}`), {
+    recursive: true,
+  });
+  const outputFile = path.join(outputDir, "index.ts");
+
+  try {
+    await generateTypesFromSwaggerFile({
+      inputFile: path.join(repoRoot, "services/api/docs/swagger.json"),
+      outputFile,
+    });
+
+    const generated = await readFile(outputFile, "utf8");
+
+    assert.match(generated, /export interface HandlersAuthResponse \{/);
+    assert.match(generated, /tokens\?: HandlersBrowserTokenPair;/);
+    assert.match(generated, /export interface ServicesLoginInput \{/);
+    assert.match(generated, /email\?: string;/);
+    assert.match(generated, /export interface ApiOperations \{/);
+    assert.match(generated, /"POST \/auth\/login": \{/);
+    assert.match(generated, /requestBody: ServicesLoginInput;/);
+    assert.match(generated, /response: HandlersResponse & \{\s+data\?: HandlersAuthResponse;/);
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
+});

--- a/packages/shared-types/scripts/generate-swagger-types.test.mjs
+++ b/packages/shared-types/scripts/generate-swagger-types.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { generateTypesFromSwaggerFile } from "./generate-swagger-types.mjs";
+import { generateTypes, generateTypesFromSwaggerFile } from "./generate-swagger-types.mjs";
 
 test("generates deterministic TypeScript contracts from committed Swagger schema", async () => {
   const repoRoot = path.resolve(import.meta.dirname, "../../..");
@@ -32,4 +32,30 @@ test("generates deterministic TypeScript contracts from committed Swagger schema
   } finally {
     await rm(outputDir, { recursive: true, force: true });
   }
+});
+
+test("ignores non-status response keys when selecting the success response schema", () => {
+  const generated = generateTypes({
+    paths: {
+      "/health": {
+        get: {
+          responses: {
+            "200ish": { schema: { type: "string" } },
+            "201": {
+              schema: {
+                type: "object",
+                properties: {
+                  created: { type: "boolean" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.match(generated, /"GET \/health": \{/);
+  assert.match(generated, /response: \{\s+created\?: boolean;/);
+  assert.doesNotMatch(generated, /response: string;/);
 });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,0 +1,482 @@
+/* eslint-disable */
+// Generated from services/api/docs/swagger.json. Do not edit by hand.
+
+export interface HandlersAddressResponse {
+  address?: ModelsShippingAddress;
+}
+
+export interface HandlersAddressesResponse {
+  addresses?: Array<ModelsShippingAddress>;
+}
+
+export interface HandlersAuthResponse {
+  tokens?: HandlersBrowserTokenPair;
+  user?: ModelsUser;
+}
+
+export interface HandlersBrowserTokenPair {
+  access_token: string;
+  expires_in: number;
+}
+
+export interface HandlersMessageResponse {
+  message?: string;
+}
+
+export interface HandlersNonceResponse {
+  issued_at?: string;
+  nonce?: string;
+}
+
+export interface HandlersPointsBalanceResponse {
+  cumulative_total?: number;
+  spendable_balance?: number;
+}
+
+export interface HandlersPointsHistoryItem {
+  amount?: number;
+  created_at?: string;
+  note?: string;
+  sku?: string;
+  type?: "earn" | "spend";
+}
+
+export interface HandlersPointsHistoryResponse {
+  transactions?: Array<HandlersPointsHistoryItem>;
+}
+
+export interface HandlersProvidersResponse {
+  providers?: Array<ModelsAuthProvider>;
+}
+
+export interface HandlersResponse {
+  data?: unknown;
+  error?: string;
+  success?: boolean;
+}
+
+export interface HandlersTokensResponse {
+  tokens?: HandlersBrowserTokenPair;
+}
+
+export interface HandlersUserResponse {
+  user?: ModelsUser;
+}
+
+export interface HandlersWalletResponse {
+  address?: string;
+}
+
+export interface HandlersClaimRequest {
+  amount?: number;
+}
+
+export interface HandlersRedeemRequest {
+  amount: number;
+  coupon_id: string;
+}
+
+export interface HandlersRedeemResponse {
+  balance?: number;
+  voucher_code?: string;
+}
+
+export interface HandlersTachiBalanceResponse {
+  tachi_balance?: number;
+}
+
+export interface ModelsAuthProvider {
+  created_at?: string;
+  id?: string;
+  metadata?: Record<string, unknown>;
+  provider?: ModelsProviderType;
+  provider_id?: string;
+  updated_at?: string;
+  user_id?: string;
+}
+
+export type ModelsProviderType = "twitch" | "google" | "web3" | "email";
+
+export interface ModelsShippingAddress {
+  address_line1?: string;
+  address_line2?: string;
+  city?: string;
+  country?: string;
+  created_at?: string;
+  district?: string;
+  id?: string;
+  is_default?: boolean;
+  phone?: string;
+  postal_code?: string;
+  recipient_name?: string;
+  updated_at?: string;
+  user_id?: string;
+}
+
+export interface ModelsUser {
+  addresses?: Array<ModelsShippingAddress>;
+  auth_providers?: Array<ModelsAuthProvider>;
+  avatar_url?: string;
+  created_at?: string;
+  email?: string;
+  email_verified?: boolean;
+  id?: string;
+  is_active?: boolean;
+  role?: ModelsUserRole;
+  updated_at?: string;
+  username?: string;
+}
+
+export type ModelsUserRole = "viewer" | "streamer" | "agency" | "admin";
+
+export interface ServicesAddressInput {
+  address_line1: string;
+  address_line2?: string;
+  city: string;
+  country?: string;
+  district?: string;
+  is_default?: boolean;
+  phone?: string;
+  postal_code?: string;
+  recipient_name: string;
+}
+
+export interface ServicesClaimInput {
+  address_line1: string;
+  address_line2?: string;
+  city: string;
+  country?: string;
+  phone?: string;
+  postal_code?: string;
+  recipient_name: string;
+}
+
+export interface ServicesLinkWalletInput {
+  address: string;
+  nonce: string;
+  signature: string;
+}
+
+export interface ServicesLoginInput {
+  email: string;
+  password: string;
+}
+
+export interface ServicesRegisterInput {
+  email: string;
+  password: string;
+  username: string;
+}
+
+export interface ServicesUpdateProfileInput {
+  avatar_url?: string;
+  username?: string;
+}
+
+export interface ServicesWeb3VerifyInput {
+  address: string;
+  nonce: string;
+  signature: string;
+}
+
+export interface ApiOperations {
+  "POST /auth/forgot-password": {
+    requestBody: {
+      email?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersMessageResponse;
+    };
+  };
+  "GET /auth/google": {
+    response: unknown;
+  };
+  "GET /auth/google/callback": {
+    queryParams: {
+      code: string;
+      state: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersAuthResponse;
+    };
+  };
+  "POST /auth/login": {
+    requestBody: ServicesLoginInput;
+    response: HandlersResponse & {
+      data?: HandlersAuthResponse;
+    };
+  };
+  "POST /auth/logout": {
+    requestBody?: {
+      refresh_token?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersMessageResponse;
+    };
+  };
+  "DELETE /auth/providers/{provider}": {
+    pathParams: {
+      provider: "twitch" | "google" | "web3" | "email";
+    };
+    response: HandlersResponse & {
+      data?: HandlersMessageResponse;
+    };
+  };
+  "POST /auth/refresh": {
+    requestBody?: {
+      refresh_token?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersTokensResponse;
+    };
+  };
+  "POST /auth/register": {
+    requestBody: ServicesRegisterInput;
+    response: HandlersResponse & {
+      data?: HandlersAuthResponse;
+    };
+  };
+  "POST /auth/reset-password": {
+    requestBody: {
+      new_password?: string;
+      token?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersMessageResponse;
+    };
+  };
+  "GET /auth/twitch": {
+    response: unknown;
+  };
+  "GET /auth/twitch/callback": {
+    queryParams: {
+      code: string;
+      state: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersAuthResponse;
+    };
+  };
+  "POST /auth/verify-email/confirm": {
+    requestBody: {
+      token?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersMessageResponse;
+    };
+  };
+  "POST /auth/verify-email/send": {
+    response: HandlersResponse & {
+      data?: HandlersMessageResponse;
+    };
+  };
+  "POST /auth/web3/nonce": {
+    requestBody: {
+      address?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersNonceResponse;
+    };
+  };
+  "POST /auth/web3/verify": {
+    requestBody: ServicesWeb3VerifyInput;
+    response: HandlersResponse & {
+      data?: HandlersAuthResponse;
+    };
+  };
+  "GET /claim/{token}": {
+    pathParams: {
+      token: string;
+    };
+    response: HandlersResponse;
+  };
+  "POST /claim/{token}": {
+    requestBody: ServicesClaimInput;
+    pathParams: {
+      token: string;
+    };
+    response: HandlersResponse;
+  };
+  "GET /dashboard/raffles": {
+    response: HandlersResponse;
+  };
+  "POST /dashboard/raffles": {
+    requestBody: {
+      title?: string;
+    };
+    response: HandlersResponse;
+  };
+  "GET /dashboard/raffles/{id}": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "POST /dashboard/raffles/{id}/complete": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "PATCH /dashboard/raffles/{id}/discord-webhook": {
+    requestBody: {
+      discord_webhook_url?: string;
+    };
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "GET /dashboard/raffles/{id}/draws": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "POST /dashboard/raffles/{id}/draws": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "POST /dashboard/raffles/{id}/entries/import-csv": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "POST /dashboard/raffles/{id}/snapshot": {
+    requestBody: {
+      source?: string;
+    };
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "POST /extension/auth/login": {
+    requestBody: {
+      extension_jwt?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersAuthResponse;
+    };
+  };
+  "POST /extension/bits/complete": {
+    requestBody: {
+      extension_jwt?: string;
+      sku?: string;
+      transaction_receipt?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersAuthResponse;
+    };
+  };
+  "GET /extension/raffles/{id}/result": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "POST /extension/t-point/complete": {
+    requestBody: {
+      extension_jwt?: string;
+      sku?: string;
+      transaction_receipt?: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersAuthResponse;
+    };
+  };
+  "POST /spend/redeem": {
+    requestBody: HandlersRedeemRequest;
+    response: HandlersResponse & {
+      data?: HandlersRedeemResponse;
+    };
+  };
+  "GET /users/me": {
+    response: HandlersResponse & {
+      data?: HandlersUserResponse;
+    };
+  };
+  "PUT /users/me": {
+    requestBody: ServicesUpdateProfileInput;
+    response: HandlersResponse & {
+      data?: HandlersUserResponse;
+    };
+  };
+  "GET /users/me/addresses": {
+    response: HandlersResponse & {
+      data?: HandlersAddressesResponse;
+    };
+  };
+  "POST /users/me/addresses": {
+    requestBody: ServicesAddressInput;
+    response: HandlersResponse & {
+      data?: HandlersAddressResponse;
+    };
+  };
+  "PUT /users/me/addresses/{id}": {
+    requestBody: ServicesAddressInput;
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersAddressResponse;
+    };
+  };
+  "DELETE /users/me/addresses/{id}": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersMessageResponse;
+    };
+  };
+  "PUT /users/me/addresses/{id}/default": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersAddressResponse;
+    };
+  };
+  "GET /users/me/points": {
+    queryParams: {
+      channel_id: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersPointsBalanceResponse;
+    };
+  };
+  "POST /users/me/points/claim": {
+    requestBody?: HandlersClaimRequest;
+    response: HandlersResponse & {
+      data?: HandlersTachiBalanceResponse;
+    };
+  };
+  "GET /users/me/points/history": {
+    queryParams: {
+      channel_id: string;
+    };
+    response: HandlersResponse & {
+      data?: HandlersPointsHistoryResponse;
+    };
+  };
+  "GET /users/me/providers": {
+    response: HandlersResponse & {
+      data?: HandlersProvidersResponse;
+    };
+  };
+  "GET /users/me/tachi/balance": {
+    response: HandlersResponse & {
+      data?: HandlersTachiBalanceResponse;
+    };
+  };
+  "POST /users/me/wallet": {
+    requestBody: ServicesLinkWalletInput;
+    response: HandlersResponse & {
+      data?: HandlersWalletResponse;
+    };
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
 
+  packages/shared-types: {}
+
 packages:
 
   '@alloc/quick-lru@5.2.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
## 什麼改動
- 新增 `packages/shared-types` workspace package，輸出從 `services/api/docs/swagger.json` 產生的 TypeScript contract types。
- 新增 zero-dependency Swagger 2.0 generator：`packages/shared-types/scripts/generate-swagger-types.mjs`。
- 新增 root scripts：`pnpm api:types:generate` 與 `pnpm api:types:check`。
- 將 workspace glob 擴充為 `packages/*`，並同步 `pnpm-lock.yaml` importer。

## 為什麼
Refs #401。

#401 要求從後端 schema 產生 frontend-facing TypeScript contracts，而不是長期手動維護 Go / TypeScript DTO。#638 已先文件化 rollout 與 Swagger 2.0 compatibility constraint；本 PR 落地下一個小切片：shared types package、可重複 generation command、以及 committed generated artifact。

這張 PR 不 close #401，因為 `packages/api-client`、frontend adoption 與 CI drift gate 仍需後續 PR。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#401 and `docs/openapi-codegen-flow.md`
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 `packages/api-client`。
  - 不修改 extension 或 dashboard runtime code。
  - 不新增 React Query hooks 或 frontend state management。
  - 不修改 backend handler / router / Swagger annotations。
  - 不新增 CI drift gate；等 generated package 穩定後另開 PR。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #401 沒有獨立 delegation plan；依 #638 文件化 rollout，執行 slice 2。
- Actual worker profile(s)：
  - controller only
- Model strength：
  - controller = GPT-5.5 xhigh main agent；未 spawned subagent。
- Verification evidence：
  - RED：`rtk node --test packages/shared-types/scripts/generate-swagger-types.test.mjs` 先以 `ERR_MODULE_NOT_FOUND` 失敗，確認測試會抓到缺少 generator。
  - GREEN：`rtk pnpm --filter @tachigo/shared-types test`
  - GREEN：`rtk pnpm api:types:generate`
  - GREEN：`rtk pnpm api:types:check`
  - GREEN：`rtk pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`
  - GREEN：`rtk git --no-optional-locks diff --cached --check`
- Self-review / exception reason：
  - 已完成 self-review；這是單一 shared-types package scaffold，無 high-risk auth / migration / payment / CI policy change。
- Worker session closeout：
  - 無 worker session；controller 直接完成 TDD、生成、驗證與 commit。
- Workflow friction / follow-up split：
  - Diff 超過 400 行主要來自 committed generated artifact；拆掉 generated file 會讓 `api:types:check` 失去可審查基準，因此保留在同一 PR。`packages/api-client`、frontend adoption、CI drift gate 已明確留給後續 PR。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增可從後端 Swagger artifact 重生的 `packages/shared-types` TypeScript contract package。
- Approx changed lines：~749；其中 ~482 行是 generated `packages/shared-types/src/index.ts`，generator 與 artifact 必須同 PR 才能讓 reviewer 驗證 repeatable output。
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試是 generator 的 regression coverage；workspace cleanup 是讓 package 可被 pnpm 發現與 root scripts 呼叫的必要 scaffolding。
- 若已拆分，相關 PR：
  - #638 先文件化 rollout；後續 PR 再處理 `packages/api-client`、frontend adoption、CI drift gate。

## Acceptance Criteria
- [x] OpenAPI/codegen flow is documented（已由 #638 完成，本 PR 依該 flow 實作下一切片）
- [x] generated TS artifacts can be consumed by current frontend apps（新增 workspace package `@tachigo/shared-types`，後續 app PR 可用 type-only import）
- [x] backend schema changes can be regenerated repeatably（`pnpm api:types:generate` / `pnpm api:types:check`）
- [ ] CI or linting prevents silent contract drift（後續 PR；本 PR 不改 CI policy）

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
RED:
rtk node --test packages/shared-types/scripts/generate-swagger-types.test.mjs
FAIL: ERR_MODULE_NOT_FOUND for generate-swagger-types.mjs（符合預期）

GREEN:
rtk pnpm --filter @tachigo/shared-types test
pass: 1 test / 0 fail

rtk pnpm api:types:generate
pass: regenerated packages/shared-types/src/index.ts

rtk pnpm api:types:check
pass: generated artifact matches committed output

rtk pnpm install --lockfile-only --frozen-lockfile --ignore-scripts
pass: lockfile is in sync

rtk git --no-optional-locks diff --cached --check
pass: no output
```

## 備註
目前後端 artifact 仍是 Swagger 2.0，因此本 PR 不使用 `openapi-typescript` 7.x 直接吃 `swagger.json`；先用 repo-local zero-dependency generator 產出 types，等 schema source 升到 OpenAPI 3.x 或導入明確 conversion step 後可再替換工具鏈。

## Notes for Claude Code Review
- 請特別看 generator 對 Swagger 2.0 `definitions`、body/path/query parameters、2xx response schema 與 `allOf` response wrapper 的處理是否足夠作為第一版 shared contract。
- 這張 PR 的 generated file 會讓 diff 超過 400 行，但不包含 frontend adoption 或 CI policy；若 reviewer 希望降低 diff，可以要求改成不 commit artifact，不過那會削弱 #401 的 repeatable artifact baseline。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 新增两个根级命令脚本：api:types:generate 与 api:types:check，用于生成与校验 API 类型定义。
  * 新增 @tachigo/shared-types 包，提供从 API 文档生成的 TypeScript 类型与统一的 API 操作映射类型。

* **Tests**
  * 添加测试以确保生成的类型文件输出确定性并校验响应/请求类型选择逻辑。

* **Chores**
  * 更新工作区配置以包含新包。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/649)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->