### PR TITLE
[frontend] Harden dependency install path

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -8,7 +8,6 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",


### PR DESCRIPTION
## 什麼改動
- 移除 `apps/extension/package.json` 的 `preinstall: "npx only-allow pnpm"`。
- 移除 `apps/dashboard/package.json` 的 `preinstall: "npx only-allow pnpm"`。
- 保留 root `packageManager: "pnpm@10.33.0"` 作為 pnpm 版本宣告，不新增替代 lifecycle hook。

## 為什麼
Closes #650。

Mini Shai-Hulud / TanStack npm supply-chain incident 顯示 dependency install time 是高風險執行路徑。本 repo 兩個 frontend app 透過 `preinstall` 執行 unpinned `npx only-allow pnpm`，會在安裝依賴時多打一條動態 package execution 路徑；本 PR 移除這條 hook，改依賴 root `packageManager` / Corepack / pnpm tooling。

TanStack 查核結果：
- 本 repo lockfile 只命中 `@tanstack/react-query@5.100.6` 與 `@tanstack/query-core@5.100.6`。
- TanStack 官方 postmortem 將 `@tanstack/query*` 標為 confirmed-clean family：https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
- GitHub Advisory `GHSA-g7cv-rxg3-hmpx` / `CVE-2026-45321` 的受影響清單沒有列出 `@tanstack/react-query` 或 `@tanstack/query-core`：https://github.com/advisories/GHSA-g7cv-rxg3-hmpx
- 因此本 PR 是 install-path hardening，不是 confirmed compromise remediation。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#650
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不更新 Refine / TanStack / React dependency 版本。
  - 不新增 lifecycle-script allowlist gate；#650 已列為 optional follow-up。
  - 不修改 CI policy、GitHub Actions trigger、Dependabot 設定或 frontend runtime code。
  - 不執行 token rotation 或 incident-remediation cleanup，因為沒有 confirmed compromise evidence。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #650 沒有獨立 delegation plan；依 issue 的 PR 1 split 執行。
- Actual worker profile(s)：
  - controller only
- Model strength：
  - controller = GPT-5.5 xhigh main agent；未 spawned subagent。
- Verification evidence：
  - `rtk rg -n '"(preinstall|install|postinstall|prepare)"' package.json apps/extension/package.json apps/dashboard/package.json`：無輸出，frontend app package manifest 已無 install lifecycle scripts。
  - `rtk rg -n "@tanstack|@mistralai|mistralai|@uipath|@opensearch-project|guardrails-ai|shai|hulud" package.json pnpm-lock.yaml apps/extension/package.json apps/dashboard/package.json`：只命中 `@tanstack/react-query@5.100.6` / `@tanstack/query-core@5.100.6`。
  - `rtk pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`：pass。
  - `rtk node -e ...` JSON audit：pass，確認 frontend package manifests 沒有 `preinstall` / `install` / `postinstall` / `prepare`。
  - `rtk node -e ...` packageManager audit：pass，確認 root `packageManager` 仍是 `pnpm@10.33.0`。
  - `rtk git --no-optional-locks diff --check`：pass。
- Self-review / exception reason：
  - 已完成 self-review；這是 package manifest hardening，未觸碰 auth、migration、payment、wallet、backend schema 或 CI policy。
- Worker session closeout：
  - 無 worker session；controller 直接完成 audit、patch、verification 與 commit。
- Workflow friction / follow-up split：
  - 本 PR 僅做 issue 指定的 PR 1。lifecycle allowlist gate 若需要，應另開 PR 2。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 移除兩個 frontend app 在 dependency install 時執行 unpinned `npx` 的 lifecycle hook。
- Approx changed lines：~2
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `npx only-allow pnpm` is removed from frontend install hooks.
- [x] `apps/extension/package.json` and `apps/dashboard/package.json` no longer execute unpinned `npx` during install.
- [x] The resolved `@tanstack/react-query@5.100.6` version is checked and the result is documented.
- [ ] `pnpm install --frozen-lockfile` still succeeds. 本地完整 install 因 `registry.npmjs.org` DNS `ENOTFOUND` 無法完成；`pnpm install --lockfile-only --frozen-lockfile --ignore-scripts` 已通過，完整安裝交由 GitHub CI 驗證。
- [ ] Frontend/dashboard lint, test, and build still pass for affected workspaces. 本地因完整 install 失敗而缺 `node_modules`，`pnpm --filter ./apps/extension lint` 停在 `eslint: command not found`；交由 GitHub CI 驗證。

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk rg -n '"(preinstall|install|postinstall|prepare)"' package.json apps/extension/package.json apps/dashboard/package.json
pass: no output

rtk rg -n "@tanstack|@mistralai|mistralai|@uipath|@opensearch-project|guardrails-ai|shai|hulud" package.json pnpm-lock.yaml apps/extension/package.json apps/dashboard/package.json
pass: only @tanstack/react-query@5.100.6 and @tanstack/query-core@5.100.6 matched

rtk pnpm install --lockfile-only --frozen-lockfile --ignore-scripts
pass

rtk node -e '<frontend lifecycle script audit>'
pass: no frontend install lifecycle scripts

rtk node -e '<root packageManager audit>'
pass: pnpm@10.33.0

rtk git --no-optional-locks diff --check
pass: no output

rtk pnpm install --frozen-lockfile --ignore-scripts
blocked locally: registry.npmjs.org DNS ENOTFOUND while fetching tarballs

rtk pnpm --filter ./apps/extension lint
blocked locally: eslint not found because node_modules is missing after install download failure
```

## 備註
本 PR 沒有發現 repo 已安裝受影響 TanStack 版本，也沒有看到 issue 中列出的其他 Mini Shai-Hulud 相關 package 名稱。

## Notes for Claude Code Review
- 請確認移除 app-level `preinstall` 後，root `packageManager` / Corepack / pnpm 使用方式是否符合 repo policy。
- 請把本地 install/lint/build 的 DNS 限制與 GitHub CI 結果一起看；此 PR 自身只改 package manifest，不應影響 runtime code。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 杂项

* 移除了包管理器安装限制。用户现在可以自由选择使用任何喜好的包管理器来安装依赖项，而不再被限制于特定的包管理器。这一更改提高了开发灵活性，允许开发人员根据个人偏好或项目需求选择合适的包管理器工具。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/651)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->