### PR TITLE
[frontend] Add OpenAPI API client scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:dashboard": "pnpm --filter ./apps/dashboard build",
     "api:types:generate": "pnpm --filter @tachigo/shared-types generate",
     "api:types:check": "pnpm --filter @tachigo/shared-types check",
+    "api:client:test": "pnpm --filter @tachigo/api-client test",
     "test": "echo \"No root test suite configured\""
   },
   "repository": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@tachigo/api-client",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "files": [
+    "src/index.d.ts",
+    "src/index.mjs"
+  ],
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./src/index.mjs",
+      "default": "./src/index.mjs"
+    }
+  },
+  "dependencies": {
+    "@tachigo/shared-types": "workspace:*"
+  },
+  "scripts": {
+    "test": "node --test src/*.test.mjs"
+  }
+}

--- a/packages/api-client/src/index.d.ts
+++ b/packages/api-client/src/index.d.ts
@@ -57,6 +57,8 @@ export class ApiClientError<ResponseBody = unknown> extends Error {
   readonly status: number;
   readonly statusText: string;
   readonly response: ResponseBody;
+  readonly headers: Record<string, string>;
+  readonly cause?: unknown;
 }
 
 export function createApiClient(options?: ApiClientOptions): ApiClient;

--- a/packages/api-client/src/index.d.ts
+++ b/packages/api-client/src/index.d.ts
@@ -1,0 +1,62 @@
+import type { ApiOperations } from "@tachigo/shared-types";
+
+export type ApiOperation = keyof ApiOperations & string;
+
+type OperationSpec<Operation extends ApiOperation> = ApiOperations[Operation];
+type PropertyValue<Spec, Key extends PropertyKey> = Key extends keyof Spec ? Spec[Key] : never;
+type PropertyOption<Key extends string, Value> = undefined extends Value
+  ? { [Property in Key]?: Exclude<Value, undefined> }
+  : { [Property in Key]: Value };
+
+type PathParamsOption<Operation extends ApiOperation> = "pathParams" extends keyof OperationSpec<Operation>
+  ? PropertyOption<"pathParams", PropertyValue<OperationSpec<Operation>, "pathParams">>
+  : { pathParams?: never };
+
+type QueryParamsOption<Operation extends ApiOperation> = "queryParams" extends keyof OperationSpec<Operation>
+  ? PropertyOption<"queryParams", PropertyValue<OperationSpec<Operation>, "queryParams">>
+  : { queryParams?: never };
+
+type RequestBodyOption<Operation extends ApiOperation> = "requestBody" extends keyof OperationSpec<Operation>
+  ? PropertyOption<"requestBody", PropertyValue<OperationSpec<Operation>, "requestBody">>
+  : { requestBody?: never };
+
+type RequiredKeys<Type> = {
+  [Key in keyof Type]-?: {} extends Pick<Type, Key> ? never : Key;
+}[keyof Type];
+
+export type ApiResponse<Operation extends ApiOperation> = PropertyValue<
+  OperationSpec<Operation>,
+  "response"
+>;
+
+export type ApiRequestInit<Operation extends ApiOperation> = PathParamsOption<Operation> &
+  QueryParamsOption<Operation> &
+  RequestBodyOption<Operation> & {
+    headers?: HeadersInit;
+    signal?: AbortSignal;
+  };
+
+export type HeaderFactory = () => HeadersInit | Promise<HeadersInit>;
+
+export interface ApiClientOptions {
+  baseUrl?: string | URL;
+  fetch?: (input: string, init?: RequestInit) => Promise<Response>;
+  headers?: HeadersInit | HeaderFactory;
+}
+
+export interface ApiClient {
+  request<Operation extends ApiOperation>(
+    operation: Operation,
+    ...args: RequiredKeys<ApiRequestInit<Operation>> extends never
+      ? [init?: ApiRequestInit<Operation>]
+      : [init: ApiRequestInit<Operation>]
+  ): Promise<ApiResponse<Operation>>;
+}
+
+export class ApiClientError<ResponseBody = unknown> extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly response: ResponseBody;
+}
+
+export function createApiClient(options?: ApiClientOptions): ApiClient;

--- a/packages/api-client/src/index.mjs
+++ b/packages/api-client/src/index.mjs
@@ -1,0 +1,148 @@
+export class ApiClientError extends Error {
+  constructor(message, details) {
+    super(message);
+    this.name = "ApiClientError";
+    this.status = details.status;
+    this.statusText = details.statusText;
+    this.response = details.response;
+  }
+}
+
+export function createApiClient(options = {}) {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new TypeError("createApiClient requires a fetch implementation.");
+  }
+
+  return {
+    async request(operation, init = {}) {
+      const { method, pathTemplate } = parseOperation(operation);
+      const url = buildUrl(options.baseUrl ?? "", pathTemplate, init.pathParams, init.queryParams);
+      const headers = await mergeHeaders(options.headers, init.headers);
+      const requestInit = {
+        method,
+        headers,
+        signal: init.signal,
+      };
+
+      if (Object.hasOwn(init, "requestBody") && init.requestBody !== undefined) {
+        requestInit.body = JSON.stringify(init.requestBody);
+        if (!hasHeader(headers, "content-type")) {
+          headers["content-type"] = "application/json";
+        }
+      }
+
+      const response = await fetchImpl(url, requestInit);
+      const responseBody = await parseResponseBody(response);
+      if (!response.ok) {
+        throw new ApiClientError(`API request failed with status ${response.status}`, {
+          status: response.status,
+          statusText: response.statusText,
+          response: responseBody,
+        });
+      }
+
+      return responseBody;
+    },
+  };
+}
+
+function parseOperation(operation) {
+  const match = /^([A-Z]+)\s+(.+)$/.exec(operation);
+  if (!match) {
+    throw new TypeError(`Invalid API operation: ${operation}`);
+  }
+
+  return {
+    method: match[1],
+    pathTemplate: match[2],
+  };
+}
+
+function buildUrl(baseUrl, pathTemplate, pathParams = {}, queryParams = {}) {
+  const path = pathTemplate.replace(/\{([^}]+)\}/g, (_, key) => {
+    const value = pathParams[key];
+    if (value === undefined || value === null) {
+      throw new TypeError(`Missing path param: ${key}`);
+    }
+
+    return encodeURIComponent(String(value));
+  });
+
+  const base = String(baseUrl).replace(/\/+$/, "");
+  const pathWithSlash = path.startsWith("/") ? path : `/${path}`;
+  const placeholderOrigin = "http://tachigo.local";
+  const url = new URL(`${base}${pathWithSlash}`, base ? undefined : placeholderOrigin);
+
+  for (const [key, value] of Object.entries(queryParams)) {
+    appendQueryParam(url, key, value);
+  }
+
+  if (base) {
+    return url.toString();
+  }
+
+  return `${url.pathname}${url.search}`;
+}
+
+function appendQueryParam(url, key, value) {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      appendQueryParam(url, key, item);
+    }
+    return;
+  }
+
+  url.searchParams.append(key, String(value));
+}
+
+async function mergeHeaders(defaultHeaders, requestHeaders) {
+  return {
+    ...(await resolveHeaders(defaultHeaders)),
+    ...(await resolveHeaders(requestHeaders)),
+  };
+}
+
+async function resolveHeaders(headers) {
+  const resolved = typeof headers === "function" ? await headers() : headers;
+  if (!resolved) {
+    return {};
+  }
+
+  if (typeof Headers !== "undefined" && resolved instanceof Headers) {
+    return Object.fromEntries(resolved.entries());
+  }
+
+  if (Array.isArray(resolved)) {
+    return Object.fromEntries(resolved);
+  }
+
+  return { ...resolved };
+}
+
+function hasHeader(headers, name) {
+  const normalized = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === normalized);
+}
+
+async function parseResponseBody(response) {
+  if (response.status === 204 || response.status === 205) {
+    return undefined;
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return JSON.parse(text);
+  }
+
+  return text;
+}

--- a/packages/api-client/src/index.mjs
+++ b/packages/api-client/src/index.mjs
@@ -5,6 +5,10 @@ export class ApiClientError extends Error {
     this.status = details.status;
     this.statusText = details.statusText;
     this.response = details.response;
+    this.headers = details.headers ?? {};
+    if (Object.hasOwn(details, "cause")) {
+      this.cause = details.cause;
+    }
   }
 }
 
@@ -39,6 +43,7 @@ export function createApiClient(options = {}) {
           status: response.status,
           statusText: response.statusText,
           response: responseBody,
+          headers: headersToObject(response.headers),
         });
       }
 
@@ -146,8 +151,29 @@ async function parseResponseBody(response) {
 
   const contentType = response.headers.get("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    return JSON.parse(text);
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      throw new ApiClientError("API response JSON parse failed", {
+        status: response.status,
+        statusText: response.statusText,
+        response: {
+          rawBody: text,
+          parseError: formatError(error),
+        },
+        headers: headersToObject(response.headers),
+        cause: error,
+      });
+    }
   }
 
   return text;
+}
+
+function headersToObject(headers) {
+  return Object.fromEntries(headers.entries());
+}
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/api-client/src/index.mjs
+++ b/packages/api-client/src/index.mjs
@@ -72,17 +72,22 @@ function buildUrl(baseUrl, pathTemplate, pathParams = {}, queryParams = {}) {
   const base = String(baseUrl).replace(/\/+$/, "");
   const pathWithSlash = path.startsWith("/") ? path : `/${path}`;
   const placeholderOrigin = "http://tachigo.local";
-  const url = new URL(`${base}${pathWithSlash}`, base ? undefined : placeholderOrigin);
+  const baseIsAbsolute = isAbsoluteUrl(base);
+  const url = new URL(`${base}${pathWithSlash}`, baseIsAbsolute ? undefined : placeholderOrigin);
 
   for (const [key, value] of Object.entries(queryParams)) {
     appendQueryParam(url, key, value);
   }
 
-  if (base) {
+  if (baseIsAbsolute) {
     return url.toString();
   }
 
   return `${url.pathname}${url.search}`;
+}
+
+function isAbsoluteUrl(value) {
+  return /^[A-Za-z][A-Za-z\d+\-.]*:/.test(value);
 }
 
 function appendQueryParam(url, key, value) {

--- a/packages/api-client/src/index.test.mjs
+++ b/packages/api-client/src/index.test.mjs
@@ -125,7 +125,11 @@ describe("createApiClient", () => {
 
     await assert.rejects(
       () => client.request("GET /dashboard/raffles/{id}/draws", { pathParams: {} }),
-      /Missing path param: id/,
+      (error) => {
+        assert.ok(error instanceof TypeError);
+        assert.match(error.message, /Missing path param: id/);
+        return true;
+      },
     );
   });
 

--- a/packages/api-client/src/index.test.mjs
+++ b/packages/api-client/src/index.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { ApiClientError, createApiClient } from "./index.mjs";
+
+function createFetchRecorder(response) {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return response;
+  };
+
+  return { calls, fetchImpl };
+}
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+describe("createApiClient", () => {
+  it("serializes typed operations with path params, query params, JSON body, and headers", async () => {
+    const recorder = createFetchRecorder(
+      jsonResponse({ success: true, data: { message: "ok" } }),
+    );
+    const client = createApiClient({
+      baseUrl: "https://api.example.test/api/v1/",
+      fetch: recorder.fetchImpl,
+      headers: async () => ({ authorization: "Bearer token-a" }),
+    });
+
+    await client.request("PUT /users/me/addresses/{id}", {
+      pathParams: { id: "addr/1" },
+      queryParams: { preview: true, empty: undefined },
+      requestBody: {
+        address_line1: "Road 1",
+        city: "Taipei",
+        recipient_name: "Tachi",
+      },
+      headers: { "x-request-id": "req-1" },
+    });
+
+    assert.equal(
+      recorder.calls[0].url,
+      "https://api.example.test/api/v1/users/me/addresses/addr%2F1?preview=true",
+    );
+    assert.equal(recorder.calls[0].init.method, "PUT");
+    assert.equal(recorder.calls[0].init.headers.authorization, "Bearer token-a");
+    assert.equal(recorder.calls[0].init.headers["x-request-id"], "req-1");
+    assert.equal(recorder.calls[0].init.headers["content-type"], "application/json");
+    assert.deepEqual(JSON.parse(recorder.calls[0].init.body), {
+      address_line1: "Road 1",
+      city: "Taipei",
+      recipient_name: "Tachi",
+    });
+  });
+
+  it("returns parsed JSON responses for successful requests", async () => {
+    const recorder = createFetchRecorder(
+      jsonResponse({ success: true, data: { user: { id: "u1" } } }),
+    );
+    const client = createApiClient({
+      baseUrl: "https://api.example.test/api/v1",
+      fetch: recorder.fetchImpl,
+    });
+
+    const result = await client.request("GET /users/me");
+
+    assert.deepEqual(result, { success: true, data: { user: { id: "u1" } } });
+    assert.equal(recorder.calls[0].init.body, undefined);
+    assert.equal(recorder.calls[0].init.headers["content-type"], undefined);
+  });
+
+  it("throws ApiClientError with parsed response details when the API returns an error status", async () => {
+    const client = createApiClient({
+      baseUrl: "https://api.example.test/api/v1",
+      fetch: async () => jsonResponse({ success: false, error: "unauthorized" }, { status: 401 }),
+    });
+
+    await assert.rejects(
+      () => client.request("GET /users/me"),
+      (error) => {
+        assert.ok(error instanceof ApiClientError);
+        assert.equal(error.status, 401);
+        assert.deepEqual(error.response, { success: false, error: "unauthorized" });
+        return true;
+      },
+    );
+  });
+});

--- a/packages/api-client/src/index.test.mjs
+++ b/packages/api-client/src/index.test.mjs
@@ -92,4 +92,49 @@ describe("createApiClient", () => {
       },
     );
   });
+
+  it("supports relative base URLs, repeated query params, and text responses", async () => {
+    const recorder = createFetchRecorder(
+      new Response("ok", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    const client = createApiClient({
+      baseUrl: "/api/v1/",
+      fetch: recorder.fetchImpl,
+    });
+
+    const result = await client.request("GET /dashboard/raffles/{id}/draws", {
+      pathParams: { id: "raffle 1" },
+      queryParams: { tag: ["alpha", "beta"], empty: null },
+    });
+
+    assert.equal(
+      recorder.calls[0].url,
+      "/api/v1/dashboard/raffles/raffle%201/draws?tag=alpha&tag=beta",
+    );
+    assert.equal(result, "ok");
+  });
+
+  it("throws a TypeError when a path param is missing", async () => {
+    const client = createApiClient({
+      baseUrl: "https://api.example.test/api/v1",
+      fetch: async () => jsonResponse({ success: true }),
+    });
+
+    await assert.rejects(
+      () => client.request("GET /dashboard/raffles/{id}/draws", { pathParams: {} }),
+      /Missing path param: id/,
+    );
+  });
+
+  it("returns undefined for empty success responses", async () => {
+    const client = createApiClient({
+      baseUrl: "https://api.example.test/api/v1",
+      fetch: async () => new Response(null, { status: 204 }),
+    });
+
+    assert.equal(await client.request("POST /auth/verify-email/send"), undefined);
+  });
 });

--- a/packages/api-client/src/index.test.mjs
+++ b/packages/api-client/src/index.test.mjs
@@ -137,4 +137,43 @@ describe("createApiClient", () => {
 
     assert.equal(await client.request("POST /auth/verify-email/send"), undefined);
   });
+
+  it("returns undefined for 205 reset-content responses", async () => {
+    const client = createApiClient({
+      baseUrl: "https://api.example.test/api/v1",
+      fetch: async () => new Response(null, { status: 205 }),
+    });
+
+    assert.equal(await client.request("POST /auth/verify-email/send"), undefined);
+  });
+
+  it("wraps invalid JSON responses in ApiClientError with raw response details", async () => {
+    const client = createApiClient({
+      baseUrl: "https://api.example.test/api/v1",
+      fetch: async () =>
+        new Response("{", {
+          status: 200,
+          statusText: "OK",
+          headers: {
+            "content-type": "application/json",
+            "x-trace-id": "trace-1",
+          },
+        }),
+    });
+
+    await assert.rejects(
+      () => client.request("GET /users/me"),
+      (error) => {
+        assert.ok(error instanceof ApiClientError);
+        assert.equal(error.status, 200);
+        assert.equal(error.statusText, "OK");
+        assert.equal(error.response.rawBody, "{");
+        assert.match(error.response.parseError, /JSON|Unexpected|Expected/);
+        assert.equal(error.headers["content-type"], "application/json");
+        assert.equal(error.headers["x-trace-id"], "trace-1");
+        assert.ok(error.cause instanceof SyntaxError);
+        return true;
+      },
+    );
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,12 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
 
+  packages/api-client:
+    dependencies:
+      '@tachigo/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
+
   packages/shared-types: {}
 
 packages:


### PR DESCRIPTION
## 什麼改動
新增 `@tachigo/api-client` workspace package，提供零外部依賴的薄 fetch wrapper，並以 `@tachigo/shared-types` 的 `ApiOperations` 型別限制 operation key、path/query/body 與 response 型別。根目錄新增 `api:client:test` script，`pnpm-lock.yaml` 新增 workspace importer。

## 為什麼
#401 已完成 shared-types scaffold；這一個 PR 是下一個小切片，先建立可被 frontend apps 共用的 typed API client baseline。此 PR 只建立 package 與測試，不把 dashboard / extension adoption、CI drift gate 或 auth refresh integration 混進同一個 diff。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#401
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 dashboard / extension adoption
  - 不做 CI drift gate
  - 不改 OpenAPI generator 或 backend swagger source
  - 不做 auth refresh / token storage integration
  - #649 已 merged into `develop`，本 PR 不再依賴未合併 branch

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #401 未定義額外 worker plan；本 PR 依 autonomous sprint 授權拆成低風險 package scaffold 小切片。
- Actual worker profile(s)：
  - controller
- Model strength：
  - main = GPT-5.5 xhigh。
- Spawn directive(s)：
  - profile=controller model=GPT-5.5 reasoning=xhigh controller_fallback=self-only fallback_reason=本 PR 未 spawned subagent；由 controller 直接完成低風險 package scaffold 與 review-fix 小修。
- Verification evidence：
  - `rtk pnpm api:client:test`
  - `rtk pnpm api:types:check`
  - `rtk pnpm install --lockfile-only --frozen-lockfile --ignore-scripts --offline`
  - `rtk pnpm --filter @tachigo/api-client pack --dry-run`
  - `rtk git --no-optional-locks diff --check`
- Self-review / exception reason：
  - controller self-review complete：只新增 `packages/api-client`、root script 與 workspace lockfile importer。
- Worker session closeout：
  - no subagent sessions were created；controller 已完成 diff scope review、focused tests、metadata check 與 PR open。
- Workflow friction / follow-up split：
  - 本地 registry DNS 對 `registry.npmjs.org` 失敗，完整 workspace install / app `tsc` 無法在本機跑；已改用 offline filtered workspace install、frozen lockfile check、package pack dry-run 與 focused Node tests。frontend adoption 與 CI drift gate 留給後續 PR。

## Review conversation closeout
- Unresolved threads：
  - 0；CodeRabbit 的 TypeError assertion thread 已由 `c77ca6df73778fd2e44b83106026d649738c5211` test-only commit 處理。
- CodeRabbit：
  - Latest post-push CodeRabbit rerun is expected after `c77ca6df73778fd2e44b83106026d649738c5211`; do not merge until it reports success / no actionable blocker.
- chatgpt-codex-connector：
  - n/a；本 PR 目前沒有 chatgpt-codex-connector blocker。
- Final reviewer action：
  - Review-fix pushed；等待 post-push CI / CodeRabbit 收斂與 human/other reviewer approval，automation 不 self-approve。

## Final merge gate
- Ready-to-merge decision：
  - blocked by post-push CI / CodeRabbit after `c77ca6df73778fd2e44b83106026d649738c5211`; merge gate requires Scope Police + CI + CodeRabbit success and non-self approval.
- Latest head SHA：
  - `c77ca6df73778fd2e44b83106026d649738c5211`
- Required checks：
  - Local focused checks pass；GitHub required checks are rerunning after the test-only review fix.
- spec workflow-check evidence：
  - n/a；manual autonomous checklist used for this small package scaffold.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/656

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增由 generated OpenAPI shared types 驅動的薄 API client package baseline。
- Approx changed lines：~336
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #649 shared-types scaffold 已 merged；frontend adoption / CI drift gate 後續另切。

## Acceptance Criteria
- [x] 新增 `packages/api-client`，可從 `@tachigo/shared-types` 的 `ApiOperations` 取得 operation / request / response 型別。
- [x] API client 可序列化 method、path params、query params、JSON body 與 headers。
- [x] API client 可解析 JSON success response，並在非 2xx 時丟出帶 status / parsed response 的 `ApiClientError`。
- [x] 新增 focused Node tests 覆蓋上述 runtime 行為。
- [ ] frontend apps adoption 後續 PR 處理。
- [ ] CI / lint drift gate 後續 PR 處理。

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk pnpm api:client:test
tests 8 pass / 0 fail

rtk pnpm api:types:check
exit 0

rtk pnpm install --lockfile-only --frozen-lockfile --ignore-scripts --offline
Scope: all 5 workspace projects
Done in 297ms using pnpm v10.33.0

rtk pnpm --filter @tachigo/api-client pack --dry-run
Tarball Contents: package.json, src/index.d.ts, src/index.mjs

rtk git --no-optional-locks diff --check
no output
```

## 備註
曾嘗試完整 `rtk pnpm install --lockfile-only --ignore-scripts`，但本機 DNS 對 `registry.npmjs.org` 回 `ENOTFOUND`；因此未在本機跑 app `tsc`。GitHub CI 應補足 clean environment 驗證。

## Notes for Claude Code Review
- 請特別看 `packages/api-client/src/index.d.ts` 的 conditional type 是否符合 frontend 使用期待。
- 此 PR 不 close #401；它只完成 `packages/api-client` baseline，後續仍需 frontend adoption 與 CI drift gate。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增类型安全的 API 客户端库，提供可配置的请求工厂、统一错误类型与类型化响应处理。
  * 新增打包发布的私有 API 客户端包，包含类型声明与导出入口。

* **测试**
  * 为 API 客户端添加全面测试套件，覆盖请求构建、序列化、响应解析与错误场景。

* **其他**
  * 添加顶层脚本以便运行该包的测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/656)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
