### PR TITLE
[infra] Backport Dependabot main updates to develop

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -19,6 +19,7 @@ const issueTemplatePath = path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'code
 const prTemplatePath = path.join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md')
 const dependabotConfigPath = path.join(repoRoot, '.github', 'dependabot.yml')
 const dependabotAutomergeWorkflowPath = path.join(currentDir, 'dependabot-automerge.yml')
+const dependabotMainBackportWorkflowPath = path.join(currentDir, 'dependabot-main-backport.yml')
 const dependabotPnpmLockfileWorkflowPath = path.join(currentDir, 'dependabot-pnpm-lockfile.yml')
 const autoMergeWorkflowPath = path.join(currentDir, 'auto-merge.yml')
 const autoReadyWorkflowPath = path.join(currentDir, 'auto-ready-pr.yml')
@@ -1702,6 +1703,28 @@ test('Dependabot auto-merge uses repository-supported merge commits', async () =
 
   assert.match(workflow, /gh pr merge --auto --merge "\$PR_URL"/)
   assert.doesNotMatch(workflow, /gh pr merge --auto --squash/)
+})
+
+test('Dependabot main backport workflow opens develop sync PRs', async () => {
+  const workflow = await readFile(dependabotMainBackportWorkflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(dependabotMainBackportWorkflowPath)
+  const job = parsedWorkflow.jobs['backport-to-develop']
+  const jobBlock = workflowJobBlock(workflow, 'backport-to-develop')
+
+  assert.deepEqual(parsedWorkflow.on.pull_request.branches, ['main'])
+  assert.deepEqual(parsedWorkflow.on.pull_request.types, ['closed'])
+  assert.equal(
+    job.if,
+    "github.event.pull_request.merged == true && github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository",
+  )
+  assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.match(jobBlock, /git checkout -B "\$branch" origin\/develop/)
+  assert.match(jobBlock, /git cherry-pick --no-commit/)
+  assert.match(jobBlock, /refs #\$\{PR_NUMBER\}/)
+  assert.match(jobBlock, /--base develop/)
+  assert.match(jobBlock, /--draft/)
+  assert.match(jobBlock, /--label auto-ready/)
+  assert.match(jobBlock, /automatic \\\`develop\\\` backport failed/)
 })
 
 test('contracts Slither report job uploads SARIF and keeps findings report-only', async () => {

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -1720,6 +1720,7 @@ test('Dependabot main backport workflow opens develop sync PRs', async () => {
   assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
   assert.match(jobBlock, /git checkout -B "\$branch" origin\/develop/)
   assert.match(jobBlock, /git cherry-pick --no-commit/)
+  assert.match(jobBlock, /git restore --staged \./)
   assert.match(jobBlock, /refs #\$\{PR_NUMBER\}/)
   assert.match(jobBlock, /--base develop/)
   assert.match(jobBlock, /--draft/)

--- a/.github/workflows/dependabot-main-backport.yml
+++ b/.github/workflows/dependabot-main-backport.yml
@@ -1,0 +1,209 @@
+name: Backport Dependabot main updates
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  backport-to-develop:
+    name: Open develop backport PR
+    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cherry-pick Dependabot changes onto develop
+        id: backport
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          branch="chore/backport-dependabot-${PR_NUMBER}-to-develop"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main develop
+          git checkout -B "$branch" origin/develop
+
+          mapfile -t commits < <(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" --jq '.[].sha')
+          if [ "${#commits[@]}" -eq 0 ]; then
+            echo "No Dependabot commits found for PR #${PR_NUMBER}."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          for sha in "${commits[@]}"; do
+            parent_count="$(git rev-list --parents -n 1 "$sha" | awk '{ print NF - 1 }')"
+            if [ "$parent_count" -gt 1 ]; then
+              git cherry-pick --no-commit -m 1 "$sha"
+            else
+              git cherry-pick --no-commit "$sha"
+            fi
+          done
+
+          if git diff --cached --quiet && git diff --quiet; then
+            echo "Develop already contains the Dependabot changes from PR #${PR_NUMBER}."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git add services/api/go.mod services/api/go.sum package.json pnpm-lock.yaml pnpm-workspace.yaml apps/dashboard/package.json apps/dashboard/pnpm-lock.yaml apps/extension/package.json apps/extension/pnpm-lock.yaml 2>/dev/null || true
+          git commit \
+            -m "chore: backport Dependabot PR #${PR_NUMBER}" \
+            -m "refs #${PR_NUMBER}" \
+            -m "Co-Authored-By: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+
+          git push --force-with-lease origin "$branch"
+
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open develop backport PR
+        if: steps.backport.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.backport.outputs.branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+
+          existing="$(gh pr list --base develop --head "$BRANCH" --state open --json number --jq '.[0].number // ""')"
+          if [ -n "$existing" ]; then
+            echo "Backport PR #${existing} already exists."
+            exit 0
+          fi
+
+          files="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+          title_prefix="[chore]"
+          if printf '%s\n' "$files" | grep -Eq '^services/api/'; then
+            title_prefix="[backend]"
+          elif printf '%s\n' "$files" | grep -Eq '^apps/'; then
+            title_prefix="[frontend]"
+          elif printf '%s\n' "$files" | grep -Eq '^\.github/|^infra/'; then
+            title_prefix="[infra]"
+          fi
+
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          ## 什麼改動
+          Backport Dependabot PR #${PR_NUMBER} from \`main\` to \`develop\`.
+
+          Source PR: ${PR_URL}
+
+          ## 為什麼
+          Dependabot security/default-branch updates can target \`main\`. The project development line is \`develop\`, so dependency updates merged into \`main\` must be made visible on \`develop\` before the next release promotion.
+
+          ## Release Context
+          - Release type：n/a
+
+          ## Workflow Type
+          - [x] Small / Medium
+          - [ ] Test-Driven / Debug Loop
+          - [ ] Architecture / High Risk
+
+          ## Scope 對齊
+          - Source of truth：#${PR_NUMBER}
+          - Depends on PR：none
+          - Backend contract already in develop:
+            - [x] yes
+            - [ ] no
+          - If no, this PR is:
+            - [ ] stacked on dependency branch
+            - [ ] intentionally blocked until dependency merges
+          - 本 PR 是否完全在 source of truth 範圍內？
+            - [x] 是
+            - [ ] 否，已另開 issue / PR 處理超出部分
+          - 本 PR 明確不做：
+            - 不修改 runtime code outside the dependency files changed by #${PR_NUMBER}.
+            - 不做 \`main -> develop\` 整體回灌。
+
+          ## Delegation Execution Log（非 Codex autonomous PR 可略過）
+          - Source issue delegation plan：
+            - #${PR_NUMBER}
+          - Actual worker profile(s)：
+            - controller
+          - Model strength：
+            - GitHub Actions workflow
+          - Verification evidence：
+            - CI required checks on this PR
+          - Self-review / exception reason：
+            - Automated narrow backport generated from Dependabot PR #${PR_NUMBER}.
+          - Worker session closeout：
+            - No subagent sessions are opened by this workflow; generated branch and PR are the closeout artifact.
+          - Workflow friction / follow-up split：
+            - If this PR conflicts or CI fails, review and fix manually before merging.
+
+          ## PR 拆分檢查
+          - 這個 PR 的單一句子目的：
+            - Backport Dependabot PR #${PR_NUMBER} to \`develop\`.
+          - Approx changed lines：see Files changed
+          - 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
+            - [x] 是
+            - [ ] 否，原因：
+          - 本 PR 是否同時包含以下多個層級？
+            - [ ] migration / schema
+            - [ ] backend domain service
+            - [ ] API handler / router
+              - [ ] 已執行 \`swag init\` 並將 \`services/api/docs/\` 變更一起 commit
+            - [ ] frontend integration
+            - [ ] tests
+            - [ ] docs
+            - [ ] refactor / cleanup
+          - 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
+            - n/a
+          - 若已拆分，相關 PR：
+            - ${PR_URL}
+
+          ## Acceptance Criteria
+          - [x] Backport contains the dependency changes from #${PR_NUMBER}.
+          - [ ] Required CI checks pass.
+
+          ## 超出範圍內容
+          無
+
+          ## 測試方式
+          - [ ] 本地測試過
+          - [ ] 有寫 / 更新測試
+
+          **驗證結果**
+          \`\`\`
+          CI will validate this generated backport PR.
+          \`\`\`
+
+          ## 備註
+          Created automatically because Dependabot PR #${PR_NUMBER} merged into \`main\`.
+
+          ## Notes for Claude Code Review
+          - Confirm this PR only backports dependency files from #${PR_NUMBER}.
+          - If CI fails, treat it like a normal Dependabot update and fix before merge.
+          EOF
+
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "${title_prefix} Backport Dependabot PR #${PR_NUMBER} to develop" \
+            --body-file "$body_file" \
+            --draft \
+            --label auto-ready
+
+      - name: Comment when backport fails
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "Dependabot PR #${PR_NUMBER} merged into \`main\`, but the automatic \`develop\` backport failed. Please open a manual backport PR before the next release promotion."

--- a/.github/workflows/dependabot-main-backport.yml
+++ b/.github/workflows/dependabot-main-backport.yml
@@ -53,13 +53,15 @@ jobs:
             fi
           done
 
-          if git diff --cached --quiet && git diff --quiet; then
-            echo "Develop already contains the Dependabot changes from PR #${PR_NUMBER}."
+          git restore --staged .
+          git add services/api/go.mod services/api/go.sum package.json pnpm-lock.yaml pnpm-workspace.yaml apps/dashboard/package.json apps/dashboard/pnpm-lock.yaml apps/extension/package.json apps/extension/pnpm-lock.yaml 2>/dev/null || true
+
+          if git diff --cached --quiet; then
+            echo "Develop already contains no whitelisted dependency changes from PR #${PR_NUMBER}."
             echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          git add services/api/go.mod services/api/go.sum package.json pnpm-lock.yaml pnpm-workspace.yaml apps/dashboard/package.json apps/dashboard/pnpm-lock.yaml apps/extension/package.json apps/extension/pnpm-lock.yaml 2>/dev/null || true
           git commit \
             -m "chore: backport Dependabot PR #${PR_NUMBER}" \
             -m "refs #${PR_NUMBER}" \

--- a/docs/dependabot-update-policy.md
+++ b/docs/dependabot-update-policy.md
@@ -59,6 +59,20 @@ triggered by security alerts on the default branch. Production security update
 PRs remain manual-review changes because dependency upgrades can introduce new
 supply-chain, compatibility, or runtime risks even when they fix a known issue.
 
+## Default-Branch Security Updates
+
+Routine Dependabot version updates target `develop`, but Dependabot
+security/default-branch updates can still open against the repository default
+branch (`main`). Treat those PRs as urgent security maintenance, not as normal
+feature or release promotion work.
+
+When a Dependabot PR is merged into `main`, `dependabot-main-backport.yml`
+creates a draft backport PR from `develop` with the same dependency changes and
+the `auto-ready` label. Review and merge that backport before the next
+`develop -> main` release promotion. If the automatic cherry-pick conflicts,
+the workflow comments on the original PR and a human must open the backport
+manually.
+
 ## Cooldown
 
 High-frequency frontend tooling updates use Dependabot cooldown:


### PR DESCRIPTION
## 什麼改動
新增 Dependabot `main` -> `develop` backport 流程：
- 新增 `.github/workflows/dependabot-main-backport.yml`
- 更新 `.github/workflows/ci.test.mjs` regression test
- 補充 `docs/dependabot-update-policy.md` 的 default-branch security update 規則

## 為什麼
refs #659

Dependabot security/default-branch PR 可能打到 `main`，但 tachigo 的日常開發線是 `develop`。#639 / #640 顯示這會讓 `main` 先拿到 dependency fix，而 `develop` 漏掉同一批依賴更新。本 PR 讓這種情況變成可見、可追蹤、可 review 的 backport PR，而不是靠人記得補。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## Scope 對齊
- Source of truth：#659
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 repository default branch。
  - 不停用 Dependabot security updates。
  - 不改任何 dependency version。
  - 不自動 merge 產出的 backport PR。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #659
- Actual worker profile(s)：
  - controller
- Model strength：
  - GPT-5.5 xHigh
- Verification evidence：
  - `node --test .github/workflows/ci.test.mjs`
  - `git diff --check`
- Self-review / exception reason：
  - Controller implemented and self-reviewed the workflow, policy doc, and regression test.
- Worker session closeout：
  - No subagent sessions were opened for this PR; controller completed the scoped implementation and verification directly.
- Workflow friction / follow-up split：
  - Dependency backport itself is split into #658. This PR only adds the future guardrail.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 Dependabot PR 合併進 `main` 後自動產生可 review 的 `develop` backport PR。
- Approx changed lines：~246
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Workflow policy needs regression coverage and operator-facing documentation in the same PR.
- 若已拆分，相關 PR：
  - #658 handles the immediate #639 / #640 dependency backport.

## Acceptance Criteria
- [x] Document that Dependabot security/default-branch PRs require a `develop` backport after merge.
- [x] Add automation that opens a draft backport PR to `develop` when a Dependabot PR merges into `main`.
- [x] Keep normal feature PRs targeting `develop` and formal release PRs targeting `main` unchanged.
- [x] Add regression coverage for the new workflow.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
tests 71
pass 71
fail 0

git diff --check
pass
```

## 備註
Generated backport PRs are draft PRs with `auto-ready`; they still need CI and normal review/merge policy.

## Notes for Claude Code Review
- 請特別看 workflow 是否只在 Dependabot merged-to-main 事件觸發。
- 請確認產出的 backport PR 不會自動 merge，只是讓 `develop` sync 顯性化。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增自动反向移植工作流：将合并到主分支的依赖更新自动创建对应的开发分支PR。

* **测试**
  * 添加反向移植工作流测试覆盖，验证关键步骤和失败处理逻辑。

* **文档**
  * 更新依赖管理策略文档，说明安全更新分支处理和反向移植流程。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/660)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->