### PR TITLE
[frontend] feat(dashboard): raffle Discord webhook 設定 UI

### DIFF
--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -2,7 +2,7 @@ import { useOne } from '@refinedev/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { completeRaffle, drawNext, importCSV, listDraws } from '@/services/raffles'
+import { completeRaffle, drawNext, importCSV, listDraws, setDiscordWebhook } from '@/services/raffles'
 import type { Raffle, RaffleDraw, RaffleStatus } from '@/services/raffles'
 
 const statusLabel: Record<RaffleStatus, string> = {
@@ -223,6 +223,90 @@ function DrawControls({
         </div>
       )}
     </div>
+  )
+}
+
+function DiscordWebhookPanel({ raffleId }: { raffleId: string }) {
+  const [url, setUrl] = useState('')
+  const [configured, setConfigured] = useState<boolean | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSave() {
+    if (saving) return
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await setDiscordWebhook(raffleId, url)
+      setConfigured(result)
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } } }
+      setError(e?.response?.data?.error ?? '儲存失敗，請稍後再試')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleClear() {
+    if (saving) return
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await setDiscordWebhook(raffleId, '')
+      setConfigured(result)
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } } }
+      setError(e?.response?.data?.error ?? '清除失敗，請稍後再試')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-white/10 bg-white/[.04] p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <h2 className="text-[10px] uppercase tracking-widest text-white/30">Discord 通知</h2>
+        {configured !== null && (
+          <span
+            data-testid="discord-webhook-status"
+            className={`text-[10px] rounded-full px-2 py-0.5 ${configured ? 'bg-green-500/20 text-green-400' : 'bg-white/10 text-white/30'}`}
+          >
+            {configured ? '已設定' : '未設定'}
+          </span>
+        )}
+      </div>
+      <div className="flex gap-2">
+        <input
+          data-testid="discord-webhook-input"
+          type="text"
+          value={url}
+          onInput={(e) => setUrl((e.target as HTMLInputElement).value)}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://discord.com/api/webhooks/..."
+          disabled={saving}
+          className="flex-1 rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-xs text-white/80 placeholder:text-white/20 focus:outline-none focus:border-amber-500/50 disabled:opacity-40"
+        />
+        <button
+          data-testid="discord-webhook-save"
+          onClick={() => { void handleSave() }}
+          disabled={saving}
+          className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-400 transition hover:bg-amber-500/20 disabled:opacity-40"
+        >
+          {saving ? '...' : '儲存'}
+        </button>
+        <button
+          data-testid="discord-webhook-clear"
+          onClick={() => { void handleClear() }}
+          disabled={saving}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/40 transition hover:bg-white/10 disabled:opacity-40"
+        >
+          清除
+        </button>
+      </div>
+      {error && (
+        <p data-testid="discord-webhook-error" className="text-xs text-red-400">{error}</p>
+      )}
+    </section>
   )
 }
 
@@ -574,6 +658,8 @@ export default function RaffleDetailPage() {
             onConfirmEnd={() => { void handleConfirmEnd() }}
             onCancelEnd={() => setConfirmEnd(false)}
           />
+
+          <DiscordWebhookPanel raffleId={raffle.id} />
 
           <div>
             <p className="mb-2 text-[10px] uppercase tracking-widest text-white/30">

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/services/raffles', async (importOriginal) => {
     drawNext: vi.fn().mockResolvedValue({}),
     importCSV: vi.fn().mockResolvedValue({ imported: 0, skipped: 0 }),
     completeRaffle: vi.fn().mockResolvedValue(undefined),
+    setDiscordWebhook: vi.fn().mockResolvedValue(true),
   }
 })
 
@@ -70,6 +71,7 @@ beforeEach(() => {
   vi.mocked(rafflesService.drawNext).mockResolvedValue(mockDraw)
   vi.mocked(rafflesService.importCSV).mockResolvedValue({ imported: 0, skipped: 0 })
   vi.mocked(rafflesService.completeRaffle).mockResolvedValue(undefined)
+  vi.mocked(rafflesService.setDiscordWebhook).mockResolvedValue(true)
 })
 afterEach(() => {
   vi.restoreAllMocks()
@@ -307,6 +309,96 @@ describe('RaffleDetailPage — end activity', () => {
     await waitFor(() => expect(completeMock).toHaveBeenCalledWith('r1'))
     await waitFor(() => expect(container.querySelector('[data-testid="end-btn"]')).toBeFalsy())
     expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(true)
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — Discord webhook', () => {
+  it('shows Discord webhook settings section', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="discord-webhook-input"]')).toBeTruthy())
+    cleanup(root, container)
+  })
+
+  it('calls setDiscordWebhook with URL when save button clicked', async () => {
+    const webhookMock = vi.mocked(rafflesService.setDiscordWebhook).mockResolvedValue(true)
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="discord-webhook-input"]')).toBeTruthy())
+
+    const input = container.querySelector('[data-testid="discord-webhook-input"]') as HTMLInputElement
+    await act(async () => {
+      input.value = 'https://discord.com/api/webhooks/123/abc'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      container.querySelector('[data-testid="discord-webhook-save"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(webhookMock).toHaveBeenCalledWith('r1', 'https://discord.com/api/webhooks/123/abc'))
+    cleanup(root, container)
+  })
+
+  it('shows configured status after successful save', async () => {
+    vi.mocked(rafflesService.setDiscordWebhook).mockResolvedValue(true)
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="discord-webhook-input"]')).toBeTruthy())
+
+    const input = container.querySelector('[data-testid="discord-webhook-input"]') as HTMLInputElement
+    await act(async () => {
+      input.value = 'https://discord.com/api/webhooks/123/abc'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      container.querySelector('[data-testid="discord-webhook-save"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(container.querySelector('[data-testid="discord-webhook-status"]')?.textContent).toContain('已設定'))
+    cleanup(root, container)
+  })
+
+  it('calls setDiscordWebhook with empty string when clear button clicked', async () => {
+    const webhookMock = vi.mocked(rafflesService.setDiscordWebhook).mockResolvedValue(false)
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="discord-webhook-clear"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="discord-webhook-clear"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(webhookMock).toHaveBeenCalledWith('r1', ''))
+    cleanup(root, container)
+  })
+
+  it('shows error message when save fails', async () => {
+    vi.mocked(rafflesService.setDiscordWebhook).mockRejectedValue({ response: { data: { error: 'invalid discord webhook url' } } })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="discord-webhook-input"]')).toBeTruthy())
+
+    const input = container.querySelector('[data-testid="discord-webhook-input"]') as HTMLInputElement
+    await act(async () => {
+      input.value = 'not-a-valid-url'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      container.querySelector('[data-testid="discord-webhook-save"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(container.querySelector('[data-testid="discord-webhook-error"]')?.textContent).toContain('invalid discord webhook url'))
     cleanup(root, container)
   })
 })

--- a/apps/dashboard/src/services/__tests__/raffles.test.ts
+++ b/apps/dashboard/src/services/__tests__/raffles.test.ts
@@ -1,15 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listRaffles, createRaffle, listDraws, drawNext, importCSV, completeRaffle } from '@/services/raffles'
+import { listRaffles, createRaffle, listDraws, drawNext, importCSV, completeRaffle, setDiscordWebhook } from '@/services/raffles'
 
 const getMock = vi.fn()
 const postMock = vi.fn()
+const patchMock = vi.fn()
 
 vi.mock('@/services/api', () => ({
-  default: { get: (...a: unknown[]) => getMock(...a), post: (...a: unknown[]) => postMock(...a) },
+  default: {
+    get: (...a: unknown[]) => getMock(...a),
+    post: (...a: unknown[]) => postMock(...a),
+    patch: (...a: unknown[]) => patchMock(...a),
+  },
 }))
 
 const mockRaffle = { id: 'r1', user_id: 'u1', title: 'Test', status: 'draft' as const, created_at: '', updated_at: '' }
-beforeEach(() => { getMock.mockReset(); postMock.mockReset() })
+beforeEach(() => { getMock.mockReset(); postMock.mockReset(); patchMock.mockReset() })
 
 describe('listRaffles', () => {
   it('returns raffles array', async () => {
@@ -69,5 +74,27 @@ describe('completeRaffle', () => {
     postMock.mockResolvedValue({ data: { success: true, data: {} } })
     await completeRaffle('r1')
     expect(postMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/complete', undefined)
+  })
+})
+
+describe('setDiscordWebhook', () => {
+  it('patches the endpoint with URL and returns configured=true', async () => {
+    patchMock.mockResolvedValue({ data: { success: true, data: { discord_webhook_configured: true } } })
+    const result = await setDiscordWebhook('r1', 'https://discord.com/api/webhooks/123/abc')
+    expect(result).toBe(true)
+    expect(patchMock).toHaveBeenCalledWith(
+      '/api/v1/dashboard/raffles/r1/discord-webhook',
+      { discord_webhook_url: 'https://discord.com/api/webhooks/123/abc' },
+    )
+  })
+
+  it('patches with empty string to clear and returns configured=false', async () => {
+    patchMock.mockResolvedValue({ data: { success: true, data: { discord_webhook_configured: false } } })
+    const result = await setDiscordWebhook('r1', '')
+    expect(result).toBe(false)
+    expect(patchMock).toHaveBeenCalledWith(
+      '/api/v1/dashboard/raffles/r1/discord-webhook',
+      { discord_webhook_url: '' },
+    )
   })
 })

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -80,3 +80,14 @@ export async function completeRaffle(raffleId: string): Promise<void> {
     undefined,
   )
 }
+
+export async function setDiscordWebhook(
+  raffleId: string,
+  webhookUrl: string,
+): Promise<boolean> {
+  const { data } = await client.patch<ApiResponse<{ discord_webhook_configured: boolean }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/discord-webhook`,
+    { discord_webhook_url: webhookUrl },
+  )
+  return data.data.discord_webhook_configured
+}


### PR DESCRIPTION
## 什麼改動
- `services/raffles.ts` 新增 `setDiscordWebhook(raffleId, webhookUrl)` — PATCH `/api/v1/dashboard/raffles/:id/discord-webhook`
- `RaffleDetailPage.tsx` 新增 `DiscordWebhookPanel` 元件：URL input、儲存、清除按鈕、設定狀態 badge、400 錯誤顯示
- service 單元測試：patch with URL / empty string
- page 整合測試：顯示面板、儲存呼叫、儲存後狀態、清除、API 錯誤顯示

## 為什麼
closes #661

後端 `PATCH /api/v1/dashboard/raffles/:id/discord-webhook` 已存在，實況主卻無法在 Dashboard 設定 Discord Webhook，必須靠 API 工具操作。本 PR 補上對應 UI。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#661
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 Discord 頻道選擇 UI（URL 由使用者自行貼入）
  - 不做 webhook URL 前端格式驗證（後端已驗證並回傳 400 error message）
  - 不做 webhook 連線測試按鈕

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- n/a

## Review conversation closeout
- n/a（開 PR 初始 body）

## Final merge gate
- Ready-to-merge decision：pending CI
- Latest head SHA：3d08047
- Required checks：PR Scope Police pass；CI pass
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：在 RaffleDetailPage 新增 Discord Webhook 設定介面，讓實況主可以在 Dashboard 設定中獎通知
- Approx changed lines：~224
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - frontend service 函式與 page 元件是不可分割的單元；tests 是其直接驗證。
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] `setDiscordWebhook` service 函式有單元測試（patch with URL / empty string）
- [x] RaffleDetailPage 顯示 Discord webhook 設定區塊
- [x] 儲存後顯示「已設定」狀態 badge
- [x] 清除後 `setDiscordWebhook(raffleId, '')` 被呼叫
- [x] 400 錯誤（URL 格式錯誤）顯示後端回傳的 error message
- [x] `npx vitest run` — 97/97 pass
- [x] `npx tsc --noEmit` — 無錯誤

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
cd apps/dashboard && npx vitest run
Test Files  13 passed (13)
Tests       97 passed (97)

npx tsc --noEmit
(no output = clean)
```

## 備註
- `DiscordWebhookPanel` 初始狀態不顯示設定狀態（backend GET raffle 未回傳 `discord_webhook_configured`，因 `DiscordWebhookURL json:"-"`）。儲存或清除後才依回傳值更新 badge。
- `onInput` + `onChange` 並用以相容測試環境與真實瀏覽器。

## Notes for Claude Code Review
- `DiscordWebhookPanel` 管理 local state；初始設定狀態 unknown（`null`），badge 只在成功 save/clear 後顯示
- 錯誤處理：取 `err.response.data.error`（後端格式），fallback 到「儲存失敗，請稍後再試」
- `handleClear` 永遠傳空字串給 `setDiscordWebhook`，回傳 `configured=false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为抽奖活动添加了 Discord 网络钩子配置面板，用户可输入、保存、清除网络钩子 URL，并实时查看配置状态与 API 错误提示。
* **测试**
  * 新增并扩展了相关测试用例，覆盖保存/清除钩子、配置状态展示及接口错误处理，确保行为一致与稳健。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/663)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->