### PR TITLE
[discussion] Clarify autonomous evidence references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,7 @@
 - Worker session closeout：
   - <!-- 例：已讀回 worker 結果，不需追加任務的 worker session 已 close；stale handle / not found 已說明 -->
 - Workflow friction / follow-up split：
-  - <!-- autonomous PR 請說明本次約 40% infra 複雜 / 約 60% 工作流摩擦中，哪些已由 worker routing / closeout / follow-up issue 收斂；非 autonomous PR 可填 n/a -->
+  - <!-- autonomous PR 請說明本次約 40% infra 複雜 / 約 60% 工作流摩擦中，哪些已由 worker routing / closeout / follow-up issue 收斂；threshold calibration 只留 #664 ledger comment URL 或 n/a，非 autonomous PR 可填 n/a -->
 
 ## Review conversation closeout
 <!-- autonomous PR 必填；非 autonomous PR 可填 n/a。所有 review finding 必須修正並回覆/resolve，或留下技術理由後 resolve。 -->
@@ -76,7 +76,7 @@
 - Required checks：
   - <!-- 例：PR Scope Police pass；CI pass；開 PR 前可填 pending with reason -->
 - spec workflow-check evidence：
-  - <!-- 使用 spec-injector 者填 local-only start/commit/merge gate evidence；未使用者填 n/a 或人工 checklist -->
+  - <!-- status + ref only：使用 spec-injector 者填 local-only gate status 與 evidence ref；未使用者填 n/a 或人工 checklist；完整三段細節留在 Evidence URL 或 review/issue comment，不塞 PR body -->
 - Evidence URL：
   - <!-- 例：final closeout comment / CI run / n/a -->
 

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -1074,6 +1074,9 @@ test('PR template includes a delegation execution log for autonomous work', asyn
   assert.match(prTemplate, /## Final merge gate/)
   assert.match(prTemplate, /Ready-to-merge decision：/)
   assert.match(prTemplate, /spec workflow-check evidence：/)
+  assert.match(prTemplate, /status \+ ref only/)
+  assert.match(prTemplate, /#664 ledger comment URL/)
+  assert.doesNotMatch(prTemplate, /spawn_count|ci_rerun_count|threshold_decision/)
   assert.match(prTemplate, /約 40% infra 複雜 \/ 約 60% 工作流摩擦/)
   assert.match(prTemplate, /改到 `\.github\/workflows\/\*\*` 時也不是 metadata-only，仍需勾選/)
 })
@@ -1101,6 +1104,20 @@ test('AWP v2 docs wire AGENTS and PR scope policy to autonomous evidence gates a
   assert.match(autonomousPrGates, /25-30%/)
   assert.match(autonomousPrGates, /review_triage_ref/)
   assert.match(autonomousPrGates, /Erick52106\/spec-injector#232/)
+  assert.match(autonomousPrGates, /thin wiring/)
+  assert.match(autonomousPrGates, /Erick52106\/spec-injector#224/)
+  assert.match(autonomousPrGates, /#664/)
+  assert.match(prScopePolicy, /status \/ ref/)
+  assert.match(prScopePolicy, /threshold calibration ledger/i)
+})
+
+test('Scope Police stays out of spec workflow-check internals and threshold metrics', async () => {
+  const workflow = await readFile(scopePolicePath, 'utf8')
+  const prScopePolicy = await readFile(prScopePolicyPath, 'utf8')
+
+  assert.doesNotMatch(workflow, /spawn_count|ci_rerun_count|threshold_decision/)
+  assert.doesNotMatch(workflow, /workflow-check --phase start|workflow-check --phase commit|workflow-check --phase merge/)
+  assert.match(prScopePolicy, /does not parse/)
 })
 
 test('PR scope police only treats a delegation log as autonomous when it has real content', async () => {

--- a/docs/ai/autonomous-pr-gates.md
+++ b/docs/ai/autonomous-pr-gates.md
@@ -47,13 +47,21 @@ final closeout 只在 merge 前狀態穩定後更新一次，避免每個 CI tic
 
 ## spec workflow-check Gates
 
-`spec-injector` 對 tachigo 是 local-only 輔助，不是不用此工具者的硬性門檻。
+`spec-injector` 對 tachigo 是 local-only 輔助，不是不用此工具者的硬性門檻。tachigo 這側只做 thin wiring：PR template 與 policy docs 保留 `status + ref` evidence slot，真正的 `spec workflow-check` phase parser、local artifact 檢查與穩定輸出格式由 `Erick52106/spec-injector#224` 實作。
 
 - Start gate：使用者要求或任務適用時，可本機執行 `spec plan <issue> --repo . --dry-run --format prompt --verbose` 或未來 `spec workflow-check --repo . --phase start`，用於產生 bounded context。
 - Commit gate：commit 前可本機執行 workflow-check，確認 PR body / non-goals / validation / `.spec-injector/` 未 staged。
 - Merge gate：merge 前可本機執行 workflow-check，確認 final closeout、unresolved thread count、latest head SHA 與 spec gate evidence。
 
 不得 commit `.spec-injector/`、spec output、private context、或工具產生的 task package。未使用 spec-injector 的 PR 可在 template 填人工 checklist / `n/a`。
+
+PR body 只應留下 gate 狀態與可讀回的 evidence ref，例如本機 `spec validate` 通過、人工 checklist、或含三段 gate 摘要的 PR / issue comment URL。完整三段細節不應塞進 PR body，也不應由 tachigo 的 Scope Police 重新解析。
+
+## Threshold Calibration Ledger
+
+Threshold 校正是暫時性的 autonomous workflow 分析資料，不是 tachigo product contract。校正紀錄集中留在 #664 的 long-lived issue comment，PR body 只需在 workflow friction / final closeout 裡放 #664 comment URL 或 `n/a`。
+
+不要把 `spawn_count`、CI rerun、review-thread count、threshold decision 等 metrics 加進 PR template，也不要讓 Scope Police 依賴這些 metrics。等 autonomous workflow 門檻穩定後，#664 可封存或停止新增紀錄，而不需要修改專案結構。
 
 ## Scope Police Contract
 

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -166,6 +166,8 @@ Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的
 
 Autonomous Worker Profiles v2 的完整 evidence discipline 與 `spec workflow-check` local-only 接入點見 [docs/ai/autonomous-pr-gates.md](ai/autonomous-pr-gates.md)。`spec-injector` 不得把 `.spec-injector/`、spec output 或 private local context commit 進 repo；未使用此工具的 PR 可填人工 checklist / `n/a`。
 
+`spec workflow-check` 對 PR Scope Police 是 status / ref 證據，不是完整三段 gate parser。Scope Police does not parse start / commit / merge gate internals；若需要三段細節，請在 PR body 留 evidence URL 指向 PR comment、issue comment 或本機驗證摘要。Threshold calibration ledger 同樣不由 Scope Police 執行，校正資料集中留在 #664 的 long-lived issue comment，PR body 不展開 metrics。
+
 使用原則：
 
 - 只有 maintainer 可以加


### PR DESCRIPTION
## 什麼改動
Clarify tachigo-side autonomous evidence references for spec workflow-check and threshold calibration.

## 為什麼
Source of truth: #654 #664

Depends on PR: none

This keeps tachigo as thin wiring: PR template and policy docs carry status/ref evidence, while spec workflow-check implementation remains in spec-injector.

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#654 #664
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作 spec-injector `spec workflow-check` CLI；該範圍在 Erick52106/spec-injector#224。
  - 不讓 PR Scope Police 解析 spec start/commit/merge gate internals。
  - 不把 threshold metrics 展開進 PR body 或專案結構；校正資料留在 #664 ledger issue comment。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #654 / #664 的 tachigo thin-wiring follow-up；本次不新增 product behavior。
- Actual worker profile(s)：
  - controller self-only；task 小於 0-3 分鐘的 readback/metadata checks 由 controller fallback 執行並已記錄原因。
- Model strength：
  - controller = GPT-5.5 high；no 5.4 worker spawned for this narrow docs/template/test patch。
- Spawn directive(s)：
  - profile=controller_self model=gpt-5.5 reasoning=high controller_fallback=allowed fallback_reason=small bounded docs/template/test patch after existing plan; no remote metadata mutation needed beyond PR creation
- Verification evidence：
  - spec plan 654 --repo . --dry-run --format prompt --verbose
  - node --test .github/workflows/ci.test.mjs
  - git diff --check
  - spec validate --repo .
- Self-review / exception reason：
  - Self-reviewed diff for scope: only PR template, autonomous docs, scope policy docs, and workflow regression tests.
- Worker session closeout：
  - No spawned worker sessions; controller fallback reason recorded above.
- Workflow friction / follow-up split：
  - spec workflow remains status/ref only in tachigo; implementation details stay in Erick52106/spec-injector#224.
  - threshold calibration uses #664 ledger comment URL / n/a only; no PR-body metrics.

## Review conversation closeout
- Unresolved threads：
  - 0（GraphQL reviewThreads readback after merge）
- CodeRabbit：
  - pass；latest review comment reported no major issues: https://github.com/nurockplayer/tachigo/pull/665#issuecomment-4441052135
- chatgpt-codex-connector：
  - pass；latest-head review request returned no major issues: https://github.com/nurockplayer/tachigo/pull/665#issuecomment-4443038311
- review_triage_ref：
  - Scope Police evidence-field drift after rebase was triaged and repaired; final sticky check passed: https://github.com/nurockplayer/tachigo/pull/665#issuecomment-4441034835
- root_cause_gate_ref：
  - not_triggered: no repeated same-concept review finding; the only late issue was stale PR body evidence after rebase / merge closeout.
- finding_disposition_ref：
  - adopted: PR body closeout updated to exact latest-head / merge evidence; no code change required after latest-head review.
- Final reviewer action：
  - merged to develop; no unresolved actionable review finding remains.

## Final merge gate
- Ready-to-merge decision：
  - merged by human on 2026-05-13T16:11:14Z.
- Latest head SHA：
  - 6b665c1c078877a9547afda63fa420494c8cf577
- Merge commit：
  - c9625834f3cea2c86dd240ff948a11b6251b5612
- Required checks：
  - pass; Scope Police pass, CodeRabbit success, backend/frontend/dashboard/contracts/security/workflow checks pass; Dependency Review and Notify Discord skipped as expected.
- spec workflow-check evidence：
  - status + ref only: local `spec plan 654 --repo . --dry-run --format prompt --verbose`, `spec validate --repo .`, `node --test .github/workflows/ci.test.mjs` (76/76), and `git diff --check` passed; no `.spec-injector/` or spec output committed.
- Evidence URL：
  - Scope Police: https://github.com/nurockplayer/tachigo/pull/665#issuecomment-4441034835
  - CodeRabbit: https://github.com/nurockplayer/tachigo/pull/665#issuecomment-4441052135
  - Codex connector: https://github.com/nurockplayer/tachigo/pull/665#issuecomment-4443038311
  - Merged PR: https://github.com/nurockplayer/tachigo/pull/665

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Document tachigo's status/ref-only spec evidence and issue-ledger threshold calibration boundary.
- Approx changed lines：~33
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Regression tests lock the docs/template governance boundary introduced by this PR.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] PR template keeps spec workflow-check as status/ref evidence instead of full three-phase detail.
- [x] docs identify spec-injector as local-only and keep implementation in Erick52106/spec-injector#224.
- [x] threshold calibration points to #664 ledger issue comment instead of PR body metrics.
- [x] Scope Police policy says it does not parse spec gate internals or threshold metrics.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
spec plan 654 --repo . --dry-run --format prompt --verbose: pass (missing always-read notice: docs/claude-codex-workflow.md not found)
node --test .github/workflows/ci.test.mjs: pass (76/76)
git diff --check: pass
spec validate --repo .: pass
```

## 備註
No `.spec-injector/` or spec output was committed.

## Notes for Claude Code Review
- Review the policy boundary: tachigo should not duplicate spec-injector's future workflow-check parser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 明确拉取请求模板和门槛规范：PR body 仅保留 gate 状态与可读证据引用（status + ref / Evidence URL 或 `n/a`），阈值校准仅以指定长期 issue 注释或 `n/a` 留存，禁止在 PR 中暴露阈值/度量字段或工具输出，spec-injector 仅作本地辅助且不得提交其产物。
* **测试**
  * 增强自动化测试，强制执行上述模板与证据走线及禁止暴露特定内部度量。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/665)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

