### PR TITLE
[backend] Propagate address DB request context

### DIFF
--- a/services/api/internal/handlers/address_handler.go
+++ b/services/api/internal/handlers/address_handler.go
@@ -123,7 +123,12 @@ func (h *AddressHandler) Delete(c *gin.Context) {
 	}
 
 	if err := h.addr.DeleteContext(c.Request.Context(), userID, addrID); err != nil {
-		notFound(c, "address not found")
+		switch err {
+		case services.ErrAddressNotFound:
+			notFound(c, "address not found")
+		default:
+			internal(c)
+		}
 		return
 	}
 	ok(c, gin.H{"message": "address deleted"})
@@ -150,7 +155,12 @@ func (h *AddressHandler) SetDefault(c *gin.Context) {
 
 	addr, err := h.addr.SetDefaultContext(c.Request.Context(), userID, addrID)
 	if err != nil {
-		notFound(c, "address not found")
+		switch err {
+		case services.ErrAddressNotFound:
+			notFound(c, "address not found")
+		default:
+			internal(c)
+		}
 		return
 	}
 	ok(c, gin.H{"address": addr})

--- a/services/api/internal/handlers/address_handler.go
+++ b/services/api/internal/handlers/address_handler.go
@@ -27,7 +27,7 @@ func (h *AddressHandler) List(c *gin.Context) {
 	claims := middleware.MustClaims(c)
 	userID, _ := uuid.Parse(claims.UserID)
 
-	addrs, err := h.addr.List(userID)
+	addrs, err := h.addr.ListContext(c.Request.Context(), userID)
 	if err != nil {
 		internal(c)
 		return
@@ -55,7 +55,7 @@ func (h *AddressHandler) Create(c *gin.Context) {
 		return
 	}
 
-	addr, err := h.addr.Create(userID, input)
+	addr, err := h.addr.CreateContext(c.Request.Context(), userID, input)
 	if err != nil {
 		internal(c)
 		return
@@ -90,7 +90,7 @@ func (h *AddressHandler) Update(c *gin.Context) {
 		return
 	}
 
-	addr, err := h.addr.Update(userID, addrID, input)
+	addr, err := h.addr.UpdateContext(c.Request.Context(), userID, addrID, input)
 	if err != nil {
 		switch err {
 		case services.ErrAddressNotFound:
@@ -122,7 +122,7 @@ func (h *AddressHandler) Delete(c *gin.Context) {
 		return
 	}
 
-	if err := h.addr.Delete(userID, addrID); err != nil {
+	if err := h.addr.DeleteContext(c.Request.Context(), userID, addrID); err != nil {
 		notFound(c, "address not found")
 		return
 	}
@@ -148,7 +148,7 @@ func (h *AddressHandler) SetDefault(c *gin.Context) {
 		return
 	}
 
-	addr, err := h.addr.SetDefault(userID, addrID)
+	addr, err := h.addr.SetDefaultContext(c.Request.Context(), userID, addrID)
 	if err != nil {
 		notFound(c, "address not found")
 		return

--- a/services/api/internal/handlers/address_handler_test.go
+++ b/services/api/internal/handlers/address_handler_test.go
@@ -26,6 +26,17 @@ func createAddress(t *testing.T, env *testEnv, accessToken, body string) string 
 	return address["id"].(string)
 }
 
+func closeHandlerDB(t *testing.T, env *testEnv) {
+	t.Helper()
+	sqlDB, err := env.db.DB()
+	if err != nil {
+		t.Fatalf("db.DB(): %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+}
+
 // ─── Create ──────────────────────────────────────────────────────────────────
 
 func TestCreateAddressHandler_Success(t *testing.T) {
@@ -221,6 +232,22 @@ func TestDeleteAddressHandler_OtherUsersAddress(t *testing.T) {
 	}
 }
 
+func TestDeleteAddressHandler_DBErrorReturnsInternal(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "delerruser", "delerr@example.com", "password123")
+	addrID := createAddress(t, env, accessToken, minimalAddress)
+	closeHandlerDB(t, env)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/me/addresses/"+addrID, nil)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("want 500 for DB error, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // ─── SetDefault ──────────────────────────────────────────────────────────────
 
 func TestSetDefaultAddressHandler_Success(t *testing.T) {
@@ -255,5 +282,21 @@ func TestSetDefaultAddressHandler_NotFound(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("want 404, got %d", w.Code)
+	}
+}
+
+func TestSetDefaultAddressHandler_DBErrorReturnsInternal(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "deferruser", "deferr@example.com", "password123")
+	addrID := createAddress(t, env, accessToken, minimalAddress)
+	closeHandlerDB(t, env)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/users/me/addresses/"+addrID+"/default", nil)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("want 500 for DB error, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/services/api/internal/services/address_service.go
+++ b/services/api/internal/services/address_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 
 	"github.com/google/uuid"
@@ -19,6 +20,26 @@ func NewAddressService(db *gorm.DB) *AddressService {
 	return &AddressService{db: db}
 }
 
+func (s *AddressService) dbWithContext(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.db.WithContext(ctx)
+}
+
+func addressContextError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return nil
+}
+
 type AddressInput struct {
 	RecipientName string  `json:"recipient_name" binding:"required"`
 	Phone         *string `json:"phone"`
@@ -32,12 +53,20 @@ type AddressInput struct {
 }
 
 func (s *AddressService) List(userID uuid.UUID) ([]models.ShippingAddress, error) {
+	return s.ListContext(context.Background(), userID)
+}
+
+func (s *AddressService) ListContext(ctx context.Context, userID uuid.UUID) ([]models.ShippingAddress, error) {
 	var addrs []models.ShippingAddress
-	err := s.db.Where("user_id = ?", userID).Order("is_default DESC, created_at ASC").Find(&addrs).Error
+	err := s.dbWithContext(ctx).Where("user_id = ?", userID).Order("is_default DESC, created_at ASC").Find(&addrs).Error
 	return addrs, err
 }
 
 func (s *AddressService) Create(userID uuid.UUID, input AddressInput) (*models.ShippingAddress, error) {
+	return s.CreateContext(context.Background(), userID, input)
+}
+
+func (s *AddressService) CreateContext(ctx context.Context, userID uuid.UUID, input AddressInput) (*models.ShippingAddress, error) {
 	country := input.Country
 	if country == "" {
 		country = "TW"
@@ -56,7 +85,7 @@ func (s *AddressService) Create(userID uuid.UUID, input AddressInput) (*models.S
 		IsDefault:     input.IsDefault,
 	}
 
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := s.dbWithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if input.IsDefault {
 			if err := tx.Model(&models.ShippingAddress{}).
 				Where("user_id = ?", userID).
@@ -73,8 +102,16 @@ func (s *AddressService) Create(userID uuid.UUID, input AddressInput) (*models.S
 }
 
 func (s *AddressService) Update(userID, addrID uuid.UUID, input AddressInput) (*models.ShippingAddress, error) {
+	return s.UpdateContext(context.Background(), userID, addrID, input)
+}
+
+func (s *AddressService) UpdateContext(ctx context.Context, userID, addrID uuid.UUID, input AddressInput) (*models.ShippingAddress, error) {
+	db := s.dbWithContext(ctx)
 	var addr models.ShippingAddress
-	if err := s.db.Where("id = ? AND user_id = ?", addrID, userID).First(&addr).Error; err != nil {
+	if err := db.Where("id = ? AND user_id = ?", addrID, userID).First(&addr).Error; err != nil {
+		if ctxErr := addressContextError(ctx, err); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, ErrAddressNotFound
 	}
 	wasDefault := addr.IsDefault
@@ -91,7 +128,7 @@ func (s *AddressService) Update(userID, addrID uuid.UUID, input AddressInput) (*
 	}
 	addr.IsDefault = input.IsDefault
 
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := db.Transaction(func(tx *gorm.DB) error {
 		if input.IsDefault && !wasDefault {
 			if err := tx.Model(&models.ShippingAddress{}).
 				Where("user_id = ? AND id != ?", userID, addrID).
@@ -108,7 +145,11 @@ func (s *AddressService) Update(userID, addrID uuid.UUID, input AddressInput) (*
 }
 
 func (s *AddressService) Delete(userID, addrID uuid.UUID) error {
-	result := s.db.Where("id = ? AND user_id = ?", addrID, userID).Delete(&models.ShippingAddress{})
+	return s.DeleteContext(context.Background(), userID, addrID)
+}
+
+func (s *AddressService) DeleteContext(ctx context.Context, userID, addrID uuid.UUID) error {
+	result := s.dbWithContext(ctx).Where("id = ? AND user_id = ?", addrID, userID).Delete(&models.ShippingAddress{})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -119,12 +160,20 @@ func (s *AddressService) Delete(userID, addrID uuid.UUID) error {
 }
 
 func (s *AddressService) SetDefault(userID, addrID uuid.UUID) (*models.ShippingAddress, error) {
+	return s.SetDefaultContext(context.Background(), userID, addrID)
+}
+
+func (s *AddressService) SetDefaultContext(ctx context.Context, userID, addrID uuid.UUID) (*models.ShippingAddress, error) {
+	db := s.dbWithContext(ctx)
 	var addr models.ShippingAddress
-	if err := s.db.Where("id = ? AND user_id = ?", addrID, userID).First(&addr).Error; err != nil {
+	if err := db.Where("id = ? AND user_id = ?", addrID, userID).First(&addr).Error; err != nil {
+		if ctxErr := addressContextError(ctx, err); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, ErrAddressNotFound
 	}
 
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.ShippingAddress{}).
 			Where("user_id = ? AND id != ?", userID, addrID).
 			Update("is_default", false).Error; err != nil {

--- a/services/api/internal/services/address_service.go
+++ b/services/api/internal/services/address_service.go
@@ -27,17 +27,20 @@ func (s *AddressService) dbWithContext(ctx context.Context) *gorm.DB {
 	return s.db.WithContext(ctx)
 }
 
-func addressContextError(ctx context.Context, err error) error {
+func addressLookupError(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
-	if ctx != nil && ctx.Err() != nil {
-		return ctx.Err()
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		if ctx != nil && ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return ErrAddressNotFound
 	}
-	return nil
+	return err
 }
 
 type AddressInput struct {
@@ -109,10 +112,7 @@ func (s *AddressService) UpdateContext(ctx context.Context, userID, addrID uuid.
 	db := s.dbWithContext(ctx)
 	var addr models.ShippingAddress
 	if err := db.Where("id = ? AND user_id = ?", addrID, userID).First(&addr).Error; err != nil {
-		if ctxErr := addressContextError(ctx, err); ctxErr != nil {
-			return nil, ctxErr
-		}
-		return nil, ErrAddressNotFound
+		return nil, addressLookupError(ctx, err)
 	}
 	wasDefault := addr.IsDefault
 
@@ -167,10 +167,7 @@ func (s *AddressService) SetDefaultContext(ctx context.Context, userID, addrID u
 	db := s.dbWithContext(ctx)
 	var addr models.ShippingAddress
 	if err := db.Where("id = ? AND user_id = ?", addrID, userID).First(&addr).Error; err != nil {
-		if ctxErr := addressContextError(ctx, err); ctxErr != nil {
-			return nil, ctxErr
-		}
-		return nil, ErrAddressNotFound
+		return nil, addressLookupError(ctx, err)
 	}
 
 	if err := db.Transaction(func(tx *gorm.DB) error {

--- a/services/api/internal/services/address_service_test.go
+++ b/services/api/internal/services/address_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -161,6 +162,18 @@ func TestCreate_DefaultClearFailureReturnsErrorAndDoesNotCreate(t *testing.T) {
 	}
 }
 
+func TestCreateContext_CanceledContextReturnsCanceled(t *testing.T) {
+	svc := NewAddressService(newTestDB(t))
+	userID := seedUser(t, svc)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.CreateContext(ctx, userID, minimalInput())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
 // ─── List ────────────────────────────────────────────────────────────────────
 
 func TestList_ReturnsUserAddresses(t *testing.T) {
@@ -211,6 +224,18 @@ func TestList_IsolatedByUser(t *testing.T) {
 	addrs, _ := svc.List(user2)
 	if len(addrs) != 0 {
 		t.Errorf("user2 should see 0 addresses, got %d", len(addrs))
+	}
+}
+
+func TestListContext_CanceledContextReturnsCanceled(t *testing.T) {
+	svc := NewAddressService(newTestDB(t))
+	userID := seedUser(t, svc)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.ListContext(ctx, userID)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }
 
@@ -306,6 +331,22 @@ func TestUpdate_DefaultClearFailureReturnsErrorAndRollsBack(t *testing.T) {
 	}
 }
 
+func TestUpdateContext_CanceledContextReturnsCanceled(t *testing.T) {
+	svc := NewAddressService(newTestDB(t))
+	userID := seedUser(t, svc)
+	addr, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create address: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = svc.UpdateContext(ctx, userID, addr.ID, minimalInput())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
 // ─── Delete ──────────────────────────────────────────────────────────────────
 
 func TestDelete_Success(t *testing.T) {
@@ -370,6 +411,22 @@ func TestDelete_ReturnsDBErrorBeforeNotFound(t *testing.T) {
 	}
 	if errors.Is(err, ErrAddressNotFound) {
 		t.Fatalf("expected DB error before ErrAddressNotFound, got %v", err)
+	}
+}
+
+func TestDeleteContext_CanceledContextReturnsCanceled(t *testing.T) {
+	svc := NewAddressService(newTestDB(t))
+	userID := seedUser(t, svc)
+	addr, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create address: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = svc.DeleteContext(ctx, userID, addr.ID)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }
 
@@ -465,5 +522,21 @@ func TestSetDefault_SaveFailureReturnsError(t *testing.T) {
 	_, err = svc.SetDefault(userID, addr.ID)
 	if !errors.Is(err, saveErr) {
 		t.Fatalf("expected save error, got %v", err)
+	}
+}
+
+func TestSetDefaultContext_CanceledContextReturnsCanceled(t *testing.T) {
+	svc := NewAddressService(newTestDB(t))
+	userID := seedUser(t, svc)
+	addr, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create address: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = svc.SetDefaultContext(ctx, userID, addr.ID)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }

--- a/services/api/internal/services/address_service_test.go
+++ b/services/api/internal/services/address_service_test.go
@@ -286,6 +286,32 @@ func TestUpdate_WrongUser(t *testing.T) {
 	}
 }
 
+func TestUpdate_ReturnsDBErrorBeforeNotFound(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAddressService(db)
+	userID := seedUser(t, svc)
+	addr, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create address: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db.DB(): %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	_, err = svc.Update(userID, addr.ID, minimalInput())
+	if err == nil {
+		t.Fatal("expected DB error, got nil")
+	}
+	if errors.Is(err, ErrAddressNotFound) {
+		t.Fatalf("expected DB error before ErrAddressNotFound, got %v", err)
+	}
+}
+
 func TestUpdate_DefaultClearFailureReturnsErrorAndRollsBack(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewAddressService(db)
@@ -463,6 +489,32 @@ func TestSetDefault_NotFound(t *testing.T) {
 	_, err := svc.SetDefault(userID, uuid.New())
 	if err != ErrAddressNotFound {
 		t.Errorf("want ErrAddressNotFound, got %v", err)
+	}
+}
+
+func TestSetDefault_ReturnsDBErrorBeforeNotFound(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAddressService(db)
+	userID := seedUser(t, svc)
+	addr, err := svc.Create(userID, minimalInput())
+	if err != nil {
+		t.Fatalf("create address: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db.DB(): %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	_, err = svc.SetDefault(userID, addr.ID)
+	if err == nil {
+		t.Fatal("expected DB error, got nil")
+	}
+	if errors.Is(err, ErrAddressNotFound) {
+		t.Fatalf("expected DB error before ErrAddressNotFound, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- 新增 AddressService 的 context-aware variants：`ListContext`、`CreateContext`、`UpdateContext`、`DeleteContext`、`SetDefaultContext`。
- Address handler request path 改用 `c.Request.Context()` 呼叫 service，讓 request timeout / cancellation 能傳到 GORM `WithContext(ctx)` 與 transaction。
- 補上 AddressService 取消 context regression tests，涵蓋 list/create/update/delete/set default。

## 為什麼
refs #645

#645 要求 service-layer DB access path 能接 request context。本 PR 只處理 AddressService 這個小切片，避免一次掃完整 backend 造成大型 PR。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 AddressService 以外的 service DB context propagation
  - 不調整 request timeout policy
  - 不改 schema / migration / API response contract

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 未提供 explicit delegation plan；本輪由 controller 選定 AddressService 小切片。
- Actual worker profile(s)：
  - controller
- Model strength：
  - main GPT-5.5 xhigh/controller
- Spawn directive(s)：
  - profile=controller model=gpt-5.5 reasoning=xhigh controller_fallback=n/a fallback_reason=main_agent_owned_backend_context_slice
- Verification evidence：
  - TDD RED：新增 tests 後，檔案級 `go test` 因 `CreateContext/ListContext/...` undefined 失敗。
  - GREEN：檔案級 AddressService tests pass；`git diff --check` pass。
- Self-review / exception reason：
  - 已自我檢查 scope，只保留 AddressService request path；#645 仍需後續 service slices。
- Worker session closeout：
  - n/a；未使用 worker session。
- Workflow friction / follow-up split：
  - 本 PR 是 #645 的第一個 backend service slice；package-wide Go test 在本地 sandbox 因 Go module cache / DNS 受限，交由 GitHub CI 補足。

## Review conversation closeout
- Unresolved threads：
  - 0；新 PR initial body。
- CodeRabbit：
  - pending；新 PR 開啟後等待 review。
- chatgpt-codex-connector：
  - n/a
- Final reviewer action：
  - pending human/other reviewer；automation 不自我 approve。

## Final merge gate
- Ready-to-merge decision：
  - blocked by CI/review pending
- Latest head SHA：
  - 4ae6b1bceebe
- Required checks：
  - GitHub CI pass；CodeRabbit success；Scope Police rerun pending after body metadata fix
- spec workflow-check evidence：
  - n/a
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 AddressService 的 HTTP request path 把 request context 傳入 GORM DB query / transaction。
- Approx changed lines：~146
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler 必須把 `c.Request.Context()` 傳入 service，service 才能用 `WithContext(ctx)`；tests 是同一 request-cancellation 行為的 regression coverage。
- 若已拆分，相關 PR：
  - #645 後續仍需其他 service slices；本 PR 只處理 AddressService。

## Acceptance Criteria
- [x] AddressService DB access path 開始支援 request context propagation。
- [x] GORM query / transaction 使用 `WithContext(ctx)`。
- [x] 新增 canceled context regression tests。
- [ ] #645 全 backend audit 尚未完成；後續 PR 繼續處理其他 services。
- [ ] timeout cancels DB work 的 integration test 尚未完成；後續 PR 處理。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk env GOCACHE=/private/tmp/tachigo-go-build-cache /Users/tachikoma/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.darwin-arm64/bin/go test ./internal/services/address_service.go ./internal/services/address_service_test.go ./internal/services/testutil_test.go
ok command-line-arguments 0.266s

rtk git --no-optional-locks diff --check
pass
```

本地限制：`go test ./internal/services` 需要下載缺失的 Go modules / toolchain metadata，但 sandbox 對 `proxy.golang.org` 無 DNS，Docker socket 也不可用；package-wide verification 交由 GitHub CI。

## 備註
- 舊的 `List/Create/Update/Delete/SetDefault` 方法保留，委派到 `context.Background()`，避免一次擴散到全部 caller。
- HTTP request path 已改用 `ListContext/CreateContext/...`，這是本 PR 的實際 cancellation path。

## Notes for Claude Code Review
- 請特別看 `UpdateContext` / `SetDefaultContext`：查無資料仍回 `ErrAddressNotFound`，但 context canceled/deadline exceeded 會保留原錯誤，不會被誤轉成 404。
- 本 PR 不關閉 #645，只是第一個 AddressService slice。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 地址管理接口改为支持请求上下文，增强对请求取消/超时的响应与错误处理，提升稳定性和可靠性
  * 对数据库故障情形的错误映射更明确，减少异常时的未知响应

* **测试**
  * 新增覆盖请求超时取消与数据库故障场景的单元/处理器测试，确保异常路径行为一致

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/666)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->