### PR TITLE
[backend] feat: raffle activate endpoint — 名單鎖定

### DIFF
--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1032,6 +1032,57 @@ const docTemplate = `{
                 }
             }
         },
+        "/dashboard/raffles/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Lock the participant list and move raffle from draft to active",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/dashboard/raffles/{id}/complete": {
             "post": {
                 "security": [

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1299,6 +1299,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1293,6 +1293,12 @@
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1026,6 +1026,57 @@
                 }
             }
         },
+        "/dashboard/raffles/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Lock the participant list and move raffle from draft to active",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/dashboard/raffles/{id}/complete": {
             "post": {
                 "security": [

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -956,6 +956,38 @@ paths:
       summary: Get raffle by ID
       tags:
       - raffles
+  /dashboard/raffles/{id}/activate:
+    post:
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Lock the participant list and move raffle from draft to active
+      tags:
+      - raffles
   /dashboard/raffles/{id}/complete:
     post:
       parameters:

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -1120,6 +1120,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.Response'
       security:
       - BearerAuth: []
       summary: Import participants from CSV

--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -137,6 +137,7 @@ func (h *RaffleHandler) Get(c *gin.Context) {
 // @Param        file formData file   true "CSV file (column 1: twitch_login, column 2: display_name)"
 // @Success      200  {object}  Response
 // @Failure      400  {object}  Response
+// @Failure      409  {object}  Response
 // @Router       /dashboard/raffles/{id}/entries/import-csv [post]
 func (h *RaffleHandler) ImportCSV(c *gin.Context) {
 	claims := middleware.MustClaims(c)
@@ -177,6 +178,10 @@ func (h *RaffleHandler) ImportCSV(c *gin.Context) {
 		}
 		if errors.Is(err, services.ErrRaffleForbidden) {
 			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+			return
+		}
+		if errors.Is(err, services.ErrRaffleNotDraft) {
+			conflict(c, err.Error())
 			return
 		}
 		log.Printf("raffle import-csv raffle_id=%s: %v", raffleID, err)

--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -319,6 +319,49 @@ func (h *RaffleHandler) Complete(c *gin.Context) {
 	ok(c, gin.H{"raffle": raffle})
 }
 
+// Activate godoc
+// @Summary      Lock the participant list and move raffle from draft to active
+// @Tags         raffles
+// @Security     BearerAuth
+// @Produce      json
+// @Param        id   path string true "Raffle ID"
+// @Success      200  {object}  Response
+// @Failure      403  {object}  Response
+// @Failure      404  {object}  Response
+// @Failure      409  {object}  Response
+// @Router       /dashboard/raffles/{id}/activate [post]
+func (h *RaffleHandler) Activate(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+
+	raffleID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid raffle id")
+		return
+	}
+
+	raffle, err := h.raffleSvc.Activate(raffleID, userID)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrRaffleNotFound):
+			notFound(c, "raffle not found")
+		case errors.Is(err, services.ErrRaffleForbidden):
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
+		case errors.Is(err, services.ErrRaffleNotDraft):
+			conflict(c, err.Error())
+		default:
+			log.Printf("raffle activate raffle_id=%s: %v", raffleID, err)
+			internal(c)
+		}
+		return
+	}
+	ok(c, gin.H{"raffle": raffle})
+}
+
 // SetDiscordWebhook godoc
 // @Summary      Set or clear the Discord webhook URL for a raffle
 // @Tags         raffles

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -1174,6 +1174,9 @@ func TestRaffle_Activate_Conflict_WhenAlreadyActive(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", bearer(token))
 	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create raffle: want 201, got %d: %s", w.Code, w.Body.String())
+	}
 	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
 
 	// First activate.

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -1194,3 +1194,46 @@ func TestRaffle_Activate_Conflict_WhenAlreadyActive(t *testing.T) {
 		t.Errorf("second activate: want 409, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestEntries_ImportCSV_Conflict_WhenRaffleActive(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "act3", "act3@test.com", "pass1234")
+
+	// Create draft raffle.
+	body, _ := json.Marshal(map[string]string{"title": "Lock CSV Test"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create raffle: want 201, got %d", w.Code)
+	}
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	// Activate to lock the participant list.
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/activate", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("activate: want 200, got %d", w.Code)
+	}
+
+	// Attempt CSV import after lock — must return 409.
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("file", "entries.csv")
+	_, _ = fw.Write([]byte("viewer1\n"))
+	mw.Close()
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/entries/import-csv", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("import after activate: want 409, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -90,6 +90,7 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 	dash.POST("/raffles/:id/entries/import-csv", raffleH.ImportCSV)
 	dash.POST("/raffles/:id/draws", raffleH.DrawNext)
 	dash.GET("/raffles/:id/draws", raffleH.ListDraws)
+	dash.POST("/raffles/:id/activate", raffleH.Activate)
 	dash.POST("/raffles/:id/complete", raffleH.Complete)
 	dash.PATCH("/raffles/:id/discord-webhook", raffleH.SetDiscordWebhook)
 	dash.POST("/raffles/:id/snapshot", raffleH.Snapshot)
@@ -1130,5 +1131,66 @@ func TestRaffle_Snapshot_UnlinkedSkip(t *testing.T) {
 	result := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["result"].(map[string]interface{})
 	if result["skipped"].(float64) != 1 || result["imported"].(float64) != 0 {
 		t.Errorf("want skipped=1 imported=0, got %v", result)
+	}
+}
+
+func TestRaffle_Activate_Success(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "act1", "act1@test.com", "pass1234")
+
+	// Create a draft raffle via the API.
+	body, _ := json.Marshal(map[string]string{"title": "Lock Test"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create raffle: want 201, got %d: %s", w.Code, w.Body.String())
+	}
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/activate", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("activate: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	raffle := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})
+	if raffle["status"] != "active" {
+		t.Errorf("expected status active, got %v", raffle["status"])
+	}
+}
+
+func TestRaffle_Activate_Conflict_WhenAlreadyActive(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "act2", "act2@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Lock Test 2"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	// First activate.
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/activate", nil)
+	req.Header.Set("Authorization", bearer(token))
+	w = httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first activate: want 200, got %d", w.Code)
+	}
+
+	// Second activate must be 409.
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/activate", nil)
+	req.Header.Set("Authorization", bearer(token))
+	w = httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("second activate: want 409, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -239,6 +239,9 @@ func New(
 		dashboard.GET("/raffles/:id/draws",
 			middleware.RequireRole(models.RoleStreamer),
 			raffleH.ListDraws)
+		dashboard.POST("/raffles/:id/activate",
+			middleware.RequireRole(models.RoleStreamer),
+			raffleH.Activate)
 		dashboard.POST("/raffles/:id/complete",
 			middleware.RequireRole(models.RoleStreamer),
 			raffleH.Complete)

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -387,17 +387,22 @@ func (s *RaffleService) ListDraws(raffleID, userID uuid.UUID) ([]models.RaffleDr
 
 // Activate locks the participant list by moving the raffle from draft to active.
 // After activation, ImportCSV will reject further uploads.
+// The update is conditional on status = draft to avoid a read-then-write race.
 func (s *RaffleService) Activate(raffleID, userID uuid.UUID) (*models.Raffle, error) {
 	raffle, err := s.GetByID(raffleID, userID)
 	if err != nil {
 		return nil, err
 	}
-	if raffle.Status != models.RaffleStatusDraft {
+	res := s.db.Model(&models.Raffle{}).
+		Where("id = ? AND status = ?", raffle.ID, models.RaffleStatusDraft).
+		Update("status", models.RaffleStatusActive)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
 		return nil, ErrRaffleNotDraft
 	}
-	if err := s.db.Model(raffle).Update("status", models.RaffleStatusActive).Error; err != nil {
-		return nil, err
-	}
+	raffle.Status = models.RaffleStatusActive
 	return raffle, nil
 }
 

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -28,6 +28,7 @@ var (
 	ErrRaffleForbidden          = errors.New("raffle does not belong to this user")
 	ErrRaffleExhausted          = errors.New("all entries have been drawn")
 	ErrRaffleCompleted          = errors.New("raffle is already completed")
+	ErrRaffleNotDraft           = errors.New("raffle is not in draft status")
 	ErrClaimTokenExpired        = errors.New("claim token has expired")
 	ErrClaimNotFound            = errors.New("claim token not found")
 	ErrClaimAlreadyDone         = errors.New("claim already submitted")
@@ -132,8 +133,12 @@ type ImportCSVResult struct {
 // First column must be twitch_login; an optional second column is display_name.
 // Rows whose twitch_login is already in the raffle are skipped (idempotent).
 func (s *RaffleService) ImportCSV(raffleID, userID uuid.UUID, r io.Reader) (*ImportCSVResult, error) {
-	if _, err := s.GetByID(raffleID, userID); err != nil {
+	raffle, err := s.GetByID(raffleID, userID)
+	if err != nil {
 		return nil, err
+	}
+	if raffle.Status != models.RaffleStatusDraft {
+		return nil, ErrRaffleNotDraft
 	}
 
 	reader := csv.NewReader(r)
@@ -378,6 +383,22 @@ func (s *RaffleService) ListDraws(raffleID, userID uuid.UUID) ([]models.RaffleDr
 		return []models.RaffleDraw{}, nil
 	}
 	return draws, nil
+}
+
+// Activate locks the participant list by moving the raffle from draft to active.
+// After activation, ImportCSV will reject further uploads.
+func (s *RaffleService) Activate(raffleID, userID uuid.UUID) (*models.Raffle, error) {
+	raffle, err := s.GetByID(raffleID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if raffle.Status != models.RaffleStatusDraft {
+		return nil, ErrRaffleNotDraft
+	}
+	if err := s.db.Model(raffle).Update("status", models.RaffleStatusActive).Error; err != nil {
+		return nil, err
+	}
+	return raffle, nil
 }
 
 // Complete marks a raffle as completed.

--- a/services/api/internal/services/raffle_service_activate_test.go
+++ b/services/api/internal/services/raffle_service_activate_test.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+// seedDraftRaffle creates a raffle in draft status via the service layer.
+func seedDraftRaffle(t *testing.T, db *gorm.DB, ownerID uuid.UUID) uuid.UUID {
+	t.Helper()
+	svc := &RaffleService{db: db}
+	raffle, err := svc.Create(ownerID, "Test Raffle")
+	if err != nil {
+		t.Fatalf("seedDraftRaffle: %v", err)
+	}
+	return raffle.ID
+}
+
+func TestActivate_SuccessFromDraft(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "activate_owner1@example.com")
+	raffleID := seedDraftRaffle(t, db, ownerID)
+
+	svc := &RaffleService{db: db}
+	raffle, err := svc.Activate(raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("Activate should succeed from draft: %v", err)
+	}
+	if raffle.Status != models.RaffleStatusActive {
+		t.Errorf("expected status active, got %q", raffle.Status)
+	}
+}
+
+func TestActivate_ReturnsErrRaffleNotDraft_WhenAlreadyActive(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "activate_owner2@example.com")
+	raffleID := seedDraftRaffle(t, db, ownerID)
+
+	svc := &RaffleService{db: db}
+	if _, err := svc.Activate(raffleID, ownerID); err != nil {
+		t.Fatalf("first activate: %v", err)
+	}
+
+	_, err := svc.Activate(raffleID, ownerID)
+	if !errors.Is(err, ErrRaffleNotDraft) {
+		t.Errorf("expected ErrRaffleNotDraft on second activate, got %v", err)
+	}
+}
+
+func TestActivate_ReturnsErrRaffleNotDraft_WhenCompleted(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "activate_owner3@example.com")
+	raffleID := seedDraftRaffle(t, db, ownerID)
+
+	svc := &RaffleService{db: db}
+	// activate first so Complete can proceed (Complete only blocks on completed)
+	if _, err := svc.Activate(raffleID, ownerID); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	if _, err := svc.Complete(raffleID, ownerID); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	_, err := svc.Activate(raffleID, ownerID)
+	if !errors.Is(err, ErrRaffleNotDraft) {
+		t.Errorf("expected ErrRaffleNotDraft when activating completed raffle, got %v", err)
+	}
+}
+
+func TestImportCSV_ReturnsErrRaffleNotDraft_WhenActive(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "activate_owner4@example.com")
+	raffleID := seedDraftRaffle(t, db, ownerID)
+
+	svc := &RaffleService{db: db}
+	if _, err := svc.Activate(raffleID, ownerID); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	csv := strings.NewReader("viewer1\n")
+	_, err := svc.ImportCSV(raffleID, ownerID, csv)
+	if !errors.Is(err, ErrRaffleNotDraft) {
+		t.Errorf("expected ErrRaffleNotDraft when importing to active raffle, got %v", err)
+	}
+}


### PR DESCRIPTION
## 什麼改動
- `ErrRaffleNotDraft`：新錯誤，用於非 draft 狀態的拒絕
- `RaffleService.Activate()`：draft → active，非 draft 回傳 `ErrRaffleNotDraft`
- `ImportCSV`：status != draft 時拒絕上傳，防止實況主在名單截止後偷換名單
- `POST /dashboard/raffles/:id/activate`：新 handler + route
- Swagger docs 更新（`swag init`）

## 為什麼
refs #667

實況主目前可在按抽獎前一秒重新上傳 CSV 換掉名單，觀眾無法信任名單的公平性。加入 Activate 機制後，按下「開始抽獎」即鎖定名單，之後的 CSV 上傳會被 409 拒絕。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#667
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改前端（另票 #668）
  - 不做 active → draft 的回退功能
  - 不修改 DrawNext 行為（DrawNext 可在 active 狀態執行，維持現有行為）

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- n/a

## Review conversation closeout
- n/a（開 PR 初始 body）

## Final merge gate
- Ready-to-merge decision：pending CI
- Latest head SHA：016f287
- Required checks：PR Scope Police pass；CI pass
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：新增 activate endpoint 讓實況主鎖定參賽名單，並在 ImportCSV 加入 status 檢查
- Approx changed lines：~220（不含 Swagger 生成）；總計 ~264（含 docs）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [x] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service、handler、route 是同一個 endpoint 不可分割的三層；tests 是直接驗證。
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] `ErrRaffleNotDraft` 存在且測試覆蓋
- [x] `Activate` draft → active 成功，返回更新後的 raffle
- [x] `Activate` active/completed 狀態返回 `ErrRaffleNotDraft`（409）
- [x] `ImportCSV` 在 active 狀態返回 `ErrRaffleNotDraft`（→ 由 handler 回 409）
- [x] `go test ./internal/services/` 全通過（含 4 個新 activate tests）
- [x] `go test ./internal/handlers/` 全通過（含 2 個新 handler tests）
- [x] `go vet ./...` 無警告
- [x] Swagger annotation 補完，`swag init` 已執行

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過（Docker）
- [x] 有寫 / 更新測試

**驗證結果**
```
docker compose run --no-deps --rm app go test ./internal/services/ ./internal/handlers/ -count=1
ok  github.com/tachigo/tachigo/internal/services  2.9s
ok  github.com/tachigo/tachigo/internal/handlers  15.5s

go vet ./...
(no output = clean)
```

## 備註
`TestMigrationDirectoryAtlasChecksumIsCurrent` 在 develop 本身即失敗（atlas.sum stale，與本 PR 無關），CI 中 Backend tests job 已知 skip。

## Notes for Claude Code Review
- `Activate` 不做 idempotent 處理：active 再次 activate → 409（語意上應明確拒絕，不靜默通過）
- `ImportCSV` 原本只做 `GetByID` 再丟棄 return value，現在改成使用 raffle 做 status check，無額外 DB 查詢
- `swag init` 生成的 docs 差異包含本次新 endpoint 及任何 CRLF normalization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增经认证的抽奖激活接口：POST /dashboard/raffles/{id}/activate，可将抽奖从草稿置为活跃并锁定参与者名单。
* **修复 / 行为变更**
  * 导入 CSV 时对非草稿状态返回 409 冲突，防止已激活或已完成抽奖被修改。
* **文档**
  * 更新 API 文档以说明激活接口与新增的 409 冲突响应。
* **测试**
  * 增加端到端与单元测试，覆盖激活成功、重复激活冲突及激活后导入 CSV 被拒绝的场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/670)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->