### PR TITLE
[infra] Wire AWP review triage refs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -58,8 +58,14 @@
   - <!-- 例：reviewed latest head；rate limit fallback；n/a -->
 - chatgpt-codex-connector：
   - <!-- 例：commented latest head；reaction-only fallback；n/a -->
+- review_triage_ref：
+  - <!-- autonomous PR：latest-head review triage evidence ref（issue / PR comment / spec output ref）；非 autonomous PR 可填 n/a -->
+- root_cause_gate_ref：
+  - <!-- autonomous PR：同概念第二次 finding 時的 root-cause / state-model evidence ref；若尚未觸發可填 latest-head rationale ref；非 autonomous PR 可填 n/a -->
+- finding_disposition_ref：
+  - <!-- autonomous PR：adopted / partial / rejected / deferred disposition evidence ref；非 autonomous PR 可填 n/a -->
 - Final reviewer action：
-  - <!-- 例：all findings fixed/resolved；not adopted with rationale；n/a -->
+  - <!-- 例：all findings fixed/resolved；adopted / partial / rejected / deferred recorded at latest head；n/a -->
 
 ## Final merge gate
 <!-- autonomous PR merge 前更新一次即可；PR initial body 請先填 pending/n/a，final closeout 只在狀態穩定後更新一次。 -->

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -1068,6 +1068,9 @@ test('PR template includes a delegation execution log for autonomous work', asyn
   assert.match(prTemplate, /Worker session closeout：/)
   assert.match(prTemplate, /Workflow friction \/ follow-up split：/)
   assert.match(prTemplate, /## Review conversation closeout/)
+  assert.match(prTemplate, /review_triage_ref：/)
+  assert.match(prTemplate, /root_cause_gate_ref：/)
+  assert.match(prTemplate, /finding_disposition_ref：/)
   assert.match(prTemplate, /## Final merge gate/)
   assert.match(prTemplate, /Ready-to-merge decision：/)
   assert.match(prTemplate, /spec workflow-check evidence：/)
@@ -1086,11 +1089,18 @@ test('AWP v2 docs wire AGENTS and PR scope policy to autonomous evidence gates a
   assert.match(agents, /docs\/ai\/autonomous-pr-gates\.md/)
   assert.match(agents, /spec workflow-check/)
   assert.match(prScopePolicy, /Autonomous evidence snapshot/)
+  assert.match(prScopePolicy, /review_triage_ref/)
+  assert.match(prScopePolicy, /只做薄檢查/)
+  assert.match(prScopePolicy, /Erick52106\/spec-injector#232/)
   assert.match(prScopePolicy, /docs\/ai\/autonomous-pr-gates\.md/)
   assert.match(autonomousPrGates, /controller_fallback_reason|fallback_reason/)
   assert.match(autonomousPrGates, /Review conversation closeout/)
   assert.match(autonomousPrGates, /Final merge gate/)
   assert.match(autonomousPrGates, /spec workflow-check/)
+  assert.match(autonomousPrGates, /necessity assessment/)
+  assert.match(autonomousPrGates, /25-30%/)
+  assert.match(autonomousPrGates, /review_triage_ref/)
+  assert.match(autonomousPrGates, /Erick52106\/spec-injector#232/)
 })
 
 test('PR scope police only treats a delegation log as autonomous when it has real content', async () => {
@@ -1472,6 +1482,9 @@ Depends on PR: none
 - Unresolved threads：0
 - CodeRabbit：reaction-only on latest head
 - chatgpt-codex-connector：commented on latest head
+- review_triage_ref：https://example.com/pr/653#issuecomment-triage
+- root_cause_gate_ref：https://example.com/pr/653#issuecomment-root-cause
+- finding_disposition_ref：https://example.com/pr/653#issuecomment-disposition
 - Final reviewer action：resolved or documented
 
 ## Final merge gate
@@ -1486,6 +1499,7 @@ Depends on PR: none
   assert.match(validRun.comments[0].body, /Autonomous evidence snapshot/i)
   assert.match(validRun.comments[0].body, /Spawn directives: pass/i)
   assert.match(validRun.comments[0].body, /Review closeout: pass/i)
+  assert.match(validRun.comments[0].body, /Review evidence refs: pass/i)
   assert.match(validRun.comments[0].body, /Final merge gate: pass/i)
 
   const missingSpawnDirectiveRun = await runScopePoliceWorkflow({
@@ -1551,6 +1565,9 @@ Depends on PR: none
 - Unresolved threads：
 - CodeRabbit：
 - chatgpt-codex-connector：
+- review_triage_ref：
+- root_cause_gate_ref：
+- finding_disposition_ref：
 - Final reviewer action：
 
 ## Final merge gate
@@ -1566,6 +1583,70 @@ Depends on PR: none
   assert.match(
     emptyCloseoutFieldsRun.comments[0].body,
     /Autonomous PR must include either `Review conversation closeout` or `Final merge gate` evidence\./,
+  )
+
+  const missingReviewEvidenceRefsRun = await runScopePoliceWorkflow({
+    body: validAutonomousBody
+      .replace(/\n- review_triage_ref：[^\n]+/, '')
+      .replace(/\n- root_cause_gate_ref：[^\n]+/, '')
+      .replace(/\n- finding_disposition_ref：[^\n]+/, ''),
+  })
+  assert.equal(missingReviewEvidenceRefsRun.failures.length, 1)
+  assert.match(
+    missingReviewEvidenceRefsRun.comments[0].body,
+    /Autonomous PR review closeout must include `review_triage_ref`, `root_cause_gate_ref`, and `finding_disposition_ref`; ready-to-merge closeout cannot leave those refs pending\./,
+  )
+  assert.match(missingReviewEvidenceRefsRun.comments[0].body, /Review evidence refs: fail/i)
+
+  const barePendingReviewEvidenceRefsRun = await runScopePoliceWorkflow({
+    body: validAutonomousBody
+      .replace(
+        '- review_triage_ref：https://example.com/pr/653#issuecomment-triage',
+        '- review_triage_ref：pending',
+      )
+      .replace(
+        '- root_cause_gate_ref：https://example.com/pr/653#issuecomment-root-cause',
+        '- root_cause_gate_ref：pending with reason',
+      ),
+  })
+  assert.equal(barePendingReviewEvidenceRefsRun.failures.length, 1)
+  assert.match(
+    barePendingReviewEvidenceRefsRun.comments[0].body,
+    /Autonomous PR review closeout must include `review_triage_ref`, `root_cause_gate_ref`, and `finding_disposition_ref`; ready-to-merge closeout cannot leave those refs pending\./,
+  )
+
+  const initialPendingWithReasonReviewEvidenceRefsRun = await runScopePoliceWorkflow({
+    body: validAutonomousBody
+      .replace(
+        '- Ready-to-merge decision：ready',
+        '- Ready-to-merge decision：pending with reason: PR just opened',
+      )
+      .replace(
+        '- review_triage_ref：https://example.com/pr/653#issuecomment-triage',
+        '- review_triage_ref：pending with reason: no review findings yet',
+      )
+      .replace(
+        '- root_cause_gate_ref：https://example.com/pr/653#issuecomment-root-cause',
+        '- root_cause_gate_ref：pending with reason: no same-concept second finding yet',
+      )
+      .replace(
+        '- finding_disposition_ref：https://example.com/pr/653#issuecomment-disposition',
+        '- finding_disposition_ref：pending with reason: no review findings yet',
+      ),
+  })
+  assert.equal(initialPendingWithReasonReviewEvidenceRefsRun.failures.length, 0)
+  assert.match(initialPendingWithReasonReviewEvidenceRefsRun.comments[0].body, /Review evidence refs: pass/i)
+
+  const readyWithPendingReasonReviewEvidenceRefsRun = await runScopePoliceWorkflow({
+    body: validAutonomousBody.replace(
+      '- review_triage_ref：https://example.com/pr/653#issuecomment-triage',
+      '- review_triage_ref：pending with reason: waiting for final review',
+    ),
+  })
+  assert.equal(readyWithPendingReasonReviewEvidenceRefsRun.failures.length, 1)
+  assert.match(
+    readyWithPendingReasonReviewEvidenceRefsRun.comments[0].body,
+    /ready-to-merge closeout cannot leave those refs pending\./,
   )
 
   const missingCloseoutSectionsRun = await runScopePoliceWorkflow({

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -76,6 +76,11 @@ jobs:
               /^Ready-to-merge decision\s*[：:]\s*(.*?)$/i
             const reviewCloseoutFieldPattern =
               /^(Unresolved threads|CodeRabbit|chatgpt-codex-connector|Final reviewer action)\s*[：:]\s*(.*?)$/i
+            const reviewEvidenceFieldPatterns = [
+              /^review_triage_ref\s*[：:]\s*(.*?)$/i,
+              /^root_cause_gate_ref\s*[：:]\s*(.*?)$/i,
+              /^finding_disposition_ref\s*[：:]\s*(.*?)$/i,
+            ]
             const finalMergeGateFieldPattern =
               /^(Ready-to-merge decision|Latest head SHA|Required checks|spec workflow-check evidence|Evidence URL)\s*[：:]\s*(.*?)$/i
             const hasMeaningfulExceptionReason = (value) =>
@@ -358,6 +363,24 @@ jobs:
               reviewConversationCloseoutSection,
               reviewCloseoutFieldPattern,
             )
+            const reviewConversationCloseoutLines = reviewConversationCloseoutSection.split('\n')
+            const hasAllReviewEvidenceRefs = reviewEvidenceFieldPatterns.every((fieldPattern) =>
+              reviewConversationCloseoutLines.some((line, index) =>
+                hasMeaningfulSectionFieldValue(reviewConversationCloseoutLines, index, fieldPattern),
+              ),
+            )
+            const hasPendingReviewEvidenceRef = reviewEvidenceFieldPatterns.some((fieldPattern) =>
+              collectSectionFieldValues(reviewConversationCloseoutLines, fieldPattern).some((value) =>
+                /^pending\b/i.test(value),
+              ),
+            )
+            const hasBarePendingReviewEvidenceRef = reviewEvidenceFieldPatterns.some((fieldPattern) =>
+              collectSectionFieldValues(reviewConversationCloseoutLines, fieldPattern).some((value) =>
+                /^pending$/i.test(value),
+              ),
+            )
+            const hasValidReviewEvidenceRefs =
+              hasReviewConversationCloseout && hasAllReviewEvidenceRefs && !hasBarePendingReviewEvidenceRef
             const finalMergeGateLines = finalMergeGateSection.split('\n')
             const hasFinalMergeGate = hasMeaningfulSectionContent(
               finalMergeGateSection,
@@ -379,6 +402,9 @@ jobs:
               readyToMergeFieldPattern,
             )
             const hasBarePendingMergeGate = readyToMergeValues.some((value) => /^pending$/i.test(value))
+            const hasReadyToMergeDecision = readyToMergeValues.some((value) => /^ready\b/i.test(value))
+            const reviewEvidenceRefsPass =
+              hasValidReviewEvidenceRefs && !(hasReadyToMergeDecision && hasPendingReviewEvidenceRef)
             const hasValidSpawnDirective = spawnDirectives.some(hasCompleteSpawnDirective)
             const hasInvalidAllowedFallbackDirective = spawnDirectives.some(
               (directive) =>
@@ -490,6 +516,15 @@ jobs:
                 if (!hasReviewConversationCloseout && !hasFinalMergeGate) {
                   policyFailures.push(
                     'Autonomous PR must include either `Review conversation closeout` or `Final merge gate` evidence.',
+                  )
+                }
+
+                if (
+                  hasReviewConversationCloseout &&
+                  (!hasValidReviewEvidenceRefs || (hasReadyToMergeDecision && hasPendingReviewEvidenceRef))
+                ) {
+                  policyFailures.push(
+                    'Autonomous PR review closeout must include `review_triage_ref`, `root_cause_gate_ref`, and `finding_disposition_ref`; ready-to-merge closeout cannot leave those refs pending.',
                   )
                 }
 
@@ -730,6 +765,11 @@ jobs:
               )
               summaryLines.push(
                 `- Review closeout: ${hasReviewConversationCloseout ? 'pass' : 'fail'}`,
+              )
+              summaryLines.push(
+                `- Review evidence refs: ${
+                  hasReviewConversationCloseout ? (reviewEvidenceRefsPass ? 'pass' : 'fail') : 'n/a'
+                }`,
               )
               summaryLines.push(`- Final merge gate: ${hasFinalMergeGate ? 'pass' : 'fail'}`)
               summaryLines.push(

--- a/docs/ai/autonomous-pr-gates.md
+++ b/docs/ai/autonomous-pr-gates.md
@@ -32,6 +32,19 @@ final closeout 只在 merge 前狀態穩定後更新一次，避免每個 CI tic
 - chatgpt-codex-connector timeout：先讀 comment / review / reaction；reaction-only 可視為 fallback evidence，但需記錄 latest head。
 - 所有 review finding 必須修正並回覆/resolve，或留下技術理由後 resolve。
 
+## Review Triage Discipline
+
+- review finding 不能照單全收；總控必須先做 necessity assessment，確認它是否真的是 blocker、是否仍對最新 head 成立、以及是否會把 PR 擴成超出原 issue 的 patch。
+- review follow-up 必須以 latest head SHA 為批次單位處理；同一 head 上的 duplicate finding 要 collapse 成同一筆 triage，不得把同義 comment 當成多個獨立工作項目。
+- 若 finding 指向舊 diff、舊 head、或已被後續 commit 覆蓋，先做 outdated finding re-check；沒有 latest-head 佐證的舊 finding，不得直接轉成新 patch。
+- 同一區塊、同一概念、或同一 state transition 第 2 次再出現 edge-case finding 時，必須升級成 root-cause / state-model 檢查，而不是只補第 2 個局部 patch。
+- parser / gate / workflow 類 follow-up 預設先做 matrix-first 或 table-driven regression tests，再補最小修正，避免一個 finding 換來另一個 parser 分支洞。
+- 若 review follow-up patch 預估超過原 PR diff 的約 25-30%，應停下來做 split assessment；能拆成 follow-up issue/PR 就不要繼續在原 PR 無限加碼。
+- final closeout 要對每個 finding 留下 `adopted`、`partial`、`rejected`、`deferred` 其中一種 disposition，並提供對應 evidence ref 或 comment/thread URL。
+- PR body 只需要薄接線：`review_triage_ref`、`root_cause_gate_ref`、`finding_disposition_ref` 三個 evidence ref。完整 triage matrix、root-cause notes、或 spec-injector output 可以留在 issue / PR comment / local-only spec evidence，不必整份塞進 PR body。
+- Scope Police 只檢查這三個 ref 是否存在與 pending marker；剛開 PR 可用 `pending with reason`，但 bare `pending` 與 ready-to-merge closeout 的任何 pending ref 都會被擋下。tachigo 不解析完整 review triage schema/checker。
+- review triage schema/checker 的 source of truth 在 `Erick52106/spec-injector#232`、`#233`、`#234`、`#235`；tachigo 只保存 evidence refs 與 lightweight gate。
+
 ## spec workflow-check Gates
 
 `spec-injector` 對 tachigo 是 local-only 輔助，不是不用此工具者的硬性門檻。

--- a/docs/ai/codex-autonomous-workflow.md
+++ b/docs/ai/codex-autonomous-workflow.md
@@ -194,6 +194,15 @@ Autonomous PR merge 前，總控必須完成 fresh readback：
 7. GitHub 允許時，將已處理的 review thread/comment resolve。
 8. 若 push 新 commit，merge 前重新讀回 head SHA 與 review/check 狀態。
 
+### Review Triage Discipline
+
+- 所有 review finding 先做 necessity assessment，再決定是採納、部分採納、駁回，或拆成 follow-up；不得因 reviewer 提到 edge case 就直接擴 scope。
+- review follow-up 必須 batch by latest head SHA；同一 head 的 duplicate finding 要 collapse，舊 head finding 要先做 outdated re-check。
+- 同一概念第 2 次再出現 finding，預設升級成 root-cause / state-model 修正，不再接受無限 local patch 疊加。
+- parser / gate / workflow 修正優先補 matrix-first regression tests，再做最小 patch。
+- follow-up patch 若逼近原 PR diff 的約 25-30%，先停下來評估拆 PR 或改開 follow-up issue。
+- final closeout 要留下 adopted / partial / rejected / deferred disposition，並把 `review_triage_ref`、`root_cause_gate_ref`、`finding_disposition_ref` 對到 latest head 的證據。
+
 CodeRabbit 由 `.coderabbit.yaml` 設定 `reviews.auto_review.base_branches: [".*"]`，讓 PR target branch 不限 default branch 都能觸發 auto review。
 
 ### Review Closeout Evidence Matrix

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -156,7 +156,10 @@ Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的
 - 自動化 PR 必須至少有一條 spawn directive，且同時包含 `profile=`、`model=`、`reasoning=`、`controller_fallback=`；若 `controller_fallback=allowed`，同一行必須有非空 `fallback_reason=`。
 - `ops_spark` 類任務不得使用高階 controller model，除非同一條 spawn directive 留下 fallback reason。
 - 自動化 PR 必須有 `Review conversation closeout` 或 `Final merge gate` evidence；ready-to-merge closeout 不可留下裸 `pending`。
+- 若已填 `Review conversation closeout`，autonomous PR 還必須提供 `review_triage_ref`、`root_cause_gate_ref`、`finding_disposition_ref` 三個 evidence ref。剛開 PR 可填 `pending with reason`，但 bare `pending` 與 ready-to-merge closeout 的任何 pending ref 都會被擋下。
 - sticky comment 會顯示 `Autonomous evidence snapshot`，列出 delegation log、worker closeout、spawn directives、controller fallback detail、review closeout、final merge gate 與 pending 是否已清除。
+- Scope Police 對 review triage 只做薄檢查：確認 ref/pending marker，不解析完整 spec-injector review triage matrix、root-cause schema 或 disposition checker。
+- review triage schema/checker 的 authoritative implementation 應留在 `Erick52106/spec-injector#232`、`#233`、`#234`、`#235`；tachigo 不複製該 checker。
 - section 內只要是空白、`n/a`、`none`、`無`、`不適用`，或非正式欄位的自由備註，不會啟動 delegation gate。
 - 只有 section 標題但欄位空白，不算 autonomous PR，也不會觸發 delegation gate。
 - 一般非 autonomous PR 不需要填寫 worker profile；不因 `Delegation Execution Log` 缺漏而被視為流程違規。


### PR DESCRIPTION
## 什麼改動
將 Hybrid AWP with Explicit Fallback Gate 的 review triage evidence refs 薄接線落到 tachigo：PR template、Scope Police、workflow regression tests 與 autonomous workflow docs。

## 為什麼
Closes #669。#657 已落地 AWP v2 evidence gates，但 review finding closeout 仍缺 `review_triage_ref` / `root_cause_gate_ref` / `finding_disposition_ref`，容易讓 autonomous PR 對 automated review finding 照單全收或反覆 local patch。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#669
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作 spec-injector review triage parser/checker
  - 不修改產品 backend/frontend runtime code
  - 不要求非 autonomous PR 填 AWP review evidence refs
  - 不把完整 review triage matrix 塞進 PR body
  - 不處理 threshold metrics / #664 類型資料化 ledger

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #669：tachigo thin wiring for AWP review triage evidence refs
- Actual worker profile(s)：
  - controller：GPT-5.5，scope / architecture / review decision / final gate
  - docs_worker：GPT-5.4，docs/template/workflow regression implementation
- Model strength：
  - controller = high
  - docs_worker = medium
- Spawn directive(s)：
  - profile=docs_worker model=gpt-5.4 reasoning=medium controller_fallback=allowed fallback_reason=worker_timeout_no_diff_then_worker_completed_before_final_closeout
  - profile=controller model=gpt-5.5 reasoning=high controller_fallback=allowed fallback_reason=trivial_readonly_issue_state_check_and_final_scope_review
- Verification evidence：
  - node --test .github/workflows/ci.test.mjs
  - git diff --check
  - spec validate --repo .
  - spec plan 669 --repo . --dry-run --format prompt --verbose
- Self-review / exception reason：
  - controller reviewed worker diff, added upstream spec-injector #232-#235 source-of-truth refs, and re-ran validation
- Worker session closeout：
  - docs_worker completed and was closed; spec-injector/tachiya workers were shut down after scope narrowed to tachigo only
- Workflow friction / follow-up split：
  - 本 PR 只做 tachigo thin wiring；完整 schema/checker 留在 spec-injector #232-#235，不混進 tachigo

## Review conversation closeout
- Unresolved threads：0（GraphQL reviewThreads readback；connector thread isResolved=true / isOutdated=true）
- CodeRabbit：latest head `c37302d994a3ccf322f1ce29c9551ab21ea505e1` check pass; latest review says no actionable comments were generated: https://github.com/nurockplayer/tachigo/pull/671#issuecomment-4442041462
- chatgpt-codex-connector：initial P1 finding was adopted, replied, and resolved; latest `@codex review` response on `c37302d994a3ccf322f1ce29c9551ab21ea505e1` reported no major issues: https://github.com/nurockplayer/tachigo/pull/671#issuecomment-4442794868
- review_triage_ref：https://github.com/nurockplayer/tachigo/pull/671#discussion_r3235057372 — adopted; initial `pending with reason` vs final ready-to-merge policy conflict was valid
- root_cause_gate_ref：not_triggered: only one same-concept blocker was found; later comments are minors/nits/readability or future-coupling observations, not repeated implementation failures
- finding_disposition_ref：https://github.com/nurockplayer/tachigo/pull/671#discussion_r3235511189 — adopted and resolved; CodeRabbit readability nit was adopted in latest head; closeout-coupling observation intentionally kept as current design because review refs supplement the Review conversation closeout section rather than replacing it
- Final reviewer action：merged to develop; all actionable findings evaluated, blocker fixed, optional readability nit adopted, remaining minor observations documented as non-blocking design/future-maintenance notes

## Final merge gate
- Ready-to-merge decision：merged by human on 2026-05-13T16:01:17Z
- Latest head SHA：c37302d994a3ccf322f1ce29c9551ab21ea505e1
- Merge commit：47f70c8fdd78600357c26bf17decaed6e624be9e
- Required checks：pass before merge; Scope Police, CodeRabbit, backend/frontend/dashboard/contracts/security/workflow checks passed; `Contracts build` initially failed during Foundry install because GitHub API returned 403 before build execution, then passed on rerun
- Post-merge notification follow-up：`Comment on conflicting PRs` failed with GitHub 403 while trying to notify PR #665; #665 was later manually rebased, reviewed, merged, and closeout completed, so no remaining action for #671
- CodeRabbit / connector state：CodeRabbit pass / no actionable comments; connector follow-up response has no major issues
- Review threads：0 unresolved; resolved thread https://github.com/nurockplayer/tachigo/pull/671#discussion_r3235057372
- spec workflow-check evidence：`spec validate --repo .` pass; `spec plan 669 --repo . --dry-run --format prompt --verbose` pass with existing config warning about missing `docs/claude-codex-workflow.md`
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/671#issuecomment-4442010585; https://github.com/nurockplayer/tachigo/pull/671#issuecomment-4442041462; https://github.com/nurockplayer/tachigo/pull/671#issuecomment-4442794868

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 tachigo autonomous PR 可引用 review triage / root-cause / finding disposition evidence refs，並由 Scope Police 做薄檢查。
- Approx changed lines：~109
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #669 是 docs/template/workflow gate 的同一條契約，測試需與 Scope Police/template 同步避免 drift。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 文件說明 review comments 不能照單全收，需 necessity assessment
- [x] 文件說明 freshness/head SHA、duplicate collapse、root-cause trigger、patch budget
- [x] PR template 有 autonomous-only evidence ref 欄位，非 autonomous PR 可填 n/a
- [x] Scope Police 保持 thin wiring，不解析完整 spec-injector evidence
- [x] workflow regression 覆蓋 autonomous refs / missing refs / pending refs / non-autonomous path

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.mjs
# pass 75/75

git diff --check
# pass

spec validate --repo .
# pass

spec plan 669 --repo . --dry-run --format prompt --verbose
# pass with existing config warning: docs/claude-codex-workflow.md missing
```

## 備註
#652 / #653 大多已由 #657 覆蓋；本 PR 補的是 Hybrid AWP 最新 review triage refs 缺口。#654 應維持 tachigo thin wiring，完整 checker 留在 spec-injector。

## Notes for Claude Code Review
- 請特別檢查 Scope Police 是否只做 ref / pending marker 薄檢查，且不會要求非 autonomous PR 填 AWP review evidence refs。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 發行說明

* **新功能**
  * PR 完結流程新增三個必要證據參考欄位：review_triage_ref、root_cause_gate_ref、finding_disposition_ref，且自動化檢查在欄位缺失或為不接受的 pending 狀態時會阻擋合併。

* **文件**
  * 新增並擴充「Review Triage Discipline」與相關自動化工作流程說明，規範發現處置與 closeout 要求。

* **測試**
  * 擴展測試以驗證證據欄位的存在性、有效性與 pending 行為（含正負案例與快照斷言）。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/671)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

