### PR TITLE
[frontend] feat: raffle activate button and CSV lock UI

### DIFF
--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -2,7 +2,7 @@ import { useOne } from '@refinedev/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { completeRaffle, drawNext, importCSV, listDraws, setDiscordWebhook } from '@/services/raffles'
+import { activateRaffle, completeRaffle, drawNext, importCSV, listDraws, setDiscordWebhook } from '@/services/raffles'
 import type { Raffle, RaffleDraw, RaffleStatus } from '@/services/raffles'
 
 const statusLabel: Record<RaffleStatus, string> = {
@@ -78,11 +78,23 @@ function WinnerList({ draws }: { draws: RaffleDraw[] }) {
 
 function CsvUploadZone({
   raffleId,
+  locked,
   onSuccess,
 }: {
   raffleId: string
+  locked: boolean
   onSuccess: (result: { imported: number; skipped: number }) => void
 }) {
+  if (locked) {
+    return (
+      <div
+        data-testid="csv-locked"
+        className="rounded-xl border border-dashed border-white/10 bg-white/[.02] px-4 py-3 text-center"
+      >
+        <p className="text-sm text-white/30">名單已鎖定，無法再匯入</p>
+      </div>
+    )
+  }
   const inputRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
   const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null)
@@ -529,8 +541,10 @@ export default function RaffleDetailPage() {
   const [confirmEnd, setConfirmEnd] = useState(false)
   const [ending, setEnding] = useState(false)
   const [localCompleted, setLocalCompleted] = useState(false)
+  const [localActivated, setLocalActivated] = useState(false)
+  const [activating, setActivating] = useState(false)
 
-  const effectiveStatus = localCompleted ? 'completed' : (raffle?.status ?? '')
+  const effectiveStatus = localCompleted ? 'completed' : localActivated ? 'active' : (raffle?.status ?? '')
 
   const fetchDraws = useCallback(async () => {
     if (!raffleId) return
@@ -577,6 +591,17 @@ export default function RaffleDetailPage() {
       }
     } finally {
       setDrawing(false)
+    }
+  }
+
+  async function handleActivate() {
+    if (!raffleId || activating) return
+    setActivating(true)
+    try {
+      await activateRaffle(raffleId)
+      setLocalActivated(true)
+    } finally {
+      setActivating(false)
     }
   }
 
@@ -645,7 +670,22 @@ export default function RaffleDetailPage() {
             <StatCard label="剩餘" value={remaining?.toString() ?? '--'} colorClass="text-amber-400" />
           </div>
 
-          <CsvUploadZone raffleId={raffle.id} onSuccess={(result) => { setTotalEntries(prev => (prev ?? 0) + result.imported); setExhausted(false) }} />
+          <CsvUploadZone
+            raffleId={raffle.id}
+            locked={effectiveStatus !== 'draft'}
+            onSuccess={(result) => { setTotalEntries(prev => (prev ?? 0) + result.imported); setExhausted(false) }}
+          />
+
+          {effectiveStatus === 'draft' && (
+            <button
+              data-testid="activate-btn"
+              disabled={activating}
+              onClick={() => { void handleActivate() }}
+              className="w-full rounded-full border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm font-bold tracking-widest text-amber-400 transition hover:bg-amber-500/20 disabled:opacity-40"
+            >
+              {activating ? '鎖定中...' : '開始抽獎（鎖定名單）'}
+            </button>
+          )}
 
           <DrawControls
             status={effectiveStatus}

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -85,6 +85,11 @@ function CsvUploadZone({
   locked: boolean
   onSuccess: (result: { imported: number; skipped: number }) => void
 }) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
   if (locked) {
     return (
       <div
@@ -95,10 +100,6 @@ function CsvUploadZone({
       </div>
     )
   }
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [uploading, setUploading] = useState(false)
-  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null)
-  const [error, setError] = useState<string | null>(null)
 
   async function handleFile(file: File) {
     setUploading(true)

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -543,6 +543,7 @@ export default function RaffleDetailPage() {
   const [localCompleted, setLocalCompleted] = useState(false)
   const [localActivated, setLocalActivated] = useState(false)
   const [activating, setActivating] = useState(false)
+  const [activateError, setActivateError] = useState<string | null>(null)
 
   const effectiveStatus = localCompleted ? 'completed' : localActivated ? 'active' : (raffle?.status ?? '')
 
@@ -597,9 +598,13 @@ export default function RaffleDetailPage() {
   async function handleActivate() {
     if (!raffleId || activating) return
     setActivating(true)
+    setActivateError(null)
     try {
       await activateRaffle(raffleId)
       setLocalActivated(true)
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } } }
+      setActivateError(e?.response?.data?.error ?? '啟動失敗，請稍後再試')
     } finally {
       setActivating(false)
     }
@@ -677,14 +682,19 @@ export default function RaffleDetailPage() {
           />
 
           {effectiveStatus === 'draft' && (
-            <button
-              data-testid="activate-btn"
-              disabled={activating}
-              onClick={() => { void handleActivate() }}
-              className="w-full rounded-full border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm font-bold tracking-widest text-amber-400 transition hover:bg-amber-500/20 disabled:opacity-40"
-            >
-              {activating ? '鎖定中...' : '開始抽獎（鎖定名單）'}
-            </button>
+            <>
+              <button
+                data-testid="activate-btn"
+                disabled={activating}
+                onClick={() => { void handleActivate() }}
+                className="w-full rounded-full border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm font-bold tracking-widest text-amber-400 transition hover:bg-amber-500/20 disabled:opacity-40"
+              >
+                {activating ? '鎖定中...' : '開始抽獎（鎖定名單）'}
+              </button>
+              {activateError && (
+                <p data-testid="activate-error" className="mt-1 text-center text-xs text-red-400">{activateError}</p>
+              )}
+            </>
           )}
 
           <DrawControls

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -453,4 +453,26 @@ describe('RaffleDetailPage — activate button', () => {
     await waitFor(() => expect(container.querySelector('[data-testid="csv-locked"]')).toBeTruthy())
     cleanup(root, container)
   })
+
+  it('shows error message when activateRaffle fails', async () => {
+    vi.mocked(rafflesService.activateRaffle).mockRejectedValue({
+      response: { data: { error: 'raffle is not in draft status' } },
+    })
+    const draftRaffle = { ...mockRaffle, status: 'draft' as const }
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="activate-btn"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="activate-btn"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="activate-error"]')?.textContent)
+        .toContain('raffle is not in draft status'),
+    )
+    cleanup(root, container)
+  })
 })

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/services/raffles', async (importOriginal) => {
     importCSV: vi.fn().mockResolvedValue({ imported: 0, skipped: 0 }),
     completeRaffle: vi.fn().mockResolvedValue(undefined),
     setDiscordWebhook: vi.fn().mockResolvedValue(true),
+    activateRaffle: vi.fn().mockResolvedValue({ id: 'r1', status: 'active' }),
   }
 })
 
@@ -72,6 +73,7 @@ beforeEach(() => {
   vi.mocked(rafflesService.importCSV).mockResolvedValue({ imported: 0, skipped: 0 })
   vi.mocked(rafflesService.completeRaffle).mockResolvedValue(undefined)
   vi.mocked(rafflesService.setDiscordWebhook).mockResolvedValue(true)
+  vi.mocked(rafflesService.activateRaffle).mockResolvedValue({ ...mockRaffle, status: 'active' as const })
 })
 afterEach(() => {
   vi.restoreAllMocks()
@@ -140,11 +142,13 @@ describe('RaffleDetailPage — winner list', () => {
   })
 })
 
+const draftRaffle = { ...mockRaffle, status: 'draft' as const }
+
 describe('RaffleDetailPage — CSV upload', () => {
   it('shows success message after upload', async () => {
     vi.mocked(rafflesService.importCSV).mockResolvedValue({ imported: 50, skipped: 2 })
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="csv-input"]')).toBeTruthy())
@@ -166,7 +170,7 @@ describe('RaffleDetailPage — CSV upload', () => {
   it('shows error message when upload fails', async () => {
     vi.mocked(rafflesService.importCSV).mockRejectedValue(new Error('network'))
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="csv-input"]')).toBeTruthy())
@@ -230,7 +234,7 @@ describe('RaffleDetailPage — draw button', () => {
     vi.mocked(rafflesService.listDraws).mockResolvedValue([mockDraw, { ...mockDraw, id: 'd2' }, { ...mockDraw, id: 'd3' }])
     vi.mocked(rafflesService.importCSV).mockResolvedValue({ imported: 3, skipped: 0 })
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="csv-input"]')).toBeTruthy())
@@ -399,6 +403,54 @@ describe('RaffleDetailPage — Discord webhook', () => {
         .dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     await waitFor(() => expect(container.querySelector('[data-testid="discord-webhook-error"]')?.textContent).toContain('invalid discord webhook url'))
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — activate button', () => {
+  it('shows activate button when status is draft', async () => {
+    const draftRaffle = { ...mockRaffle, status: 'draft' as const }
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="activate-btn"]')).toBeTruthy())
+    cleanup(root, container)
+  })
+
+  it('calls activateRaffle when activate button is clicked', async () => {
+    const activateMock = vi.mocked(rafflesService.activateRaffle)
+    const draftRaffle = { ...mockRaffle, status: 'draft' as const }
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="activate-btn"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="activate-btn"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(activateMock).toHaveBeenCalledWith('r1'))
+    cleanup(root, container)
+  })
+
+  it('hides activate button when status is active', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="draw-btn"]')).toBeTruthy())
+    expect(container.querySelector('[data-testid="activate-btn"]')).toBeFalsy()
+    cleanup(root, container)
+  })
+
+  it('shows CSV locked message when status is active', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="csv-locked"]')).toBeTruthy())
     cleanup(root, container)
   })
 })

--- a/apps/dashboard/src/services/__tests__/raffles.test.ts
+++ b/apps/dashboard/src/services/__tests__/raffles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listRaffles, createRaffle, listDraws, drawNext, importCSV, completeRaffle, setDiscordWebhook } from '@/services/raffles'
+import { listRaffles, createRaffle, listDraws, drawNext, importCSV, completeRaffle, setDiscordWebhook, activateRaffle } from '@/services/raffles'
 
 const getMock = vi.fn()
 const postMock = vi.fn()
@@ -74,6 +74,16 @@ describe('completeRaffle', () => {
     postMock.mockResolvedValue({ data: { success: true, data: {} } })
     await completeRaffle('r1')
     expect(postMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/complete', undefined)
+  })
+})
+
+describe('activateRaffle', () => {
+  it('posts to activate endpoint and returns updated raffle', async () => {
+    const activeRaffle = { ...mockRaffle, status: 'active' as const }
+    postMock.mockResolvedValue({ data: { success: true, data: { raffle: activeRaffle } } })
+    const result = await activateRaffle('r1')
+    expect(result).toEqual(activeRaffle)
+    expect(postMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/activate', undefined)
   })
 })
 

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -74,6 +74,14 @@ export async function importCSV(
   return data.data
 }
 
+export async function activateRaffle(raffleId: string): Promise<Raffle> {
+  const { data } = await client.post<ApiResponse<{ raffle: Raffle }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/activate`,
+    undefined,
+  )
+  return data.data.raffle
+}
+
 export async function completeRaffle(raffleId: string): Promise<void> {
   await client.post(
     `/api/v1/dashboard/raffles/${raffleId}/complete`,


### PR DESCRIPTION
## 什麼改動
- `services/raffles.ts` 新增 `activateRaffle(raffleId)` — POST `/api/v1/dashboard/raffles/:id/activate`
- `CsvUploadZone`：新增 `locked` prop，status != draft 時顯示「名單已鎖定，無法再匯入」（`data-testid="csv-locked"`）
- `RaffleDetailPage`：新增「開始抽獎（鎖定名單）」按鈕（`data-testid="activate-btn"`），僅在 `status === 'draft'` 顯示；點擊後呼叫 `activateRaffle`，本地 status 更新為 active
- service 單元測試、page 整合測試（按鈕顯示條件、activate 呼叫、CSV locked 提示）

## 為什麼
closes #668

後端 #667/#670 已實作名單鎖定機制，本 PR 補上 Dashboard UI，讓實況主可一鍵鎖定名單並開始抽獎。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#668
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否
- 本 PR 明確不做：
  - 不實作 active → draft 的解鎖 UI
  - 不修改後端
  - 不修改 Extension

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- n/a

## Review conversation closeout
- n/a

## Final merge gate
- Ready-to-merge decision：pending CI
- Latest head SHA：4e5b5c4
- Required checks：PR Scope Police pass；CI pass
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：在 Dashboard RaffleDetailPage 新增 Activate 按鈕與 CSV 鎖定提示
- Approx changed lines：~117
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service 函式與 page 元件是不可分割的單元；tests 是直接驗證。
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] `activateRaffle` service 函式有單元測試
- [x] draft 狀態下「開始抽獎（鎖定名單）」按鈕可見並可點擊
- [x] 點擊後呼叫 `activateRaffle`，成功後 effectiveStatus 更新為 active
- [x] active / completed 狀態下按鈕不顯示
- [x] active 狀態下 CSV 上傳區塊顯示「名單已鎖定」並 disable
- [x] `npx vitest run` — 102/102 pass
- [x] `npx tsc --noEmit` — 無錯誤

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
cd apps/dashboard && npx vitest run
Test Files  13 passed (13)
Tests       102 passed (102)

npx tsc --noEmit
(no output = clean)
```

## 備註
- `draftRaffle` 常數已加入 page 測試，CSV upload 測試改用 draft raffle（避免 active 狀態下 CsvUploadZone 顯示 locked message 而找不到 csv-input）
- `effectiveStatus` 追蹤本地 activate 狀態（`localActivated`），與現有的 `localCompleted` 模式一致，不需 refetch

## Notes for Claude Code Review
- `CsvUploadZone` 加 `locked` prop 為必填，避免忘記傳入時靜默顯示 upload zone
- `effectiveStatus` 優先序：localCompleted > localActivated > raffle.status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增「開始抽獎（鎖定名單）」啟動流程：草稿狀態顯示按鈕並觸發啟動。
  * 啟動成功後將名單鎖定：CSV 上傳介面切換為鎖定/停用，防止再修改。
  * 啟動會向後端發送啟動請求；啟動失敗則在頁面顯示錯誤訊息。

* **測試**
  * 新增與更新測試：覆蓋啟動按鈕可見性、啟動行為、鎖定 UI 與錯誤情境。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/672)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->