### PR TITLE
[infra] Guard auto-ready workflow PR auto-merge

### DIFF
--- a/.github/workflows/auto-ready-pr.yml
+++ b/.github/workflows/auto-ready-pr.yml
@@ -148,6 +148,25 @@ jobs:
               return response.data.statuses || []
             }
 
+            const listChangedFilePaths = async (pr) => {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              })
+              return files.flatMap((file) =>
+                file.status === 'renamed' && file.previous_filename
+                  ? [file.filename, file.previous_filename]
+                  : [file.filename],
+              )
+            }
+
+            const changesWorkflowFiles = async (pr) => {
+              const paths = await listChangedFilePaths(pr)
+              return paths.some((filePath) => filePath.startsWith('.github/workflows/'))
+            }
+
             const checkRunPassed = (run, allowedConclusions) =>
               run.status === 'completed' && allowedConclusions.has(run.conclusion)
 
@@ -305,6 +324,14 @@ jobs:
               }
 
               const markedReady = pr.draft === true
+              let workflowFileChanged = false
+              try {
+                workflowFileChanged = await changesWorkflowFiles(pr)
+              } catch (error) {
+                core.warning(`Skipping PR #${pr.number}: failed to fetch changed files (${error?.message || error}).`)
+                continue
+              }
+
               if (markedReady) {
                 try {
                   await readyForReview(pr)
@@ -314,13 +341,17 @@ jobs:
                 }
               }
 
-              try {
-                await enableAutoMerge(pr)
-              } catch (error) {
-                core.warning(
-                  `Failed to arm auto-merge for PR #${pr.number}; ${autoReadyLabel} will retry while the label remains (${error?.message || error}).`,
-                )
-                continue
+              if (!workflowFileChanged) {
+                try {
+                  await enableAutoMerge(pr)
+                } catch (error) {
+                  core.warning(
+                    `Failed to arm auto-merge for PR #${pr.number}; ${autoReadyLabel} will retry while the label remains (${error?.message || error}).`,
+                  )
+                  continue
+                }
+              } else {
+                core.info(`Skipping auto-merge for workflow-file PR #${pr.number}.`)
               }
 
               try {
@@ -333,5 +364,9 @@ jobs:
               }
 
               const readyMessage = markedReady ? 'marked ready for review, ' : ''
-              core.notice(`PR #${pr.number} ${readyMessage}armed auto-merge, and flagged for Codex review.`)
+              if (workflowFileChanged) {
+                core.notice(`PR #${pr.number} ${readyMessage}skipped auto-merge for workflow-file PR, and flagged for Codex review.`)
+              } else {
+                core.notice(`PR #${pr.number} ${readyMessage}armed auto-merge, and flagged for Codex review.`)
+              }
             }

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2891,6 +2891,49 @@ test('Codex review label workflow clears changes requested when the last trusted
   ])
 })
 
+test('Codex review label workflow keeps dismissed PRs in the review queue when another trusted reviewer still blocks', async () => {
+  const result = await runCodexReviewFlagWorkflow({
+    action: 'dismissed',
+    prOverrides: {
+      labels: [{ name: 'needs-codex-review' }, { name: 'changes-requested' }],
+    },
+    reviewOverrides: {
+      id: 9001,
+      user: { login: 'reviewer-a' },
+      state: 'CHANGES_REQUESTED',
+      author_association: 'COLLABORATOR',
+      commit_id: 'head_sha',
+      submitted_at: '2026-05-13T11:39:00Z',
+    },
+    reviews: [
+      {
+        id: 9001,
+        user: { login: 'reviewer-a' },
+        state: 'CHANGES_REQUESTED',
+        author_association: 'COLLABORATOR',
+        commit_id: 'head_sha',
+        submitted_at: '2026-05-13T11:39:00Z',
+      },
+      {
+        id: 9002,
+        user: { login: 'reviewer-b' },
+        state: 'CHANGES_REQUESTED',
+        author_association: 'MEMBER',
+        commit_id: 'head_sha',
+        submitted_at: '2026-05-13T11:40:00Z',
+      },
+    ],
+  })
+
+  assert.deepEqual(result.labelsAdded, [
+    { issue_number: 472, labels: ['needs-codex-review', 'changes-requested'] },
+  ])
+  assert.deepEqual(result.labelsRemoved, [])
+  assert.deepEqual(result.notices, [
+    'PR #472 flagged for Codex review after dismissal; a trusted reviewer still requests changes.',
+  ])
+})
+
 test('Codex review label workflow clears review labels when PRs close', async () => {
   const parsedWorkflow = parseYaml(codexReviewFlagWorkflowPath)
   const result = await runCodexReviewFlagWorkflow({

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2817,6 +2817,26 @@ test('Codex review label workflow clears review labels for collaborator approval
   assert.deepEqual(result.notices, ['PR #472 cleared review-state labels after approval.'])
 })
 
+test('Codex review label workflow clears review labels when PRs close', async () => {
+  const parsedWorkflow = parseYaml(codexReviewFlagWorkflowPath)
+  const result = await runCodexReviewFlagWorkflow({
+    eventName: 'pull_request',
+    action: 'closed',
+    prOverrides: {
+      state: 'closed',
+      labels: [{ name: 'needs-codex-review' }, { name: 'changes-requested' }],
+    },
+  })
+
+  assert.ok(parsedWorkflow.on.pull_request.types.includes('closed'))
+  assert.deepEqual(result.labelsAdded, [])
+  assert.deepEqual(result.labelsRemoved, [
+    { issue_number: 472, name: 'changes-requested' },
+    { issue_number: 472, name: 'needs-codex-review' },
+  ])
+  assert.deepEqual(result.notices, ['PR #472 cleared review-state labels after close.'])
+})
+
 test('Codex review re-request workflow requests reviewer and notifies Discord', async () => {
   const workflow = await readFile(codexReviewRerequestWorkflowPath, 'utf8')
   const parsedWorkflow = parseYaml(codexReviewRerequestWorkflowPath)

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2854,6 +2854,43 @@ test('Codex review label workflow keeps changes requested when another trusted r
   ])
 })
 
+test('Codex review label workflow clears changes requested when the last trusted blocker is dismissed', async () => {
+  const result = await runCodexReviewFlagWorkflow({
+    action: 'dismissed',
+    prOverrides: {
+      labels: [{ name: 'needs-codex-review' }, { name: 'changes-requested' }],
+    },
+    reviewOverrides: {
+      id: 9001,
+      user: { login: 'reviewer-a' },
+      state: 'CHANGES_REQUESTED',
+      author_association: 'COLLABORATOR',
+      commit_id: 'head_sha',
+      submitted_at: '2026-05-13T11:39:00Z',
+    },
+    reviews: [
+      {
+        id: 9001,
+        user: { login: 'reviewer-a' },
+        state: 'CHANGES_REQUESTED',
+        author_association: 'COLLABORATOR',
+        commit_id: 'head_sha',
+        submitted_at: '2026-05-13T11:39:00Z',
+      },
+    ],
+  })
+
+  assert.deepEqual(result.labelsAdded, [
+    { issue_number: 472, labels: ['needs-codex-review'] },
+  ])
+  assert.deepEqual(result.labelsRemoved, [
+    { issue_number: 472, name: 'changes-requested' },
+  ])
+  assert.deepEqual(result.notices, [
+    'PR #472 flagged for Codex review after dismissal.',
+  ])
+})
+
 test('Codex review label workflow clears review labels when PRs close', async () => {
   const parsedWorkflow = parseYaml(codexReviewFlagWorkflowPath)
   const result = await runCodexReviewFlagWorkflow({

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2817,6 +2817,43 @@ test('Codex review label workflow clears review labels for collaborator approval
   assert.deepEqual(result.notices, ['PR #472 cleared review-state labels after approval.'])
 })
 
+test('Codex review label workflow keeps changes requested when another trusted reviewer still blocks', async () => {
+  const result = await runCodexReviewFlagWorkflow({
+    reviewOverrides: {
+      user: { login: 'reviewer-b' },
+      state: 'approved',
+      author_association: 'MEMBER',
+      submitted_at: '2026-05-13T11:40:00Z',
+    },
+    reviews: [
+      {
+        user: { login: 'reviewer-a' },
+        state: 'CHANGES_REQUESTED',
+        author_association: 'COLLABORATOR',
+        commit_id: 'head_sha',
+        submitted_at: '2026-05-13T11:39:00Z',
+      },
+      {
+        user: { login: 'reviewer-b' },
+        state: 'APPROVED',
+        author_association: 'MEMBER',
+        commit_id: 'head_sha',
+        submitted_at: '2026-05-13T11:40:00Z',
+      },
+    ],
+  })
+
+  assert.deepEqual(result.labelsAdded, [
+    { issue_number: 472, labels: ['changes-requested'] },
+  ])
+  assert.deepEqual(result.labelsRemoved, [
+    { issue_number: 472, name: 'needs-codex-review' },
+  ])
+  assert.deepEqual(result.notices, [
+    'PR #472 kept changes-requested because a trusted reviewer still requests changes.',
+  ])
+})
+
 test('Codex review label workflow clears review labels when PRs close', async () => {
   const parsedWorkflow = parseYaml(codexReviewFlagWorkflowPath)
   const result = await runCodexReviewFlagWorkflow({

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -25,6 +25,7 @@ const dependabotPnpmLockfileWorkflowPath = path.join(currentDir, 'dependabot-pnp
 const autoMergeWorkflowPath = path.join(currentDir, 'auto-merge.yml')
 const autoReadyWorkflowPath = path.join(currentDir, 'auto-ready-pr.yml')
 const aiSprintDiscordWorkflowPath = path.join(currentDir, 'ai-sprint-discord.yml')
+const codexReviewFlagWorkflowPath = path.join(currentDir, 'codex-review-flag.yml')
 const codexReviewRerequestWorkflowPath = path.join(currentDir, 'codex-review-rerequest.yml')
 const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-on-develop-merge.yml')
 const dependencyInventoryWorkflowPath = path.join(currentDir, 'dependency-inventory.yml')
@@ -161,6 +162,7 @@ async function runAutoReadyWorkflow({
   eventName = 'pull_request',
   checkRuns = [],
   statuses = [],
+  files = [],
   checkRunsError = null,
   statusesError = null,
   graphqlError = null,
@@ -174,6 +176,7 @@ async function runAutoReadyWorkflow({
     eventName,
     checkRuns,
     statuses,
+    files,
     checkRunsError,
     statusesError,
     graphqlError,
@@ -352,6 +355,7 @@ async function runAutoReadyScript({
   eventName = 'pull_request',
   checkRuns = [],
   statuses = [],
+  files = [],
   checkRunsError = null,
   statusesError = null,
   graphqlError = null,
@@ -403,6 +407,7 @@ async function runAutoReadyScript({
       pulls: {
         list: async () => ({ data: [pr] }),
         get: async () => ({ data: livePr }),
+        listFiles: async () => ({ data: files }),
       },
       issues: {
         getLabel: async ({ name }) => ({ data: { name } }),
@@ -483,6 +488,90 @@ async function runAutoReadyScript({
     }
   }
   return { autoMergeMutations, graphqlCalls, labelsAdded, labelsCreated, labelsRemoved, mutations, notices, warnings }
+}
+
+async function runCodexReviewFlagWorkflow({
+  eventName = 'pull_request_review',
+  action = 'submitted',
+  prOverrides = {},
+  reviewOverrides = {},
+  reviews = [],
+} = {}) {
+  const parsedWorkflow = parseYaml(codexReviewFlagWorkflowPath)
+  const script = parsedWorkflow.jobs['label-state'].steps[0].with.script
+  const basePr = {
+    number: 472,
+    base: { ref: 'develop' },
+    draft: false,
+    head: { sha: 'head_sha' },
+    updated_at: '2026-05-13T11:39:34Z',
+    labels: [{ name: 'needs-codex-review' }],
+  }
+  const baseReview = {
+    user: { login: 'Erick52106' },
+    state: 'approved',
+    author_association: 'COLLABORATOR',
+    commit_id: 'head_sha',
+    submitted_at: '2026-05-13T11:39:34Z',
+  }
+  const pr = {
+    ...basePr,
+    ...prOverrides,
+    base: { ...basePr.base, ...(prOverrides.base || {}) },
+    head: { ...basePr.head, ...(prOverrides.head || {}) },
+    labels: prOverrides.labels || basePr.labels,
+  }
+  const review = {
+    ...baseReview,
+    ...reviewOverrides,
+    user: { ...baseReview.user, ...(reviewOverrides.user || {}) },
+  }
+  const labelsAdded = []
+  const labelsRemoved = []
+  const labelsCreated = []
+  const notices = []
+  const github = {
+    rest: {
+      pulls: {
+        list: async () => ({ data: [pr] }),
+        listReviews: async () => ({ data: reviews }),
+      },
+      issues: {
+        getLabel: async ({ name }) => ({ data: { name } }),
+        createLabel: async (args) => {
+          labelsCreated.push(args)
+          return { data: { name: args.name } }
+        },
+        addLabels: async ({ issue_number, labels }) => {
+          labelsAdded.push({ issue_number, labels })
+          return { data: labels.map((name) => ({ name })) }
+        },
+        removeLabel: async ({ issue_number, name }) => {
+          labelsRemoved.push({ issue_number, name })
+          return { data: { name } }
+        },
+      },
+    },
+    paginate: async (fn, args) => {
+      const result = await fn(args)
+      return result.data || result
+    },
+  }
+  const core = {
+    notice: (message) => notices.push(message),
+  }
+  const context = {
+    repo: { owner: 'nurockplayer', repo: 'tachigo' },
+    eventName,
+    payload: {
+      action,
+      pull_request: pr,
+      review,
+    },
+  }
+
+  await AsyncFunction('context', 'github', 'core', script)(context, github, core)
+  return { labelsAdded, labelsCreated, labelsRemoved, notices }
 }
 
 async function runCloseIssueOnDevelopMergeWorkflow({
@@ -2527,6 +2616,35 @@ test('auto-ready workflow retries auto-merge for already-ready auto-ready PRs', 
   ])
 })
 
+test('auto-ready workflows skip native auto-merge for workflow-file PRs', async () => {
+  const workflowFiles = [
+    {
+      filename: 'docs/renamed-workflow.md',
+      previous_filename: '.github/workflows/old-workflow.yml',
+      status: 'renamed',
+    },
+  ]
+  const standalone = await runAutoReadyWorkflow({
+    checkRuns: successfulDevelopRequiredCheckRuns(),
+    files: workflowFiles,
+  })
+  const ci = await runCiAutoReadyAfterCiWorkflow({
+    checkRuns: successfulDevelopRequiredCheckRuns(),
+    files: workflowFiles,
+  })
+
+  assert.deepEqual(standalone.graphqlCalls, ['ready'])
+  assert.deepEqual(ci.graphqlCalls, ['ready'])
+  assert.deepEqual(standalone.autoMergeMutations, [])
+  assert.deepEqual(ci.autoMergeMutations, [])
+  assert.deepEqual(standalone.labelsAdded, [
+    { issue_number: 472, labels: ['needs-codex-review'] },
+  ])
+  assert.deepEqual(ci.labelsAdded, [
+    { issue_number: 472, labels: ['needs-codex-review'] },
+  ])
+})
+
 test('auto-ready required-check snapshots stay aligned across workflows', () => {
   const standaloneScript =
     parseYaml(autoReadyWorkflowPath).jobs['auto-ready'].steps[0].with.script
@@ -2686,6 +2804,17 @@ test('auto-ready workflow skips when check/status lookup fails', async () => {
   assert.equal(result.mutations.length, 0)
   assert.equal(result.warnings.length, 1)
   assert.match(result.warnings[0], /failed to fetch checks\/statuses/)
+})
+
+test('Codex review label workflow clears review labels for collaborator approvals', async () => {
+  const result = await runCodexReviewFlagWorkflow()
+
+  assert.deepEqual(result.labelsAdded, [])
+  assert.deepEqual(result.labelsRemoved, [
+    { issue_number: 472, name: 'changes-requested' },
+    { issue_number: 472, name: 'needs-codex-review' },
+  ])
+  assert.deepEqual(result.notices, ['PR #472 cleared review-state labels after approval.'])
 })
 
 test('Codex review re-request workflow requests reviewer and notifies Discord', async () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -966,6 +966,25 @@ jobs:
               return response.data.statuses || []
             }
 
+            const listChangedFilePaths = async (pr) => {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              })
+              return files.flatMap((file) =>
+                file.status === 'renamed' && file.previous_filename
+                  ? [file.filename, file.previous_filename]
+                  : [file.filename],
+              )
+            }
+
+            const changesWorkflowFiles = async (pr) => {
+              const paths = await listChangedFilePaths(pr)
+              return paths.some((filePath) => filePath.startsWith('.github/workflows/'))
+            }
+
             const checkRunPassed = (run) =>
               run.status === 'completed' && successConclusions.has(run.conclusion)
 
@@ -1048,6 +1067,14 @@ jobs:
             }
 
             const markedReady = pr.draft === true
+            let workflowFileChanged = false
+            try {
+              workflowFileChanged = await changesWorkflowFiles(pr)
+            } catch (error) {
+              core.warning(`Skipping PR #${pr.number}: failed to fetch changed files (${error?.message || error}).`)
+              return
+            }
+
             if (markedReady) {
               try {
                 await github.graphql(
@@ -1069,13 +1096,17 @@ jobs:
               }
             }
 
-            try {
-              await enableAutoMerge(pr)
-            } catch (error) {
-              core.warning(
-                `Failed to arm auto-merge for PR #${pr.number}; ${autoReadyLabel} will retry while the label remains (${error?.message || error}).`,
-              )
-              return
+            if (!workflowFileChanged) {
+              try {
+                await enableAutoMerge(pr)
+              } catch (error) {
+                core.warning(
+                  `Failed to arm auto-merge for PR #${pr.number}; ${autoReadyLabel} will retry while the label remains (${error?.message || error}).`,
+                )
+                return
+              }
+            } else {
+              core.info(`Skipping auto-merge for workflow-file PR #${pr.number}.`)
             }
 
             try {
@@ -1088,7 +1119,11 @@ jobs:
             }
 
             const readyMessage = markedReady ? 'marked ready for review, ' : ''
-            core.notice(`PR #${pr.number} ${readyMessage}armed auto-merge, and flagged for Codex review.`)
+            if (workflowFileChanged) {
+              core.notice(`PR #${pr.number} ${readyMessage}skipped auto-merge for workflow-file PR, and flagged for Codex review.`)
+            } else {
+              core.notice(`PR #${pr.number} ${readyMessage}armed auto-merge, and flagged for Codex review.`)
+            }
 
   notify-discord:
     timeout-minutes: 5

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -26,10 +26,17 @@ jobs:
             const repo = context.repo.repo
             const reviewLabel = 'needs-codex-review'
             const changesLabel = 'changes-requested'
-            const reviewer = 'nurockplayer'
+            const trustedAuthorAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR'])
             const targetBaseBranches = new Set(['main', 'develop'])
 
             const isTargetBase = (pr) => targetBaseBranches.has(pr.base?.ref)
+
+            const isTrustedReview = (review) => {
+              const login = review.user?.login || ''
+              if (!trustedAuthorAssociations.has(review.author_association)) return false
+              if (review.user?.type === 'Bot' || login.endsWith('[bot]')) return false
+              return true
+            }
 
             const ensureLabel = async (name, color, description) => {
               try {
@@ -58,13 +65,13 @@ jobs:
               }
             }
 
-            // For schedule cron: find the last review by self (any state)
+            // For schedule cron: find the last trusted review (any state)
             // to detect whether new commits have been pushed since the last review.
-            const getLastReviewBySelf = async (pr) => {
+            const getLastTrustedReview = async (pr) => {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner, repo, pull_number: pr.number, per_page: 100,
               })
-              return [...reviews].reverse().find(r => r.user?.login === reviewer)
+              return [...reviews].reverse().find(isTrustedReview)
             }
 
             // shouldFlag is only used by the schedule cron as a fallback sweep.
@@ -80,7 +87,7 @@ jobs:
               const labels = (pr.labels || []).map(l => l.name)
               if (labels.includes(reviewLabel)) return false
 
-              const lastReview = await getLastReviewBySelf(pr)
+              const lastReview = await getLastTrustedReview(pr)
 
               // No prior Codex review means the PR likely missed the original
               // flagging event and should be put into the review queue.
@@ -119,7 +126,7 @@ jobs:
                 return
               }
 
-              if (review.user?.login !== reviewer) {
+              if (!isTrustedReview(review)) {
                 core.notice(`Ignoring review from ${review.user?.login || 'unknown reviewer'}.`)
                 return
               }

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -183,6 +183,19 @@ jobs:
               const currentReview = dismissedReview ? null : review
               const trustedReviewSummary = await fetchTrustedReviewSummary(pr, currentReview, dismissedReview)
 
+              if (context.payload.action === 'dismissed') {
+                if (trustedReviewSummary.hasChangesRequested) {
+                  await addLabels(pr.number, [reviewLabel, changesLabel])
+                  core.notice(`PR #${pr.number} flagged for Codex review after dismissal; a trusted reviewer still requests changes.`)
+                  return
+                }
+
+                await addLabels(pr.number, [reviewLabel])
+                await removeLabel(pr.number, changesLabel)
+                core.notice(`PR #${pr.number} flagged for Codex review after dismissal.`)
+                return
+              }
+
               if (trustedReviewSummary.hasChangesRequested) {
                 await addLabels(pr.number, [changesLabel])
                 await removeLabel(pr.number, reviewLabel)
@@ -194,14 +207,6 @@ jobs:
                 await removeLabel(pr.number, changesLabel)
                 await removeLabel(pr.number, reviewLabel)
                 core.notice(`PR #${pr.number} cleared review-state labels after approval.`)
-                return
-              }
-
-              if (context.payload.action === 'dismissed') {
-                // Dismissed means the review is no longer active — always re-flag.
-                await addLabels(pr.number, [reviewLabel])
-                await removeLabel(pr.number, changesLabel)
-                core.notice(`PR #${pr.number} flagged for Codex review after dismissal.`)
                 return
               }
 

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -42,11 +42,22 @@ jobs:
             const reviewSubmittedAt = (review) => (
               Date.parse(review.submitted_at || review.submittedAt || review.updated_at || review.updatedAt || '') || 0
             )
+            const isSameReview = (review, otherReview) => {
+              if (!review || !otherReview) return false
+              if (review.id && otherReview.id && review.id === otherReview.id) return true
+              if (review.node_id && otherReview.node_id && review.node_id === otherReview.node_id) return true
+              return (
+                (review.user?.login || '') === (otherReview.user?.login || '') &&
+                (review.commit_id || '') === (otherReview.commit_id || '') &&
+                (review.submitted_at || review.submittedAt || '') === (otherReview.submitted_at || otherReview.submittedAt || '') &&
+                reviewState(review) === reviewState(otherReview)
+              )
+            }
             const isReviewNewer = (review, currentReview) => (
               reviewSubmittedAt(review) >= reviewSubmittedAt(currentReview)
             )
 
-            const fetchTrustedReviewSummary = async (pr, currentReview = null) => {
+            const fetchTrustedReviewSummary = async (pr, currentReview = null, dismissedReview = null) => {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner, repo, pull_number: pr.number, per_page: 100,
               })
@@ -54,6 +65,8 @@ jobs:
               let lastTrustedReview = null
 
               for (const review of [...reviews, currentReview].filter(Boolean)) {
+                if (reviewState(review) === 'dismissed') continue
+                if (dismissedReview && isSameReview(review, dismissedReview)) continue
                 if (!isTrustedReview(review)) continue
                 const login = review.user?.login
                 if (!login) continue
@@ -166,7 +179,9 @@ jobs:
                 return
               }
 
-              const trustedReviewSummary = await fetchTrustedReviewSummary(pr, review)
+              const dismissedReview = context.payload.action === 'dismissed' ? review : null
+              const currentReview = dismissedReview ? null : review
+              const trustedReviewSummary = await fetchTrustedReviewSummary(pr, currentReview, dismissedReview)
 
               if (trustedReviewSummary.hasChangesRequested) {
                 await addLabels(pr.number, [changesLabel])

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -38,6 +38,43 @@ jobs:
               return true
             }
 
+            const reviewState = (review) => (review.state || '').toLowerCase()
+            const reviewSubmittedAt = (review) => (
+              Date.parse(review.submitted_at || review.submittedAt || review.updated_at || review.updatedAt || '') || 0
+            )
+            const isReviewNewer = (review, currentReview) => (
+              reviewSubmittedAt(review) >= reviewSubmittedAt(currentReview)
+            )
+
+            const fetchTrustedReviewSummary = async (pr, currentReview = null) => {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner, repo, pull_number: pr.number, per_page: 100,
+              })
+              const latestByReviewer = new Map()
+              let lastTrustedReview = null
+
+              for (const review of [...reviews, currentReview].filter(Boolean)) {
+                if (!isTrustedReview(review)) continue
+                const login = review.user?.login
+                if (!login) continue
+
+                if (!lastTrustedReview || isReviewNewer(review, lastTrustedReview)) {
+                  lastTrustedReview = review
+                }
+
+                const latestReview = latestByReviewer.get(login)
+                if (!latestReview || isReviewNewer(review, latestReview)) {
+                  latestByReviewer.set(login, review)
+                }
+              }
+
+              const latestReviews = [...latestByReviewer.values()]
+              return {
+                hasChangesRequested: latestReviews.some((review) => reviewState(review) === 'changes_requested'),
+                lastTrustedReview,
+              }
+            }
+
             const ensureLabel = async (name, color, description) => {
               try {
                 await github.rest.issues.getLabel({ owner, repo, name })
@@ -68,10 +105,8 @@ jobs:
             // For schedule cron: find the last trusted review (any state)
             // to detect whether new commits have been pushed since the last review.
             const getLastTrustedReview = async (pr) => {
-              const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                owner, repo, pull_number: pr.number, per_page: 100,
-              })
-              return [...reviews].reverse().find(isTrustedReview)
+              const { lastTrustedReview } = await fetchTrustedReviewSummary(pr)
+              return lastTrustedReview
             }
 
             // shouldFlag is only used by the schedule cron as a fallback sweep.
@@ -131,14 +166,16 @@ jobs:
                 return
               }
 
-              if (review.state === 'changes_requested') {
+              const trustedReviewSummary = await fetchTrustedReviewSummary(pr, review)
+
+              if (trustedReviewSummary.hasChangesRequested) {
                 await addLabels(pr.number, [changesLabel])
                 await removeLabel(pr.number, reviewLabel)
-                core.notice(`PR #${pr.number} marked as ${changesLabel}.`)
+                core.notice(`PR #${pr.number} kept ${changesLabel} because a trusted reviewer still requests changes.`)
                 return
               }
 
-              if (review.state === 'approved') {
+              if (reviewState(review) === 'approved') {
                 await removeLabel(pr.number, changesLabel)
                 await removeLabel(pr.number, reviewLabel)
                 core.notice(`PR #${pr.number} cleared review-state labels after approval.`)

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '*/10 * * * *'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, closed]
     branches: [main, develop]
   pull_request_review:
     types: [submitted, dismissed]
@@ -173,6 +173,13 @@ jobs:
               }
 
               const action = context.payload.action
+
+              if (action === 'closed') {
+                await removeLabel(pr.number, changesLabel)
+                await removeLabel(pr.number, reviewLabel)
+                core.notice(`PR #${pr.number} cleared review-state labels after close.`)
+                continue
+              }
 
               if (pr.draft) {
                 const reason = context.eventName === 'pull_request' ? `${action}` : 'schedule'


### PR DESCRIPTION
## 什麼改動
修正 auto-ready / Codex review label workflow 的三個自動化邊界：
- auto-ready PR 若修改 `.github/workflows/**`，仍可轉 ready 並標記 `needs-codex-review`，但不再由 `github-actions` 啟用 native auto-merge。
- `codex-review-flag.yml` 不再只認 `nurockplayer` 的 review，改接受 `OWNER` / `MEMBER` / `COLLABORATOR` 的非 bot review 來清理 review-state labels。
- PR closed / merged 時，自動移除 `needs-codex-review` 與 `changes-requested`，避免已關閉 PR 留著待審狀態 label。
- 補 regression tests 覆蓋 workflow-file PR 不 arm auto-merge、collaborator approval 會清 label、closed PR 會清 label。

## 為什麼
refs #660

#660 顯示 workflow-file PR 即使 checks / review / conversation 都已滿足，也可能因 `github-actions` actor 嘗試合併 workflow 檔案而卡住；同時 `needs-codex-review` label 因 review workflow 寫死 reviewer 帳號而沒有在 collaborator approval 後清掉。後續也確認 closed PR 若保留 `needs-codex-review` / `changes-requested` 會污染 review queue。本 PR 讓 workflow-file PR 保留人工 merge 路徑，並讓實際 maintainer / collaborator approval 與 PR 關閉事件正確收斂 label 狀態。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#660 follow-up
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 branch protection。
  - 不改 repository auto-merge 設定。
  - 不讓 workflow-file PR 自動 merge。
  - 不移除 `auto-ready`、`scope-violation`、`blocked-by-dependency` 等非 review-state labels。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #660 follow-up from observed auto-merge / label handling failure
- Actual worker profile(s)：
  - controller
- Model strength：
  - GPT-5.5
- Spawn directive(s)：
  - profile=controller model=gpt-5.5 reasoning=medium controller_fallback=not-needed
- Verification evidence：
  - `node --test --test-name-pattern "auto-ready workflows skip native auto-merge|Codex review label workflow clears review labels" .github/workflows/ci.test.mjs`
  - `node --test --test-name-pattern "Codex review label workflow clears review labels when PRs close" .github/workflows/ci.test.mjs`
  - `node --test .github/workflows/ci.test.mjs`
  - `git diff --check`
- Self-review / exception reason：
  - Controller implemented and self-reviewed the scoped workflow fix.
- Worker session closeout：
  - No subagent sessions were opened; controller-only workflow fix.
- Workflow friction / follow-up split：
  - n/a

## Review conversation closeout
- Unresolved threads：
  - 0 known before initial review
- CodeRabbit：
  - pending latest review after new commit
- chatgpt-codex-connector：
  - pending latest review after new commit
- Final reviewer action：
  - pending human review
- review_triage_ref：
  - Controller read #673 metadata, latest head `51f62824e2cc997cf4fd61f36203f092ac1b3c38`, Scope Police sticky comment, labels, draft state, auto-merge state, and local diff before this update.
- root_cause_gate_ref：
  - Root cause isolated to workflow automation policy: workflow-file PRs must not be native auto-merged by `github-actions`, and review-state labels needed trusted collaborator approval plus PR close lifecycle handling.
- finding_disposition_ref：
  - Implemented scoped workflow/test updates only; local workflow regression suite passed `tests 78 / pass 78 / fail 0`, and `git diff --check` passed.

## Final merge gate
- Ready-to-merge decision：
  - pending CI / human approval
- Latest head SHA：
  - 51f62824e2cc997cf4fd61f36203f092ac1b3c38
- Required checks：
  - pending after latest push
- spec workflow-check evidence：
  - n/a
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 防止 auto-ready workflow 對 workflow-file PR 啟用 native auto-merge，並讓 collaborator approval / PR close 事件正確清理 review labels。
- Approx changed lines：~280
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Workflow-file PRs are not armed for native auto-merge by auto-ready automation.
- [x] Auto-ready workflow-file PRs can still be marked ready and queued for Codex review.
- [x] Collaborator approvals clear `needs-codex-review` / `changes-requested` labels.
- [x] Closed / merged PRs clear `needs-codex-review` / `changes-requested` labels.
- [x] Regression tests cover all three behaviors.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test --test-name-pattern "auto-ready workflows skip native auto-merge|Codex review label workflow clears review labels" .github/workflows/ci.test.mjs
tests 2
pass 2
fail 0

node --test --test-name-pattern "Codex review label workflow clears review labels when PRs close" .github/workflows/ci.test.mjs
tests 1
pass 1
fail 0

node --test .github/workflows/ci.test.mjs
tests 78
pass 78
fail 0

git diff --check
pass
```

## 備註
This PR is intentionally opened without `AUTO_READY=1` because it changes workflow files and fixes the old auto-ready path that could arm native auto-merge for workflow-file PRs.

## Notes for Claude Code Review
- 請特別確認 workflow-file PR 仍會被標記 ready / `needs-codex-review`，但不會 arm native auto-merge。
- 請確認 trusted review 的範圍只包含 `OWNER` / `MEMBER` / `COLLABORATOR`，且排除 bot review。
- 請確認 PR close 事件只清 review-state labels，不動其他 workflow / scope 相關 labels。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 检测 PR 是否修改工作流文件：修改工作流文件的 PR 会跳过自动合并并保留审查标记，通知会说明已启用或已跳过自动合并。
  * 扩展受信任审核者规则：更准确处理批准、请求变更和撤销的标签变更，并在 PR 关闭时清理相关标签。
* **测试**
  * 增强自动化测试以覆盖工作流文件变更场景和审查状态处理。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/673)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->