### PR TITLE
[frontend] polish Dev Portal homepage

### DIFF
--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -1,42 +1,50 @@
 :root {
-  --ifm-color-primary: #2a6f6a;
-  --ifm-color-primary-dark: #245e5a;
-  --ifm-color-primary-darker: #205550;
-  --ifm-color-primary-darkest: #183f3c;
-  --ifm-color-primary-light: #34857f;
-  --ifm-color-primary-lighter: #419891;
-  --ifm-color-primary-lightest: #66b8b1;
-  --ifm-background-color: #f6f3ec;
-  --ifm-navbar-background-color: rgba(246, 243, 236, 0.94);
-  --ifm-font-family-base: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --ifm-heading-font-family: ui-serif, "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  --ifm-color-primary: #1f6f68;
+  --ifm-color-primary-dark: #1a5d57;
+  --ifm-color-primary-darker: #164f4a;
+  --ifm-color-primary-darkest: #103b37;
+  --ifm-color-primary-light: #2d867d;
+  --ifm-color-primary-lighter: #399a90;
+  --ifm-color-primary-lightest: #65bbb2;
+  --ifm-background-color: #f4f7f1;
+  --ifm-navbar-background-color: rgba(244, 247, 241, 0.94);
+  --ifm-font-family-base: "Avenir Next", "Segoe UI", "Noto Sans TC", sans-serif;
+  --ifm-heading-font-family: "Optima", "Avenir Next", "Noto Sans TC", sans-serif;
   --ifm-code-font-size: 92%;
   --tachigo-ink: #17201f;
-  --tachigo-muted: #52605d;
-  --tachigo-line: rgba(23, 32, 31, 0.14);
-  --tachigo-panel: rgba(255, 252, 244, 0.84);
-  --tachigo-signal: #c9483d;
-  --tachigo-amber: #bf8d2c;
-  --tachigo-cyan: #2a8b9f;
+  --tachigo-muted: #53625f;
+  --tachigo-line: rgba(23, 32, 31, 0.16);
+  --tachigo-soft-line: rgba(23, 32, 31, 0.08);
+  --tachigo-panel: rgba(255, 255, 250, 0.9);
+  --tachigo-panel-strong: #ffffff;
+  --tachigo-field: #e7ede2;
+  --tachigo-signal: #c74235;
+  --tachigo-amber: #b77b23;
+  --tachigo-cyan: #237f92;
+  --tachigo-violet: #5f5aa2;
 }
 
 [data-theme='dark'] {
-  --ifm-color-primary: #7bd2c8;
-  --ifm-color-primary-dark: #5fc8bd;
-  --ifm-color-primary-darker: #4dbeb3;
-  --ifm-color-primary-darkest: #358a82;
-  --ifm-color-primary-light: #9fe0d8;
-  --ifm-color-primary-lighter: #b7ece6;
-  --ifm-color-primary-lightest: #d6f7f3;
-  --ifm-background-color: #111816;
-  --ifm-navbar-background-color: rgba(17, 24, 22, 0.94);
-  --tachigo-ink: #edf6f3;
-  --tachigo-muted: #afc4bd;
-  --tachigo-line: rgba(237, 246, 243, 0.16);
-  --tachigo-panel: rgba(21, 31, 28, 0.88);
-  --tachigo-signal: #ff806f;
-  --tachigo-amber: #e7b85c;
-  --tachigo-cyan: #67c4d8;
+  --ifm-color-primary: #79d5c8;
+  --ifm-color-primary-dark: #5fcabd;
+  --ifm-color-primary-darker: #4bbcaf;
+  --ifm-color-primary-darkest: #348a81;
+  --ifm-color-primary-light: #a4e3db;
+  --ifm-color-primary-lighter: #bceee8;
+  --ifm-color-primary-lightest: #ddf9f5;
+  --ifm-background-color: #101513;
+  --ifm-navbar-background-color: rgba(16, 21, 19, 0.94);
+  --tachigo-ink: #edf6f2;
+  --tachigo-muted: #aebfba;
+  --tachigo-line: rgba(237, 246, 242, 0.16);
+  --tachigo-soft-line: rgba(237, 246, 242, 0.08);
+  --tachigo-panel: rgba(21, 31, 29, 0.9);
+  --tachigo-panel-strong: #17211f;
+  --tachigo-field: #1d2a27;
+  --tachigo-signal: #ff7d6f;
+  --tachigo-amber: #e5b75d;
+  --tachigo-cyan: #6fc8d9;
+  --tachigo-violet: #ada8ff;
 }
 
 .navbar {
@@ -61,60 +69,112 @@
 }
 
 .tachigo-home {
+  width: min(100%, 1180px);
   color: var(--tachigo-ink);
 }
 
 .tachigo-hero {
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 1.05fr);
-  gap: 2rem;
+  grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
+  gap: 1.2rem;
   align-items: stretch;
-  min-height: 520px;
-  margin: -1.2rem -0.2rem 2rem;
-  padding: 2.4rem;
+  min-height: 560px;
+  margin: -1.2rem -0.2rem 1.4rem;
+  padding: 1rem;
   border: 1px solid var(--tachigo-line);
   border-radius: 8px;
   background:
-    linear-gradient(135deg, rgba(42, 111, 106, 0.16), transparent 42%),
-    linear-gradient(225deg, rgba(191, 141, 44, 0.18), transparent 44%),
-    var(--tachigo-panel);
+    linear-gradient(var(--tachigo-soft-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--tachigo-soft-line) 1px, transparent 1px),
+    linear-gradient(135deg, rgba(35, 127, 146, 0.14), transparent 42%),
+    linear-gradient(315deg, rgba(199, 66, 53, 0.12), transparent 38%),
+    var(--tachigo-field);
+  background-size: 32px 32px, 32px 32px, auto, auto, auto;
+  overflow: hidden;
+}
+
+.tachigo-hero::before {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+  background:
+    linear-gradient(90deg, transparent 0 68%, rgba(23, 32, 31, 0.08) 68% 68.2%, transparent 68.2%),
+    linear-gradient(180deg, transparent 0 18%, rgba(23, 32, 31, 0.07) 18% 18.2%, transparent 18.2%);
+}
+
+.tachigo-hero__copy,
+.tachigo-topology {
+  position: relative;
+  z-index: 1;
+  border: 1px solid var(--tachigo-line);
+  border-radius: 8px;
+  background: var(--tachigo-panel);
 }
 
 .tachigo-hero__copy {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 2rem;
+  gap: 1.5rem;
+  padding: 1.35rem;
 }
 
 .tachigo-kicker {
-  margin: 0 0 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  margin: 0 0 1rem;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--tachigo-signal), var(--tachigo-line) 35%);
+  border-radius: 999px;
   color: var(--tachigo-signal);
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   font-weight: 800;
   letter-spacing: 0;
   text-transform: uppercase;
 }
 
 .tachigo-hero h1 {
+  max-width: 9ch;
   margin: 0;
-  font-size: clamp(2.6rem, 5vw, 5.8rem);
-  line-height: 0.94;
+  font-size: 4.35rem;
+  line-height: 0.96;
   letter-spacing: 0;
 }
 
 .tachigo-lede {
-  max-width: 42rem;
-  margin: 1.35rem 0 0;
+  max-width: 38rem;
+  margin: 1.2rem 0 0;
   color: var(--tachigo-muted);
-  font-size: 1.05rem;
-  line-height: 1.78;
+  font-size: 1.02rem;
+  line-height: 1.72;
+}
+
+.tachigo-status-rail {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.tachigo-status-rail span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--tachigo-line);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--tachigo-panel-strong), transparent 20%);
+  color: var(--tachigo-muted);
+  font-size: 0.78rem;
+  font-weight: 760;
 }
 
 .tachigo-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.85rem;
+  gap: 0.65rem;
 }
 
 .tachigo-action {
@@ -122,11 +182,12 @@
   align-items: center;
   justify-content: center;
   min-height: 44px;
-  padding: 0.76rem 1rem;
+  padding: 0.72rem 0.95rem;
   border: 1px solid var(--tachigo-line);
   border-radius: 6px;
   color: var(--tachigo-ink);
   font-weight: 780;
+  line-height: 1.2;
   text-decoration: none;
   transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
 }
@@ -147,43 +208,115 @@
   color: var(--ifm-background-color);
 }
 
-.tachigo-map {
+.tachigo-topology {
+  display: flex;
+  flex-direction: column;
+  padding: 0.95rem;
+}
+
+.tachigo-topology__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 48px;
+  margin-bottom: 0.8rem;
+  border-bottom: 1px solid var(--tachigo-line);
+}
+
+.tachigo-topology__header span {
+  color: var(--tachigo-signal);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.tachigo-topology__header strong {
+  max-width: 18rem;
+  text-align: right;
+  font-size: 0.92rem;
+}
+
+.tachigo-topology__grid {
+  position: relative;
   display: grid;
+  flex: 1;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  grid-template-rows: repeat(3, minmax(100px, 1fr));
+  grid-template-rows: repeat(3, minmax(118px, 1fr));
   gap: 0.8rem;
+}
+
+.tachigo-topology__grid::before {
+  position: absolute;
+  inset: 12% 10%;
+  z-index: -1;
+  border: 1px dashed color-mix(in srgb, var(--tachigo-cyan), transparent 30%);
+  border-radius: 8px;
+  content: "";
+}
+
+.tachigo-topology__grid::after {
+  position: absolute;
+  inset: 50% 8% auto;
+  height: 1px;
+  z-index: -1;
+  content: "";
+  background: linear-gradient(90deg, transparent, var(--tachigo-signal), var(--tachigo-cyan), transparent);
 }
 
 .tachigo-node {
   display: flex;
-  min-height: 96px;
+  min-height: 112px;
   flex-direction: column;
   justify-content: space-between;
   padding: 0.85rem;
   border: 1px solid var(--tachigo-line);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--tachigo-panel), transparent 12%);
+  background: color-mix(in srgb, var(--tachigo-panel-strong), transparent 8%);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-.tachigo-node strong {
-  font-size: 0.98rem;
+.tachigo-node__tag {
+  width: fit-content;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: var(--tachigo-field);
+  color: var(--tachigo-muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
 }
 
-.tachigo-node span {
+.tachigo-node strong {
+  margin-top: 0.55rem;
+  font-size: 1rem;
+}
+
+.tachigo-node span:last-child {
   color: var(--tachigo-muted);
   font-size: 0.78rem;
   line-height: 1.42;
 }
 
+.tachigo-node--viewer {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.tachigo-node--client {
+  grid-column: 1;
+  grid-row: 2;
+  border-color: color-mix(in srgb, var(--tachigo-violet), var(--tachigo-line) 45%);
+}
+
 .tachigo-node--api {
   grid-column: 2;
   grid-row: 2;
-  border-color: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 30%);
-  background: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-panel) 86%);
+  border-color: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 24%);
+  background: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-panel-strong) 86%);
 }
 
-.tachigo-node--data {
+.tachigo-node--ledger {
   grid-column: 2;
   grid-row: 3;
 }
@@ -191,30 +324,41 @@
 .tachigo-node--tachiya {
   grid-column: 3;
   grid-row: 2;
-  border-color: color-mix(in srgb, var(--tachigo-amber), var(--tachigo-line) 28%);
+  border-color: color-mix(in srgb, var(--tachigo-amber), var(--tachigo-line) 26%);
 }
 
-.tachigo-node--chain {
+.tachigo-node--external {
   grid-column: 3;
   grid-row: 3;
+  border-color: color-mix(in srgb, var(--tachigo-signal), var(--tachigo-line) 36%);
 }
 
-.tachigo-grid {
+.tachigo-route-board {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0 2.2rem;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 1.4rem 0 1rem;
 }
 
 .tachigo-card {
-  min-height: 180px;
+  display: flex;
+  min-height: 184px;
+  flex-direction: column;
+  justify-content: space-between;
   padding: 1rem;
   border: 1px solid var(--tachigo-line);
   border-radius: 8px;
   background: var(--tachigo-panel);
   color: var(--tachigo-ink);
   text-decoration: none;
-  transition: transform 160ms ease, border-color 160ms ease;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.tachigo-card--wide {
+  grid-column: span 2;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--tachigo-ink), transparent 4%), color-mix(in srgb, var(--tachigo-ink), transparent 12%));
+  color: var(--ifm-background-color);
 }
 
 .tachigo-card:hover {
@@ -224,38 +368,90 @@
   border-color: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 30%);
 }
 
+.tachigo-card--wide:hover {
+  color: var(--ifm-background-color);
+}
+
 .tachigo-card__eyebrow {
-  margin-bottom: 1.2rem;
   color: var(--tachigo-signal);
   font-size: 0.72rem;
   font-weight: 800;
   text-transform: uppercase;
 }
 
+.tachigo-card--wide .tachigo-card__eyebrow {
+  color: color-mix(in srgb, var(--tachigo-amber), #ffffff 24%);
+}
+
 .tachigo-card h2 {
-  margin: 0 0 0.55rem;
-  font-size: 1.2rem;
+  margin: 1.2rem 0 0.55rem;
+  font-size: 1.22rem;
 }
 
 .tachigo-card__body {
-  margin: 0;
   color: var(--tachigo-muted);
   font-size: 0.92rem;
   line-height: 1.58;
 }
 
+.tachigo-card--wide .tachigo-card__body {
+  color: color-mix(in srgb, var(--ifm-background-color), transparent 18%);
+}
+
+.tachigo-flow-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 1rem 0 1.2rem;
+}
+
+.tachigo-flow {
+  display: grid;
+  grid-template-columns: minmax(76px, 0.6fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: stretch;
+  min-height: 72px;
+  padding: 0.65rem;
+  border: 1px solid var(--tachigo-line);
+  border-radius: 8px;
+  background: var(--tachigo-panel);
+}
+
+.tachigo-flow span,
+.tachigo-flow strong {
+  display: inline-flex;
+  align-items: center;
+  min-height: 42px;
+  padding: 0.4rem 0.48rem;
+  border: 1px solid var(--tachigo-soft-line);
+  border-radius: 6px;
+  font-size: 0.76rem;
+  line-height: 1.25;
+}
+
+.tachigo-flow strong {
+  color: var(--tachigo-ink);
+  background: color-mix(in srgb, var(--tachigo-cyan), transparent 88%);
+}
+
+.tachigo-flow span {
+  color: var(--tachigo-muted);
+}
+
 .tachigo-band {
-  margin: 1.8rem 0;
-  padding: 1.15rem;
+  margin: 1.4rem 0 1.8rem;
+  padding: 1.05rem;
   border-left: 4px solid var(--tachigo-signal);
-  background: color-mix(in srgb, var(--tachigo-panel), transparent 15%);
+  background: color-mix(in srgb, var(--tachigo-panel), transparent 10%);
+  color: var(--tachigo-muted);
+  line-height: 1.65;
 }
 
 .tachigo-checklist {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-  margin: 1rem 0 2rem;
+  gap: 0.85rem;
+  margin: 1.2rem 0;
 }
 
 .tachigo-checklist section {
@@ -287,40 +483,90 @@
   font-weight: 760;
 }
 
-@media (max-width: 996px) {
+@media (max-width: 1120px) {
   .tachigo-hero {
     grid-template-columns: 1fr;
-    padding: 1.4rem;
   }
 
-  .tachigo-grid,
-  .tachigo-checklist {
+  .tachigo-hero h1 {
+    max-width: 14ch;
+    font-size: 3.8rem;
+  }
+
+  .tachigo-route-board {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 996px) {
+  .tachigo-hero {
+    min-height: auto;
+    padding: 0.8rem;
+  }
+
+  .tachigo-route-board,
+  .tachigo-checklist,
+  .tachigo-flow-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tachigo-card--wide {
+    grid-column: span 2;
+  }
+
+  .tachigo-flow {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 640px) {
   .tachigo-hero {
-    min-height: auto;
     margin-top: 0;
+    padding: 0.6rem;
   }
 
-  .tachigo-map {
+  .tachigo-hero__copy,
+  .tachigo-topology {
+    padding: 1rem;
+  }
+
+  .tachigo-hero h1 {
+    max-width: 12ch;
+    font-size: 2.65rem;
+  }
+
+  .tachigo-status-rail,
+  .tachigo-topology__grid,
+  .tachigo-route-board,
+  .tachigo-checklist,
+  .tachigo-flow-strip {
     grid-template-columns: 1fr;
+  }
+
+  .tachigo-topology__grid {
     grid-template-rows: none;
   }
 
   .tachigo-node,
+  .tachigo-node--viewer,
+  .tachigo-node--client,
   .tachigo-node--api,
-  .tachigo-node--data,
+  .tachigo-node--ledger,
   .tachigo-node--tachiya,
-  .tachigo-node--chain {
+  .tachigo-node--external,
+  .tachigo-card--wide {
     grid-column: auto;
     grid-row: auto;
   }
 
-  .tachigo-grid,
-  .tachigo-checklist {
-    grid-template-columns: 1fr;
+  .tachigo-topology__header {
+    display: block;
+  }
+
+  .tachigo-topology__header strong {
+    display: block;
+    max-width: none;
+    margin-top: 0.35rem;
+    text-align: left;
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,100 +16,118 @@ related_repos:
 ---
 
 <div className="tachigo-home">
-  <section className="tachigo-hero">
+  <section className="tachigo-hero" aria-labelledby="tachigo-home-title">
     <div className="tachigo-hero__copy">
       <div>
-        <div className="tachigo-kicker">Repo-first guide</div>
-        <h1>tachigo Dev Portal</h1>
-        <div className="tachigo-lede">
-          給新同事與日常開發者使用的專案導覽入口：先看系統地圖，再進 domain map，
-          最後一路點回實際 source、tests、API route 與跨 repo flow。
+        <div className="tachigo-kicker">Project navigation console</div>
+        <h1 id="tachigo-home-title">tachigo / tachiya project map</h1>
+        <div className="tachigo-lede"><span>給新同事與日常開發者使用的專案導覽入口。先建立系統 mental model， 再追 domain、flow、source、tests 與跨 repo 邊界。</span></div>
+      </div>
+
+      <div className="tachigo-status-rail" aria-label="portal status">
+        <span>source of truth</span>
+        <span>reviewed 2026-05-13</span>
+        <span>base develop</span>
+        <span>P0 onboarding</span>
+      </div>
+
+      <div className="tachigo-actions">
+        <a className="tachigo-action tachigo-action--primary" href="/tachigo/dev-portal/start-here">Start here</a>
+        <a className="tachigo-action" href="/tachigo/dev-portal/domain-maps">Domain maps</a>
+        <a className="tachigo-action" href="/tachigo/dev-portal/source-index">Source index</a>
+      </div>
+    </div>
+
+    <div className="tachigo-topology" aria-label="tachigo and tachiya topology">
+      <div className="tachigo-topology__header">
+        <span>runtime path</span>
+        <strong>viewer action to commerce boundary</strong>
+      </div>
+      <div className="tachigo-topology__grid">
+        <div className="tachigo-node tachigo-node--viewer">
+          <span className="tachigo-node__tag">entry</span>
+          <strong>Twitch</strong>
+          <span>Viewer identity, channel context, extension session</span>
+        </div>
+        <div className="tachigo-node tachigo-node--client">
+          <span className="tachigo-node__tag">frontend</span>
+          <strong>Extension + Dashboard</strong>
+          <span>Sidepanel UX, streamer operations, agency workflows</span>
+        </div>
+        <div className="tachigo-node tachigo-node--api">
+          <span className="tachigo-node__tag">core</span>
+          <strong>tachigo API</strong>
+          <span>Go boundary for auth, watch, points, spend, claims</span>
+        </div>
+        <div className="tachigo-node tachigo-node--ledger">
+          <span className="tachigo-node__tag">state</span>
+          <strong>Ledger + PostgreSQL</strong>
+          <span>Users, balances, sessions, redemptions, receipts</span>
+        </div>
+        <div className="tachigo-node tachigo-node--tachiya">
+          <span className="tachigo-node__tag">commerce</span>
+          <strong>tachiya</strong>
+          <span>FastAPI integration and Saleor protection layer</span>
+        </div>
+        <div className="tachigo-node tachigo-node--external">
+          <span className="tachigo-node__tag">edges</span>
+          <strong>Saleor + Chain</strong>
+          <span>Checkout, orders, discount application, future claims</span>
         </div>
       </div>
-      <div className="tachigo-actions">
-        <a className="tachigo-action tachigo-action--primary" href="/tachigo/dev-portal/start-here">Start onboarding path</a>
-        <a className="tachigo-action" href="/tachigo/dev-portal/domain-maps">Find a feature</a>
-        <a className="tachigo-action" href="/tachigo/dev-portal/source-index">Open source index</a>
-      </div>
-    </div>
-    <div className="tachigo-map" aria-label="tachigo system map">
-      <div className="tachigo-node">
-        <strong>Twitch</strong>
-        <span>Viewer identity, channel context, extension session</span>
-      </div>
-      <div className="tachigo-node">
-        <strong>Extension</strong>
-        <span>Sidepanel UI, heartbeat, point balance, coupon shop</span>
-      </div>
-      <div className="tachigo-node">
-        <strong>Dashboard</strong>
-        <span>Agency and streamer operations surface</span>
-      </div>
-      <div className="tachigo-node tachigo-node--api">
-        <strong>tachigo API</strong>
-        <span>Go + Gin boundary for auth, watch, points, spend, claim</span>
-      </div>
-      <div className="tachigo-node tachigo-node--data">
-        <strong>PostgreSQL</strong>
-        <span>Users, providers, watch sessions, ledger, balances, redemptions</span>
-      </div>
-      <div className="tachigo-node tachigo-node--tachiya">
-        <strong>tachiya</strong>
-        <span>FastAPI commerce integration and Saleor protection layer</span>
-      </div>
-      <div className="tachigo-node">
-        <strong>Saleor</strong>
-        <span>Checkout, orders, discount application</span>
-      </div>
-      <div className="tachigo-node tachigo-node--chain">
-        <strong>Chain</strong>
-        <span>Future claim / soulbound token surface</span>
-      </div>
     </div>
   </section>
 
-  <section className="tachigo-grid" aria-label="primary guide cards">
-    <a className="tachigo-card" href="/tachigo/dev-portal/start-here">
-      <div className="tachigo-card__eyebrow">01</div>
-      <h2>Onboarding</h2>
-      <div className="tachigo-card__body">First hour、first day、first PR：照著走，先建立正確 mental model。</div>
+  <section className="tachigo-route-board" aria-label="primary guide routes">
+    <a className="tachigo-card tachigo-card--wide" href="/tachigo/dev-portal/start-here">
+      <span className="tachigo-card__eyebrow">01 / first hour</span>
+      <h2>Onboarding path</h2>
+      <span className="tachigo-card__body">先看系統地圖、開發環境、第一個 PR 的安全路徑。</span>
     </a>
     <a className="tachigo-card" href="/tachigo/dev-portal/domain-maps">
-      <div className="tachigo-card__eyebrow">02</div>
-      <h2>Domain Maps</h2>
-      <div className="tachigo-card__body">Points、Auth、Extension 三個 P0 domain 的 source、tests、routes 與踩雷點。</div>
+      <span className="tachigo-card__eyebrow">02 / domains</span>
+      <h2>Domain maps</h2>
+      <span className="tachigo-card__body">Points、Auth、Extension 的 source、routes、tests 與風險。</span>
+    </a>
+    <a className="tachigo-card" href="/tachigo/dev-portal/flows">
+      <span className="tachigo-card__eyebrow">03 / cross repo</span>
+      <h2>Flow traces</h2>
+      <span className="tachigo-card__body">watch-to-points、spend-to-tachiya、claim flow 的邊界。</span>
     </a>
     <a className="tachigo-card" href="/tachigo/dev-portal/daily-dev-guide">
-      <div className="tachigo-card__eyebrow">03</div>
-      <h2>Daily Dev</h2>
-      <div className="tachigo-card__body">「我要改 X」時該從哪裡打開、跑哪些測試、PR scope 要怎麼守住。</div>
+      <span className="tachigo-card__eyebrow">04 / daily work</span>
+      <h2>Daily dev</h2>
+      <span className="tachigo-card__body">改功能前先定位 owner、測試、PR scope 與 rollback path。</span>
     </a>
     <a className="tachigo-card" href="/tachigo/dev-portal/graph-explorer">
-      <div className="tachigo-card__eyebrow">04</div>
-      <h2>Graph Explorer</h2>
-      <div className="tachigo-card__body">把 graphify 當成影響範圍雷達，而不是架構真相本身。</div>
+      <span className="tachigo-card__eyebrow">05 / radar</span>
+      <h2>Graph explorer</h2>
+      <span className="tachigo-card__body">把 graphify 當成影響範圍雷達，而不是架構真相本身。</span>
     </a>
   </section>
-</div>
 
-## 這個入口怎麼用
+  <section className="tachigo-flow-strip" aria-label="frequent development flows">
+    <div className="tachigo-flow"><span>watch</span><strong>Extension heartbeat</strong><span>API session</span><span>points ledger</span></div>
+    <div className="tachigo-flow"><span>spend</span><strong>balance check</strong><span>tachiya handoff</span><span>Saleor order</span></div>
+    <div className="tachigo-flow"><span>review</span><strong>domain map</strong><span>source index</span><span>targeted tests</span></div>
+  </section>
 
-<div className="tachigo-checklist">
-  <section>
-    <h2>新同事</h2>
-    <div className="tachigo-checklist__body">從 <a href="/tachigo/dev-portal/start-here">Start Here</a> 開始，先理解主要系統，再挑一條 flow 追 source。</div>
+  <section className="tachigo-checklist" aria-label="entry points by role">
+    <section>
+      <h2>新同事</h2>
+      <div className="tachigo-checklist__body"><span>從 </span><a href="/tachigo/dev-portal/start-here">Start Here</a><span> 進入，先跑完 first-hour route。</span></div>
+    </section>
+    <section>
+      <h2>日常開發</h2>
+      <div className="tachigo-checklist__body"><span>從 </span><a href="/tachigo/dev-portal/daily-dev-guide">Daily Dev Guide</a><span> 找改動入口，再回 domain map。</span></div>
+    </section>
+    <section>
+      <h2>架構 review</h2>
+      <div className="tachigo-checklist__body"><span>從 </span><a href="/tachigo/dev-portal/flows">Cross-Repo Flows</a><span> 判斷是否碰到 repo、權限或 ledger 邊界。</span></div>
+    </section>
   </section>
-  <section>
-    <h2>日常開發</h2>
-    <div className="tachigo-checklist__body">從 <a href="/tachigo/dev-portal/daily-dev-guide">Daily Dev Guide</a> 找改動入口，再用 Domain Maps 確認測試。</div>
-  </section>
-  <section>
-    <h2>架構 review</h2>
-    <div className="tachigo-checklist__body">從 <a href="/tachigo/dev-portal/flows">Cross-Repo Flows</a> 判斷改動是否跨 repo、跨權限或跨 ledger。</div>
-  </section>
-</div>
 
-<div className="tachigo-band">
-  Markdown 仍是 source of truth。既有 docs taxonomy、文件狀態說明與 source links 已搬到
-  <a href="/tachigo/dev-portal/source-index"> Source Index</a>；這個首頁只保留導覽任務。
+  <div className="tachigo-band">
+    <span>Markdown 仍是 source of truth。既有 docs taxonomy、文件狀態說明與 source links 已搬到 </span><a href="/tachigo/dev-portal/source-index">Source Index</a><span>；首頁只負責導覽決策。</span>
+  </div>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ related_repos:
       <div>
         <div className="tachigo-kicker">Project navigation console</div>
         <h1 id="tachigo-home-title">tachigo / tachiya project map</h1>
-        <div className="tachigo-lede"><span>給新同事與日常開發者使用的專案導覽入口。先建立系統 mental model， 再追 domain、flow、source、tests 與跨 repo 邊界。</span></div>
+        <div className="tachigo-lede"><span>給新同事與日常開發者使用的專案導覽入口。先建立系統 mental model，再追 domain、flow、source、tests 與跨 repo 邊界。</span></div>
       </div>
 
       <div className="tachigo-status-rail" aria-label="portal status">


### PR DESCRIPTION
## 什麼改動
把 Dev Portal 首頁從預設 docs 入口打磨成更像專案導覽網站的 first screen：加入 tachigo / tachiya runtime map、route cards、常用 flow strip、role-based 入口與更完整的首頁 CSS。

## 為什麼
refs #674。#679 已建立 Dev Portal 內容骨架，這個 PR 專注補上首頁視覺層級與導覽體驗，讓新同事與日常開發者能更快理解專案架構。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#674
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 Docusaurus routing、sidebar structure 或 docs plugin 設定。
  - 不新增外部 dependency、圖片 asset 或 runtime feature。
  - 不修改 tachigo / tachiya product code。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #674
- Actual worker profile(s)：
  - controller self-review only
- Model strength：
  - controller = high
- Spawn directive(s)：
  - n/a; trivial/self-only docs homepage polish
- Verification evidence：
  - `pnpm build:docs` pass
  - `git diff --check` pass
  - Browser smoke check at `http://localhost:51774/tachigo/`
- Self-review / exception reason：
  - trivial/self-only exception reason: docs homepage visual polish touched only `docs/index.md` and `apps/docs/src/css/custom.css`, so no worker delegation was needed.
- Worker session closeout：
  - Self-review completed; no worker sessions were opened for this scoped docs-site polish.
- Workflow friction / follow-up split：
  - n/a; kept under Scope Police 600-line soft warning and limited to one docs-site surface.

## Review conversation closeout
- Unresolved threads：
  - 0; initial PR has no review threads yet.
- CodeRabbit：
  - n/a; no review has run yet.
- chatgpt-codex-connector：
  - n/a; no review has run yet.
- review_triage_ref：
  - pending with reason: initial PR before reviewer feedback.
- root_cause_gate_ref：
  - pending with reason: initial PR before reviewer feedback.
- finding_disposition_ref：
  - pending with reason: initial PR before reviewer feedback.
- Final reviewer action：
  - n/a; awaiting reviewer feedback.

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: initial PR before remote checks and human review.
- Latest head SHA：
  - n/a; will be available after push.
- Required checks：
  - pending with reason: PR not opened yet.
- spec workflow-check evidence：
  - n/a; manual checklist for #674 docs-site polish.
- Evidence URL：
  - n/a; initial PR body.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Polish the Dev Portal homepage into a high-signal project navigation entry.
- Approx changed lines：~588; docs homepage markup and matching CSS need to be reviewed together, and this stays below the Scope Police 600-line soft warning.
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] AC 1：Dev Portal homepage clearly presents tachigo / tachiya project map and primary guide routes.
- [x] AC 2：Homepage remains repo-first and links to Start Here, Domain Maps, Source Index, Flows, Daily Dev Guide, and Graph Explorer.
- [x] AC 3：Docs build passes and page is visually smoke-tested in browser.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
pnpm build:docs
PASS: Docusaurus production build generated static files successfully.

git diff --check
PASS: no whitespace errors.

Browser smoke check
PASS: http://localhost:51774/tachigo/ rendered the new homepage with project map, route cards, flow strip, and role entries.
```

## 備註
No dependency, lockfile, or generated build output changes.

## Notes for Claude Code Review
- Please focus review on information hierarchy, scope cleanliness, and whether the homepage now works as a polished project navigation entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 文档首页重构：引入“Dev Portal”风格英雄区、运行时拓扑视图与路由板块
  * 新增“常用开发流程”条与更新后的卡片/广域卡片展示

* **样式优化**
  * 更新主题色彩与面板/按钮样式
  * 大幅重做布局与响应式规则，改进不同断点下的版式与间距调整
* **内容更新**
  * 调整首页 CTA 文案与卡片副文本，重写角色检查清单条目

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/680)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->