### PR TITLE
[backend] Propagate watch request context

### DIFF
--- a/services/api/internal/handlers/watch_handler.go
+++ b/services/api/internal/handlers/watch_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -12,7 +13,7 @@ import (
 )
 
 type watchPointsService interface {
-	AddHeartbeatTime(userID uuid.UUID, channelID string, seconds int64) error
+	AddHeartbeatTimeContext(ctx context.Context, userID uuid.UUID, channelID string, seconds int64) error
 }
 
 type WatchHandler struct {
@@ -42,7 +43,7 @@ func (h *WatchHandler) StartSession(c *gin.Context) {
 		return
 	}
 
-	session, err := h.watchSvc.StartSession(userID, body.ChannelID)
+	session, err := h.watchSvc.StartSessionContext(c.Request.Context(), userID, body.ChannelID)
 	if err != nil {
 		internal(c)
 		return
@@ -64,7 +65,7 @@ func (h *WatchHandler) Heartbeat(c *gin.Context) {
 		return
 	}
 
-	result, err := h.watchSvc.Heartbeat(userID, body.ChannelID)
+	result, err := h.watchSvc.HeartbeatContext(c.Request.Context(), userID, body.ChannelID)
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSession) {
 			badRequest(c, "no active session")
@@ -75,7 +76,7 @@ func (h *WatchHandler) Heartbeat(c *gin.Context) {
 	}
 
 	if result.DeltaSeconds > 0 {
-		if err := h.pointsSvc.AddHeartbeatTime(userID, body.ChannelID, result.DeltaSeconds); err != nil {
+		if err := h.pointsSvc.AddHeartbeatTimeContext(c.Request.Context(), userID, body.ChannelID, result.DeltaSeconds); err != nil {
 			internal(c)
 			return
 		}
@@ -101,7 +102,7 @@ func (h *WatchHandler) EndSession(c *gin.Context) {
 		return
 	}
 
-	if err := h.watchSvc.EndSession(userID, body.ChannelID); err != nil {
+	if err := h.watchSvc.EndSessionContext(c.Request.Context(), userID, body.ChannelID); err != nil {
 		internal(c)
 		return
 	}
@@ -122,7 +123,7 @@ func (h *WatchHandler) Click(c *gin.Context) {
 		return
 	}
 
-	result, err := h.watchSvc.RecordClick(userID, body.ChannelID)
+	result, err := h.watchSvc.RecordClickContext(c.Request.Context(), userID, body.ChannelID)
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSession) {
 			badRequest(c, "no active session")
@@ -160,7 +161,7 @@ func (h *WatchHandler) GetBalance(c *gin.Context) {
 		return
 	}
 
-	spendable, cumulative, err := h.watchSvc.GetBalance(userID, channelID)
+	spendable, cumulative, err := h.watchSvc.GetBalanceContext(c.Request.Context(), userID, channelID)
 	if err != nil {
 		internal(c)
 		return

--- a/services/api/internal/handlers/watch_handler_test.go
+++ b/services/api/internal/handlers/watch_handler_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -48,9 +49,11 @@ func newWatchTestEnv(t *testing.T) *watchEnv {
 
 type failingPointsService struct {
 	addHeartbeatTimeErr error
+	gotContext          context.Context
 }
 
-func (s *failingPointsService) AddHeartbeatTime(uuid.UUID, string, int64) error {
+func (s *failingPointsService) AddHeartbeatTimeContext(ctx context.Context, _ uuid.UUID, _ string, _ int64) error {
+	s.gotContext = ctx
 	return s.addHeartbeatTimeErr
 }
 
@@ -197,6 +200,40 @@ func TestWatchHandler_Heartbeat_PointsServiceFailure_Returns500(t *testing.T) {
 	}
 	if resp.Error != "internal server error" {
 		t.Fatalf("expected internal server error, got %q", resp.Error)
+	}
+}
+
+type watchHandlerContextKey string
+
+func TestWatchHandler_Heartbeat_PassesRequestContextToPointsService(t *testing.T) {
+	base := newTestEnv(t)
+	watchSvc := services.NewWatchService(base.db)
+	pointsSvc := &failingPointsService{}
+	watchH := handlers.NewWatchHandler(watchSvc, pointsSvc)
+
+	watch := base.router.Group("/api/v1/extension/watch")
+	watch.Use(middleware.JWTAuth(base.authSvc))
+	watch.POST("/heartbeat", watchH.Heartbeat)
+
+	e := &watchEnv{testEnv: base, watchSvc: watchSvc}
+	channelID := "ch_test_context"
+	userID, token := e.registerViewer(t, "ctx")
+	e.seedActiveSession(t, userID, channelID, 30)
+
+	key := watchHandlerContextKey("request-context")
+	body, _ := json.Marshal(map[string]string{"channel_id": channelID})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/extension/watch/heartbeat", bytes.NewReader(body)).
+		WithContext(context.WithValue(context.Background(), key, "watch-request"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	base.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if pointsSvc.gotContext == nil || pointsSvc.gotContext.Value(key) != "watch-request" {
+		t.Fatal("expected heartbeat handler to pass request context to points service")
 	}
 }
 

--- a/services/api/internal/services/context_probe_test.go
+++ b/services/api/internal/services/context_probe_test.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+func installDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Create().Before("gorm:create").Register(name+":create", probe); err != nil {
+		t.Fatalf("register create context probe: %v", err)
+	}
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+	if err := db.Callback().Update().Before("gorm:update").Register(name+":update", probe); err != nil {
+		t.Fatalf("register update context probe: %v", err)
+	}
+	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", probe); err != nil {
+		t.Fatalf("register raw context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Create().Remove(name + ":create")
+		_ = db.Callback().Query().Remove(name + ":query")
+		_ = db.Callback().Update().Remove(name + ":update")
+		_ = db.Callback().Raw().Remove(name + ":raw")
+	})
+
+	return func() int {
+		return seen
+	}
+}

--- a/services/api/internal/services/points_service.go
+++ b/services/api/internal/services/points_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -54,6 +55,13 @@ type PointsService struct {
 
 func NewPointsService(db *gorm.DB, watchSvc *WatchService) *PointsService {
 	return &PointsService{db: db, watchSvc: watchSvc}
+}
+
+func (s *PointsService) dbWithContext(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.db.WithContext(ctx)
 }
 
 // GetBalance wraps WatchService.GetBalance and returns a PointsBalance struct.
@@ -297,7 +305,11 @@ func (s *PointsService) addBroadcastTime(db *gorm.DB, channelID string, seconds 
 // AddHeartbeatTime atomically accumulates viewer watch time and broadcaster
 // broadcast time for a single heartbeat delta.
 func (s *PointsService) AddHeartbeatTime(userID uuid.UUID, channelID string, seconds int64) error {
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	return s.AddHeartbeatTimeContext(context.Background(), userID, channelID, seconds)
+}
+
+func (s *PointsService) AddHeartbeatTimeContext(ctx context.Context, userID uuid.UUID, channelID string, seconds int64) error {
+	return s.dbWithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := s.addWatchTime(tx, userID, channelID, seconds); err != nil {
 			return err
 		}

--- a/services/api/internal/services/points_service_test.go
+++ b/services/api/internal/services/points_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+type pointsContextKey string
 
 // newPointsSvc creates a PointsService backed by an in-memory SQLite test DB.
 func newPointsSvc(t *testing.T) (*PointsService, *WatchService) {
@@ -578,6 +581,23 @@ func TestPointsService_AddBroadcastTime_WritesLogAndStat(t *testing.T) {
 	svc.db.Raw("SELECT COUNT(*) FROM broadcast_time_logs WHERE streamer_id = ?", streamerID).Scan(&count)
 	if count != 2 {
 		t.Errorf("broadcast_time_logs: want 2 entries, got %d", count)
+	}
+}
+
+func TestPointsService_AddHeartbeatTimeContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+	channelID := "ch_context"
+	seedStreamer(t, svc, channelID)
+	key := pointsContextKey("add-heartbeat-time-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-heartbeat")
+
+	err := svc.AddHeartbeatTimeContext(context.WithValue(context.Background(), key, "points-heartbeat"), userID, channelID, 30)
+	if err != nil {
+		t.Fatalf("add heartbeat time with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected AddHeartbeatTimeContext DB operations to carry request context")
 	}
 }
 

--- a/services/api/internal/services/watch_service.go
+++ b/services/api/internal/services/watch_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"math"
 	"time"
@@ -47,6 +48,13 @@ func NewWatchService(db *gorm.DB) *WatchService {
 	return &WatchService{db: db}
 }
 
+func (s *WatchService) dbWithContext(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.db.WithContext(ctx)
+}
+
 // StartSession returns or creates an active watch session.
 //   - active and not stale → return existing session
 //   - active but stale     → close old session, create new
@@ -56,9 +64,13 @@ func NewWatchService(db *gorm.DB) *WatchService {
 // with a row-level lock so concurrent requests cannot race into the partial-unique
 // index constraint on (user_id, channel_id) WHERE is_active = true.
 func (s *WatchService) StartSession(userID uuid.UUID, channelID string) (*models.WatchSession, error) {
+	return s.StartSessionContext(context.Background(), userID, channelID)
+}
+
+func (s *WatchService) StartSessionContext(ctx context.Context, userID uuid.UUID, channelID string) (*models.WatchSession, error) {
 	var result models.WatchSession
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.dbWithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var session models.WatchSession
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 			Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
@@ -130,9 +142,13 @@ type HeartbeatResult struct {
 //   - PointsLedger is updated via an atomic INSERT … ON CONFLICT DO UPDATE, which
 //     prevents balance overwrites under concurrent writes.
 func (s *WatchService) Heartbeat(userID uuid.UUID, channelID string) (*HeartbeatResult, error) {
+	return s.HeartbeatContext(context.Background(), userID, channelID)
+}
+
+func (s *WatchService) HeartbeatContext(ctx context.Context, userID uuid.UUID, channelID string) (*HeartbeatResult, error) {
 	var result HeartbeatResult
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.dbWithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Lock the row so concurrent heartbeats queue up rather than racing.
 		var session models.WatchSession
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -238,8 +254,12 @@ func (s *WatchService) Heartbeat(userID uuid.UUID, channelID string) (*Heartbeat
 // EndSession marks the viewer's active session in the given channel as ended.
 // If no active session exists the call is a no-op (idempotent).
 func (s *WatchService) EndSession(userID uuid.UUID, channelID string) error {
+	return s.EndSessionContext(context.Background(), userID, channelID)
+}
+
+func (s *WatchService) EndSessionContext(ctx context.Context, userID uuid.UUID, channelID string) error {
 	now := time.Now()
-	return s.db.Model(&models.WatchSession{}).
+	return s.dbWithContext(ctx).Model(&models.WatchSession{}).
 		Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
 		Updates(map[string]interface{}{
 			"is_active": false,
@@ -262,9 +282,13 @@ type ClickResult struct {
 //
 // Concurrency: SELECT FOR UPDATE on the session row serialises concurrent clicks.
 func (s *WatchService) RecordClick(userID uuid.UUID, channelID string) (*ClickResult, error) {
+	return s.RecordClickContext(context.Background(), userID, channelID)
+}
+
+func (s *WatchService) RecordClickContext(ctx context.Context, userID uuid.UUID, channelID string) (*ClickResult, error) {
 	var result ClickResult
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.dbWithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var session models.WatchSession
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 			Where("user_id = ? AND channel_id = ? AND is_active = true", userID, channelID).
@@ -326,8 +350,12 @@ func (s *WatchService) RecordClick(userID uuid.UUID, channelID string) (*ClickRe
 // GetBalance returns the viewer's current spendable balance and cumulative total
 // for the given channel. Returns (0, 0, nil) if no ledger exists yet.
 func (s *WatchService) GetBalance(userID uuid.UUID, channelID string) (spendable, cumulative int64, err error) {
+	return s.GetBalanceContext(context.Background(), userID, channelID)
+}
+
+func (s *WatchService) GetBalanceContext(ctx context.Context, userID uuid.UUID, channelID string) (spendable, cumulative int64, err error) {
 	var ledger models.PointsLedger
-	if err := s.db.Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
+	if err := s.dbWithContext(ctx).Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return 0, 0, nil
 		}

--- a/services/api/internal/services/watch_service_test.go
+++ b/services/api/internal/services/watch_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"math"
 	"testing"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+type watchContextKey string
 
 // seedWatchUser inserts a minimal users row so FK constraints pass in watch tests.
 func seedWatchUser(t *testing.T, svc *WatchService) uuid.UUID {
@@ -44,6 +47,86 @@ func reloadSession(t *testing.T, svc *WatchService, id uuid.UUID) *models.WatchS
 		t.Fatalf("reload session: %v", err)
 	}
 	return &s
+}
+
+func TestStartSessionContext_UsesRequestContext(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	key := watchContextKey("start-session-context")
+	seen := installDBContextProbe(t, svc.db, key, "watch-start")
+
+	_, err := svc.StartSessionContext(context.WithValue(context.Background(), key, "watch-start"), userID, "ch_context")
+	if err != nil {
+		t.Fatalf("start session with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected StartSessionContext DB operations to carry request context")
+	}
+}
+
+func TestHeartbeatContext_UsesRequestContext(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	channelID := "ch_context"
+	s, _ := svc.StartSession(userID, channelID)
+	backdateHeartbeat(t, svc, s.ID, 25*time.Second)
+	key := watchContextKey("heartbeat-context")
+	seen := installDBContextProbe(t, svc.db, key, "watch-heartbeat")
+
+	_, err := svc.HeartbeatContext(context.WithValue(context.Background(), key, "watch-heartbeat"), userID, channelID)
+	if err != nil {
+		t.Fatalf("heartbeat with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected HeartbeatContext DB operations to carry request context")
+	}
+}
+
+func TestEndSessionContext_UsesRequestContext(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	channelID := "ch_context"
+	svc.StartSession(userID, channelID)
+	key := watchContextKey("end-session-context")
+	seen := installDBContextProbe(t, svc.db, key, "watch-end")
+
+	if err := svc.EndSessionContext(context.WithValue(context.Background(), key, "watch-end"), userID, channelID); err != nil {
+		t.Fatalf("end session with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected EndSessionContext DB operations to carry request context")
+	}
+}
+
+func TestRecordClickContext_UsesRequestContext(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	channelID := "ch_context"
+	svc.StartSession(userID, channelID)
+	key := watchContextKey("record-click-context")
+	seen := installDBContextProbe(t, svc.db, key, "watch-click")
+
+	if _, err := svc.RecordClickContext(context.WithValue(context.Background(), key, "watch-click"), userID, channelID); err != nil {
+		t.Fatalf("record click with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected RecordClickContext DB operations to carry request context")
+	}
+}
+
+func TestGetBalanceContext_UsesRequestContext(t *testing.T) {
+	svc := NewWatchService(newTestDB(t))
+	userID := seedWatchUser(t, svc)
+	key := watchContextKey("get-balance-context")
+	seen := installDBContextProbe(t, svc.db, key, "watch-balance")
+
+	_, _, err := svc.GetBalanceContext(context.WithValue(context.Background(), key, "watch-balance"), userID, "ch_context")
+	if err != nil {
+		t.Fatalf("get balance with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetBalanceContext DB operations to carry request context")
+	}
 }
 
 // ─── StartSession ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 什麼改動
新增 watch request path 的 context-aware DB entrypoints，讓 extension watch handler 把 `c.Request.Context()` 傳入 watch / heartbeat aggregation service 層。

## 為什麼
refs #645

#645 要逐步把 request timeout cancellation 傳到 service-layer DB access。本 PR 只處理 extension watch flow 的最小可獨立切片：`WatchService` methods 與 heartbeat 後的 `PointsService.AddHeartbeatTime` aggregation，不處理 repo-wide service audit。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不宣稱完成 #645 的 repo-wide DB context audit。
  - 不修改 timeout policy values。
  - 不修改 schema / migration。
  - 不修改 points ledger reward rules 或 balance semantics。
  - 不修改 StreamerService / ClaimService / SpendService / AuthService context propagation。
  - 不修改 frontend 或 API response shape。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request context propagation follow-up；本輪選擇 extension watch request path 作為單一小切片。
- Actual worker profile(s)：
  - controller + low-risk read-only sidecar
- Model strength：
  - main agent = GPT-5.5 xhigh；sidecar = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=repo_scout model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied purpose=read-only service-slice scan for #645; public_write=denied; code_edit=denied
- Verification evidence：
  - `gofmt` pass
  - `git diff --check` pass
  - focused service / handler Go tests attempted; blocked locally by sandbox Go module cache lock / DNS, to be covered by GitHub CI
- Self-review / exception reason：
  - high-risk points/watch path kept under main controller review; sidecar only recommended slice and did not edit or decide.
- Worker session closeout：
  - Sidecar completed read-only scan; no open worker sessions remain.
- Workflow friction / follow-up split：
  - #645 remains open for further service slices and integration timeout cancellation proof.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: initial PR before reviewer feedback.
- CodeRabbit：
  - pending with reason: initial PR before automated review.
- chatgpt-codex-connector：
  - pending with reason: initial PR before automated review.
- review_triage_ref：
  - pending with reason: initial PR before reviewer feedback.
- root_cause_gate_ref：
  - #645 root cause is request timeout middleware already sets request context, but service DB entrypoints must use `WithContext(ctx)`.
- finding_disposition_ref：
  - pending with reason: initial PR before reviewer feedback.
- Final reviewer action：
  - pending with reason: initial PR before reviewer feedback.

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: remote CI and review have not run yet.
- Latest head SHA：
  - 4069df52
- Required checks：
  - pending with reason: PR not opened yet.
- spec workflow-check evidence：
  - manual checklist for #645 watch request path slice; spec workflow-check not used.
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through extension watch DB operations and heartbeat aggregation.
- Approx changed lines：~230
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler request context handoff、WatchService DB context propagation、heartbeat aggregation context propagation 與 regression tests 是同一條 extension watch request path；拆開會讓 route 仍有部分 DB work 不受 request cancellation 控制。
- 若已拆分，相關 PR：
  - #666 AddressService slice；#685 ChannelConfigService slice；本 PR 是 #645 的下一個獨立 watch slice。

## Acceptance Criteria
- [x] WatchService DB reads/writes now have context-aware entrypoints using `WithContext(ctx)`.
- [x] Extension watch handler passes `c.Request.Context()` into watch DB operations.
- [x] Heartbeat watch-time aggregation has a context-aware `AddHeartbeatTimeContext` path.
- [x] Added regression tests for DB statement context propagation and handler request context handoff.
- [ ] Full #645 repo-wide DB query audit remains open for later slices.
- [ ] Integration test proving timeout cancels DB work remains open for later slices.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk gofmt -w services/api/internal/services/watch_service.go services/api/internal/services/points_service.go services/api/internal/handlers/watch_handler.go services/api/internal/services/context_probe_test.go services/api/internal/services/watch_service_test.go services/api/internal/services/points_service_test.go services/api/internal/handlers/watch_handler_test.go
PASS

rtk git --no-optional-locks diff --check
PASS: no output

rtk env GOCACHE=/private/tmp/tachigo-go-build-cache go test ./internal/services -run 'Test(StartSessionContext|HeartbeatContext|EndSessionContext|RecordClickContext|GetBalanceContext|PointsService_AddHeartbeatTimeContext|StartSession_CreatesNewSession|Heartbeat_AwardsPointsAt60Seconds|RecordClick_AwardsPoint|GetBalance_NoLedger)' -count=1
BLOCKED locally: default GOMODCACHE cannot create go.opentelemetry.io/otel@v1.43.0 lock files under sandbox.

rtk env GOMODCACHE=/private/tmp/tachigo-go-mod-cache GOCACHE=/private/tmp/tachigo-go-build-cache go test ./internal/services -run '...' -count=1
BLOCKED locally: sandbox DNS cannot resolve proxy.golang.org to populate writable module cache.

rtk env GOCACHE=/private/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestWatchHandler_Heartbeat_(PassesRequestContextToPointsService|AccumulatesWatchTime|PointsServiceFailure_Returns500)' -count=1
BLOCKED locally: same GOMODCACHE lock issue.
```

## 備註
Legacy non-context methods remain as compatibility wrappers using `context.Background()`.

## Notes for Claude Code Review
- 請特別確認這張 PR 只處理 extension watch request path；#645 不應因此關閉。
- 這條路徑碰到 watch sessions / points ledger / heartbeat aggregation，因此請注意 transaction context 是否完整帶到 `tx`。
- 本地 Go test 被 sandbox module cache / DNS 擋住；請以 GitHub CI 作為最終測試來源。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 改进了内部服务中的请求上下文处理机制，增强了数据库操作的上下文追踪能力。

* **测试**
  * 新增测试覆盖，验证请求上下文在心跳、会话和操作流程中的正确传播。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/686)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->