### PR TITLE
[frontend] Refresh generated OpenAPI shared types

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -312,6 +312,12 @@ export interface ApiOperations {
     };
     response: HandlersResponse;
   };
+  "POST /dashboard/raffles/{id}/activate": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
   "POST /dashboard/raffles/{id}/complete": {
     pathParams: {
       id: string;


### PR DESCRIPTION
## 什麼改動
刷新 `packages/shared-types/src/index.ts` 的 generated OpenAPI TypeScript contract，補上已存在於 backend Swagger artifact 的 `POST /dashboard/raffles/{id}/activate` operation。

## 為什麼
refs #401

`services/api/docs/swagger.json` 已包含 dashboard raffle activate endpoint，但 committed shared types 落後，導致 `pnpm api:types:check` 失敗。本 PR 只修正 generated artifact drift，讓 frontend-facing contract 回到可重複產生狀態。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#401
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 frontend runtime API client 或 axios/fetch 行為。
  - 不新增 CI policy / workflow guardrail。
  - 不修改 backend Swagger annotations 或 `swag init` output。
  - 不導入新的 external dependency。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #401 OpenAPI codegen flow rollout；本輪只處理 committed generated types drift。
- Actual worker profile(s)：
  - controller self-only
- Model strength：
  - main agent = GPT-5.5 xhigh
- Spawn directive(s)：
  - profile=self-only model=gpt-5.5 reasoning=xhigh controller_fallback=allowed fallback_reason=generated-artifact-only drift fix; public_write=controller-owned
- Verification evidence：
  - `pnpm api:types:check` RED: `src/index.ts is out of date`
  - `pnpm api:types:generate`
  - `pnpm api:types:check` pass
  - `pnpm --filter @tachigo/shared-types test` pass
  - `pnpm api:client:test` pass
  - `git diff --check` pass
- Self-review / exception reason：
  - Diff is generated-only and limited to one `ApiOperations` entry; no subagent needed.
- Worker session closeout：
  - No worker sessions were opened.
- Workflow friction / follow-up split：
  - CI drift guardrail remains a separate #401 follow-up because it touches CI policy.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: initial PR before reviewer feedback.
- CodeRabbit：
  - pending with reason: initial PR before automated review.
- chatgpt-codex-connector：
  - pending with reason: initial PR before reviewer feedback.
- review_triage_ref：
  - pending with reason: initial PR before reviewer feedback.
- root_cause_gate_ref：
  - drift was detected by existing `api:types:check`; committed generated file lagged behind backend Swagger artifact.
- finding_disposition_ref：
  - adopted: regenerate shared types only; deferred CI workflow guardrail to later #401 slice.
- Final reviewer action：
  - pending with reason: initial PR before reviewer feedback.

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: remote CI and review have not run yet.
- Latest head SHA：
  - n/a; will be available after push.
- Required checks：
  - pending with reason: PR not opened yet.
- spec workflow-check evidence：
  - manual checklist for #401 generated types drift; spec workflow-check not used.
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Refresh generated OpenAPI shared types so they match committed backend Swagger schema.
- Approx changed lines：~6
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #649 shared-types scaffold；#656 api-client scaffold。CI guardrail / frontend runtime adoption 留待後續 #401 小切片。

## Acceptance Criteria
- [x] backend schema changes can be regenerated repeatably
- [x] generated TS artifacts stay aligned with committed Swagger schema for the activate raffle endpoint
- [ ] generated TS artifacts can be consumed by current frontend apps
- [ ] CI or linting prevents silent contract drift

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk pnpm api:types:check
RED: src/index.ts is out of date. Run pnpm api:types:generate.

rtk pnpm api:types:generate
PASS

rtk pnpm api:types:check
PASS

rtk pnpm --filter @tachigo/shared-types test
PASS: 2 tests, 0 fail

rtk pnpm api:client:test
PASS: 8 tests, 0 fail

rtk git --no-optional-locks diff --check
PASS: no output
```

## 備註
這張 PR 是 generated-only drift fix。`/dashboard/raffles/{id}/activate` 已在 `services/api/docs/swagger.json`，本 PR 不改 backend contract。

## Notes for Claude Code Review
- 請確認 diff 只新增 generated `ApiOperations` entry，沒有把 CI guardrail 或 frontend runtime migration 混入同一 PR。
