### PR TITLE
[backend] Propagate email auth request context

### DIFF
--- a/services/api/internal/handlers/email_auth_handler.go
+++ b/services/api/internal/handlers/email_auth_handler.go
@@ -64,7 +64,7 @@ func (h *EmailAuthHandler) ConfirmVerification(c *gin.Context) {
 		return
 	}
 
-	if err := h.emailAuth.VerifyEmail(body.Token); err != nil {
+	if err := h.emailAuth.VerifyEmail(c.Request.Context(), body.Token); err != nil {
 		switch err {
 		case services.ErrInvalidVerifyToken:
 			badRequest(c, "invalid or expired verification token")
@@ -124,7 +124,7 @@ func (h *EmailAuthHandler) ResetPassword(c *gin.Context) {
 		return
 	}
 
-	if err := h.emailAuth.ResetPassword(body.Token, body.NewPassword); err != nil {
+	if err := h.emailAuth.ResetPassword(c.Request.Context(), body.Token, body.NewPassword); err != nil {
 		switch err {
 		case services.ErrInvalidResetToken:
 			badRequest(c, "invalid or expired reset token")

--- a/services/api/internal/services/email_auth_service.go
+++ b/services/api/internal/services/email_auth_service.go
@@ -40,8 +40,13 @@ func NewEmailAuthService(db *gorm.DB, cfg *config.Config, mailer Mailer) *EmailA
 
 // SendVerificationEmail generates a token and emails a verification link to the user.
 func (s *EmailAuthService) SendVerificationEmail(ctx context.Context, userID uuid.UUID) error {
+	db := s.db.WithContext(ctx)
+
 	var user models.User
-	if err := s.db.First(&user, "id = ?", userID).Error; err != nil {
+	if err := db.First(&user, "id = ?", userID).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
 		return ErrUserNotFound
 	}
 	if user.EmailVerified {
@@ -57,11 +62,11 @@ func (s *EmailAuthService) SendVerificationEmail(ctx context.Context, userID uui
 	}
 
 	// Replace any existing verification token for this user
-	if err := s.db.Where("user_id = ?", userID).Delete(&models.EmailVerification{}).Error; err != nil {
+	if err := db.Where("user_id = ?", userID).Delete(&models.EmailVerification{}).Error; err != nil {
 		return err
 	}
 
-	if err := s.db.Create(&models.EmailVerification{
+	if err := db.Create(&models.EmailVerification{
 		UserID:    userID,
 		TokenHash: hashToken(rawToken),
 		ExpiresAt: time.Now().Add(verifyTokenTTL),
@@ -75,19 +80,23 @@ func (s *EmailAuthService) SendVerificationEmail(ctx context.Context, userID uui
 }
 
 // VerifyEmail marks the user's email as verified using a raw token.
-func (s *EmailAuthService) VerifyEmail(rawToken string) error {
+func (s *EmailAuthService) VerifyEmail(ctx context.Context, rawToken string) error {
+	db := s.db.WithContext(ctx)
 	hash := hashToken(rawToken)
 
 	var record models.EmailVerification
-	if err := s.db.Where("token_hash = ?", hash).First(&record).Error; err != nil {
+	if err := db.Where("token_hash = ?", hash).First(&record).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
 		return ErrInvalidVerifyToken
 	}
 	if record.IsExpired() {
-		s.db.Delete(&record)
+		db.Delete(&record)
 		return ErrInvalidVerifyToken
 	}
 
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	return db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.User{}).Where("id = ?", record.UserID).
 			Update("email_verified", true).Error; err != nil {
 			return err
@@ -104,8 +113,10 @@ func (s *EmailAuthService) VerifyEmail(rawToken string) error {
 // ForgotPassword sends a password reset link to the given email.
 // Returns nil even when the email is not found to avoid user enumeration.
 func (s *EmailAuthService) ForgotPassword(ctx context.Context, email string) error {
+	db := s.db.WithContext(ctx)
+
 	var user models.User
-	if err := s.db.Where("email = ?", email).First(&user).Error; err != nil {
+	if err := db.Where("email = ?", email).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// Do not reveal whether the email exists (anti-enumeration)
 			return nil
@@ -119,11 +130,11 @@ func (s *EmailAuthService) ForgotPassword(ctx context.Context, email string) err
 	}
 
 	// Replace any existing reset token for this email
-	if err := s.db.Where("email = ?", email).Delete(&models.PasswordReset{}).Error; err != nil {
+	if err := db.Where("email = ?", email).Delete(&models.PasswordReset{}).Error; err != nil {
 		return err
 	}
 
-	if err := s.db.Create(&models.PasswordReset{
+	if err := db.Create(&models.PasswordReset{
 		Email:     email,
 		TokenHash: hashToken(rawToken),
 		ExpiresAt: time.Now().Add(resetTokenTTL),
@@ -140,15 +151,19 @@ func (s *EmailAuthService) ForgotPassword(ctx context.Context, email string) err
 }
 
 // ResetPassword validates the token and updates the user's password.
-func (s *EmailAuthService) ResetPassword(rawToken, newPassword string) error {
+func (s *EmailAuthService) ResetPassword(ctx context.Context, rawToken, newPassword string) error {
+	db := s.db.WithContext(ctx)
 	hash := hashToken(rawToken)
 
 	var record models.PasswordReset
-	if err := s.db.Where("token_hash = ?", hash).First(&record).Error; err != nil {
+	if err := db.Where("token_hash = ?", hash).First(&record).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
 		return ErrInvalidResetToken
 	}
 	if record.IsExpired() {
-		s.db.Delete(&record)
+		db.Delete(&record)
 		return ErrInvalidResetToken
 	}
 
@@ -157,7 +172,7 @@ func (s *EmailAuthService) ResetPassword(rawToken, newPassword string) error {
 		return err
 	}
 
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	return db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.User{}).Where("email = ?", record.Email).
 			Update("password_hash", string(hashed)).Error; err != nil {
 			return err

--- a/services/api/internal/services/email_auth_service.go
+++ b/services/api/internal/services/email_auth_service.go
@@ -92,7 +92,12 @@ func (s *EmailAuthService) VerifyEmail(ctx context.Context, rawToken string) err
 		return ErrInvalidVerifyToken
 	}
 	if record.IsExpired() {
-		db.Delete(&record)
+		if err := db.Delete(&record).Error; err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return err
+		}
 		return ErrInvalidVerifyToken
 	}
 
@@ -163,7 +168,12 @@ func (s *EmailAuthService) ResetPassword(ctx context.Context, rawToken, newPassw
 		return ErrInvalidResetToken
 	}
 	if record.IsExpired() {
-		db.Delete(&record)
+		if err := db.Delete(&record).Error; err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return err
+		}
 		return ErrInvalidResetToken
 	}
 

--- a/services/api/internal/services/email_auth_service_test.go
+++ b/services/api/internal/services/email_auth_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -129,6 +130,27 @@ func TestSendVerificationEmail_DeleteExistingTokenFailureReturnsError(t *testing
 	}
 }
 
+func TestSendVerificationEmail_CanceledContextDoesNotPersistOrSend(t *testing.T) {
+	svc, mailer := newEmailAuthSvc(t)
+	userID := seedEmailUser(t, svc, "verify-canceled@example.com", false)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := svc.SendVerificationEmail(ctx, userID)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+
+	var count int64
+	svc.db.Model(&models.EmailVerification{}).Where("user_id = ?", userID).Count(&count)
+	if count != 0 {
+		t.Fatalf("verification token should not be persisted after canceled context, got %d", count)
+	}
+	if len(mailer.sent) != 0 {
+		t.Fatalf("email should not be sent after canceled context, got %d sends", len(mailer.sent))
+	}
+}
+
 // ─── VerifyEmail ──────────────────────────────────────────────────────────────
 
 func TestVerifyEmail_Success(t *testing.T) {
@@ -143,7 +165,7 @@ func TestVerifyEmail_Success(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	if err := svc.VerifyEmail(rawToken); err != nil {
+	if err := svc.VerifyEmail(context.Background(), rawToken); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -182,7 +204,7 @@ func TestVerifyEmail_DeleteTokenFailureReturnsError(t *testing.T) {
 		t.Fatalf("create email verification consume delete trigger: %v", err)
 	}
 
-	err := svc.VerifyEmail(rawToken)
+	err := svc.VerifyEmail(context.Background(), rawToken)
 	if err == nil {
 		t.Fatal("want delete error, got nil")
 	}
@@ -194,7 +216,7 @@ func TestVerifyEmail_DeleteTokenFailureReturnsError(t *testing.T) {
 func TestVerifyEmail_InvalidToken(t *testing.T) {
 	svc, _ := newEmailAuthSvc(t)
 
-	err := svc.VerifyEmail("no-such-token")
+	err := svc.VerifyEmail(context.Background(), "no-such-token")
 	if err != ErrInvalidVerifyToken {
 		t.Errorf("want ErrInvalidVerifyToken, got %v", err)
 	}
@@ -211,7 +233,7 @@ func TestVerifyEmail_ExpiredToken(t *testing.T) {
 		ExpiresAt: time.Now().Add(-time.Minute), // already expired
 	})
 
-	err := svc.VerifyEmail(rawToken)
+	err := svc.VerifyEmail(context.Background(), rawToken)
 	if err != ErrInvalidVerifyToken {
 		t.Errorf("want ErrInvalidVerifyToken, got %v", err)
 	}
@@ -243,7 +265,7 @@ func TestVerifyEmail_RoundTrip(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	if err := svc.VerifyEmail(rawToken); err != nil {
+	if err := svc.VerifyEmail(context.Background(), rawToken); err != nil {
 		t.Fatalf("verify: %v", err)
 	}
 
@@ -274,7 +296,7 @@ func TestVerifyEmail_RollsBackUserUpdateWhenTokenDeleteFails(t *testing.T) {
 		t.Fatalf("create delete failure trigger: %v", err)
 	}
 
-	if err := svc.VerifyEmail(rawToken); err == nil {
+	if err := svc.VerifyEmail(context.Background(), rawToken); err == nil {
 		t.Fatal("expected VerifyEmail to return delete failure")
 	}
 
@@ -287,6 +309,35 @@ func TestVerifyEmail_RollsBackUserUpdateWhenTokenDeleteFails(t *testing.T) {
 	svc.db.Model(&models.EmailVerification{}).Where("user_id = ?", userID).Count(&count)
 	if count != 1 {
 		t.Errorf("expected verification token to remain after rollback, got %d", count)
+	}
+}
+
+func TestVerifyEmail_CanceledContextDoesNotVerifyOrConsumeToken(t *testing.T) {
+	svc, _ := newEmailAuthSvc(t)
+	userID := seedEmailUser(t, svc, "verify-token-canceled@example.com", false)
+	rawToken, _ := generateNonce()
+	svc.db.Create(&models.EmailVerification{
+		UserID:    userID,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := svc.VerifyEmail(ctx, rawToken)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+
+	var user models.User
+	svc.db.First(&user, "id = ?", userID)
+	if user.EmailVerified {
+		t.Fatal("email should not be verified after canceled context")
+	}
+	var count int64
+	svc.db.Model(&models.EmailVerification{}).Where("user_id = ?", userID).Count(&count)
+	if count != 1 {
+		t.Fatalf("verification token should remain after canceled context, got %d", count)
 	}
 }
 
@@ -368,6 +419,28 @@ func TestForgotPassword_DeleteExistingTokenFailureReturnsError(t *testing.T) {
 	}
 }
 
+func TestForgotPassword_CanceledContextDoesNotPersistOrSend(t *testing.T) {
+	svc, mailer := newEmailAuthSvc(t)
+	email := "reset-canceled@example.com"
+	seedEmailUser(t, svc, email, true)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := svc.ForgotPassword(ctx, email)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+
+	var count int64
+	svc.db.Model(&models.PasswordReset{}).Where("email = ?", email).Count(&count)
+	if count != 0 {
+		t.Fatalf("reset token should not be persisted after canceled context, got %d", count)
+	}
+	if len(mailer.sent) != 0 {
+		t.Fatalf("email should not be sent after canceled context, got %d sends", len(mailer.sent))
+	}
+}
+
 // ─── ResetPassword ────────────────────────────────────────────────────────────
 
 func TestResetPassword_Success(t *testing.T) {
@@ -382,7 +455,7 @@ func TestResetPassword_Success(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	if err := svc.ResetPassword(rawToken, "newpassword123"); err != nil {
+	if err := svc.ResetPassword(context.Background(), rawToken, "newpassword123"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -416,7 +489,7 @@ func TestResetPassword_DeleteTokenFailureReturnsError(t *testing.T) {
 		t.Fatalf("create password reset consume delete trigger: %v", err)
 	}
 
-	err := svc.ResetPassword(rawToken, "newpassword123")
+	err := svc.ResetPassword(context.Background(), rawToken, "newpassword123")
 	if err == nil {
 		t.Fatal("want delete error, got nil")
 	}
@@ -428,7 +501,7 @@ func TestResetPassword_DeleteTokenFailureReturnsError(t *testing.T) {
 func TestResetPassword_InvalidToken(t *testing.T) {
 	svc, _ := newEmailAuthSvc(t)
 
-	err := svc.ResetPassword("bad-token", "newpassword123")
+	err := svc.ResetPassword(context.Background(), "bad-token", "newpassword123")
 	if err != ErrInvalidResetToken {
 		t.Errorf("want ErrInvalidResetToken, got %v", err)
 	}
@@ -446,7 +519,7 @@ func TestResetPassword_ExpiredToken(t *testing.T) {
 		ExpiresAt: time.Now().Add(-time.Minute),
 	})
 
-	err := svc.ResetPassword(rawToken, "newpassword123")
+	err := svc.ResetPassword(context.Background(), rawToken, "newpassword123")
 	if err != ErrInvalidResetToken {
 		t.Errorf("want ErrInvalidResetToken, got %v", err)
 	}
@@ -479,7 +552,7 @@ func TestResetPassword_AllowsLoginWithNewPassword(t *testing.T) {
 	})
 
 	// Reset password
-	if err := emailSvc.ResetPassword(rawToken, "newpassword123"); err != nil {
+	if err := emailSvc.ResetPassword(context.Background(), rawToken, "newpassword123"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
 
@@ -527,7 +600,7 @@ func TestResetPassword_RollsBackPasswordHashWhenTokenDeleteFails(t *testing.T) {
 		t.Fatalf("create delete failure trigger: %v", err)
 	}
 
-	if err := emailSvc.ResetPassword(rawToken, "newpassword123"); err == nil {
+	if err := emailSvc.ResetPassword(context.Background(), rawToken, "newpassword123"); err == nil {
 		t.Fatal("expected ResetPassword to return delete failure")
 	}
 
@@ -541,5 +614,30 @@ func TestResetPassword_RollsBackPasswordHashWhenTokenDeleteFails(t *testing.T) {
 	db.Model(&models.PasswordReset{}).Where("email = ?", *user.Email).Count(&count)
 	if count != 1 {
 		t.Errorf("expected reset token to remain after rollback, got %d", count)
+	}
+}
+
+func TestResetPassword_CanceledContextDoesNotConsumeToken(t *testing.T) {
+	svc, _ := newEmailAuthSvc(t)
+	email := "reset-token-canceled@example.com"
+	seedEmailUser(t, svc, email, true)
+	rawToken, _ := generateNonce()
+	svc.db.Create(&models.PasswordReset{
+		Email:     email,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := svc.ResetPassword(ctx, rawToken, "newpassword123")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+
+	var count int64
+	svc.db.Model(&models.PasswordReset{}).Where("email = ?", email).Count(&count)
+	if count != 1 {
+		t.Fatalf("reset token should remain after canceled context, got %d", count)
 	}
 }

--- a/services/api/internal/services/email_auth_service_test.go
+++ b/services/api/internal/services/email_auth_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/tachigo/tachigo/internal/models"
+	"gorm.io/gorm"
 )
 
 // mockMailer records sent emails for assertion in tests.
@@ -236,6 +237,34 @@ func TestVerifyEmail_ExpiredToken(t *testing.T) {
 	err := svc.VerifyEmail(context.Background(), rawToken)
 	if err != ErrInvalidVerifyToken {
 		t.Errorf("want ErrInvalidVerifyToken, got %v", err)
+	}
+}
+
+func TestVerifyEmail_ExpiredTokenDeleteCanceledReturnsContextError(t *testing.T) {
+	svc, _ := newEmailAuthSvc(t)
+	userID := seedEmailUser(t, svc, "expired-delete-canceled@example.com", false)
+
+	rawToken, _ := generateNonce()
+	svc.db.Create(&models.EmailVerification{
+		UserID:    userID,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().Add(-time.Minute),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	callbackName := "test:cancel_email_verification_expired_delete"
+	if err := svc.db.Callback().Delete().Before("gorm:delete").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Table == "email_verifications" {
+			cancel()
+		}
+	}); err != nil {
+		t.Fatalf("register delete callback: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.db.Callback().Delete().Remove(callbackName) })
+
+	err := svc.VerifyEmail(ctx, rawToken)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
 	}
 }
 
@@ -522,6 +551,35 @@ func TestResetPassword_ExpiredToken(t *testing.T) {
 	err := svc.ResetPassword(context.Background(), rawToken, "newpassword123")
 	if err != ErrInvalidResetToken {
 		t.Errorf("want ErrInvalidResetToken, got %v", err)
+	}
+}
+
+func TestResetPassword_ExpiredTokenDeleteCanceledReturnsContextError(t *testing.T) {
+	svc, _ := newEmailAuthSvc(t)
+	email := "expired-reset-delete-canceled@example.com"
+	seedEmailUser(t, svc, email, true)
+
+	rawToken, _ := generateNonce()
+	svc.db.Create(&models.PasswordReset{
+		Email:     email,
+		TokenHash: hashToken(rawToken),
+		ExpiresAt: time.Now().Add(-time.Minute),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	callbackName := "test:cancel_password_reset_expired_delete"
+	if err := svc.db.Callback().Delete().Before("gorm:delete").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Table == "password_resets" {
+			cancel()
+		}
+	}); err != nil {
+		t.Fatalf("register delete callback: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.db.Callback().Delete().Remove(callbackName) })
+
+	err := svc.ResetPassword(ctx, rawToken, "newpassword123")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- 讓 `EmailAuthService` 的驗證信、驗證 token、忘記密碼、重設密碼 DB 存取全數使用 request `context.Context`。
- `ConfirmVerification` / `ResetPassword` handler 會把 `c.Request.Context()` 傳入 service。
- 新增取消 context regression tests，確認取消後不會新增 token、消耗 token 或寄信。
- CodeRabbit 指出的 expired token cleanup 路徑也已修正：清理過期驗證 / reset token 時會回傳 DB/context delete error。

## 為什麼
- refs #645
- #645 要求 service-layer DB access paths 傳遞 request context，避免 request timeout 後 DB work 繼續執行。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 timeout policy 調整
  - 不做 queue / worker architecture redesign
  - 不做 #645 全服務掃描收斂或 integration timeout test

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 DB query context propagation audit
- Actual worker profile(s)：
  - main controller；read-only explorer sidecar
- Model strength：
  - main = GPT-5.5 xhigh；sidecar = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=explorer model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a；scope=read-only EmailAuthService candidate scan；public GitHub actions denied
- Verification evidence：
  - RED：`go test ./internal/services -run 'Test(SendVerificationEmail_CanceledContextDoesNotPersistOrSend|VerifyEmail_CanceledContextDoesNotVerifyOrConsumeToken|ForgotPassword_CanceledContextDoesNotPersistOrSend|ResetPassword_CanceledContextDoesNotConsumeToken)' -count=1` failed because `VerifyEmail` / `ResetPassword` lacked context parameters
  - GREEN：same focused test command passed
  - `go test ./internal/services -run 'Test(SendVerificationEmail|VerifyEmail|ForgotPassword|ResetPassword)' -count=1`
  - `go test ./internal/handlers -run 'Test.*Email|Test.*Password|TestAuthHandler_Register' -count=1`
  - `go test ./internal/services ./internal/handlers -count=1`
  - `git diff --check`
  - CodeRabbit follow-up：`go test ./internal/services -run 'Test(VerifyEmail_ExpiredTokenDeleteCanceledReturnsContextError|ResetPassword_ExpiredTokenDeleteCanceledReturnsContextError)' -count=1`
  - CodeRabbit follow-up：`go test ./internal/services -run 'Test(SendVerificationEmail|VerifyEmail|ForgotPassword|ResetPassword)' -count=1`
  - CodeRabbit follow-up：`go test ./internal/handlers -run 'Test.*Email|Test.*Password|TestAuthHandler_Register' -count=1`
  - CodeRabbit follow-up：`go test ./internal/services ./internal/handlers -count=1`
- Self-review / exception reason：
  - 已完成 self-review；確認只修改 EmailAuth service、handler context forwarding、expired token cleanup error propagation 與 focused tests
- Worker session closeout：
  - 已讀回 sidecar 建議，採用 EmailAuthService 小切片；不需追加任務
- Workflow friction / follow-up split：
  - #645 全服務 audit / integration cancellation test 留在後續 PR；本 PR 只處理 EmailAuthService

## Review conversation closeout
- Unresolved threads：
  - CodeRabbit initial actionable expired-token cleanup comment fixed in `92c6b2e2`
- CodeRabbit：
  - latest re-review hit rate limit / usage credits after `92c6b2e2`；bot confirmation pending
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - local TDD and self-review evidence in this PR body
- root_cause_gate_ref：
  - #645 timeout cancellation risk；local RED test proves missing context boundary
- finding_disposition_ref：
  - adopted：EmailAuthService DB calls now use `WithContext(ctx)`；expired-token cleanup delete errors are no longer swallowed
- Final reviewer action：
  - pending review

## Final merge gate
- Ready-to-merge decision：
  - pending refreshed CI / CodeRabbit re-review capacity / human review
- Latest head SHA：
  - 92c6b2e2
- Required checks：
  - pending refreshed GitHub CI after CodeRabbit follow-up commit
- spec workflow-check evidence：
  - n/a；manual checklist via #645 acceptance criteria slice
- Evidence URL：
  - n/a at PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through EmailAuthService DB access.
- Approx changed lines：~237
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler 只傳遞既有 request context；service 簽名變更需要同步更新呼叫點，tests 驗證同一行為邊界。
- 若已拆分，相關 PR：
  - #666 AddressService；#685 ChannelConfigService；#686 WatchService；本 PR 是 EmailAuthService follow-up slice

## Acceptance Criteria
- [ ] Audit all DB queries and transactions under `services/api`
- [x] EmailAuthService DB access paths propagate request context
- [x] EmailAuthService GORM queries use `WithContext(ctx)`
- [x] Transaction helpers preserve context for email verification and password reset
- [x] Add regression tests for canceled request context in this service
- [ ] Add at least one integration test proving timeout cancels DB work
- [ ] Document any intentionally detached async job paths

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
go test ./internal/services -run 'Test(SendVerificationEmail_CanceledContextDoesNotPersistOrSend|VerifyEmail_CanceledContextDoesNotVerifyOrConsumeToken|ForgotPassword_CanceledContextDoesNotPersistOrSend|ResetPassword_CanceledContextDoesNotConsumeToken)' -count=1
FAIL: VerifyEmail / ResetPassword did not accept context.Context yet

GREEN:
ok  	github.com/tachigo/tachigo/internal/services	0.267s

go test ./internal/services -run 'Test(SendVerificationEmail|VerifyEmail|ForgotPassword|ResetPassword)' -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.917s

go test ./internal/handlers -run 'Test.*Email|Test.*Password|TestAuthHandler_Register' -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.780s

go test ./internal/services ./internal/handlers -count=1
ok  	github.com/tachigo/tachigo/internal/services	3.108s
ok  	github.com/tachigo/tachigo/internal/handlers	20.724s

git diff --check
pass

CodeRabbit follow-up:
go test ./internal/services -run 'Test(VerifyEmail_ExpiredTokenDeleteCanceledReturnsContextError|ResetPassword_ExpiredTokenDeleteCanceledReturnsContextError)' -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.305s

go test ./internal/services -run 'Test(SendVerificationEmail|VerifyEmail|ForgotPassword|ResetPassword)' -count=1
ok  	github.com/tachigo/tachigo/internal/services	1.116s

go test ./internal/handlers -run 'Test.*Email|Test.*Password|TestAuthHandler_Register' -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.879s

go test ./internal/services ./internal/handlers -count=1
ok  	github.com/tachigo/tachigo/internal/services	3.771s
ok  	github.com/tachigo/tachigo/internal/handlers	26.611s
```

## 備註
- `VerifyEmail` / `ResetPassword` 現在會把非 `gorm.ErrRecordNotFound` 的 DB/context 錯誤往上回傳，避免把 cancellation 或 DB failure 誤報為 invalid token。
- 過期 token cleanup 現在也會檢查 `db.Delete(...).Error`，避免 cleanup cancellation 被吞掉。

## Notes for Claude Code Review
- 請特別看 `VerifyEmail` / `ResetPassword` 簽名變更是否符合目前 handler boundary；這個 PR 沒有調整 API response 文案。
