### PR TITLE
[backend] Propagate agency request context

### DIFF
--- a/services/api/internal/handlers/agency_handler.go
+++ b/services/api/internal/handlers/agency_handler.go
@@ -45,7 +45,7 @@ func (h *AgencyHandler) Create(c *gin.Context) {
 		return
 	}
 
-	user, err := h.agencySvc.Create(req.Name, req.Email)
+	user, err := h.agencySvc.CreateContext(c.Request.Context(), req.Name, req.Email)
 	if err != nil {
 		if errors.Is(err, services.ErrAgencyEmailTaken) {
 			conflict(c, err.Error())
@@ -101,7 +101,7 @@ func (h *AgencyHandler) Get(c *gin.Context) {
 		return
 	}
 
-	user, complete, err := h.agencySvc.GetByID(agencyID)
+	user, complete, err := h.agencySvc.GetByIDContext(c.Request.Context(), agencyID)
 	if err != nil {
 		if errors.Is(err, services.ErrAgencyNotFound) {
 			notFound(c, "agency not found")
@@ -136,7 +136,7 @@ func (h *AgencyHandler) ResendSetup(c *gin.Context) {
 		return
 	}
 
-	user, complete, err := h.agencySvc.GetByID(agencyID)
+	user, complete, err := h.agencySvc.GetByIDContext(c.Request.Context(), agencyID)
 	if err != nil {
 		if errors.Is(err, services.ErrAgencyNotFound) {
 			notFound(c, "agency not found")
@@ -199,7 +199,7 @@ func (h *AgencyHandler) UpdateSettings(c *gin.Context) {
 		return
 	}
 
-	if err := h.agencySvc.UpdateSettings(agencyID, req.Name); err != nil {
+	if err := h.agencySvc.UpdateSettingsContext(c.Request.Context(), agencyID, req.Name); err != nil {
 		if errors.Is(err, services.ErrAgencyNotFound) {
 			notFound(c, "agency not found")
 			return
@@ -233,7 +233,7 @@ func (h *AgencyHandler) ListStreamers(c *gin.Context) {
 		return
 	}
 
-	streamers, err := h.agencySvc.ListStreamers(agencyID)
+	streamers, err := h.agencySvc.ListStreamersContext(c.Request.Context(), agencyID)
 	if err != nil {
 		if errors.Is(err, services.ErrAgencyNotFound) {
 			notFound(c, "agency not found")
@@ -249,7 +249,7 @@ func (h *AgencyHandler) ListStreamers(c *gin.Context) {
 		channelIDs = append(channelIDs, streamer.ChannelID)
 	}
 
-	userIDsByChannel, err := h.agencySvc.ListStreamerUserIDs(channelIDs)
+	userIDsByChannel, err := h.agencySvc.ListStreamerUserIDsContext(c.Request.Context(), channelIDs)
 	if err != nil {
 		log.Printf("agency list streamer users: unexpected error: %v", err)
 		internal(c)

--- a/services/api/internal/handlers/agency_handler_test.go
+++ b/services/api/internal/handlers/agency_handler_test.go
@@ -161,6 +161,32 @@ func seedAgencyStreamerListData(t *testing.T, db *gorm.DB, agencyID uuid.UUID) [
 	}
 }
 
+type agencyHandlerContextKey struct{}
+
+func installAgencyHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:agency_handler_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name + ":query")
+	})
+
+	return func() int {
+		return seen
+	}
+}
+
 func TestAgencyHandler_Get_ReturnsProfile(t *testing.T) {
 	env, r := newFullAgencyTestEnv(t)
 	agencyID := seedAgencyUser(t, env.db, "agency-get", "agency-get@example.com")
@@ -820,6 +846,26 @@ func TestAgencyHandler_ListStreamers_AdminCanQuery(t *testing.T) {
 		if streamer["user_id"] != expected[i]["user_id"] {
 			t.Fatalf("streamer %d user_id: expected %s, got %v", i, expected[i]["user_id"], streamer["user_id"])
 		}
+	}
+}
+
+func TestAgencyHandler_ListStreamers_UsesRequestContext(t *testing.T) {
+	env, r := newAgencyTestEnv(t)
+	agencyID := uuid.New()
+	seedAgencyStreamerListData(t, env.db, agencyID)
+	ctx := context.WithValue(context.Background(), agencyHandlerContextKey{}, "list-streamers")
+	seenContext := installAgencyHandlerDBContextProbe(t, env.db, agencyHandlerContextKey{}, "list-streamers")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(ctx, "GET", "/api/v1/agencies/"+agencyID.String()+"/streamers", nil)
+	req.Header.Set("Authorization", "Bearer "+makeAccessToken(t, models.RoleAdmin))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seenContext() == 0 {
+		t.Fatal("expected ListStreamers handler to pass request context to GORM")
 	}
 }
 

--- a/services/api/internal/services/agency_service.go
+++ b/services/api/internal/services/agency_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"unicode/utf8"
@@ -26,13 +27,25 @@ func NewAgencyService(db *gorm.DB) *AgencyService {
 	return &AgencyService{db: db}
 }
 
+func (s *AgencyService) dbWithContext(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.db.WithContext(ctx)
+}
+
 func (s *AgencyService) Create(name, email string) (*models.User, error) {
+	return s.CreateContext(context.Background(), name, email)
+}
+
+func (s *AgencyService) CreateContext(ctx context.Context, name, email string) (*models.User, error) {
+	db := s.dbWithContext(ctx)
 	if utf8.RuneCountInString(name) > 50 {
 		return nil, ErrAgencyNameTooLong
 	}
 
 	var count int64
-	if err := s.db.Model(&models.User{}).Where("email = ?", email).Count(&count).Error; err != nil {
+	if err := db.Model(&models.User{}).Where("email = ?", email).Count(&count).Error; err != nil {
 		return nil, err
 	}
 	if count > 0 {
@@ -40,7 +53,7 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 	}
 
 	count = 0
-	if err := s.db.Model(&models.User{}).Where("username = ?", name).Count(&count).Error; err != nil {
+	if err := db.Model(&models.User{}).Where("username = ?", name).Count(&count).Error; err != nil {
 		return nil, err
 	}
 	if count > 0 {
@@ -57,7 +70,7 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 
 	// Wrap user + email auth_provider in one transaction so we never end up
 	// with a users row but no auth_providers row (or vice-versa).
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(user).Error; err != nil {
 			return err
 		}
@@ -88,11 +101,15 @@ func (s *AgencyService) Create(name, email string) (*models.User, error) {
 }
 
 func (s *AgencyService) UpdateSettings(agencyID uuid.UUID, name string) error {
+	return s.UpdateSettingsContext(context.Background(), agencyID, name)
+}
+
+func (s *AgencyService) UpdateSettingsContext(ctx context.Context, agencyID uuid.UUID, name string) error {
 	if utf8.RuneCountInString(name) > 50 {
 		return ErrAgencyNameTooLong
 	}
 
-	res := s.db.Model(&models.User{}).
+	res := s.dbWithContext(ctx).Model(&models.User{}).
 		Where("id = ? AND role = ?", agencyID, models.RoleAgency).
 		Update("username", name)
 	if res.Error != nil {
@@ -115,8 +132,12 @@ func (s *AgencyService) UpdateSettings(agencyID uuid.UUID, name string) error {
 // onboardingComplete is true when the agency has set a password (PasswordHash IS NOT NULL).
 // Returns ErrAgencyNotFound if no user with the given id and role=agency exists.
 func (s *AgencyService) GetByID(id uuid.UUID) (*models.User, bool, error) {
+	return s.GetByIDContext(context.Background(), id)
+}
+
+func (s *AgencyService) GetByIDContext(ctx context.Context, id uuid.UUID) (*models.User, bool, error) {
 	var user models.User
-	if err := s.db.Where("id = ? AND role = ?", id, models.RoleAgency).First(&user).Error; err != nil {
+	if err := s.dbWithContext(ctx).Where("id = ? AND role = ?", id, models.RoleAgency).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, false, ErrAgencyNotFound
 		}
@@ -126,16 +147,25 @@ func (s *AgencyService) GetByID(id uuid.UUID) (*models.User, bool, error) {
 }
 
 func (s *AgencyService) OwnsChannel(agencyUserID uuid.UUID, channelID string) (bool, error) {
+	return s.OwnsChannelContext(context.Background(), agencyUserID, channelID)
+}
+
+func (s *AgencyService) OwnsChannelContext(ctx context.Context, agencyUserID uuid.UUID, channelID string) (bool, error) {
 	var count int64
-	err := s.db.Model(&models.AgencyStreamer{}).
+	err := s.dbWithContext(ctx).Model(&models.AgencyStreamer{}).
 		Where("agency_id = ? AND channel_id = ?", agencyUserID, channelID).
 		Count(&count).Error
 	return count > 0, err
 }
 
 func (s *AgencyService) ListStreamers(agencyID uuid.UUID) ([]models.AgencyStreamer, error) {
+	return s.ListStreamersContext(context.Background(), agencyID)
+}
+
+func (s *AgencyService) ListStreamersContext(ctx context.Context, agencyID uuid.UUID) ([]models.AgencyStreamer, error) {
+	db := s.dbWithContext(ctx)
 	var streamers []models.AgencyStreamer
-	if err := s.db.
+	if err := db.
 		Where("agency_id = ?", agencyID).
 		Order("created_at ASC").
 		Find(&streamers).Error; err != nil {
@@ -143,7 +173,7 @@ func (s *AgencyService) ListStreamers(agencyID uuid.UUID) ([]models.AgencyStream
 	}
 	if len(streamers) == 0 {
 		var count int64
-		if err := s.db.Model(&models.User{}).
+		if err := db.Model(&models.User{}).
 			Where("id = ? AND role = ?", agencyID, models.RoleAgency).
 			Count(&count).Error; err != nil {
 			return nil, err
@@ -156,6 +186,10 @@ func (s *AgencyService) ListStreamers(agencyID uuid.UUID) ([]models.AgencyStream
 }
 
 func (s *AgencyService) ListStreamerUserIDs(channelIDs []string) (map[string]uuid.UUID, error) {
+	return s.ListStreamerUserIDsContext(context.Background(), channelIDs)
+}
+
+func (s *AgencyService) ListStreamerUserIDsContext(ctx context.Context, channelIDs []string) (map[string]uuid.UUID, error) {
 	type streamerUserRow struct {
 		ChannelID string
 		UserID    uuid.UUID
@@ -166,7 +200,7 @@ func (s *AgencyService) ListStreamerUserIDs(channelIDs []string) (map[string]uui
 	}
 
 	var rows []streamerUserRow
-	if err := s.db.Model(&models.Streamer{}).
+	if err := s.dbWithContext(ctx).Model(&models.Streamer{}).
 		Select("channel_id, user_id").
 		Where("channel_id IN ?", channelIDs).
 		Find(&rows).Error; err != nil {

--- a/services/api/internal/services/agency_service_test.go
+++ b/services/api/internal/services/agency_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+type agencyContextKey struct{}
 
 func seedAgencyStreamerRelation(t *testing.T, db *gorm.DB, agencyID uuid.UUID, channelID string) {
 	t.Helper()
@@ -75,6 +78,26 @@ func TestAgencyOwnsChannel_IsolatedByAgency(t *testing.T) {
 	}
 	if owns {
 		t.Fatal("expected other agency to not own channel")
+	}
+}
+
+func TestAgencyOwnsChannelContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+	agencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+	seedAgencyStreamerRelation(t, db, agencyID, "ch_ctx_owned")
+	ctx := context.WithValue(context.Background(), agencyContextKey{}, "owns")
+	seenContext := installDBContextProbe(t, db, agencyContextKey{}, "owns")
+
+	owns, err := svc.OwnsChannelContext(ctx, agencyID, "ch_ctx_owned")
+	if err != nil {
+		t.Fatalf("owns channel context failed: %v", err)
+	}
+	if !owns {
+		t.Fatal("expected agency to own channel")
+	}
+	if seenContext() == 0 {
+		t.Fatal("expected OwnsChannelContext to pass request context to GORM")
 	}
 }
 
@@ -156,6 +179,20 @@ func TestAgencyService_Create_NameTooLong(t *testing.T) {
 	}
 }
 
+func TestAgencyService_CreateContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+	ctx := context.WithValue(context.Background(), agencyContextKey{}, "create")
+	seenContext := installDBContextProbe(t, db, agencyContextKey{}, "create")
+
+	if _, err := svc.CreateContext(ctx, "agency_ctx_create", "agency_ctx_create@example.com"); err != nil {
+		t.Fatalf("create context failed: %v", err)
+	}
+	if seenContext() == 0 {
+		t.Fatal("expected CreateContext to pass request context to GORM")
+	}
+}
+
 func TestAgencyService_Create_DuplicateEmail(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewAgencyService(db)
@@ -170,6 +207,21 @@ func TestAgencyService_Create_DuplicateEmail(t *testing.T) {
 	}
 }
 
+func TestAgencyService_UpdateSettingsContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+	agencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+	ctx := context.WithValue(context.Background(), agencyContextKey{}, "update")
+	seenContext := installDBContextProbe(t, db, agencyContextKey{}, "update")
+
+	if err := svc.UpdateSettingsContext(ctx, agencyID, "agency_ctx_update"); err != nil {
+		t.Fatalf("update settings context failed: %v", err)
+	}
+	if seenContext() == 0 {
+		t.Fatal("expected UpdateSettingsContext to pass request context to GORM")
+	}
+}
+
 func TestAgencyService_GetByID_NotFound(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewAgencyService(db)
@@ -177,6 +229,21 @@ func TestAgencyService_GetByID_NotFound(t *testing.T) {
 	_, _, err := svc.GetByID(uuid.New())
 	if !errors.Is(err, ErrAgencyNotFound) {
 		t.Fatalf("expected ErrAgencyNotFound, got %v", err)
+	}
+}
+
+func TestAgencyService_GetByIDContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+	agencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+	ctx := context.WithValue(context.Background(), agencyContextKey{}, "get")
+	seenContext := installDBContextProbe(t, db, agencyContextKey{}, "get")
+
+	if _, _, err := svc.GetByIDContext(ctx, agencyID); err != nil {
+		t.Fatalf("get by id context failed: %v", err)
+	}
+	if seenContext() == 0 {
+		t.Fatal("expected GetByIDContext to pass request context to GORM")
 	}
 }
 
@@ -247,6 +314,46 @@ func TestAgencyService_GetByID_WrongRole(t *testing.T) {
 	_, _, err := svc.GetByID(id)
 	if !errors.Is(err, ErrAgencyNotFound) {
 		t.Fatalf("expected ErrAgencyNotFound for non-agency role, got %v", err)
+	}
+}
+
+func TestAgencyService_ListStreamersContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+	agencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+	seedAgencyStreamerRelation(t, db, agencyID, "ch_ctx_list")
+	ctx := context.WithValue(context.Background(), agencyContextKey{}, "list")
+	seenContext := installDBContextProbe(t, db, agencyContextKey{}, "list")
+
+	streamers, err := svc.ListStreamersContext(ctx, agencyID)
+	if err != nil {
+		t.Fatalf("list streamers context failed: %v", err)
+	}
+	if len(streamers) != 1 {
+		t.Fatalf("expected 1 streamer, got %d", len(streamers))
+	}
+	if seenContext() == 0 {
+		t.Fatal("expected ListStreamersContext to pass request context to GORM")
+	}
+}
+
+func TestAgencyService_ListStreamerUserIDsContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAgencyService(db)
+	agencyID := seedStreamerUserRow(t, db, models.RoleAgency)
+	seedAgencyStreamerRelation(t, db, agencyID, "ch_ctx_user_ids")
+	ctx := context.WithValue(context.Background(), agencyContextKey{}, "user_ids")
+	seenContext := installDBContextProbe(t, db, agencyContextKey{}, "user_ids")
+
+	userIDs, err := svc.ListStreamerUserIDsContext(ctx, []string{"ch_ctx_user_ids"})
+	if err != nil {
+		t.Fatalf("list streamer user IDs context failed: %v", err)
+	}
+	if _, ok := userIDs["ch_ctx_user_ids"]; !ok {
+		t.Fatal("expected streamer user ID for channel")
+	}
+	if seenContext() == 0 {
+		t.Fatal("expected ListStreamerUserIDsContext to pass request context to GORM")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
新增 `AgencyService` 的 context-aware DB entrypoints，並讓 agency handler 把 `c.Request.Context()` 傳到 service 層。

## 為什麼
refs #645

#645 要逐步把 request timeout cancellation 傳到 service-layer DB access。本 PR 只處理 agency management request path 的最小可獨立切片，不宣稱完成 repo-wide audit。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不宣稱完成 #645 的 repo-wide DB context audit。
  - 不修改 request timeout policy values。
  - 不修改 schema / migration。
  - 不修改 airdrop / rewards / points ledger behavior。
  - 不修改 auth / wallet / signature / payment flow。
  - 不修改 frontend 或 API response shape。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request context propagation follow-up；本輪選擇 `AgencyService` / agency handler 作為單一小切片。
- Actual worker profile(s)：
  - controller + low-risk read-only sidecar
- Model strength：
  - main agent = GPT-5.5 xhigh；sidecar = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=repo_scout model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied purpose=read-only service-slice scan for #645; public_write=denied; code_edit=denied
- Verification evidence：
  - RED: `go test ./internal/services -run 'TestAgencyService_(CreateContext_UsesRequestContext|UpdateSettingsContext_UsesRequestContext|GetByIDContext_UsesRequestContext)' -count=1` failed on missing `*Context` methods
  - RED: `go test ./internal/handlers -run 'TestAgencyHandler_ListStreamers_UsesRequestContext' -count=1` failed because handler used background-wrapper service methods
  - GREEN: `go test ./internal/services -run 'TestAgency' -count=1`
  - GREEN: `go test ./internal/handlers -run 'TestAgencyHandler' -count=1`
  - GREEN: `go test ./internal/services ./internal/handlers -count=1`
  - `git diff --check` pass
- Self-review / exception reason：
  - Agency management path is a bounded backend service/handler slice; high-risk auth/wallet/payment/rewards/schema/CI surfaces are excluded.
- Worker session closeout：
  - Sidecar completed read-only scan and recommended Agency as the safest next slice; no worker edited files or performed public actions.
- Workflow friction / follow-up split：
  - #645 remains open for StreamerService, RaffleService, remaining services, and integration timeout cancellation proof.

## Review conversation closeout
- Unresolved threads：
  - 0 at latest audit.
- CodeRabbit：
  - rate limited on latest head: CodeRabbit reported usage credits / hourly commit review limit exceeded; no actionable comments were produced.
- chatgpt-codex-connector：
  - pending with reason: initial PR before reviewer feedback.
- review_triage_ref：
  - PR #691 latest-head audit in automation thread.
- root_cause_gate_ref：
  - #645 root cause is request timeout middleware already sets request context, but service DB entrypoints must use `WithContext(ctx)`.
- finding_disposition_ref：
  - adopted: agency service and handler path now use request context; deferred airdrop/rewards-related agency ownership call because it touches higher-risk rewards surface.
- Final reviewer action：
  - pending with reason: human / non-author review required and CodeRabbit review was rate-limited.

## Final merge gate
- Ready-to-merge decision：
  - blocked by review capacity: CI green, but CodeRabbit was rate-limited and reviewDecision is still `REVIEW_REQUIRED`.
- Latest head SHA：
  - 50543561d3e40e07580a39376a7cc460e29a3e22
- Required checks：
  - Scope Police PASS; Backend tests / integration / Backend CI gate PASS; CodeRabbit status context success but review comment reports rate limit exceeded.
- spec workflow-check evidence：
  - manual checklist for #645 agency request path slice; spec workflow-check not used.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/actions/runs/25847624228

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through agency management service DB operations.
- Approx changed lines：~202
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service context entrypoints、handler request context handoff、regression tests 是同一條 agency request cancellation path，拆開會不可驗證。
- 若已拆分，相關 PR：
  - #666 AddressService slice；#685 ChannelConfigService slice；#686 WatchService slice；本 PR 是 #645 的下一個 agency slice。

## Acceptance Criteria
- [x] AgencyService DB reads/writes now have context-aware entrypoints using `WithContext(ctx)`.
- [x] Agency handler passes `c.Request.Context()` into agency service DB access.
- [x] Added regression tests for service DB statement context propagation.
- [x] Added handler regression test for request context handoff.
- [ ] Full #645 repo-wide DB query audit remains open for later slices.
- [ ] Integration test proving timeout cancels DB work remains open for later slices.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk env GOCACHE=/private/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestAgency' -count=1
PASS: ok github.com/tachigo/tachigo/internal/services

rtk env GOCACHE=/private/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestAgencyHandler' -count=1
PASS: ok github.com/tachigo/tachigo/internal/handlers

rtk env GOCACHE=/private/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -count=1
PASS: ok github.com/tachigo/tachigo/internal/services; ok github.com/tachigo/tachigo/internal/handlers

rtk git --no-optional-locks diff --check
PASS: no output
```

## 備註
Legacy non-context methods remain as compatibility wrappers using `context.Background()`.

## Notes for Claude Code Review
- 請特別確認這張 PR 只處理 agency management path；#645 不應因此關閉。
- `airdrop_handler.go` 仍呼叫 `OwnsChannel` compatibility wrapper；該 path touches rewards/airdrop surface，刻意留給後續高風險 slice。
