### PR TITLE
[infra] Add OpenAPI contract drift CI gate

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -199,6 +199,7 @@ async function runCiAutoReadyAfterCiWorkflow({
       SUPPLY_CHAIN_GUARDRAILS_RESULT: 'success',
       BACKEND_CI_RESULT: 'success',
       DEPENDENCY_REVIEW_RESULT: 'success',
+      API_CONTRACTS_RESULT: 'success',
       FRONTEND_RESULT: 'success',
       DASHBOARD_RESULT: 'success',
       CONTRACTS_RESULT: 'success',
@@ -1805,6 +1806,7 @@ test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
     run_backend_integration: 'false',
     run_backend_scanners: 'false',
     run_dependency_review: 'false',
+    run_api_contracts: 'false',
     run_frontend: 'true',
     run_dashboard: 'false',
     run_contracts: 'false',
@@ -1829,6 +1831,23 @@ test('scope gate emits dependency review output only for dependency file PRs', a
   assert.equal(frontendSource.outputs.run_dependency_review, 'false')
 })
 
+test('scope gate emits API contract drift output for generated contract surfaces', async () => {
+  const sharedTypes = await runCiScopeGateWorkflow({
+    files: [{ filename: 'packages/shared-types/src/index.ts', additions: 9, deletions: 2, status: 'modified' }],
+  })
+  const swaggerArtifact = await runCiScopeGateWorkflow({
+    prOverrides: { title: '[backend] Refresh OpenAPI schema' },
+    files: [{ filename: 'services/api/docs/swagger.json', additions: 9, deletions: 2, status: 'modified' }],
+  })
+  const frontendSource = await runCiScopeGateWorkflow({
+    files: [{ filename: 'apps/extension/src/App.tsx', additions: 9, deletions: 2, status: 'modified' }],
+  })
+
+  assert.equal(sharedTypes.outputs.run_api_contracts, 'true')
+  assert.equal(swaggerArtifact.outputs.run_api_contracts, 'true')
+  assert.equal(frontendSource.outputs.run_api_contracts, 'false')
+})
+
 test('scope gate emits backend scanner outputs for backend PRs and scheduled scans', async () => {
   const backendPr = await runCiScopeGateWorkflow({
     files: [{ filename: 'services/api/internal/services/watch_service.go', additions: 3, deletions: 1, status: 'modified' }],
@@ -1841,6 +1860,7 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
     run_backend_integration: 'true',
     run_backend_scanners: 'true',
     run_dependency_review: 'false',
+    run_api_contracts: 'false',
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
@@ -1853,6 +1873,7 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
     run_backend_integration: 'false',
     run_backend_scanners: 'true',
     run_dependency_review: 'false',
+    run_api_contracts: 'false',
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'false',
@@ -1873,6 +1894,7 @@ test('scope gate emits contracts report outputs for contracts PRs', async () => 
     run_backend_integration: 'true',
     run_backend_scanners: 'false',
     run_dependency_review: 'false',
+    run_api_contracts: 'false',
     run_frontend: 'false',
     run_dashboard: 'false',
     run_contracts: 'true',
@@ -1912,6 +1934,7 @@ Backend contract already in develop:
     run_backend_integration: 'true',
     run_backend_scanners: 'true',
     run_dependency_review: 'false',
+    run_api_contracts: 'true',
     run_frontend: 'true',
     run_dashboard: 'true',
     run_contracts: 'true',
@@ -1938,6 +1961,7 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   const dependencyReview = workflowJobBlock(workflow, 'dependency-review')
   const frontend = workflowJobBlock(workflow, 'frontend')
   const dashboard = workflowJobBlock(workflow, 'dashboard')
+  const apiContracts = workflowJobBlock(workflow, 'api-contracts')
   const contracts = workflowJobBlock(workflow, 'contracts')
   const contractsSlither = workflowJobBlock(workflow, 'contracts-slither')
   const contractsGasSnapshot = workflowJobBlock(workflow, 'contracts-gas-snapshot')
@@ -1950,10 +1974,32 @@ test('CI product jobs are gated by path-aware scope outputs', async () => {
   assert.match(dependencyReview, /needs\.scope-gate\.outputs\.run_dependency_review == 'true'/)
   assert.match(frontend, /needs\.scope-gate\.outputs\.run_frontend == 'true'/)
   assert.match(dashboard, /needs\.scope-gate\.outputs\.run_dashboard == 'true'/)
+  assert.match(apiContracts, /needs\.scope-gate\.outputs\.run_api_contracts == 'true'/)
   assert.match(contracts, /needs\.scope-gate\.outputs\.run_contracts == 'true'/)
   assert.match(contractsSlither, /needs\.scope-gate\.outputs\.run_contracts_slither == 'true'/)
   assert.match(contractsGasSnapshot, /needs\.scope-gate\.outputs\.run_contracts_gas_report == 'true'/)
   assert.deepEqual(backendIntegrationJob.needs, ['scope-gate', 'check-cache-wiring'])
+})
+
+test('API contract drift CI job checks generated types and typed client', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
+  const job = parsedWorkflow.jobs['api-contracts']
+  const jobBlock = workflowJobBlock(workflow, 'api-contracts')
+
+  assert.equal(job.name, 'API contract drift')
+  assert.equal(job['timeout-minutes'], 10)
+  assert.equal(job.needs, 'scope-gate')
+  assert.equal(job.if, "needs.scope-gate.outputs.run_api_contracts == 'true'")
+  assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.match(jobBlock, pinnedActionRef('actions/setup-node', 'v4'))
+  assert.match(jobBlock, pinnedActionRef('pnpm/action-setup', 'v4'))
+  assert.match(jobBlock, /version: 10\.33\.0/)
+  assert.match(jobBlock, /run_install: false/)
+  assert.doesNotMatch(jobBlock, /corepack prepare pnpm@10\.33\.0 --activate/)
+  assert.match(jobBlock, /pnpm install --frozen-lockfile --ignore-scripts/)
+  assert.match(jobBlock, /pnpm api:types:check/)
+  assert.match(jobBlock, /pnpm api:client:test/)
 })
 
 test('PR commit message check skips formal release promotion PRs', () => {
@@ -2587,7 +2633,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
 
   assert.equal(job.name, 'Auto-ready draft PR after CI')
   assert.equal(job.if, "always() && github.event_name == 'pull_request'")
-  assert.deepEqual(job.needs, ['scope-gate', 'supply-chain-guardrails', 'backend-ci', 'dependency-review', 'frontend', 'dashboard', 'contracts', 'contracts-slither', 'contracts-gas-snapshot'])
+  assert.deepEqual(job.needs, ['scope-gate', 'supply-chain-guardrails', 'backend-ci', 'dependency-review', 'api-contracts', 'frontend', 'dashboard', 'contracts', 'contracts-slither', 'contracts-gas-snapshot'])
   assert.equal(job.permissions['pull-requests'], 'write')
   assert.equal(job.permissions.contents, 'write')
   assert.equal(job.permissions.issues, 'write')
@@ -2602,6 +2648,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /SUPPLY_CHAIN_GUARDRAILS_RESULT/)
   assert.match(jobBlock, /BACKEND_CI_RESULT/)
   assert.match(jobBlock, /DEPENDENCY_REVIEW_RESULT/)
+  assert.match(jobBlock, /API_CONTRACTS_RESULT/)
   assert.match(jobBlock, /FRONTEND_RESULT/)
   assert.match(jobBlock, /DASHBOARD_RESULT/)
   assert.match(jobBlock, /CONTRACTS_RESULT/)

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -1993,6 +1993,7 @@ test('API contract drift CI job checks generated types and typed client', async 
   assert.equal(job.if, "needs.scope-gate.outputs.run_api_contracts == 'true'")
   assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
   assert.match(jobBlock, pinnedActionRef('actions/setup-node', 'v4'))
+  assert.match(jobBlock, /node-version: 22\.16\.0/)
   assert.match(jobBlock, pinnedActionRef('pnpm/action-setup', 'v4'))
   assert.match(jobBlock, /version: 10\.33\.0/)
   assert.match(jobBlock, /run_install: false/)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22.12.0
+          node-version: 22.16.0
 
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       run_backend_integration: ${{ steps.evaluate.outputs.run_backend_integration }}
       run_backend_scanners: ${{ steps.evaluate.outputs.run_backend_scanners }}
       run_dependency_review: ${{ steps.evaluate.outputs.run_dependency_review }}
+      run_api_contracts: ${{ steps.evaluate.outputs.run_api_contracts }}
       run_frontend: ${{ steps.evaluate.outputs.run_frontend }}
       run_dashboard: ${{ steps.evaluate.outputs.run_dashboard }}
       run_contracts: ${{ steps.evaluate.outputs.run_contracts }}
@@ -48,6 +49,7 @@ jobs:
               runBackendIntegration,
               runBackendScanners,
               runDependencyReview,
+              runApiContracts,
               runFrontend,
               runDashboard,
               runContracts,
@@ -59,6 +61,7 @@ jobs:
               core.setOutput('run_backend_integration', runBackendIntegration ? 'true' : 'false')
               core.setOutput('run_backend_scanners', runBackendScanners ? 'true' : 'false')
               core.setOutput('run_dependency_review', runDependencyReview ? 'true' : 'false')
+              core.setOutput('run_api_contracts', runApiContracts ? 'true' : 'false')
               core.setOutput('run_frontend', runFrontend ? 'true' : 'false')
               core.setOutput('run_dashboard', runDashboard ? 'true' : 'false')
               core.setOutput('run_contracts', runContracts ? 'true' : 'false')
@@ -71,6 +74,7 @@ jobs:
               runBackendIntegration: true,
               runBackendScanners: true,
               runDependencyReview: false,
+              runApiContracts: true,
               runFrontend: true,
               runDashboard: true,
               runContracts: true,
@@ -83,6 +87,7 @@ jobs:
               runBackendIntegration: false,
               runBackendScanners: false,
               runDependencyReview: false,
+              runApiContracts: false,
               runFrontend: false,
               runDashboard: false,
               runContracts: false,
@@ -100,6 +105,7 @@ jobs:
                   runBackendIntegration: false,
                   runBackendScanners: true,
                   runDependencyReview: false,
+                  runApiContracts: false,
                   runFrontend: false,
                   runDashboard: false,
                   runContracts: false,
@@ -255,6 +261,13 @@ jobs:
               /^pnpm-lock\.yaml$/,
               /^pnpm-workspace\.yaml$/,
             ]
+            const apiContractPaths = [
+              /^packages\/(?:shared-types|api-client)\//,
+              /^services\/api\/docs\/(?:docs\.go|swagger\.json|swagger\.ya?ml)$/,
+              /^package\.json$/,
+              /^pnpm-lock\.yaml$/,
+              /^pnpm-workspace\.yaml$/,
+            ]
             const runFullCi = runCi && (
               isReleasePromotionPr ||
               allFilePaths.some((name) => ciWorkflowPaths.some((pattern) => pattern.test(name)))
@@ -275,6 +288,9 @@ jobs:
             const runDependencyReview = runCi && allFilePaths.some((name) =>
               dependencyReviewPaths.some((pattern) => pattern.test(name)),
             )
+            const runApiContracts = runFullCi || (runCi && allFilePaths.some((name) =>
+              apiContractPaths.some((pattern) => pattern.test(name)),
+            ))
             const runBackendIntegration = allFilePaths.some((name) =>
               backendIntegrationPaths.some((pattern) => pattern.test(name)),
             )
@@ -287,6 +303,7 @@ jobs:
                 runBackendIntegration: shouldRunBackendIntegration,
                 runBackendScanners,
                 runDependencyReview,
+                runApiContracts,
                 runFrontend,
                 runDashboard,
                 runContracts,
@@ -601,6 +618,33 @@ jobs:
           comment-summary-in-pr: never
           show-openssf-scorecard: false
 
+  api-contracts:
+    timeout-minutes: 10
+    name: API contract drift
+    needs: scope-gate
+    if: needs.scope-gate.outputs.run_api_contracts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.12.0
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Check generated API types
+        run: pnpm api:types:check
+
+      - name: Test typed API client
+        run: pnpm api:client:test
+
   frontend:
     timeout-minutes: 15
     name: Frontend build
@@ -783,7 +827,7 @@ jobs:
   auto-ready-after-ci:
     timeout-minutes: 5
     name: Auto-ready draft PR after CI
-    needs: [scope-gate, supply-chain-guardrails, backend-ci, dependency-review, frontend, dashboard, contracts, contracts-slither, contracts-gas-snapshot]
+    needs: [scope-gate, supply-chain-guardrails, backend-ci, dependency-review, api-contracts, frontend, dashboard, contracts, contracts-slither, contracts-gas-snapshot]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -800,6 +844,7 @@ jobs:
           SUPPLY_CHAIN_GUARDRAILS_RESULT: ${{ needs.supply-chain-guardrails.result }}
           BACKEND_CI_RESULT: ${{ needs.backend-ci.result }}
           DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
+          API_CONTRACTS_RESULT: ${{ needs.api-contracts.result }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           DASHBOARD_RESULT: ${{ needs.dashboard.result }}
           CONTRACTS_RESULT: ${{ needs.contracts.result }}
@@ -835,6 +880,7 @@ jobs:
               ['supply-chain-guardrails', process.env.SUPPLY_CHAIN_GUARDRAILS_RESULT],
               ['backend-ci', process.env.BACKEND_CI_RESULT],
               ['dependency-review', process.env.DEPENDENCY_REVIEW_RESULT],
+              ['api-contracts', process.env.API_CONTRACTS_RESULT],
               ['frontend', process.env.FRONTEND_RESULT],
               ['dashboard', process.env.DASHBOARD_RESULT],
               ['contracts', process.env.CONTRACTS_RESULT],


### PR DESCRIPTION
## 什麼改動
新增 CI 的 `API contract drift` job，讓 OpenAPI generated types / typed API client 相關路徑變更時，會執行 `pnpm api:types:check` 與 `pnpm api:client:test`。

## 為什麼
refs #401

#401 要求 CI 或 linting 防止 contract drift；目前 `packages/shared-types` 與 `packages/api-client` 已落地，但 `develop` 還沒有專門 gate 會在相關路徑變更時檢查 generated artifacts 與 typed client。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## Scope 對齊
- Source of truth：#401
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 generated API types 或 typed client runtime
  - 不導入新的 dependency
  - 不改 frontend / backend product behavior

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #401 OpenAPI codegen acceptance criteria
- Actual worker profile(s)：
  - main controller only
- Model strength：
  - main GPT-5.5 xhigh
- Spawn directive(s)：
  - profile=main_controller model=gpt-5.5 reasoning=xhigh controller_fallback=denied fallback_reason=CI_policy_owned_by_controller
  - 未 spawned subagent；此切片涉及 CI policy，由 main agent 直接處理
- Verification evidence：
  - `rtk node --test .github/workflows/ci.test.mjs`
  - `rtk pnpm install --frozen-lockfile --ignore-scripts`
  - `rtk pnpm api:types:check`
  - `rtk pnpm api:client:test`
  - `rtk git --no-optional-locks diff --check`
- Self-review / exception reason：
  - 已完成 self-review；CI policy 小切片，仍需 human review
- Worker session closeout：
  - n/a，未使用 worker
- Workflow friction / follow-up split：
  - n/a

## Review conversation closeout
- Unresolved threads：
  - 0；新 PR initial body
- CodeRabbit：
  - status context SUCCESS；latest CodeRabbit comment reports rate limit/usage credits exceeded，未產生 actionable review comments
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - local TDD RED/GREEN evidence in automation thread
- root_cause_gate_ref：
  - #401 acceptance criteria: CI / linting prevents silent contract drift
- finding_disposition_ref：
  - adopted: add path-aware `run_api_contracts` output plus dedicated CI job
- Final reviewer action：
  - pending reviewer

## Final merge gate
- Ready-to-merge decision：
  - pending human review；CI success，CodeRabbit status context SUCCESS but review body is rate-limited
- Latest head SHA：
  - e3a82440e3ccb55f3e9aae176daebee835969bc7
- Required checks：
  - CI run 25848285052 success；API contract drift success；Backend CI (gate) success
- spec workflow-check evidence：
  - n/a
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/actions/runs/25848285052

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 為 #401 的 OpenAPI generated types 與 typed API client 加上 path-aware CI drift gate。
- Approx changed lines：~90
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 只包含 CI workflow 與其 regression tests；tests 是 workflow change 的必要驗證。
- 若已拆分，相關 PR：
  - #638 docs flow, #649 shared-types scaffold, #656 api-client scaffold, #687 generated type refresh

## Acceptance Criteria
- [x] OpenAPI/codegen flow is documented
- [x] generated TS artifacts can be consumed by current frontend apps
- [x] backend schema changes can be regenerated repeatably
- [x] CI or linting prevents silent contract drift

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk node --test .github/workflows/ci.test.mjs
# tests 85, pass 85, fail 0

rtk pnpm install --frozen-lockfile --ignore-scripts
# Done in 716ms using pnpm v10.33.0

rtk pnpm api:types:check
# pass

rtk pnpm api:client:test
# tests 8, pass 8, fail 0

rtk git --no-optional-locks diff --check
# pass
```

## 備註
`API contract drift` job 只在 `packages/shared-types`, `packages/api-client`, `services/api/docs` Swagger artifacts, root pnpm workspace/dependency files, 或 full CI workflow 變更時啟動。
CI 使用 pinned `pnpm/action-setup` 啟用 pnpm，避免 runner 內建 Corepack 金鑰過期造成假紅燈。

## Notes for Claude Code Review
- 這是 CI policy 變更；請特別看 `run_api_contracts` path 判斷是否過寬或過窄。

