### PR TITLE
[infra] add sandboxed docs compose service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.worktrees
+.DS_Store
+.claude
+.codex
+.config
+
+**/.env
+**/.env.*
+**/node_modules
+
+apps/docs/.docusaurus
+apps/docs/build
+build
+coverage
+dist
+graphify-out

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ docker compose up --build
 | Backend  | http://localhost:8080                    |
 | Swagger  | http://localhost:8080/swagger/index.html |
 | Frontend | http://localhost:5173                    |
+| Dev Portal | http://localhost:3000/tachigo/         |
 | Postgres | localhost:5433                           |
 
 If you want local `.env` files, copy the examples first. Docker Compose can still start without them because the env files are optional.
@@ -78,6 +79,7 @@ On Windows PowerShell, you can generate the local env files with:
 ```bash
 docker compose up --build     # start all services (foreground — see logs)
 docker compose up -d --build  # start in background
+docker compose up docs --build # start only the Dev Portal docs site
 docker compose down           # stop all services
 docker compose logs -f        # tail all logs
 ```

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,0 +1,24 @@
+# dev only - not for production
+FROM node:24-alpine
+
+RUN addgroup -S app && adduser -S app -G app
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+WORKDIR /workspace
+ENV CI=1
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/docs/package.json apps/docs/package.json
+COPY apps/dashboard/package.json apps/dashboard/package.json
+COPY apps/extension/package.json apps/extension/package.json
+COPY packages/api-client/package.json packages/api-client/package.json
+COPY packages/shared-types/package.json packages/shared-types/package.json
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter ./apps/docs
+
+COPY --chown=app:app apps/docs apps/docs
+COPY --chown=app:app docs docs
+
+USER app
+EXPOSE 3000
+
+CMD ["pnpm", "--filter", "./apps/docs", "start", "--host", "0.0.0.0", "--port", "3000"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,5 +27,8 @@ services:
       - app
     restart: "no"
 
+  docs:
+    restart: "no"
+
 volumes:
   go_mod_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,5 +64,34 @@ services:
       - app
     restart: unless-stopped
 
+  docs:
+    build:
+      context: .
+      dockerfile: apps/docs/Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - type: bind
+        source: ./docs
+        target: /workspace/docs
+        read_only: true
+      - type: bind
+        source: ./apps/docs/src
+        target: /workspace/apps/docs/src
+        read_only: true
+      - type: bind
+        source: ./apps/docs/static
+        target: /workspace/apps/docs/static
+        read_only: true
+      - type: bind
+        source: ./apps/docs/docusaurus.config.ts
+        target: /workspace/apps/docs/docusaurus.config.ts
+        read_only: true
+      - type: bind
+        source: ./apps/docs/sidebars.ts
+        target: /workspace/apps/docs/sidebars.ts
+        read_only: true
+    restart: unless-stopped
+
 volumes:
   postgres_data:

--- a/docs/ai/supply-chain-security.md
+++ b/docs/ai/supply-chain-security.md
@@ -22,6 +22,7 @@ AI agent 不得自行執行下列動作：
 - `make supply-chain-check` 跑 `infra/scripts/check-supply-chain-guardrails.mjs`。
 - CI 的 `Supply-chain guardrails` job 會拒絕新的 `preinstall`、`install`、`postinstall`、`prepare` scripts。
 - 同一個 guardrail 會拒絕 package scripts 內的 `npx`、`pnpm dlx`、`npm exec`、`curl | bash`、`wget | sh`。
+- 同一個 guardrail 會要求 Dockerfile 中的 `pnpm install` 同時使用 `--frozen-lockfile` 與 `--ignore-scripts`。
 - Frontend Docker install 使用 `pnpm install --frozen-lockfile --ignore-scripts`。
 - GitHub dependency review 已在 CI 中啟用；runtime high-severity vulnerability 會 fail PR。
 

--- a/infra/scripts/check-supply-chain-guardrails.mjs
+++ b/infra/scripts/check-supply-chain-guardrails.mjs
@@ -15,6 +15,7 @@ const ignoredDirs = new Set([
 ])
 
 const packageFiles = new Set(['package.json'])
+const dockerfileNames = new Set(['Dockerfile'])
 const lockfileNames = new Set([
   'bun.lock',
   'bun.lockb',
@@ -167,6 +168,20 @@ async function checkAdvisoryContent(root, filePath) {
   return problems
 }
 
+async function checkDockerfile(root, filePath) {
+  const problems = []
+  const content = await readFile(filePath, 'utf8')
+  const normalized = content.replace(/\\\r?\n\s*/g, ' ')
+  const installCommands = normalized.matchAll(/\bpnpm\s+install\b[^\n]*/gi)
+  for (const match of installCommands) {
+    const command = match[0]
+    if (!command.includes('--frozen-lockfile') || !command.includes('--ignore-scripts')) {
+      problems.push(`${relative(root, filePath)}: Dockerfile pnpm install must use --frozen-lockfile --ignore-scripts`)
+    }
+  }
+  return problems
+}
+
 async function main() {
   const { root } = parseArgs(process.argv.slice(2))
   const resolvedRoot = path.resolve(root)
@@ -184,6 +199,8 @@ async function main() {
     if (packageFiles.has(name)) {
       problems.push(...await checkPackageJson(resolvedRoot, filePath))
       problems.push(...await checkAdvisoryContent(resolvedRoot, filePath))
+    } else if (dockerfileNames.has(name)) {
+      problems.push(...await checkDockerfile(resolvedRoot, filePath))
     } else if (lockfileNames.has(name)) {
       const content = await readFile(filePath, 'utf8')
       tanstackReactQueryObserved ||= /@tanstack\/react-query@5\.100\.6/.test(content)

--- a/infra/scripts/check-supply-chain-guardrails.test.sh
+++ b/infra/scripts/check-supply-chain-guardrails.test.sh
@@ -104,9 +104,20 @@ packages:
 EOF
 }
 
+dockerfile_install_without_ignore_scripts_fixture() {
+  local repo="$1"
+  mkdir -p "$repo/apps/docs"
+  cat > "$repo/apps/docs/Dockerfile" <<'EOF'
+FROM node:24-alpine
+RUN corepack enable
+RUN pnpm install --frozen-lockfile
+EOF
+}
+
 run_case clean 0 "Supply-chain guardrails passed" clean_fixture
 run_case preinstall 1 "disallowed lifecycle script" preinstall_fixture
 run_case dynamic_exec 1 "disallowed dynamic package execution" dynamic_exec_fixture
 run_case ioc 1 "Mini Shai-Hulud indicator" ioc_fixture
+run_case dockerfile_install_without_ignore_scripts 1 "Dockerfile pnpm install must use --frozen-lockfile --ignore-scripts" dockerfile_install_without_ignore_scripts_fixture
 
 echo "supply-chain guardrail regression tests passed"


### PR DESCRIPTION
## 什麼改動
新增 Dev Portal docs 專用 Docker/Compose 啟動路徑，讓同事可以用 container 預覽 `/tachigo/`，並把 docs Docker install 固定在 `--frozen-lockfile --ignore-scripts`。

## 為什麼
follow-up to #674。Dev Portal 已經成為專案導覽入口，這個 PR 補上較適合團隊預覽的 container 啟動方式，同時降低 npm supply-chain install scripts 直接污染開發者主機的風險。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#674 follow-up from user-approved Dev Portal ops discussion
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 Dev Portal 內容與視覺設計。
  - 不新增或升級 npm dependency。
  - 不新增 CI deploy、GitHub Pages 或 hosted artifact。
  - 不改 API / extension / dashboard runtime 行為。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #674 follow-up; user requested proceeding with docs container/supply-chain recommendation.
- Actual worker profile(s)：
  - controller self-review only
- Model strength：
  - controller = high
- Spawn directive(s)：
  - n/a; trivial/self-only infra docs follow-up
- Verification evidence：
  - `bash infra/scripts/check-supply-chain-guardrails.test.sh` pass
  - `make supply-chain-check` pass
  - `docker compose config --quiet` pass
  - `git diff --check` pass
- Self-review / exception reason：
  - trivial/self-only exception reason: scoped config + guardrail update under 120 changed lines, no worker delegation needed.
- Worker session closeout：
  - Self-review completed; no worker sessions were opened for this scoped infra follow-up.
- Workflow friction / follow-up split：
  - Docker daemon unavailable locally, so image build is documented as not run; Compose config and guardrail tests are covered here.

## Review conversation closeout
- Unresolved threads：
  - 0; initial PR has no review threads yet.
- CodeRabbit：
  - n/a; no review has run yet.
- chatgpt-codex-connector：
  - n/a; no review has run yet.
- review_triage_ref：
  - pending with reason: initial PR before reviewer feedback.
- root_cause_gate_ref：
  - pending with reason: initial PR before reviewer feedback.
- finding_disposition_ref：
  - pending with reason: initial PR before reviewer feedback.
- Final reviewer action：
  - n/a; awaiting reviewer feedback.

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: initial PR before remote checks and human review.
- Latest head SHA：
  - n/a; will be available after push.
- Required checks：
  - pending with reason: PR not opened yet.
- spec workflow-check evidence：
  - n/a; manual checklist for docs container/supply-chain follow-up.
- Evidence URL：
  - n/a; initial PR body.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add a sandboxed Docker Compose entrypoint for the Dev Portal docs site.
- Approx changed lines：~104
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The docs container and Dockerfile guardrail should land together so the new install path is covered by regression tests.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] AC 1：`docker compose up docs --build` has a dedicated docs service definition.
- [x] AC 2：docs Dockerfile uses `pnpm install --frozen-lockfile --ignore-scripts`.
- [x] AC 3：supply-chain guardrail rejects Dockerfile `pnpm install` commands missing the required flags.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
bash infra/scripts/check-supply-chain-guardrails.test.sh
PASS: supply-chain guardrail regression tests passed

make supply-chain-check
PASS: Supply-chain guardrails passed

docker compose config --quiet
PASS: compose config parsed successfully

git diff --check
PASS: no whitespace errors

docker compose build docs
NOT RUN: Docker daemon unavailable at unix:///Users/tachikoma/.orbstack/run/docker.sock
```

## 備註
The docs image build is intentionally rooted at the repo root so it can use the root workspace lockfile. `.dockerignore` excludes local env files, Git metadata, node_modules, build output, and graphify artifacts from that root build context.

## Notes for Claude Code Review
- Please check whether the root `.dockerignore` excludes the right local-only files without hiding files the docs Docker build needs.
- Please check whether the Dockerfile guardrail should also cover npm/yarn install commands in a later PR; this PR only enforces the new pnpm install path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 發佈說明

* **Documentation**
  * 更新快速啟動指南，新增 Dev Portal 服務說明

* **Chores**
  * 改進 Docker 基礎設施配置和構建優化
  * 增強供應鏈安全檢查機制，確保依賴包安裝的完整性和安全性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/700)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->