### PR TITLE
[frontend] add dev portal frontmatter validator

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -1,3 +1,4 @@
+import frontmatterValidatorPlugin from './plugins/frontmatter-validator/index.js'
 import {themes as prismThemes} from 'prism-react-renderer'
 import type {Config} from '@docusaurus/types'
 import type * as Preset from '@docusaurus/preset-classic'
@@ -28,6 +29,14 @@ const config: Config = {
   },
 
   themes: ['@docusaurus/theme-mermaid'],
+  plugins: [
+    [
+      frontmatterValidatorPlugin,
+      {
+        include: ['**/*.md'],
+      },
+    ],
+  ],
 
   presets: [
     [

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,8 @@
     "start": "docusaurus start --host 0.0.0.0",
     "build": "docusaurus build",
     "serve": "docusaurus serve --host 0.0.0.0",
-    "clear": "docusaurus clear"
+    "clear": "docusaurus clear",
+    "test:frontmatter-validator": "node --experimental-strip-types --no-warnings --test ./plugins/frontmatter-validator/index.test.ts"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.1",
@@ -16,9 +17,12 @@
     "@mdx-js/react": "3.1.1",
     "@mermaid-js/layout-elk": "0.1.9",
     "clsx": "2.1.1",
+    "fast-glob": "3.3.3",
+    "gray-matter": "4.0.3",
     "prism-react-renderer": "2.4.1",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.1",

--- a/apps/docs/plugins/frontmatter-validator/__fixtures__/include-option/included.md
+++ b/apps/docs/plugins/frontmatter-validator/__fixtures__/include-option/included.md
@@ -1,0 +1,5 @@
+---
+status: active
+---
+
+# Included

--- a/apps/docs/plugins/frontmatter-validator/__fixtures__/include-option/skipped.md
+++ b/apps/docs/plugins/frontmatter-validator/__fixtures__/include-option/skipped.md
@@ -1,0 +1,6 @@
+---
+related_issues:
+  - nope
+---
+
+# Skipped

--- a/apps/docs/plugins/frontmatter-validator/__fixtures__/invalid-related-issues/index.md
+++ b/apps/docs/plugins/frontmatter-validator/__fixtures__/invalid-related-issues/index.md
@@ -1,0 +1,6 @@
+---
+related_issues:
+  - foo
+---
+
+# Invalid related issues

--- a/apps/docs/plugins/frontmatter-validator/__fixtures__/invalid-reverse-scope/index.md
+++ b/apps/docs/plugins/frontmatter-validator/__fixtures__/invalid-reverse-scope/index.md
@@ -1,0 +1,8 @@
+---
+code_areas:
+  - services/api
+reverse_index_scope:
+  - apps/dashboard
+---
+
+# Invalid reverse scope

--- a/apps/docs/plugins/frontmatter-validator/__fixtures__/unquoted-date/index.md
+++ b/apps/docs/plugins/frontmatter-validator/__fixtures__/unquoted-date/index.md
@@ -1,0 +1,5 @@
+---
+last_reviewed: 2026-05-13
+---
+
+# Unquoted date

--- a/apps/docs/plugins/frontmatter-validator/__fixtures__/valid-docs/index.md
+++ b/apps/docs/plugins/frontmatter-validator/__fixtures__/valid-docs/index.md
@@ -1,0 +1,6 @@
+---
+status: active
+owner: engineering
+---
+
+# Valid

--- a/apps/docs/plugins/frontmatter-validator/__fixtures__/valid-reverse-scope/index.md
+++ b/apps/docs/plugins/frontmatter-validator/__fixtures__/valid-reverse-scope/index.md
@@ -1,0 +1,8 @@
+---
+code_areas:
+  - services/api
+reverse_index_scope:
+  - services/api/internal/watchtime
+---
+
+# Valid reverse scope

--- a/apps/docs/plugins/frontmatter-validator/index.test.ts
+++ b/apps/docs/plugins/frontmatter-validator/index.test.ts
@@ -1,0 +1,101 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  default as frontmatterValidatorPlugin,
+  validateFrontmatterDocs,
+} from './index.ts'
+
+test('scans docs/index.md so validator cannot no-op', async () => {
+  const result = await validateFrontmatterDocs({
+    docsRoot: new URL('./__fixtures__/valid-docs/', import.meta.url),
+  })
+
+  assert.ok(
+    result.files.some((file) => file.relativePath === 'index.md'),
+    'expected docs/index.md to be scanned',
+  )
+})
+
+test('fails when related_issues contains a string', async () => {
+  await assert.rejects(
+    () =>
+      validateFrontmatterDocs({
+        docsRoot: new URL('./__fixtures__/invalid-related-issues/', import.meta.url),
+      }),
+    (error) => {
+      assert.match(error.message, /index\.md/)
+      assert.match(error.message, /related_issues/)
+      return true
+    },
+  )
+})
+
+test('accepts unquoted YAML date scalars after normalization', async () => {
+  const result = await validateFrontmatterDocs({
+    docsRoot: new URL('./__fixtures__/unquoted-date/', import.meta.url),
+  })
+
+  const doc = result.files.find((file) => file.relativePath === 'index.md')
+  assert.equal(doc.frontmatter.last_reviewed, '2026-05-13')
+})
+
+test('accepts reverse_index_scope values nested under code_areas', async () => {
+  const result = await validateFrontmatterDocs({
+    docsRoot: new URL('./__fixtures__/valid-reverse-scope/', import.meta.url),
+  })
+
+  const doc = result.files.find((file) => file.relativePath === 'index.md')
+  assert.deepEqual(doc.frontmatter.reverse_index_scope, ['services/api/internal/watchtime'])
+})
+
+test('fails when reverse_index_scope falls outside code_areas', async () => {
+  await assert.rejects(
+    () =>
+      validateFrontmatterDocs({
+        docsRoot: new URL('./__fixtures__/invalid-reverse-scope/', import.meta.url),
+      }),
+    (error) => {
+      assert.match(error.message, /index\.md/)
+      assert.match(error.message, /reverse_index_scope/)
+      return true
+    },
+  )
+})
+
+test('plugin lifecycle loads content and publishes global data', async () => {
+  const plugin = frontmatterValidatorPlugin(
+    {siteDir: new URL('.', import.meta.url).pathname},
+    {docsRoot: new URL('./__fixtures__/valid-docs/', import.meta.url)},
+  )
+  const content = await plugin.loadContent()
+  let globalData
+
+  await plugin.contentLoaded({
+    content,
+    actions: {
+      setGlobalData(data) {
+        globalData = data
+      },
+    },
+  })
+
+  assert.ok(content.files.some((file) => file.relativePath === 'index.md'))
+  assert.equal(globalData, content)
+})
+
+test('plugin lifecycle respects include option', async () => {
+  const plugin = frontmatterValidatorPlugin(
+    {siteDir: new URL('.', import.meta.url).pathname},
+    {
+      docsRoot: new URL('./__fixtures__/include-option/', import.meta.url),
+      include: ['included.md'],
+    },
+  )
+  const content = await plugin.loadContent()
+
+  assert.deepEqual(
+    content.files.map((file) => file.relativePath),
+    ['included.md'],
+  )
+})

--- a/apps/docs/plugins/frontmatter-validator/index.ts
+++ b/apps/docs/plugins/frontmatter-validator/index.ts
@@ -1,0 +1,191 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import type {LoadContext, Plugin} from '@docusaurus/types'
+import fg from 'fast-glob'
+import matter from 'gray-matter'
+import {z} from 'zod'
+
+const dateStringSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD')
+
+const frontmatterSchema = z
+  .object({
+    status: z.enum(['active', 'proposed', 'deprecated']).optional(),
+    owner: z.string().min(1).optional(),
+    last_reviewed: dateStringSchema.optional(),
+    source_of_truth: z.boolean().optional(),
+    code_areas: z.array(z.string()).optional(),
+    related_repos: z.array(z.string()).optional(),
+    related_issues: z.array(z.number().int().positive()).optional(),
+    implemented_in: z.array(z.number().int().positive()).optional(),
+    implemented_at: dateStringSchema.optional(),
+    impl_status: z.enum(['shipped', 'in_progress', 'proposed']).optional(),
+    reverse_index_mode: z.enum(['inferred', 'explicit_only', 'disabled']).optional(),
+    reverse_index_scope: z.array(z.string()).optional(),
+    excluded_from_llms: z.boolean().optional(),
+    internal: z.boolean().optional(),
+  })
+  .superRefine((frontmatter, ctx) => {
+    if (!frontmatter.reverse_index_scope) {
+      return
+    }
+
+    const codeAreas = frontmatter.code_areas ?? []
+
+    for (const [index, scope] of frontmatter.reverse_index_scope.entries()) {
+      const isValid = codeAreas.some(
+        (codeArea) => scope === codeArea || scope.startsWith(`${codeArea}/`),
+      )
+
+      if (!isValid) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['reverse_index_scope', index],
+          message: 'must equal a code_areas value or be nested beneath one',
+        })
+      }
+    }
+  })
+
+export type FrontmatterData = z.infer<typeof frontmatterSchema>
+
+export interface FrontmatterValidatorOptions {
+  docsRoot?: string | URL
+  include?: string[]
+  allowWarnings?: boolean
+}
+
+export interface ValidatedDocFile {
+  absolutePath: string
+  relativePath: string
+  frontmatter: FrontmatterData
+}
+
+export interface ValidationResult {
+  docsRoot: string
+  files: ValidatedDocFile[]
+  warnings: string[]
+}
+
+function normalizeDateScalar(value: unknown): unknown {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString().slice(0, 10)
+  }
+
+  return value
+}
+
+function normalizeFrontmatter(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [key, normalizeDateScalar(value)]),
+  )
+}
+
+function resolveDocsRoot(siteDir: string, docsRoot?: string | URL): string {
+  if (docsRoot instanceof URL) {
+    return path.resolve(fileURLToPath(docsRoot))
+  }
+
+  if (typeof docsRoot === 'string') {
+    return path.isAbsolute(docsRoot) ? docsRoot : path.resolve(siteDir, docsRoot)
+  }
+
+  return path.resolve(siteDir, '../../docs')
+}
+
+function formatIssues(relativePath: string, issues: z.ZodIssue[]): string[] {
+  return issues.map((issue) => {
+    const field = issue.path.length > 0 ? issue.path.join('.') : '(frontmatter)'
+    return `${relativePath}: ${field} ${issue.message}`
+  })
+}
+
+function isLocalWarningEscapeEnabled(): boolean {
+  return process.env.CI !== 'true' && process.env.DOCS_FRONTMATTER_VALIDATOR_ALLOW_WARNINGS === '1'
+}
+
+export async function validateFrontmatterDocs(
+  options: FrontmatterValidatorOptions & {siteDir?: string} = {},
+): Promise<ValidationResult> {
+  const siteDir = options.siteDir ?? process.cwd()
+  const docsRoot = resolveDocsRoot(siteDir, options.docsRoot)
+  const include = options.include ?? ['**/*.md']
+  const relativePaths = (
+    await fg(include, {
+      cwd: docsRoot,
+      onlyFiles: true,
+    })
+  ).sort()
+
+  if (relativePaths.length === 0) {
+    throw new Error(`Frontmatter validation failed: no markdown files found under ${docsRoot}`)
+  }
+
+  const files: ValidatedDocFile[] = []
+  const warnings: string[] = []
+
+  for (const relativePath of relativePaths) {
+    const absolutePath = path.join(docsRoot, relativePath)
+    const source = await fs.readFile(absolutePath, 'utf8')
+    const parsed = matter(source)
+    const normalized = normalizeFrontmatter(parsed.data as Record<string, unknown>)
+    const result = frontmatterSchema.safeParse(normalized)
+
+    if (!result.success) {
+      warnings.push(...formatIssues(relativePath, result.error.issues))
+      continue
+    }
+
+    files.push({
+      absolutePath,
+      relativePath,
+      frontmatter: result.data,
+    })
+  }
+
+  if (warnings.length > 0 && !options.allowWarnings) {
+    throw new Error(`Frontmatter validation failed:\n${warnings.join('\n')}`)
+  }
+
+  return {
+    docsRoot,
+    files,
+    warnings,
+  }
+}
+
+export default function frontmatterValidatorPlugin(
+  context: LoadContext,
+  options: FrontmatterValidatorOptions = {},
+): Plugin<ValidationResult> {
+  return {
+    name: 'tachigo-frontmatter-validator',
+
+    async loadContent() {
+      const result = await validateFrontmatterDocs({
+        siteDir: context.siteDir,
+        docsRoot: options.docsRoot,
+        include: options.include,
+        allowWarnings: options.allowWarnings ?? isLocalWarningEscapeEnabled(),
+      })
+
+      if (result.warnings.length > 0) {
+        console.warn(
+          [
+            'Frontmatter validator warnings were allowed by local escape hatch:',
+            ...result.warnings,
+          ].join('\n'),
+        )
+      }
+
+      return result
+    },
+
+    async contentLoaded({content, actions}) {
+      actions.setGlobalData(content)
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,12 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      fast-glob:
+        specifier: 3.3.3
+        version: 3.3.3
+      gray-matter:
+        specifier: 4.0.3
+        version: 4.0.3
       prism-react-renderer:
         specifier: 2.4.1
         version: 2.4.1(react@18.3.1)
@@ -149,6 +155,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.1


### PR DESCRIPTION
## 什麼改動
新增 Dev Portal frontmatter validator plugin，讓 `docs/**/*.md` 的 Phase 1 Link Layer 欄位在 build-time 受到 schema 檢查。

## 為什麼
#694 要先建立可信的 frontmatter 基礎，後續 #695 related links、#696 reverse-index、#697 llms manifest 才不會吃到型別錯誤或不一致的資料。

closes #694

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#694
- Depends on PR：#701
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 #695 related links UI。
  - 不做 #696 reverse-index / changelog。
  - 不做 #697 llms.txt / manifest.json。
  - 不做 #698 local search。
  - 不做 #699 deployment tracker / Cloudflare Pages 設定。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #694 Issue Delegation Plan: https://github.com/nurockplayer/tachigo/issues/694#issuecomment-4450313377
- Actual worker profile(s)：
  - frontend_worker / spec_reviewer / quality_reviewer / controller
- Model strength：
  - frontend_worker = GPT-5.4 medium; spec_reviewer = GPT-5.4 medium; quality_reviewer = GPT-5.4 medium; controller = GPT-5.5 high
- Spawn directive(s)：
  - profile=frontend_worker model=gpt-5.4 reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=spec_reviewer model=gpt-5.4 reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=quality_reviewer model=gpt-5.4 reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=controller model=gpt-5.5 reasoning=high controller_fallback=allowed fallback_reason=review_or_merge_decision: controller owns scope, finding disposition, PR body, and final merge gate; evidence=https://github.com/nurockplayer/tachigo/issues/694#issuecomment-4450313377
- Verification evidence：
  - `spec plan 694 --repo . --dry-run --format prompt --verbose` pass
  - `spec workflow-check --repo . --phase start --issue 694` pass
  - `pnpm install --frozen-lockfile --ignore-scripts` pass
  - `npx -p node@22.12.0 node --experimental-strip-types --no-warnings --test ./apps/docs/plugins/frontmatter-validator/index.test.ts` pass, 7/7
  - `pnpm --filter ./apps/docs test:frontmatter-validator` pass, 7/7
  - `CI=true DOCS_FRONTMATTER_VALIDATOR_ALLOW_WARNINGS=1 pnpm build:docs` pass
  - `pnpm build:docs` pass
  - `git diff --check` pass
- Self-review / exception reason：
  - Self-review completed; spec reviewer finding on CI-safe local escape was adopted; quality reviewer findings on Node 22 compatibility and plugin lifecycle coverage and include-option scope clarity were adopted.
- Worker session closeout：
  - frontend_worker, spec_reviewer, and quality_reviewer results were read back by controller; completed worker handles were closed before PR finalization.
- Workflow friction / follow-up split：
  - #695-#699 remain split follow-up implementation PRs. threshold_ledger_ref=https://github.com/nurockplayer/tachigo/issues/664 pending with reason: dogfood comment is posted after PR merge with exact head/merge SHA.

## Review conversation closeout
- routing_evidence_status: pass
- routing_evidence_ref: https://github.com/nurockplayer/tachigo/issues/694#issuecomment-4450313377
- routing_evidence_ref_match: yes
- spark_readback_evidence: https://github.com/nurockplayer/tachigo/issues/694#issuecomment-4450313377
- worker_5_4_evidence: https://github.com/nurockplayer/tachigo/issues/694#issuecomment-4450313377
- finding_disposition_status: pass
- finding_disposition_ref: local pre-PR reviewer findings adopted; evidence file: local-only /tmp/tachigo-pr-694-finding.json
- threshold_evidence_status: pass
- threshold_ledger_ref: https://github.com/nurockplayer/tachigo/issues/664
- task_size: small
- risk: medium
- delegation_decision: spawned
- expected_delegation_cost: medium
- actual_friction: minor
- Unresolved threads：
  - 0 by GraphQL readback at head df254daeea1fbdbf726b524cb60819486b91b7b4.
- CodeRabbit：
  - skipped by status context; no actionable finding.
- chatgpt-codex-connector：
  - n/a; no connector review present in latestReviews at readback.
- review_triage_ref：
  - Local review findings were triaged before PR and adopted; remote review has no unresolved threads.
- root_cause_gate_ref：
  - pass: repeated local findings traced to test/runtime compatibility and plugin lifecycle coverage, both fixed before push.
- Final reviewer action：
  - pending with explicit reason: repository currently requires reviewer approval; all CI checks are pass/skipped and mergeability is otherwise clean.

## Final merge gate
- Ready-to-merge decision：
  - blocked only by required reviewer approval; implementation, CI, Scope Police, and review-thread readback are clean.
- Latest head SHA：
  - df254daeea1fbdbf726b524cb60819486b91b7b4
- Required checks：
  - pass/skipped only by gh PR checks readback at 2026-05-14T11:46Z.
- Review threads：
  - 0 unresolved by GraphQL readback.
- CodeRabbit：
  - skipped by status context; no actionable finding.
- spec workflow-check evidence：
  - spec_evidence_status: manual-pass; start=pass, commit=pass, merge readback=manual because spec-injector #242 checker hit a gh checks JSON field mismatch (conclusion vs state). Controller readback verified equivalent required evidence manually.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/694#issuecomment-4450313377
- Threshold ledger：
  - https://github.com/nurockplayer/tachigo/issues/664 after merge with exact merge SHA.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add a build-time frontmatter validator for Dev Portal link-layer metadata.
- Approx changed lines：~330
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The Docusaurus plugin registration and its validator regression tests are one reviewable behavior change for #694.
- 若已拆分，相關 PR：
  - #701 spec prerequisite; #695, #696, #697, #698, #699 remain follow-up PRs.

## Acceptance Criteria
- [x] AC 1：`apps/docs/plugins/frontmatter-validator/index.ts` implements a Docusaurus plugin.
- [x] AC 2：`docsRoot` option defaults from `context.siteDir` back to repo `docs/`.
- [x] AC 3：filesystem scan uses `fast-glob` + `gray-matter` for `docs/**/*.md`.
- [x] AC 4：zod schema validates optional fields only when present.
- [x] AC 5：errors include doc path and field.
- [x] AC 6：plugin is registered in `apps/docs/docusaurus.config.ts`.
- [x] AC 7：local-only warning escape is disabled in CI.
- [x] AC 8：tests cover no-op guard, invalid `related_issues`, unquoted date scalar, and valid/invalid `reverse_index_scope`.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm install --frozen-lockfile --ignore-scripts
PASS

npx -p node@22.12.0 node --experimental-strip-types --no-warnings --test ./apps/docs/plugins/frontmatter-validator/index.test.ts
PASS: 7/7

pnpm --filter ./apps/docs test:frontmatter-validator
PASS: 7/7

CI=true DOCS_FRONTMATTER_VALIDATOR_ALLOW_WARNINGS=1 pnpm build:docs
PASS

pnpm build:docs
PASS

git diff --check
PASS
```

## 備註
`DOCS_FRONTMATTER_VALIDATOR_ALLOW_WARNINGS=1` is accepted only when `CI` is not `true`; CI builds keep validation failures blocking.

## Notes for Claude Code Review
- Please verify that the local warning escape cannot bypass CI.
- Please verify that `reverse_index_scope` accepts exact/prefix children of `code_areas` and rejects unrelated paths.
- Please verify the Node 22.12 test command remains compatible with repo CI expectations.
- Please verify the explicit include option remains repo `docs/**/*.md` as required by #694.

