### PR TITLE
[frontend] add Dev Portal related links

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -1,5 +1,6 @@
 import frontmatterValidatorPlugin from './plugins/frontmatter-validator/index.js'
 import llmsTxtPlugin from './plugins/llms-txt/index.js'
+import relatedLinksPlugin from './plugins/related-links/index.js'
 import {themes as prismThemes} from 'prism-react-renderer'
 import type {Config} from '@docusaurus/types'
 import type * as Preset from '@docusaurus/preset-classic'
@@ -53,6 +54,12 @@ const config: Config = {
     ],
     [
       llmsTxtPlugin,
+      {
+        include: ['**/*.md'],
+      },
+    ],
+    [
+      relatedLinksPlugin,
       {
         include: ['**/*.md'],
       },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,10 +11,12 @@
     "build:reverse-index": "node --experimental-strip-types --no-warnings ./scripts/build-reverse-index.ts",
     "test:reverse-index": "node --experimental-strip-types --no-warnings --test ./scripts/build-reverse-index.test.ts",
     "test:frontmatter-validator": "node --experimental-strip-types --no-warnings --test ./plugins/frontmatter-validator/index.test.ts",
-    "test:llms-txt": "node --experimental-strip-types --no-warnings --test ./plugins/llms-txt/index.test.ts"
+    "test:llms-txt": "node --experimental-strip-types --no-warnings --test ./plugins/llms-txt/index.test.ts",
+    "test:related-links": "node --experimental-strip-types --no-warnings --test ./plugins/related-links/index.test.ts"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.1",
+    "@docusaurus/plugin-content-docs": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/theme-mermaid": "3.10.1",
     "@easyops-cn/docusaurus-search-local": "0.55.1",

--- a/apps/docs/plugins/related-links/__fixtures__/docs/no-links.md
+++ b/apps/docs/plugins/related-links/__fixtures__/docs/no-links.md
@@ -1,0 +1,5 @@
+---
+owner: engineering
+---
+
+# No links

--- a/apps/docs/plugins/related-links/__fixtures__/docs/pr-only.md
+++ b/apps/docs/plugins/related-links/__fixtures__/docs/pr-only.md
@@ -1,0 +1,5 @@
+---
+implemented_in: [680]
+---
+
+# PR only

--- a/apps/docs/plugins/related-links/__fixtures__/docs/warning-only.md
+++ b/apps/docs/plugins/related-links/__fixtures__/docs/warning-only.md
@@ -1,0 +1,5 @@
+---
+related_issues: ["695"]
+---
+
+# Warning only

--- a/apps/docs/plugins/related-links/__fixtures__/docs/with-links.md
+++ b/apps/docs/plugins/related-links/__fixtures__/docs/with-links.md
@@ -1,0 +1,6 @@
+---
+related_issues: [674, 695]
+implemented_in: [679]
+---
+
+# With links

--- a/apps/docs/plugins/related-links/index.test.ts
+++ b/apps/docs/plugins/related-links/index.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {fileURLToPath} from 'node:url'
+
+import {
+  collectRelatedLinks,
+  default as relatedLinksPlugin,
+} from './index.ts'
+import {validateFrontmatterDocs} from '../frontmatter-validator/index.ts'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+const fixtureDocsRoot = new URL('./__fixtures__/docs/', import.meta.url)
+
+test('collects only docs with related issues or implemented PRs', async () => {
+  const validation = await validateFrontmatterDocs({
+    docsRoot: fixtureDocsRoot,
+    allowWarnings: true,
+  })
+
+  const relatedLinks = collectRelatedLinks(validation)
+
+  assert.deepEqual(relatedLinks.docs, {
+    'with-links.md': {
+      related_issues: [674, 695],
+      implemented_in: [679],
+    },
+    'pr-only.md': {
+      implemented_in: [680],
+    },
+  })
+})
+
+test('plugin lifecycle publishes related links as global data', async () => {
+  const plugin = relatedLinksPlugin(
+    {siteDir: currentDir},
+    {docsRoot: fixtureDocsRoot},
+  )
+  const content = await plugin.loadContent()
+  let globalData
+
+  await plugin.contentLoaded({
+    content,
+    actions: {
+      setGlobalData(data) {
+        globalData = data
+      },
+    },
+  })
+
+  assert.equal(globalData, content)
+  assert.deepEqual(content.docs['with-links.md'].related_issues, [674, 695])
+  assert.equal(content.docs['warning-only.md'], undefined)
+})
+
+test('plugin allows frontmatter warnings by default', async () => {
+  const plugin = relatedLinksPlugin(
+    {siteDir: currentDir},
+    {docsRoot: fixtureDocsRoot},
+  )
+
+  const content = await plugin.loadContent()
+
+  assert.deepEqual(content.docs['with-links.md'].related_issues, [674, 695])
+})

--- a/apps/docs/plugins/related-links/index.ts
+++ b/apps/docs/plugins/related-links/index.ts
@@ -1,0 +1,81 @@
+import type {LoadContext, Plugin} from '@docusaurus/types'
+
+import {
+  validateFrontmatterDocs,
+  type FrontmatterValidatorOptions,
+  type ValidationResult,
+} from '../frontmatter-validator/index.ts'
+
+export interface DocRelated {
+  related_issues?: number[]
+  implemented_in?: number[]
+}
+
+export interface RelatedLinksGlobalData {
+  docs: Record<string, DocRelated>
+}
+
+export type RelatedLinksPluginOptions = Pick<
+  FrontmatterValidatorOptions,
+  'docsRoot' | 'include' | 'allowWarnings'
+>
+
+function copyNumbers(values: number[] | undefined): number[] | undefined {
+  if (!values || values.length === 0) {
+    return undefined
+  }
+
+  return [...values]
+}
+
+function hasRelatedLinks(related: DocRelated): boolean {
+  return Boolean(related.related_issues?.length || related.implemented_in?.length)
+}
+
+export function collectRelatedLinks(validation: ValidationResult): RelatedLinksGlobalData {
+  const docs: Record<string, DocRelated> = {}
+
+  for (const file of validation.files) {
+    const related: DocRelated = {}
+    const relatedIssues = copyNumbers(file.frontmatter.related_issues)
+    const implementedIn = copyNumbers(file.frontmatter.implemented_in)
+
+    if (relatedIssues) {
+      related.related_issues = relatedIssues
+    }
+
+    if (implementedIn) {
+      related.implemented_in = implementedIn
+    }
+
+    if (hasRelatedLinks(related)) {
+      docs[file.relativePath] = related
+    }
+  }
+
+  return {docs}
+}
+
+export default function relatedLinksPlugin(
+  context: LoadContext,
+  options: RelatedLinksPluginOptions = {},
+): Plugin<RelatedLinksGlobalData> {
+  return {
+    name: 'tachigo-related-links',
+
+    async loadContent() {
+      const validation = await validateFrontmatterDocs({
+        siteDir: context.siteDir,
+        docsRoot: options.docsRoot,
+        include: options.include,
+        allowWarnings: options.allowWarnings ?? true,
+      })
+
+      return collectRelatedLinks(validation)
+    },
+
+    async contentLoaded({content, actions}) {
+      actions.setGlobalData(content)
+    },
+  }
+}

--- a/apps/docs/src/components/RelatedLinks.tsx
+++ b/apps/docs/src/components/RelatedLinks.tsx
@@ -1,0 +1,143 @@
+import React from 'react'
+import {useDoc} from '@docusaurus/plugin-content-docs/client'
+import {usePluginData} from '@docusaurus/useGlobalData'
+
+type DocRelated = {
+  related_issues?: number[]
+  implemented_in?: number[]
+}
+
+type RelatedLinksGlobalData = {
+  docs?: Record<string, DocRelated>
+}
+
+type DocMetadata = {
+  id?: string
+  source?: string
+  frontMatter?: DocRelated
+}
+
+const GITHUB_REPO_URL = 'https://github.com/nurockplayer/tachigo'
+
+function uniquePositiveNumbers(values: number[] | undefined): number[] {
+  if (!values) {
+    return []
+  }
+
+  return [...new Set(values.filter((value) => Number.isInteger(value) && value > 0))]
+}
+
+function normalizeSourceKey(source: string): string {
+  return source
+    .replace(/^@site\//, '')
+    .replace(/^(\.\.\/)+docs\//, '')
+    .replace(/^docs\//, '')
+}
+
+function candidateDocKeys(metadata: DocMetadata): string[] {
+  const candidates = new Set<string>()
+
+  if (metadata.source) {
+    candidates.add(normalizeSourceKey(metadata.source))
+  }
+
+  if (metadata.id) {
+    candidates.add(`${metadata.id}.md`)
+    candidates.add(`${metadata.id}/index.md`)
+  }
+
+  return [...candidates]
+}
+
+function findPluginRelated(
+  data: RelatedLinksGlobalData | undefined,
+  metadata: DocMetadata,
+): DocRelated | undefined {
+  const docs = data?.docs
+
+  if (!docs) {
+    return undefined
+  }
+
+  for (const key of candidateDocKeys(metadata)) {
+    if (docs[key]) {
+      return docs[key]
+    }
+  }
+
+  return undefined
+}
+
+export function resolveDocRelated(
+  data: RelatedLinksGlobalData | undefined,
+  metadata: DocMetadata,
+): DocRelated {
+  return findPluginRelated(data, metadata) ?? metadata.frontMatter ?? {}
+}
+
+function RelatedChip({href, number}: {href: string; number: number}): JSX.Element {
+  return (
+    <a
+      className="tachigo-related-links__chip"
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+    >
+      #{number}
+    </a>
+  )
+}
+
+function RelatedGroup({
+  title,
+  hrefBase,
+  numbers,
+}: {
+  title: string
+  hrefBase: string
+  numbers: number[]
+}): JSX.Element | null {
+  if (numbers.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="tachigo-related-links__group">
+      <h3>{title}</h3>
+      <div className="tachigo-related-links__chips">
+        {numbers.map((number) => (
+          <RelatedChip key={number} href={`${hrefBase}/${number}`} number={number} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function RelatedLinks(): JSX.Element | null {
+  const {metadata} = useDoc()
+  const pluginData = usePluginData('tachigo-related-links') as
+    | RelatedLinksGlobalData
+    | undefined
+  const related = resolveDocRelated(pluginData, metadata as DocMetadata)
+  const relatedIssues = uniquePositiveNumbers(related.related_issues)
+  const implementedIn = uniquePositiveNumbers(related.implemented_in)
+
+  if (relatedIssues.length === 0 && implementedIn.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="tachigo-related-links" aria-label="相關連結">
+      <RelatedGroup
+        title="相關 issue"
+        hrefBase={`${GITHUB_REPO_URL}/issues`}
+        numbers={relatedIssues}
+      />
+      <RelatedGroup
+        title="實作 PR"
+        hrefBase={`${GITHUB_REPO_URL}/pull`}
+        numbers={implementedIn}
+      />
+    </section>
+  )
+}

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -483,6 +483,56 @@
   font-weight: 760;
 }
 
+.tachigo-related-links {
+  display: grid;
+  gap: 0.85rem;
+  margin: 2rem 0 1.2rem;
+  padding: 1rem;
+  border: 1px solid var(--tachigo-line);
+  border-radius: 8px;
+  background: var(--tachigo-panel);
+}
+
+.tachigo-related-links__group {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.tachigo-related-links__group h3 {
+  margin: 0;
+  color: var(--tachigo-muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.tachigo-related-links__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tachigo-related-links__chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 0.2rem 0.62rem;
+  border: 1px solid color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 45%);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tachigo-cyan), transparent 88%);
+  color: var(--tachigo-ink);
+  font-size: 0.84rem;
+  font-weight: 800;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.tachigo-related-links__chip:hover {
+  border-color: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 18%);
+  color: var(--tachigo-ink);
+  text-decoration: none;
+}
+
 @media (max-width: 1120px) {
   .tachigo-hero {
     grid-template-columns: 1fr;

--- a/apps/docs/src/theme/DocItem/Footer/index.tsx
+++ b/apps/docs/src/theme/DocItem/Footer/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import DocItemFooter from '@theme-original/DocItem/Footer'
+
+import RelatedLinks from '../../../components/RelatedLinks'
+
+export default function Footer(props): JSX.Element {
+  return (
+    <>
+      <RelatedLinks />
+      <DocItemFooter {...props} />
+    </>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@docusaurus/core':
         specifier: 3.10.1
         version: 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(debug@4.4.3)(postcss@8.5.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs':
+        specifier: 3.10.1
+        version: 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(debug@4.4.3)(postcss@8.5.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       '@docusaurus/preset-classic':
         specifier: 3.10.1
         version: 3.10.1(@algolia/client-search@5.52.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(postcss@8.5.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@6.0.3)


### PR DESCRIPTION
## 什麼改動
新增 Dev Portal related-links plugin 與 `RelatedLinks` footer UI，讓文件 frontmatter 的 `related_issues` / `implemented_in` 顯示為 GitHub issue / PR chips。

## 為什麼
#695 要先把手動標記的 link layer 做成可見 UI，但不打 GitHub API、不讀 reverse-index cache，避免 PR2 擴張到 PR3 的 metadata 工作。

closes #695

## Scope 對齊
- Source of truth：#695; #693 spec `docs/superpowers/specs/2026-05-14-dev-portal-link-layer-design.md` PR 2 section
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- Dependency note：#702 / #694 validator is already merged into `develop`.

## 本 PR 明確不做
- 不取 issue / PR title。
- 不取 issue / PR state。
- 不顯示 mergedAt。
- 不打 GitHub API。
- 不依賴 reverse-index cache。
- 不做 #696 reverse-index / changelog。

## Delegation Execution Log
- Source issue delegation plan: https://github.com/nurockplayer/tachigo/issues/695#issuecomment-4450408184
- Actual worker profile(s): frontend_worker / controller
- Model strength: frontend_worker=GPT-5.4 medium; controller=GPT-5.5 high
- Spawn directive(s)：
  - profile=frontend_worker model=gpt-5.4 reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=controller model=gpt-5.5 reasoning=high controller_fallback=allowed fallback_reason=worker_timeout_after_initial_patch_for_verification_and_private_import_fix; implementation patch came from worker, controller only finished validation, fixed Docusaurus public import, PR body, and final gate
- Verification evidence:
  - `spec plan 695 --repo . --dry-run --format prompt --verbose` pass
  - `spec workflow-check --repo . --phase start --issue 695` pass
  - `pnpm install --frozen-lockfile` pass
  - `pnpm --filter ./apps/docs test:related-links` pass, 3/3
  - `pnpm --filter ./apps/docs test:frontmatter-validator` pass, 7/7
  - `pnpm build:docs` pass
  - browser smoke pass: temporary `related_issues: [674]` / `implemented_in: [679]` rendered chips and links in light/dark mode; doc without frontmatter links had no empty container
  - `git diff --check` pass
- Worker session closeout: worker implementation was read back; controller closed the verification loop after worker timeout/interruption.

## Review conversation closeout
- branch_sync_ref: rebased onto develop after #707 and #709 merges; resolved docs package/config conflicts by preserving reverse-index, llms, search, and related-links wiring; validation rerun on head `3aea904e6626e71ef72083ceeb28d8efe4639d7d`
- routing_evidence_status: pass
- routing_evidence_ref: https://github.com/nurockplayer/tachigo/issues/695#issuecomment-4450408184
- finding_disposition_status: pass
- review_triage_ref: PR #706 review from YUAN-117 found two valid issues: related-links warning crash risk and AI-created merge commit history risk
- root_cause_gate_ref: pass; root causes were missing `allowWarnings` forwarding and conflict remediation recorded as a merge commit instead of a linear branch rewrite
- finding_disposition_ref: adopted; `allowWarnings: options.allowWarnings ?? true` plus warning-only fixture test added, branch rewritten to linear head, and CodeRabbit test-path nit fixed with `fileURLToPath(new URL(...))` in current head `3aea904e6626e71ef72083ceeb28d8efe4639d7d`
- threshold_evidence_status: pending with reason: #664 dogfood comment is posted after PR merge with exact head and merge SHA
- Unresolved threads: 0 unresolved by GraphQL readback at head 3aea904e6626e71ef72083ceeb28d8efe4639d7d
- CodeRabbit: latest actionable nit adopted; latest status context success; rate-limit notice is informational

## Final merge gate
- Ready-to-merge decision: yes; merged into develop after stale YUAN-117 CR was dismissed with current-head evidence and HanaYukii approval
- Latest head SHA: 3aea904e6626e71ef72083ceeb28d8efe4639d7d
- Merge commit: 580320c56eb2a5168289e0caa66bb7d0b4eea29b
- Required checks: pass; GitHub statusCheckRollup completed successfully for Scope Police, workflow regression, frontend/dashboard/backend gates, automerge, and auto-ready checks on merged head
- Review state: APPROVED; old YUAN-117 CHANGES_REQUESTED review on head 39dcd90 was dismissed because both findings were adopted and HanaYukii approved current head 3aea904e
- spec workflow-check evidence: start=pass; commit=manual-pass local because PR body was not passed to local tool; merge=pass by live GitHub readback after merge
- Threshold ledger: https://github.com/nurockplayer/tachigo/issues/664 after merge

## PR 拆分檢查
- 這個 PR 的單一句子目的：Render hand-authored issue/PR links on doc pages as chips.
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是，#702 validator 已合併，這張行為獨立
- 本 PR 是否同時包含以下多個層級？
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] backend / schema / API
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The Docusaurus plugin, footer component, and focused tests are one user-visible behavior change for #695.

## Acceptance Criteria
- [x] `apps/docs/plugins/related-links/index.ts` injects `related_issues` / `implemented_in` through `setGlobalData`.
- [x] `apps/docs/src/components/RelatedLinks.tsx` renders related issue and implementation PR sections.
- [x] Every issue/PR shows `#<num>` chip + GitHub link.
- [x] Docs without related frontmatter render no empty container.
- [x] `apps/docs/src/theme/DocItem/Footer/index.tsx` inserts `<RelatedLinks />` above the original footer.
- [x] GitHub API and reverse-index cache remain unused.

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

```text
pnpm install --frozen-lockfile
PASS

pnpm --filter ./apps/docs test:related-links
PASS: 3/3

pnpm --filter ./apps/docs test:frontmatter-validator
PASS: 7/7

pnpm build:docs
PASS

git diff --check
PASS

browser smoke
PASS: light/dark chips and links visible; docs without related frontmatter render no empty container on doc without related frontmatter
```





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 文档页脚现已显示相关的GitHub issues和pull requests链接

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/706)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





