### PR TITLE
[backend] TwitchCallback 支援 web redirect（供領獎頁面 OAuth 流程使用）

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -246,6 +246,9 @@ export interface ApiOperations {
     };
   };
   "GET /auth/twitch": {
+    queryParams: {
+      redirect_to?: string;
+    };
     response: unknown;
   };
   "GET /auth/twitch/callback": {

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -508,9 +508,23 @@ const docTemplate = `{
                     "auth"
                 ],
                 "summary": "Redirect to Twitch OAuth",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Relative path to redirect after successful login (e.g. /claim/abc123)",
+                        "name": "redirect_to",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "302": {
                         "description": "Found"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }
@@ -558,6 +572,9 @@ const docTemplate = `{
                                 }
                             ]
                         }
+                    },
+                    "302": {
+                        "description": "Found"
                     },
                     "400": {
                         "description": "Bad Request",

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -502,9 +502,23 @@
                     "auth"
                 ],
                 "summary": "Redirect to Twitch OAuth",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Relative path to redirect after successful login (e.g. /claim/abc123)",
+                        "name": "redirect_to",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "302": {
                         "description": "Found"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }
@@ -552,6 +566,9 @@
                                 }
                             ]
                         }
+                    },
+                    "302": {
+                        "description": "Found"
                     },
                     "400": {
                         "description": "Bad Request",

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -633,11 +633,20 @@ paths:
       - auth
   /auth/twitch:
     get:
+      parameters:
+      - description: Relative path to redirect after successful login (e.g. /claim/abc123)
+        in: query
+        name: redirect_to
+        type: string
       produces:
       - application/json
       responses:
         "302":
           description: Found
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
       summary: Redirect to Twitch OAuth
       tags:
       - auth
@@ -666,6 +675,8 @@ paths:
                 data:
                   $ref: '#/definitions/handlers.AuthResponse'
               type: object
+        "302":
+          description: Found
         "400":
           description: Bad Request
           schema:

--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -178,10 +180,17 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 // @Summary      Redirect to Twitch OAuth
 // @Tags         auth
 // @Produce      json
+// @Param        redirect_to query string false "Relative path to redirect after successful login (e.g. /claim/abc123)"
 // @Success      302
+// @Failure      400  {object}  Response
 // @Router       /auth/twitch [get]
 func (h *AuthHandler) TwitchLogin(c *gin.Context) {
-	state := oauthState()
+	redirectTo := c.Query("redirect_to")
+	if redirectTo != "" && !isValidRedirectTo(redirectTo) {
+		badRequest(c, "invalid redirect_to parameter")
+		return
+	}
+	state := oauthStateWithRedirect(redirectTo)
 	h.setOAuthStateCookie(c, state)
 	c.Redirect(http.StatusFound, h.auth.TwitchAuthURL(state))
 }
@@ -193,6 +202,7 @@ func (h *AuthHandler) TwitchLogin(c *gin.Context) {
 // @Param        code  query string true "OAuth authorization code"
 // @Param        state query string true "OAuth state"
 // @Success      200  {object}  Response{data=AuthResponse}
+// @Success      302
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
 // @Router       /auth/twitch/callback [get]
@@ -202,6 +212,7 @@ func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 		badRequest(c, "invalid state parameter")
 		return
 	}
+	redirectTo := parseOAuthStatePayload(c.Query("state")).RedirectTo
 	h.clearOAuthStateCookie(c)
 
 	code := c.Query("code")
@@ -212,6 +223,10 @@ func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 	}
 
 	h.setRefreshCookie(c, tokens.RefreshToken)
+	if redirectTo != "" {
+		c.Redirect(http.StatusFound, strings.TrimRight(h.cfg.App.FrontendURL, "/")+redirectTo)
+		return
+	}
 	ok(c, gin.H{"user": user, "tokens": browserTokenPair(tokens)})
 }
 
@@ -351,10 +366,36 @@ func (h *AuthHandler) UnlinkProvider(c *gin.Context) {
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
+type oauthStatePayload struct {
+	Nonce      string `json:"n"`
+	RedirectTo string `json:"r,omitempty"`
+}
+
 func oauthState() string {
+	return oauthStateWithRedirect("")
+}
+
+func oauthStateWithRedirect(redirectTo string) string {
 	b := make([]byte, 16)
 	rand.Read(b)
-	return hex.EncodeToString(b)
+	p := oauthStatePayload{Nonce: hex.EncodeToString(b), RedirectTo: redirectTo}
+	data, _ := json.Marshal(p)
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func parseOAuthStatePayload(state string) oauthStatePayload {
+	data, err := base64.RawURLEncoding.DecodeString(state)
+	if err != nil {
+		return oauthStatePayload{}
+	}
+	var p oauthStatePayload
+	json.Unmarshal(data, &p) //nolint:errcheck
+	return p
+}
+
+// isValidRedirectTo ensures the redirect target is a relative path, guarding against open-redirect attacks.
+func isValidRedirectTo(s string) bool {
+	return strings.HasPrefix(s, "/") && !strings.HasPrefix(s, "//")
 }
 
 func validateOAuthState(c *gin.Context) error {

--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -3,9 +3,7 @@ package handlers
 import (
 	"context"
 	"crypto/rand"
-	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -24,11 +22,14 @@ import (
 )
 
 const (
-	refreshTokenCookieName = "refresh_token"
-	refreshTokenCookiePath = "/api/v1/auth"
-	oauthStateCookieName   = "oauth_state"
-	oauthStateCookiePath   = "/"
-	oauthStateCookieMaxAge = 300
+	refreshTokenCookieName    = "refresh_token"
+	refreshTokenCookiePath    = "/api/v1/auth"
+	oauthStateCookieName      = "oauth_state"
+	oauthStateCookiePath      = "/"
+	oauthStateCookieMaxAge    = 300
+	oauthRedirectCookieName   = "oauth_redirect"
+	oauthRedirectCookiePath   = "/"
+	oauthRedirectCookieMaxAge = 300
 )
 
 type AuthHandler struct {
@@ -190,7 +191,10 @@ func (h *AuthHandler) TwitchLogin(c *gin.Context) {
 		badRequest(c, "invalid redirect_to parameter")
 		return
 	}
-	state := oauthStateWithRedirect(redirectTo)
+	if redirectTo != "" {
+		h.setOAuthRedirectCookie(c, redirectTo)
+	}
+	state := oauthState()
 	h.setOAuthStateCookie(c, state)
 	c.Redirect(http.StatusFound, h.auth.TwitchAuthURL(state))
 }
@@ -212,8 +216,9 @@ func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 		badRequest(c, "invalid state parameter")
 		return
 	}
-	redirectTo := parseOAuthStatePayload(c.Query("state")).RedirectTo
+	redirectTo, _ := c.Cookie(oauthRedirectCookieName)
 	h.clearOAuthStateCookie(c)
+	h.clearOAuthRedirectCookie(c)
 
 	code := c.Query("code")
 	user, tokens, err := h.auth.TwitchCallback(c.Request.Context(), code)
@@ -366,31 +371,10 @@ func (h *AuthHandler) UnlinkProvider(c *gin.Context) {
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
-type oauthStatePayload struct {
-	Nonce      string `json:"n"`
-	RedirectTo string `json:"r,omitempty"`
-}
-
 func oauthState() string {
-	return oauthStateWithRedirect("")
-}
-
-func oauthStateWithRedirect(redirectTo string) string {
 	b := make([]byte, 16)
 	rand.Read(b)
-	p := oauthStatePayload{Nonce: hex.EncodeToString(b), RedirectTo: redirectTo}
-	data, _ := json.Marshal(p)
-	return base64.RawURLEncoding.EncodeToString(data)
-}
-
-func parseOAuthStatePayload(state string) oauthStatePayload {
-	data, err := base64.RawURLEncoding.DecodeString(state)
-	if err != nil {
-		return oauthStatePayload{}
-	}
-	var p oauthStatePayload
-	json.Unmarshal(data, &p) //nolint:errcheck
-	return p
+	return hex.EncodeToString(b)
 }
 
 // isValidRedirectTo ensures the redirect target is a relative path, guarding against open-redirect attacks.
@@ -429,6 +413,32 @@ func (h *AuthHandler) clearOAuthStateCookie(c *gin.Context) {
 		"",
 		-1,
 		oauthStateCookiePath,
+		"",
+		h.refreshCookieSecure(),
+		true,
+	)
+}
+
+func (h *AuthHandler) setOAuthRedirectCookie(c *gin.Context, redirectTo string) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(
+		oauthRedirectCookieName,
+		redirectTo,
+		oauthRedirectCookieMaxAge,
+		oauthRedirectCookiePath,
+		"",
+		h.refreshCookieSecure(),
+		true,
+	)
+}
+
+func (h *AuthHandler) clearOAuthRedirectCookie(c *gin.Context) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(
+		oauthRedirectCookieName,
+		"",
+		-1,
+		oauthRedirectCookiePath,
 		"",
 		h.refreshCookieSecure(),
 		true,

--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -389,7 +389,7 @@ func isValidRedirectTo(s string) bool {
 	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Opaque != "" {
 		return false
 	}
-	if hasUnsafeRedirectChar(parsed.Path) || hasUnsafeRedirectChar(parsed.Fragment) {
+	if parsed.Fragment != "" || hasUnsafeRedirectChar(parsed.Path) {
 		return false
 	}
 	if parsed.RawQuery != "" {

--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -193,6 +193,8 @@ func (h *AuthHandler) TwitchLogin(c *gin.Context) {
 	}
 	if redirectTo != "" {
 		h.setOAuthRedirectCookie(c, redirectTo)
+	} else {
+		h.clearOAuthRedirectCookie(c)
 	}
 	state := oauthState()
 	h.setOAuthStateCookie(c, state)
@@ -213,6 +215,7 @@ func (h *AuthHandler) TwitchLogin(c *gin.Context) {
 func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 	if err := validateOAuthState(c); err != nil {
 		h.clearOAuthStateCookie(c)
+		h.clearOAuthRedirectCookie(c)
 		badRequest(c, "invalid state parameter")
 		return
 	}

--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -186,12 +186,12 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 // @Failure      400  {object}  Response
 // @Router       /auth/twitch [get]
 func (h *AuthHandler) TwitchLogin(c *gin.Context) {
-	redirectTo := c.Query("redirect_to")
-	if redirectTo != "" && !isValidRedirectTo(redirectTo) {
+	redirectTo, hasRedirectTo := c.GetQuery("redirect_to")
+	if hasRedirectTo && !isValidRedirectTo(redirectTo) {
 		badRequest(c, "invalid redirect_to parameter")
 		return
 	}
-	if redirectTo != "" {
+	if hasRedirectTo {
 		h.setOAuthRedirectCookie(c, redirectTo)
 	} else {
 		h.clearOAuthRedirectCookie(c)
@@ -231,7 +231,7 @@ func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 	}
 
 	h.setRefreshCookie(c, tokens.RefreshToken)
-	if redirectTo != "" {
+	if redirectTo != "" && isValidRedirectTo(redirectTo) {
 		c.Redirect(http.StatusFound, strings.TrimRight(h.cfg.App.FrontendURL, "/")+redirectTo)
 		return
 	}
@@ -382,7 +382,35 @@ func oauthState() string {
 
 // isValidRedirectTo ensures the redirect target is a relative path, guarding against open-redirect attacks.
 func isValidRedirectTo(s string) bool {
-	return strings.HasPrefix(s, "/") && !strings.HasPrefix(s, "//")
+	if s == "" || strings.HasPrefix(s, "//") || hasUnsafeRedirectChar(s) {
+		return false
+	}
+	parsed, err := url.Parse(s)
+	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Opaque != "" {
+		return false
+	}
+	if hasUnsafeRedirectChar(parsed.Path) || hasUnsafeRedirectChar(parsed.Fragment) {
+		return false
+	}
+	if parsed.RawQuery != "" {
+		decodedQuery, err := url.QueryUnescape(parsed.RawQuery)
+		if err != nil || hasUnsafeRedirectChar(decodedQuery) {
+			return false
+		}
+	}
+	return strings.HasPrefix(parsed.Path, "/") && !strings.HasPrefix(parsed.Path, "//")
+}
+
+func hasUnsafeRedirectChar(s string) bool {
+	if strings.Contains(s, "\\") {
+		return true
+	}
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
 }
 
 func validateOAuthState(c *gin.Context) error {

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -414,6 +414,46 @@ func TestOAuthCallback_ValidStateClearsStateCookieBeforeOAuthExchange(t *testing
 	assertOAuthStateCookieCleared(t, w, http.SameSiteLaxMode, false)
 }
 
+// ─── TwitchLogin redirect_to ─────────────────────────────────────────────────
+
+func TestTwitchLogin_WithExternalRedirectTo_ReturnsBadRequest(t *testing.T) {
+	for _, bad := range []string{"http://evil.com", "//evil.com", "https://evil.com", "://evil.com"} {
+		t.Run(bad, func(t *testing.T) {
+			env := newTestEnv(t)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch?redirect_to="+bad, nil)
+			w := httptest.NewRecorder()
+			env.router.ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("want 400 for redirect_to=%q, got %d", bad, w.Code)
+			}
+		})
+	}
+}
+
+func TestTwitchLogin_WithValidRelativeRedirectTo_RedirectsToTwitch(t *testing.T) {
+	env := newTestEnv(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch?redirect_to=/claim/abc123", nil)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d: %s", w.Code, w.Body.String())
+	}
+	assertOAuthStateCookieSet(t, w, http.SameSiteLaxMode, false)
+}
+
+func TestTwitchLogin_WithoutRedirectTo_RedirectsToTwitch(t *testing.T) {
+	env := newTestEnv(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch", nil)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d: %s", w.Code, w.Body.String())
+	}
+	assertOAuthStateCookieSet(t, w, http.SameSiteLaxMode, false)
+}
+
 func assertRefreshCookieSet(
 	t *testing.T,
 	w *httptest.ResponseRecorder,

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -418,10 +419,25 @@ func TestOAuthCallback_ValidStateClearsStateCookieBeforeOAuthExchange(t *testing
 // ─── TwitchLogin redirect_to ─────────────────────────────────────────────────
 
 func TestTwitchLogin_WithExternalRedirectTo_ReturnsBadRequest(t *testing.T) {
-	for _, bad := range []string{"http://evil.com", "//evil.com", "https://evil.com", "://evil.com"} {
+	for _, bad := range []string{
+		"http://evil.com",
+		"//evil.com",
+		"https://evil.com",
+		"://evil.com",
+		"/\\evil.com",
+		"/%5Cevil.com",
+		"/\r\nLocation: https://evil.com",
+		"/%0d%0aLocation: https://evil.com",
+		"",
+		"relative/path",
+	} {
 		t.Run(bad, func(t *testing.T) {
 			env := newTestEnv(t)
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch?redirect_to="+bad, nil)
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"/api/v1/auth/twitch?redirect_to="+url.QueryEscape(bad),
+				nil,
+			)
 			w := httptest.NewRecorder()
 			env.router.ServeHTTP(w, req)
 			if w.Code != http.StatusBadRequest {
@@ -465,13 +481,7 @@ func TestTwitchLogin_WithoutRedirectTo_ClearsStaleRedirectCookie(t *testing.T) {
 	if w.Code != http.StatusFound {
 		t.Fatalf("want 302, got %d: %s", w.Code, w.Body.String())
 	}
-	cookie := responseCookie(t, w, "oauth_redirect")
-	if cookie == nil {
-		t.Fatal("expected oauth_redirect cookie to be present in response (cleared)")
-	}
-	if cookie.MaxAge >= 0 {
-		t.Fatalf("expected oauth_redirect cookie to be cleared (MaxAge < 0), got %d", cookie.MaxAge)
-	}
+	assertOAuthRedirectCookieCleared(t, w, http.SameSiteLaxMode, false)
 }
 
 func TestTwitchCallback_StateMismatch_ClearsRedirectCookie(t *testing.T) {
@@ -485,13 +495,7 @@ func TestTwitchCallback_StateMismatch_ClearsRedirectCookie(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
 	}
-	cookie := responseCookie(t, w, "oauth_redirect")
-	if cookie == nil {
-		t.Fatal("expected oauth_redirect cookie to be cleared on state mismatch")
-	}
-	if cookie.MaxAge >= 0 {
-		t.Fatalf("expected oauth_redirect cleared (MaxAge < 0), got %d", cookie.MaxAge)
-	}
+	assertOAuthRedirectCookieCleared(t, w, http.SameSiteLaxMode, false)
 }
 
 func TestTwitchCallback_StaleRedirectCookie_WithoutRedirectLogin_ReturnsJSON(t *testing.T) {
@@ -650,6 +654,35 @@ func assertOAuthStateCookieCleared(
 	}
 }
 
+func assertOAuthRedirectCookieCleared(
+	t *testing.T,
+	w *httptest.ResponseRecorder,
+	expectedSameSite http.SameSite,
+	expectedSecure bool,
+) {
+	t.Helper()
+
+	cookie := responseCookie(t, w, "oauth_redirect")
+	if cookie.Value != "" {
+		t.Fatalf("expected cleared oauth redirect cookie, got %q", cookie.Value)
+	}
+	if cookie.MaxAge >= 0 {
+		t.Fatalf("expected cleared oauth redirect cookie MaxAge < 0, got %d", cookie.MaxAge)
+	}
+	if cookie.Path != "/" {
+		t.Fatalf("expected oauth redirect cookie path /, got %q", cookie.Path)
+	}
+	if !cookie.HttpOnly {
+		t.Fatal("expected cleared oauth redirect cookie to be HttpOnly")
+	}
+	if cookie.SameSite != expectedSameSite {
+		t.Fatalf("expected cleared oauth redirect cookie SameSite %v, got %v", expectedSameSite, cookie.SameSite)
+	}
+	if cookie.Secure != expectedSecure {
+		t.Fatalf("expected cleared oauth redirect cookie Secure %t, got %t", expectedSecure, cookie.Secure)
+	}
+}
+
 type failingRoundTripper struct{}
 
 func (failingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
@@ -696,6 +729,39 @@ func TestTwitchCallback_WithRedirectCookie_Redirects(t *testing.T) {
 	location := w.Header().Get("Location")
 	if location != "http://localhost:5174/claim/abc123" {
 		t.Errorf("want Location http://localhost:5174/claim/abc123, got %q", location)
+	}
+}
+
+func TestTwitchCallback_WithInvalidRedirectCookie_ReturnsJSON(t *testing.T) {
+	for _, redirectCookie := range []string{
+		"//evil.com",
+		"/%5Cevil.com",
+		"/%0d%0aLocation:%20https://evil.com",
+	} {
+		t.Run(redirectCookie, func(t *testing.T) {
+			env := newTestEnvWithConfig(t, "development", "http://localhost:5174")
+			httpClient := &http.Client{Transport: mockTwitchRoundTripper{}}
+			ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+
+			state := "teststate789"
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch/callback?code=mockcode&state="+state, nil).WithContext(ctx)
+			req.AddCookie(&http.Cookie{Name: "oauth_state", Value: state, Path: "/"})
+			req.AddCookie(&http.Cookie{Name: "oauth_redirect", Value: redirectCookie, Path: "/"})
+			w := httptest.NewRecorder()
+			env.router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("want 200 fallback for invalid redirect cookie, got %d: %s", w.Code, w.Body.String())
+			}
+			if location := w.Header().Get("Location"); location != "" {
+				t.Fatalf("expected no redirect Location, got %q", location)
+			}
+			resp := parseBody(t, w.Body.Bytes())
+			if resp["success"] != true {
+				t.Errorf("want success: true")
+			}
+			assertOAuthRedirectCookieCleared(t, w, http.SameSiteLaxMode, false)
+		})
 	}
 }
 

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -428,6 +428,8 @@ func TestTwitchLogin_WithExternalRedirectTo_ReturnsBadRequest(t *testing.T) {
 		"/%5Cevil.com",
 		"/\r\nLocation: https://evil.com",
 		"/%0d%0aLocation: https://evil.com",
+		"/path#javascript:alert(1)",
+		"/path#//evil.com",
 		"",
 		"relative/path",
 	} {
@@ -457,6 +459,7 @@ func TestTwitchLogin_WithValidRelativeRedirectTo_RedirectsToTwitch(t *testing.T)
 		t.Fatalf("want 302, got %d: %s", w.Code, w.Body.String())
 	}
 	assertOAuthStateCookieSet(t, w, http.SameSiteLaxMode, false)
+	assertOAuthRedirectCookieSet(t, w, "/claim/abc123", http.SameSiteLaxMode, false)
 }
 
 func TestTwitchLogin_WithoutRedirectTo_RedirectsToTwitch(t *testing.T) {
@@ -651,6 +654,40 @@ func assertOAuthStateCookieCleared(
 	}
 	if cookie.Secure != expectedSecure {
 		t.Fatalf("expected cleared oauth state cookie Secure %t, got %t", expectedSecure, cookie.Secure)
+	}
+}
+
+func assertOAuthRedirectCookieSet(
+	t *testing.T,
+	w *httptest.ResponseRecorder,
+	expectedValue string,
+	expectedSameSite http.SameSite,
+	expectedSecure bool,
+) {
+	t.Helper()
+
+	cookie := responseCookie(t, w, "oauth_redirect")
+	decodedValue, err := url.QueryUnescape(cookie.Value)
+	if err != nil {
+		decodedValue = cookie.Value
+	}
+	if decodedValue != expectedValue {
+		t.Fatalf("expected oauth redirect cookie value %q, got %q", expectedValue, cookie.Value)
+	}
+	if cookie.MaxAge <= 0 {
+		t.Fatalf("expected oauth redirect cookie MaxAge > 0, got %d", cookie.MaxAge)
+	}
+	if cookie.Path != "/" {
+		t.Fatalf("expected oauth redirect cookie path /, got %q", cookie.Path)
+	}
+	if !cookie.HttpOnly {
+		t.Fatal("expected oauth redirect cookie to be HttpOnly")
+	}
+	if cookie.SameSite != expectedSameSite {
+		t.Fatalf("expected oauth redirect cookie SameSite %v, got %v", expectedSameSite, cookie.SameSite)
+	}
+	if cookie.Secure != expectedSecure {
+		t.Fatalf("expected oauth redirect cookie Secure %t, got %t", expectedSecure, cookie.Secure)
 	}
 }
 

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -590,6 +591,69 @@ type failingRoundTripper struct{}
 
 func (failingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, fmt.Errorf("blocked test OAuth request")
+}
+
+// mockTwitchRoundTripper mocks the Twitch OAuth token exchange and user info endpoints.
+type mockTwitchRoundTripper struct{}
+
+func (mockTwitchRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+	switch {
+	case strings.Contains(req.URL.Host, "id.twitch.tv"):
+		body = `{"access_token":"mock-token","token_type":"bearer","expires_in":3600,"scope":""}`
+	case strings.Contains(req.URL.Host, "api.twitch.tv"):
+		body = `{"data":[{"id":"1","login":"mockuser","display_name":"Mock User","email":"mock@example.com","profile_image_url":""}]}`
+	default:
+		return nil, fmt.Errorf("unexpected OAuth request: %s", req.URL)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// ─── TwitchCallback redirect ─────────────────────────────────────────────────
+
+func TestTwitchCallback_WithRedirectCookie_Redirects(t *testing.T) {
+	env := newTestEnvWithConfig(t, "development", "http://localhost:5174")
+	httpClient := &http.Client{Transport: mockTwitchRoundTripper{}}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+
+	state := "teststate123"
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch/callback?code=mockcode&state="+state, nil).WithContext(ctx)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: state, Path: "/"})
+	req.AddCookie(&http.Cookie{Name: "oauth_redirect", Value: "/claim/abc123", Path: "/"})
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d: %s", w.Code, w.Body.String())
+	}
+	location := w.Header().Get("Location")
+	if location != "http://localhost:5174/claim/abc123" {
+		t.Errorf("want Location http://localhost:5174/claim/abc123, got %q", location)
+	}
+}
+
+func TestTwitchCallback_WithoutRedirectCookie_ReturnsJSON(t *testing.T) {
+	env := newTestEnv(t)
+	httpClient := &http.Client{Transport: mockTwitchRoundTripper{}}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+
+	state := "teststate456"
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch/callback?code=mockcode&state="+state, nil).WithContext(ctx)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: state, Path: "/"})
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if resp["success"] != true {
+		t.Errorf("want success: true")
+	}
 }
 
 // ─── Web3 Nonce ───────────────────────────────────────────────────────────────

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -455,6 +455,69 @@ func TestTwitchLogin_WithoutRedirectTo_RedirectsToTwitch(t *testing.T) {
 	assertOAuthStateCookieSet(t, w, http.SameSiteLaxMode, false)
 }
 
+func TestTwitchLogin_WithoutRedirectTo_ClearsStaleRedirectCookie(t *testing.T) {
+	env := newTestEnv(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_redirect", Value: "/claim/stale", Path: "/"})
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d: %s", w.Code, w.Body.String())
+	}
+	cookie := responseCookie(t, w, "oauth_redirect")
+	if cookie == nil {
+		t.Fatal("expected oauth_redirect cookie to be present in response (cleared)")
+	}
+	if cookie.MaxAge >= 0 {
+		t.Fatalf("expected oauth_redirect cookie to be cleared (MaxAge < 0), got %d", cookie.MaxAge)
+	}
+}
+
+func TestTwitchCallback_StateMismatch_ClearsRedirectCookie(t *testing.T) {
+	env := newTestEnv(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch/callback?code=code&state=wrong", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "expected", Path: "/"})
+	req.AddCookie(&http.Cookie{Name: "oauth_redirect", Value: "/claim/abc", Path: "/"})
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+	cookie := responseCookie(t, w, "oauth_redirect")
+	if cookie == nil {
+		t.Fatal("expected oauth_redirect cookie to be cleared on state mismatch")
+	}
+	if cookie.MaxAge >= 0 {
+		t.Fatalf("expected oauth_redirect cleared (MaxAge < 0), got %d", cookie.MaxAge)
+	}
+}
+
+func TestTwitchCallback_StaleRedirectCookie_WithoutRedirectLogin_ReturnsJSON(t *testing.T) {
+	// Regression：先前有 redirect_to 的 flow 中斷後，新的無 redirect_to TwitchLogin 必須清掉
+	// stale oauth_redirect，確保後續 callback 回傳 200 JSON 而非誤 redirect。
+	env := newTestEnvWithConfig(t, "development", "http://localhost:5174")
+	httpClient := &http.Client{Transport: mockTwitchRoundTripper{}}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+
+	// 步驟 1：模擬 TwitchLogin without redirect_to 已清除 stale cookie（不帶 oauth_redirect）
+	state := "freshstate"
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch/callback?code=mockcode&state="+state, nil).WithContext(ctx)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: state, Path: "/"})
+	// 不帶 oauth_redirect cookie（模擬 TwitchLogin 已清除）
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 JSON (no stale redirect), got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if resp["success"] != true {
+		t.Errorf("want success: true")
+	}
+}
+
 func assertRefreshCookieSet(
 	t *testing.T,
 	w *httptest.ResponseRecorder,


### PR DESCRIPTION
## 什麼改動

`TwitchLogin` 新增可選 `redirect_to` query param；`TwitchCallback` 成功後若有 `redirect_to`，會 302 redirect 回 `frontendURL + redirect_to`；無 `redirect_to` 時維持原有 JSON 回傳行為。

`redirect_to` 儲存在獨立的 `oauth_redirect` HttpOnly cookie，不放進 OAuth state，避免 claim 路徑洩漏至 Twitch OAuth 流程。

## 為什麼

架構決策 #662 決定將領獎頁面 `/claim/:token` 放在 Dashboard，以「用 Twitch 登入」作為驗證身份方式。目前 `TwitchCallback` 直接回傳 JSON，無法支援 SPA 的 web redirect OAuth 流程。

closes #704

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## Scope 對齊
- Source of truth：#704
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Google OAuth 同樣改動（可 follow-up）
  - 修改 token 回傳格式
  - LoginPage 新增 Twitch 登入按鈕（屬於 #705 範圍）

## Delegation Execution Log（非 Codex autonomous PR 可略過）
n/a

## Review conversation closeout
- Unresolved threads：0
- CodeRabbit：latest head `577f77c7c716a1802df0c2f73b3ae327d2b99d68` reviewed；status context SUCCESS；latest summary reports no actionable comments
- chatgpt-codex-connector：n/a；manual Codex / human review findings addressed
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：Erick CR state leak adopted（`8435905`）；Erick stale-cookie blocker adopted（`624126b`）；CodeRabbit defense-in-depth adopted（`f228ddb6`）；callback behavior tests adopted
- Final reviewer action：known actionable findings fixed and nurockplayer approved latest head；still waiting for Erick52106 / human re-review or dismissal of stale `CHANGES_REQUESTED`

## Final merge gate
- Ready-to-merge decision：blocked by stale `CHANGES_REQUESTED`; CI / Scope Police / CodeRabbit latest-head are green, waiting for Erick52106 or human re-review / dismissal
- Latest head SHA：577f77c7c716a1802df0c2f73b3ae327d2b99d68
- Required checks：CI success；PR Scope Police pass；API contract drift pass；CodeRabbit latest-head success
- spec workflow-check evidence：n/a
- Evidence URL：https://github.com/nurockplayer/tachigo/actions/runs/25869439084；https://github.com/nurockplayer/tachigo/pull/708#pullrequestreview-4291292571

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 TwitchCallback 在 OAuth 成功後能 redirect 回指定的前端相對路徑（redirect_to 儲存於 HttpOnly cookie）
- Approx changed lines：~373
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
    - [x] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？：handler 修改、API 文件 / shared types、對應測試是同一個 #704 OAuth redirect 行為變更的必要交付面
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] `GET /api/v1/auth/twitch?redirect_to=/claim/abc123` 完成 OAuth 後 redirect 回 `${frontendURL}/claim/abc123`
- [x] `redirect_to` 為外部 URL 時（含 `http://`、`//`）回傳 400
- [x] 無 `redirect_to` 時行為與現在完全相同（不 breaking）
- [x] `redirect_to` 不放進 OAuth state，存於第一方 HttpOnly cookie
- [x] TwitchCallback 成功路徑測試：有 / 無 redirect cookie 兩種情境

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
go test ./internal/handlers -run 'TestTwitch(Login_WithExternalRedirectTo_ReturnsBadRequest|Callback_WithInvalidRedirectCookie_ReturnsJSON)'  # PASS
go test ./internal/handlers  # PASS
go test ./cmd/server ./docs ./internal/...  # PASS
GitHub CI run 25869439084  # SUCCESS
PR Scope Police  # PASS
CodeRabbit latest-head status  # SUCCESS
```

## 備註

Swagger / OpenAPI generated artifacts and `packages/shared-types` 已隨 `redirect_to` contract 更新；latest CI 的 `API contract drift` 通過。

## Notes for Claude Code Review
- `oauth_redirect` cookie 設計：HttpOnly、SameSiteLax、300s TTL，與 `oauth_state` 相同安全屬性。
- `oauthState()` 恢復為純 32-char hex nonce，JSON state 格式全部移除。
- `TwitchCallback` 在 state 驗證通過後立即讀取並清除 `oauth_redirect` cookie；latest head 會在使用 cookie redirect 前再次呼叫 `isValidRedirectTo`，驗證失敗則 fallback 到原 JSON success response。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 在 Twitch OAuth 登录流程中新增自定义重定向路径功能，支持登录后跳转至指定内部页面，包含完整的安全验证机制。

* **Tests**
  * 新增重定向验证、会话管理相关测试用例。

* **Documentation**
  * 更新 API 文档，补充新增查询参数说明和 HTTP 302 响应定义。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/708)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->