### PR TITLE
[frontend] emit Dev Portal llms manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,13 @@ apps/dashboard/.env
 apps/dashboard/.env.local
 apps/dashboard/*.local
 
+apps/docs/node_modules/
+apps/docs/build/
+apps/docs/.docusaurus/
+apps/docs/.env
+apps/docs/.env.local
+apps/docs/*.local
+
 extensions/tachigo-demo-sidepanel/node_modules/
 extensions/tachigo-demo-sidepanel/dist/
 extensions/tachigo-demo-sidepanel/.env

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -1,4 +1,5 @@
 import frontmatterValidatorPlugin from './plugins/frontmatter-validator/index.js'
+import llmsTxtPlugin from './plugins/llms-txt/index.js'
 import {themes as prismThemes} from 'prism-react-renderer'
 import type {Config} from '@docusaurus/types'
 import type * as Preset from '@docusaurus/preset-classic'
@@ -46,6 +47,12 @@ const config: Config = {
   plugins: [
     [
       frontmatterValidatorPlugin,
+      {
+        include: ['**/*.md'],
+      },
+    ],
+    [
+      llmsTxtPlugin,
       {
         include: ['**/*.md'],
       },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,7 +10,8 @@
     "clear": "docusaurus clear",
     "build:reverse-index": "node --experimental-strip-types --no-warnings ./scripts/build-reverse-index.ts",
     "test:reverse-index": "node --experimental-strip-types --no-warnings --test ./scripts/build-reverse-index.test.ts",
-    "test:frontmatter-validator": "node --experimental-strip-types --no-warnings --test ./plugins/frontmatter-validator/index.test.ts"
+    "test:frontmatter-validator": "node --experimental-strip-types --no-warnings --test ./plugins/frontmatter-validator/index.test.ts",
+    "test:llms-txt": "node --experimental-strip-types --no-warnings --test ./plugins/llms-txt/index.test.ts"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.1",

--- a/apps/docs/plugins/llms-txt/index.test.ts
+++ b/apps/docs/plugins/llms-txt/index.test.ts
@@ -1,0 +1,114 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  buildLlmsArtifacts,
+  collectLlmsDocs,
+  default as llmsTxtPlugin,
+  parseRootSourceOfTruthLinks,
+} from './index.ts'
+
+const doc = (body: string, fm = '') => `${fm ? `---\n${fm}---\n\n` : ''}${body.trimStart()}`
+const sourceIndex = (table: string, heading = 'Root source of truth') =>
+  doc(`# Source Index\n\n## ${heading}\n\n| 文件 | 定位 |\n|---|---|\n${table}`, 'title: Source Index\nstatus: active\n')
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'tachigo-llms-docs-'))
+
+  for (const [name, source] of Object.entries(files)) {
+    await fs.mkdir(path.dirname(path.join(root, name)), {recursive: true})
+    await fs.writeFile(path.join(root, name), source, 'utf8')
+  }
+
+  return root
+}
+
+test('filters docs by tier rules', async () => {
+  const docsRoot = await fixture({
+    'dev-portal/start-here.md': doc('# Start Here\n\nDev Portal entry point.', 'title: Start Here\nstatus: active\n'),
+    'dev-portal/source-index.md': sourceIndex(
+      '| [architecture.md](/tachigo/architecture) | System map |\n| [tokenomics.md](/tachigo/tokenomics) | Token model |',
+    ),
+    'architecture.md': doc('# System Architecture\n\nSystem map content.'),
+    'tokenomics.md': doc('# Tokenomics\n\nToken model content.'),
+    'feature-discussion.md': doc('# Feature Discussion\n\nBackground only.'),
+    'superpowers/specs/proposed-design.md': doc(
+      '# Proposed Design',
+      'title: Proposed Design\nstatus: proposed\nsource_of_truth: true\n',
+    ),
+    'superpowers/plans/implementation-plan.md': doc('# Plan', 'title: Plan\nstatus: active\n'),
+    'internal.md': doc('# Internal Note', 'title: Internal Note\nstatus: active\ninternal: true\n'),
+    'excluded.md': doc('# Excluded Note', 'title: Excluded Note\nstatus: active\nexcluded_from_llms: true\n'),
+  })
+
+  const result = await collectLlmsDocs({docsRoot, baseUrl: '/tachigo/'})
+
+  assert.deepEqual(
+    result.docs.map((item) => item.relativePath),
+    ['architecture.md', 'dev-portal/source-index.md', 'dev-portal/start-here.md', 'tokenomics.md'],
+  )
+  assert.equal(result.warnings.length, 0)
+})
+
+test('falls back to tier 1 only when the root source table cannot be parsed', async () => {
+  const docsRoot = await fixture({
+    'dev-portal/start-here.md': doc('# Start Here', 'title: Start Here\nstatus: active\n'),
+    'dev-portal/source-index.md': sourceIndex('| [architecture.md](/tachigo/architecture) | System map |', 'Other table'),
+    'architecture.md': doc('# System Architecture'),
+  })
+
+  const result = await collectLlmsDocs({docsRoot, baseUrl: '/tachigo/'})
+
+  assert.deepEqual(
+    result.docs.map((item) => item.relativePath),
+    ['dev-portal/source-index.md', 'dev-portal/start-here.md'],
+  )
+  assert.match(result.warnings.join('\n'), /Root source of truth/)
+})
+
+test('parses root source links from the first Root source of truth table', () => {
+  assert.deepEqual(
+    parseRootSourceOfTruthLinks(
+      sourceIndex(
+        '| [architecture.md](/tachigo/architecture) | System map |\n| [auth-architecture.md](/tachigo/auth-architecture) | Auth map |\n\n## Other table\n\n| 文件 | 定位 |\n|---|---|\n| [ignored.md](/tachigo/ignored) | Ignore me |',
+      ),
+    ),
+    new Set(['architecture.md', 'auth-architecture.md']),
+  )
+})
+
+test('builds llms text, full text, manifest, and postBuild files', async () => {
+  const docsRoot = await fixture({
+    'dev-portal/start-here.md': doc(
+      '# Start Here\n\nDev Portal entry point.',
+      'title: Start Here\nstatus: active\nowner: engineering\nrelated_issues:\n  - 697\nimplemented_in:\n  - 700\n',
+    ),
+    'dev-portal/source-index.md': sourceIndex('| [architecture.md](/tachigo/architecture) | System map |'),
+    'architecture.md': doc('# System Architecture\n\nSystem map content.'),
+  })
+  const result = await collectLlmsDocs({docsRoot, baseUrl: '/tachigo/'})
+  const artifacts = buildLlmsArtifacts({
+    docs: result.docs,
+    baseUrl: '/tachigo/',
+    generatedAt: '2026-05-14T00:00:00.000Z',
+  })
+
+  assert.match(artifacts.llmsTxt, /^# tachigo Dev Portal\n\n> /)
+  assert.match(artifacts.llmsTxt, /## Architecture\n- \[System Architecture\]\(\/tachigo\/architecture\): System map content\./)
+  assert.match(artifacts.llmsFullTxt, /Source: \/tachigo\/architecture/)
+  assert.deepEqual(
+    artifacts.manifest.docs.map((item) => item.path),
+    ['/tachigo/architecture', '/tachigo/dev-portal/source-index', '/tachigo/dev-portal/start-here'],
+  )
+  assert.deepEqual(artifacts.manifest.docs.at(-1)?.related_issues, [697])
+
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachigo-llms-build-'))
+  await llmsTxtPlugin({siteDir: new URL('.', import.meta.url).pathname}, {docsRoot}).postBuild({outDir})
+
+  assert.match(await fs.readFile(path.join(outDir, 'llms.txt'), 'utf8'), /# tachigo Dev Portal/)
+  assert.match(await fs.readFile(path.join(outDir, 'llms-full.txt'), 'utf8'), /Source: \/tachigo\/architecture/)
+  assert.equal(JSON.parse(await fs.readFile(path.join(outDir, 'manifest.json'), 'utf8')).docs.length, 3)
+})

--- a/apps/docs/plugins/llms-txt/index.ts
+++ b/apps/docs/plugins/llms-txt/index.ts
@@ -1,0 +1,442 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import type {LoadContext, Plugin} from '@docusaurus/types'
+import fg from 'fast-glob'
+import matter from 'gray-matter'
+
+type ManifestStatus = 'active' | 'proposed' | 'deprecated'
+
+interface LlmFrontmatter {
+  title?: string
+  description?: string
+  status?: ManifestStatus
+  owner?: string
+  source_of_truth?: boolean
+  code_areas?: string[]
+  related_issues?: number[]
+  implemented_in?: number[]
+  excluded_from_llms?: boolean
+  internal?: boolean
+}
+
+export interface LlmsDoc {
+  relativePath: string
+  source: string
+  content: string
+  frontmatter: LlmFrontmatter
+  title: string
+  description: string
+  url: string
+  section: string
+}
+
+export interface LlmsManifest {
+  version: '1.0'
+  generated_at: string
+  base_url: string
+  docs: Array<{
+    path: string
+    title: string
+    status?: ManifestStatus
+    owner?: string
+    code_areas?: string[]
+    related_issues?: number[]
+    implemented_in?: number[]
+  }>
+}
+
+export interface LlmsArtifacts {
+  llmsTxt: string
+  llmsFullTxt: string
+  manifest: LlmsManifest
+}
+
+export interface LlmsTxtOptions {
+  docsRoot?: string | URL
+  include?: string[]
+  baseUrl?: string
+}
+
+interface CollectOptions extends LlmsTxtOptions {
+  siteDir?: string
+}
+
+interface CollectResult {
+  docsRoot: string
+  docs: LlmsDoc[]
+  warnings: string[]
+}
+
+const DEFAULT_BASE_URL = '/tachigo/'
+const SOURCE_INDEX_RELATIVE_PATH = 'dev-portal/source-index.md'
+
+function resolveDocsRoot(siteDir: string, docsRoot?: string | URL): string {
+  if (docsRoot instanceof URL) {
+    return path.resolve(fileURLToPath(docsRoot))
+  }
+
+  if (typeof docsRoot === 'string') {
+    return path.isAbsolute(docsRoot) ? docsRoot : path.resolve(siteDir, docsRoot)
+  }
+
+  return path.resolve(siteDir, '../../docs')
+}
+
+function normalizeBaseUrl(baseUrl = DEFAULT_BASE_URL): string {
+  const withLeadingSlash = baseUrl.startsWith('/') ? baseUrl : `/${baseUrl}`
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`
+}
+
+function relativePathToUrl(relativePath: string, baseUrl: string): string {
+  const slug = relativePath.replace(/\.mdx?$/, '').replace(/(^|\/)index$/, '$1').replace(/\/$/, '')
+
+  if (!slug) {
+    return baseUrl
+  }
+
+  return `${baseUrl}${slug}`
+}
+
+function slugToRelativePath(slug: string): string {
+  const normalized = slug.replace(/^\/+/, '').replace(/\/+$/, '')
+
+  if (!normalized) {
+    return 'index.md'
+  }
+
+  return normalized.endsWith('.md') ? normalized : `${normalized}.md`
+}
+
+function titleFromFilename(relativePath: string): string {
+  const basename = path.basename(relativePath, path.extname(relativePath))
+  return basename
+    .split('-')
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}`)
+    .join(' ')
+}
+
+function extractTitle(content: string, frontmatter: LlmFrontmatter, relativePath: string): string {
+  if (frontmatter.title) {
+    return frontmatter.title
+  }
+
+  const heading = content.match(/^#\s+(.+)$/m)
+  return heading?.[1]?.trim() || titleFromFilename(relativePath)
+}
+
+function stripMarkdownInline(text: string): string {
+  return text
+    .replace(/^>\s*/, '')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[`*_~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function extractDescription(content: string, frontmatter: LlmFrontmatter): string {
+  if (frontmatter.description) {
+    return frontmatter.description
+  }
+
+  const lines = content.split(/\r?\n/)
+  let inFence = false
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    if (trimmed.startsWith('```')) {
+      inFence = !inFence
+      continue
+    }
+
+    if (
+      inFence ||
+      trimmed.length === 0 ||
+      trimmed.startsWith('#') ||
+      trimmed.startsWith('|') ||
+      trimmed.startsWith('---') ||
+      trimmed.startsWith('<') ||
+      trimmed.startsWith('![')
+    ) {
+      continue
+    }
+
+    return stripMarkdownInline(trimmed)
+  }
+
+  return 'tachigo Dev Portal document'
+}
+
+function sectionForDoc(relativePath: string): string {
+  if (relativePath.startsWith('dev-portal/')) {
+    return 'Dev Portal'
+  }
+
+  if (relativePath.startsWith('ai/')) {
+    return 'AI Workflow'
+  }
+
+  if (relativePath.startsWith('history/')) {
+    return 'History'
+  }
+
+  if (relativePath.startsWith('superpowers/')) {
+    return 'Design Specs'
+  }
+
+  return 'Architecture'
+}
+
+function isExcluded(relativePath: string, frontmatter: LlmFrontmatter): boolean {
+  if (relativePath.startsWith('superpowers/plans/')) {
+    return true
+  }
+
+  if (
+    relativePath.startsWith('superpowers/specs/') &&
+    (frontmatter.status === 'proposed' || frontmatter.status === 'deprecated')
+  ) {
+    return true
+  }
+
+  return (
+    frontmatter.status === 'deprecated' ||
+    frontmatter.internal === true ||
+    frontmatter.excluded_from_llms === true
+  )
+}
+
+function isTierOne(relativePath: string, frontmatter: LlmFrontmatter): boolean {
+  return (
+    frontmatter.status === 'active' ||
+    frontmatter.source_of_truth === true ||
+    relativePath.startsWith('dev-portal/')
+  )
+}
+
+export function parseRootSourceOfTruthLinks(source: string): Set<string> {
+  const lines = source.split(/\r?\n/)
+  const headingIndex = lines.findIndex((line) => /^##+\s+Root source of truth\s*$/i.test(line.trim()))
+
+  if (headingIndex === -1) {
+    throw new Error('Root source of truth table was not found')
+  }
+
+  const tableLines: string[] = []
+
+  for (const line of lines.slice(headingIndex + 1)) {
+    const trimmed = line.trim()
+
+    if (trimmed.length === 0) {
+      if (tableLines.length === 0) {
+        continue
+      }
+
+      break
+    }
+
+    if (!trimmed.startsWith('|')) {
+      if (tableLines.length === 0) {
+        continue
+      }
+
+      break
+    }
+
+    tableLines.push(trimmed)
+  }
+
+  const rootPaths = new Set<string>()
+
+  for (const line of tableLines) {
+    if (/^\|\s*-+/.test(line)) {
+      continue
+    }
+
+    const matches = line.matchAll(/\[[^\]]+\]\(([^)#?]+)[^)]*\)/g)
+
+    for (const match of matches) {
+      const href = match[1]
+      const slug = href.startsWith('/tachigo/') ? href.slice('/tachigo/'.length) : href
+
+      if (slug.startsWith('http://') || slug.startsWith('https://')) {
+        continue
+      }
+
+      rootPaths.add(slugToRelativePath(slug))
+    }
+  }
+
+  if (rootPaths.size === 0) {
+    throw new Error('Root source of truth table did not contain markdown links')
+  }
+
+  return rootPaths
+}
+
+async function loadRootSourceOfTruthPaths(docsRoot: string): Promise<{
+  rootPaths: Set<string>
+  warnings: string[]
+}> {
+  try {
+    const source = await fs.readFile(path.join(docsRoot, SOURCE_INDEX_RELATIVE_PATH), 'utf8')
+    return {rootPaths: parseRootSourceOfTruthLinks(source), warnings: []}
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      rootPaths: new Set(),
+      warnings: [`llms-txt: Root source of truth fallback disabled: ${message}`],
+    }
+  }
+}
+
+function toManifestDoc(doc: LlmsDoc): LlmsManifest['docs'][number] {
+  return {
+    path: doc.url,
+    title: doc.title,
+    ...(doc.frontmatter.status ? {status: doc.frontmatter.status} : {}),
+    ...(doc.frontmatter.owner ? {owner: doc.frontmatter.owner} : {}),
+    ...(doc.frontmatter.code_areas ? {code_areas: doc.frontmatter.code_areas} : {}),
+    ...(doc.frontmatter.related_issues ? {related_issues: doc.frontmatter.related_issues} : {}),
+    ...(doc.frontmatter.implemented_in ? {implemented_in: doc.frontmatter.implemented_in} : {}),
+  }
+}
+
+export async function collectLlmsDocs(options: CollectOptions = {}): Promise<CollectResult> {
+  const siteDir = options.siteDir ?? process.cwd()
+  const docsRoot = resolveDocsRoot(siteDir, options.docsRoot)
+  const baseUrl = normalizeBaseUrl(options.baseUrl)
+  const include = options.include ?? ['**/*.md']
+  const [relativePaths, rootSourceResult] = await Promise.all([
+    fg(include, {cwd: docsRoot, onlyFiles: true}),
+    loadRootSourceOfTruthPaths(docsRoot),
+  ])
+  const docs: LlmsDoc[] = []
+
+  for (const relativePath of relativePaths.sort()) {
+    const source = await fs.readFile(path.join(docsRoot, relativePath), 'utf8')
+    const parsed = matter(source)
+    const frontmatter = parsed.data as LlmFrontmatter
+
+    if (isExcluded(relativePath, frontmatter)) {
+      continue
+    }
+
+    if (!isTierOne(relativePath, frontmatter) && !rootSourceResult.rootPaths.has(relativePath)) {
+      continue
+    }
+
+    docs.push({
+      relativePath,
+      source,
+      content: parsed.content.trim(),
+      frontmatter,
+      title: extractTitle(parsed.content, frontmatter, relativePath),
+      description: extractDescription(parsed.content, frontmatter),
+      url: relativePathToUrl(relativePath, baseUrl),
+      section: sectionForDoc(relativePath),
+    })
+  }
+
+  return {
+    docsRoot,
+    docs,
+    warnings: rootSourceResult.warnings,
+  }
+}
+
+export function buildLlmsArtifacts(options: {
+  docs: LlmsDoc[]
+  baseUrl?: string
+  generatedAt?: string
+}): LlmsArtifacts {
+  const baseUrl = normalizeBaseUrl(options.baseUrl)
+  const generatedAt = options.generatedAt ?? new Date().toISOString()
+  const llmsLines = [
+    '# tachigo Dev Portal',
+    '',
+    '> tachigo / tachiya 專案導覽入口，供 AI agent 快速取得 source-of-truth 文件索引。',
+    '',
+  ]
+  const currentSections = new Set<string>()
+
+  for (const doc of options.docs) {
+    if (!currentSections.has(doc.section)) {
+      if (currentSections.size > 0) {
+        llmsLines.push('')
+      }
+
+      llmsLines.push(`## ${doc.section}`)
+      currentSections.add(doc.section)
+    }
+
+    llmsLines.push(`- [${doc.title}](${doc.url}): ${doc.description}`)
+  }
+
+  const llmsFullTxt = options.docs
+    .map((doc) =>
+      [
+        '---',
+        `Title: ${doc.title}`,
+        `Source: ${doc.url}`,
+        `Path: docs/${doc.relativePath}`,
+        '---',
+        '',
+        doc.content,
+      ].join('\n'),
+    )
+    .join('\n\n')
+
+  return {
+    llmsTxt: `${llmsLines.join('\n').trimEnd()}\n`,
+    llmsFullTxt: `${llmsFullTxt.trimEnd()}\n`,
+    manifest: {
+      version: '1.0',
+      generated_at: generatedAt,
+      base_url: baseUrl,
+      docs: options.docs.map(toManifestDoc),
+    },
+  }
+}
+
+export default function llmsTxtPlugin(
+  context: LoadContext,
+  options: LlmsTxtOptions = {},
+): Plugin<void> {
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? context.baseUrl ?? DEFAULT_BASE_URL)
+
+  return {
+    name: 'tachigo-llms-txt',
+
+    async postBuild({outDir}) {
+      const result = await collectLlmsDocs({
+        siteDir: context.siteDir,
+        docsRoot: options.docsRoot,
+        include: options.include,
+        baseUrl,
+      })
+
+      for (const warning of result.warnings) {
+        console.warn(warning)
+      }
+
+      const artifacts = buildLlmsArtifacts({
+        docs: result.docs,
+        baseUrl,
+      })
+
+      await Promise.all([
+        fs.writeFile(path.join(outDir, 'llms.txt'), artifacts.llmsTxt, 'utf8'),
+        fs.writeFile(path.join(outDir, 'llms-full.txt'), artifacts.llmsFullTxt, 'utf8'),
+        fs.writeFile(
+          path.join(outDir, 'manifest.json'),
+          `${JSON.stringify(artifacts.manifest, null, 2)}\n`,
+          'utf8',
+        ),
+      ])
+    },
+  }
+}


### PR DESCRIPTION
## 什麼改動
新增 Dev Portal `llms-txt` Docusaurus plugin，build 後輸出 `llms.txt`、`llms-full.txt`、`manifest.json`，並補上過濾規則與 fixture tests。

## 為什麼
#697 要讓 AI agent 能一次取得 Dev Portal 的 source-of-truth 文件索引與可讀內容，同時避免把 proposed specs、plans、internal / excluded docs 打包進公開 manifest。

closes #697

## Scope 對齊
- Source of truth：#697; #693 spec `docs/superpowers/specs/2026-05-14-dev-portal-link-layer-design.md` PR 4 section
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] not selected
- If backend contract were missing, this PR would be:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- Dependency note：#702 / #694 validator is already merged into `develop`.

## 本 PR 明確不做
- 不打 GitHub API。
- 不接 MCP server。
- 不做 AI chatbot。
- 不消費 #696 reverse-index cache。
- 不改 sidebar / routing。

## Delegation Execution Log
- Source issue delegation plan: https://github.com/nurockplayer/tachigo/issues/697#issuecomment-4450993393
- Actual worker profile(s): docs_worker / controller
- Model strength: docs_worker=GPT-5.4 medium; controller=GPT-5.5 high
- Spawn directive(s)：
  - profile=docs_worker model=gpt-5.4 reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=controller model=gpt-5.5 reasoning=high controller_fallback=allowed fallback_reason=review_or_merge_decision; worker handled implementation/tests, controller reran validation, build artifact checks, PR body, and final gate
- Verification evidence:
  - `spec plan 697 --repo . --dry-run --format prompt --verbose` pass
  - `spec workflow-check --phase start --issue 697 --repo .` pass
  - `pnpm --filter ./apps/docs test:llms-txt` pass, 4/4
  - `pnpm build:docs` pass
  - build output check pass: `llms.txt`, `llms-full.txt`, `manifest.json` exist
  - manifest validation pass: docs=18; required root docs present; proposed specs/plans excluded
  - `git diff --check` pass
- Worker session closeout: worker commit was read back by controller; controller reran focused tests/build/artifact assertions and cleaned generated build outputs before push.

## Review conversation closeout
- branch_sync_ref: rebased onto develop after #707 merge; resolved docs package script conflict by preserving reverse-index and llms test scripts; validation rerun on head `067412adf6f3478d7b62eb631699e1507d4598c3`
- routing_evidence_status: pass
- routing_evidence_ref: https://github.com/nurockplayer/tachigo/issues/697#issuecomment-4450993393
- finding_disposition_status: pass
- review_triage_ref: controller review accepted worker patch after verifying Tier 1/Tier 2/Tier 3 filtering, Source Index fallback, and artifact output; evidence=this PR validation section
- root_cause_gate_ref: pass; historical #697 risk was over-including proposed specs/plans/internal docs, addressed by explicit include/exclude tiers and tests
- finding_disposition_ref: adopted; tests cover filtering, fallback, link parsing, and postBuild file emission at head `067412adf6f3478d7b62eb631699e1507d4598c3`
- threshold_evidence_status: pending with reason: #664 dogfood comment is posted after PR merge with exact head and merge SHA
- Unresolved threads: 0 unresolved by GraphQL readback
- CodeRabbit: rate-limited notice only; no actionable finding; status context success
- chatgpt-codex-connector: no review thread present

## Final merge gate
- Ready-to-merge decision: pending with reason: branch rebased onto latest develop after #707 merge; waiting for refreshed CI/Scope Police/CodeRabbit and review-decision readback
- Latest head SHA: 067412adf6f3478d7b62eb631699e1507d4598c3
- Required checks: pending with reason: checks are rerunning after force-with-lease push to head 067412adf6f3478d7b62eb631699e1507d4598c3
- spec workflow-check evidence: start=pass; commit=manual-pass local because PR body was not passed to local tool; merge=pending until checks and review-decision refresh
- Evidence URL: https://github.com/nurockplayer/tachigo/issues/697#issuecomment-4450993393
- Threshold ledger: https://github.com/nurockplayer/tachigo/issues/664 after merge

## PR 拆分檢查
- 這個 PR 的單一句子目的：Emit static AI-consumable Dev Portal manifests during docs build.
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是；#702 validator 已合併，本 PR 不依賴 #695/#696/#698
- 本 PR 是否同時包含以下多個層級？
  - [x] docs build plugin
  - [x] tests
  - [ ] frontend UI
  - [ ] backend / schema / API
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The Docusaurus build plugin and focused node:test coverage are one artifact-generation behavior change for #697.

## Acceptance Criteria
- [x] `apps/docs/plugins/llms-txt/index.ts` emits `llms.txt`, `llms-full.txt`, and `manifest.json` during docs build.
- [x] `llms.txt` uses one H1, blockquote intro, H2 sections, and list entries.
- [x] `manifest.json` is valid JSON and includes Tier 1 + Tier 2 docs.
- [x] Required root docs are present: architecture, auth architecture, watch-to-points, tokenomics, PR scope policy.
- [x] Proposed specs, plans, `internal: true`, and `excluded_from_llms: true` docs are excluded.
- [x] Missing Source Index root table falls back to Tier 1 with warning and build success.
- [x] GitHub API / MCP / chatbot paths remain unused.

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

```text
pnpm --filter ./apps/docs test:llms-txt
PASS: 4/4

pnpm build:docs
PASS

build output assertion
PASS: llms.txt, llms-full.txt, manifest.json exist; manifest docs=18; required root docs present; forbidden docs absent

git diff --check
PASS
```


