### PR TITLE
[frontend] dev-portal: show reverse-index links

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -1,6 +1,7 @@
 import frontmatterValidatorPlugin from './plugins/frontmatter-validator/index.js'
 import llmsTxtPlugin from './plugins/llms-txt/index.js'
 import relatedLinksPlugin from './plugins/related-links/index.js'
+import reverseIndexPlugin from './plugins/reverse-index/index.js'
 import {themes as prismThemes} from 'prism-react-renderer'
 import type {Config} from '@docusaurus/types'
 import type * as Preset from '@docusaurus/preset-classic'
@@ -64,6 +65,7 @@ const config: Config = {
         include: ['**/*.md'],
       },
     ],
+    [reverseIndexPlugin, {}],
   ],
 
   presets: [

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,7 @@
     "serve": "docusaurus serve --host 0.0.0.0",
     "clear": "docusaurus clear",
     "build:reverse-index": "node --experimental-strip-types --no-warnings ./scripts/build-reverse-index.ts",
-    "test:reverse-index": "node --experimental-strip-types --no-warnings --test ./scripts/build-reverse-index.test.ts",
+    "test:reverse-index": "node --experimental-strip-types --no-warnings --test ./scripts/build-reverse-index.test.ts ./plugins/reverse-index/index.test.ts",
     "test:frontmatter-validator": "node --experimental-strip-types --no-warnings --test ./plugins/frontmatter-validator/index.test.ts",
     "test:llms-txt": "node --experimental-strip-types --no-warnings --test ./plugins/llms-txt/index.test.ts",
     "test:related-links": "node --experimental-strip-types --no-warnings --test ./plugins/related-links/index.test.ts"

--- a/apps/docs/plugins/related-links/index.test.ts
+++ b/apps/docs/plugins/related-links/index.test.ts
@@ -7,6 +7,7 @@ import {
   default as relatedLinksPlugin,
 } from './index.ts'
 import {validateFrontmatterDocs} from '../frontmatter-validator/index.ts'
+import {resolveRelatedLinksData} from '../../src/components/relatedLinksData.ts'
 
 const currentDir = fileURLToPath(new URL('.', import.meta.url))
 const fixtureDocsRoot = new URL('./__fixtures__/docs/', import.meta.url)
@@ -61,4 +62,69 @@ test('plugin allows frontmatter warnings by default', async () => {
   const content = await plugin.loadContent()
 
   assert.deepEqual(content.docs['with-links.md'].related_issues, [674, 695])
+})
+
+test('resolved related links keep authoritative and inferred PRs separate', () => {
+  const resolved = resolveRelatedLinksData({
+    metadata: {
+      id: 'watch-to-points-design',
+      source: '@site/docs/watch-to-points-design.md',
+      frontMatter: {
+        related_issues: [696],
+        implemented_in: [709],
+      },
+    },
+    reverseIndex: {
+      byPr: {
+        709: {
+          pr: 709,
+          title: 'Authoritative PR should not duplicate inferred section',
+          mergedAt: '2026-05-14T08:00:00Z',
+          docs: [
+            {
+              path: 'docs/watch-to-points-design.md',
+              title: 'Authoritative PR should not duplicate inferred section',
+              mergedAt: '2026-05-14T08:00:00Z',
+              additions: 12,
+              deletions: 2,
+              weight: 1,
+              reasons: ['body:docs/watch-to-points-design.md'],
+              paths: ['docs/watch-to-points-design.md'],
+            },
+          ],
+        },
+        710: {
+          pr: 710,
+          title: 'Infer from watchtime scope',
+          mergedAt: '2026-05-15T08:00:00Z',
+          docs: [
+            {
+              path: 'docs/watch-to-points-design.md',
+              title: 'Infer from watchtime scope',
+              mergedAt: '2026-05-15T08:00:00Z',
+              additions: 18,
+              deletions: 3,
+              weight: 0.5,
+              reasons: ['changedFiles:services/api/internal/watchtime'],
+              paths: ['services/api/internal/watchtime/session.go'],
+            },
+          ],
+        },
+      },
+    },
+  })
+
+  assert.deepEqual(resolved.authoritative, {
+    relatedIssues: [696],
+    implementedIn: [709],
+  })
+  assert.deepEqual(resolved.inferredPullRequests, [
+    {
+      pr: 710,
+      title: 'Infer from watchtime scope',
+      mergedAt: '2026-05-15T08:00:00Z',
+      weight: 0.5,
+      reasons: ['changedFiles:services/api/internal/watchtime'],
+    },
+  ])
 })

--- a/apps/docs/plugins/related-links/index.test.ts
+++ b/apps/docs/plugins/related-links/index.test.ts
@@ -110,6 +110,23 @@ test('resolved related links keep authoritative and inferred PRs separate', () =
             },
           ],
         },
+        711: {
+          pr: 711,
+          title: 'Below-threshold match should stay hidden',
+          mergedAt: '2026-05-15T09:00:00Z',
+          docs: [
+            {
+              path: 'docs/watch-to-points-design.md',
+              title: 'Below-threshold match should stay hidden',
+              mergedAt: '2026-05-15T09:00:00Z',
+              additions: 8,
+              deletions: 1,
+              weight: 0.49,
+              reasons: ['changedFiles:services/api/internal/low-signal'],
+              paths: ['services/api/internal/low-signal/example.go'],
+            },
+          ],
+        },
       },
     },
   })

--- a/apps/docs/plugins/reverse-index/index.test.ts
+++ b/apps/docs/plugins/reverse-index/index.test.ts
@@ -1,0 +1,98 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import reverseIndexPlugin, {
+  loadReverseIndexCache,
+  normalizeReverseIndexCache,
+} from './index.ts'
+
+test('normalizes cache entries and drops malformed rows', () => {
+  const cache = normalizeReverseIndexCache({
+    generatedAt: '2026-05-14T00:00:00.000Z',
+    stale: false,
+    source: {
+      repository: 'nurockplayer/tachigo',
+      limit: 200,
+    },
+    entries: {
+      'docs/architecture.md': [
+        {
+          pr: 648,
+          title: '[chore] Align dashboard architecture state',
+          mergedAt: '2026-05-13T07:50:30Z',
+          additions: 5,
+          deletions: 4,
+          weight: 1,
+          reasons: ['body:docs/architecture.md'],
+          paths: ['docs/architecture.md'],
+        },
+        {pr: 'nope'},
+      ],
+    },
+  })
+
+  assert.equal(cache.entries['docs/architecture.md'].length, 1)
+  assert.equal(cache.entries['docs/architecture.md'][0].pr, 648)
+  assert.equal(cache.byPr[648].docs[0].path, 'docs/architecture.md')
+  assert.equal(cache.source.limit, 200)
+})
+
+test('missing cache is published as stale empty data instead of failing build', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachigo-reverse-index-'))
+  const cache = await loadReverseIndexCache(path.join(tempDir, 'missing.json'))
+
+  assert.equal(cache.stale, true)
+  assert.deepEqual(cache.entries, {})
+  assert.deepEqual(cache.byPr, {})
+  assert.match(cache.warning ?? '', /not found/)
+})
+
+test('plugin lifecycle publishes reverse index cache as global data', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachigo-reverse-index-'))
+  const cachePath = path.join(tempDir, 'pr-to-doc.json')
+  await fs.writeFile(
+    cachePath,
+    JSON.stringify({
+      generatedAt: '2026-05-14T00:00:00.000Z',
+      stale: false,
+      source: {
+        repository: 'nurockplayer/tachigo',
+        limit: 1,
+      },
+      entries: {
+        'docs/watch-to-points-design.md': [
+          {
+            pr: 374,
+            title: '[backend] T-point docs cleanup',
+            mergedAt: '2026-04-27T08:01:32Z',
+            additions: 7,
+            deletions: 5,
+            weight: 1,
+            reasons: ['body:docs/watch-to-points-design.md'],
+            paths: ['docs/watch-to-points-design.md'],
+          },
+        ],
+      },
+    }),
+  )
+
+  const plugin = reverseIndexPlugin({siteDir: tempDir}, {cachePath})
+  const content = await plugin.loadContent()
+  let globalData
+
+  await plugin.contentLoaded({
+    content,
+    actions: {
+      setGlobalData(data) {
+        globalData = data
+      },
+    },
+  })
+
+  assert.equal(globalData, content)
+  assert.equal(content.entries['docs/watch-to-points-design.md'][0].pr, 374)
+  assert.equal(content.byPr[374].docs[0].path, 'docs/watch-to-points-design.md')
+})

--- a/apps/docs/plugins/reverse-index/index.ts
+++ b/apps/docs/plugins/reverse-index/index.ts
@@ -1,0 +1,188 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type {LoadContext, Plugin} from '@docusaurus/types'
+
+export interface ReverseIndexEntry {
+  pr: number
+  title: string
+  mergedAt: string
+  additions: number
+  deletions: number
+  weight: number
+  reasons: string[]
+  paths: string[]
+}
+
+export interface ReverseIndexDocMatch extends ReverseIndexEntry {
+  path: string
+}
+
+export interface ReverseIndexByPrEntry {
+  pr: number
+  title: string
+  mergedAt: string
+  docs: ReverseIndexDocMatch[]
+}
+
+export interface ReverseIndexGlobalData {
+  generatedAt: string
+  stale: boolean
+  warning?: string
+  source: {
+    repository: string
+    limit: number
+  }
+  entries: Record<string, ReverseIndexEntry[]>
+  byPr: Record<number, ReverseIndexByPrEntry>
+}
+
+export interface ReverseIndexPluginOptions {
+  cachePath?: string
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function normalizeEntry(value: unknown): ReverseIndexEntry | undefined {
+  if (!isObject(value)) {
+    return undefined
+  }
+
+  const pr = Number(value.pr)
+  const weight = Number(value.weight)
+
+  if (!Number.isInteger(pr) || pr <= 0 || !Number.isFinite(weight)) {
+    return undefined
+  }
+
+  return {
+    pr,
+    title: typeof value.title === 'string' ? value.title : `PR #${pr}`,
+    mergedAt: typeof value.mergedAt === 'string' ? value.mergedAt : '',
+    additions: Number.isFinite(Number(value.additions)) ? Number(value.additions) : 0,
+    deletions: Number.isFinite(Number(value.deletions)) ? Number(value.deletions) : 0,
+    weight,
+    reasons: toStringArray(value.reasons),
+    paths: toStringArray(value.paths),
+  }
+}
+
+export function normalizeReverseIndexCache(raw: unknown): ReverseIndexGlobalData {
+  const cache = isObject(raw) ? raw : {}
+  const rawEntries = isObject(cache.entries) ? cache.entries : {}
+  const entries: ReverseIndexGlobalData['entries'] = {}
+
+  for (const [docPath, rawDocEntries] of Object.entries(rawEntries)) {
+    if (!Array.isArray(rawDocEntries)) {
+      continue
+    }
+
+    const normalized = rawDocEntries.flatMap((entry) => {
+      const item = normalizeEntry(entry)
+      return item ? [item] : []
+    })
+
+    if (normalized.length > 0) {
+      entries[docPath] = normalized
+    }
+  }
+
+  return {
+    generatedAt:
+      typeof cache.generatedAt === 'string' ? cache.generatedAt : new Date(0).toISOString(),
+    stale: Boolean(cache.stale),
+    warning: typeof cache.warning === 'string' ? cache.warning : undefined,
+    source: {
+      repository:
+        isObject(cache.source) && typeof cache.source.repository === 'string'
+          ? cache.source.repository
+          : 'nurockplayer/tachigo',
+      limit:
+        isObject(cache.source) && Number.isFinite(Number(cache.source.limit))
+          ? Number(cache.source.limit)
+          : 0,
+    },
+    entries,
+    byPr: buildByPr(entries),
+  }
+}
+
+function buildByPr(
+  entries: Record<string, ReverseIndexEntry[]>,
+): Record<number, ReverseIndexByPrEntry> {
+  const byPr: Record<number, ReverseIndexByPrEntry> = {}
+
+  for (const [docPath, docEntries] of Object.entries(entries)) {
+    for (const entry of docEntries) {
+      byPr[entry.pr] ??= {
+        pr: entry.pr,
+        title: entry.title,
+        mergedAt: entry.mergedAt,
+        docs: [],
+      }
+
+      byPr[entry.pr].docs.push({
+        ...entry,
+        path: docPath,
+      })
+    }
+  }
+
+  return byPr
+}
+
+export async function loadReverseIndexCache(cachePath: string): Promise<ReverseIndexGlobalData> {
+  try {
+    const source = await fs.readFile(cachePath, 'utf8')
+    return normalizeReverseIndexCache(JSON.parse(source))
+  } catch (error) {
+    const warning =
+      error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT'
+        ? `reverse-index cache not found at ${cachePath}`
+        : `reverse-index cache could not be loaded: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+
+    console.warn(`[reverse-index] ${warning}`)
+
+    return {
+      generatedAt: new Date(0).toISOString(),
+      stale: true,
+      warning,
+      source: {
+        repository: 'nurockplayer/tachigo',
+        limit: 0,
+      },
+      entries: {},
+      byPr: {},
+    }
+  }
+}
+
+export default function reverseIndexPlugin(
+  context: LoadContext,
+  options: ReverseIndexPluginOptions = {},
+): Plugin<ReverseIndexGlobalData> {
+  const cachePath = options.cachePath ?? path.join(context.siteDir, '.cache/pr-to-doc.json')
+
+  return {
+    name: 'tachigo-reverse-index',
+
+    async loadContent() {
+      return loadReverseIndexCache(cachePath)
+    },
+
+    async contentLoaded({content, actions}) {
+      actions.setGlobalData(content)
+    },
+  }
+}

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -17,6 +17,7 @@ const sidebars: SidebarsConfig = {
         'dev-portal/daily-dev-guide',
         'dev-portal/flows',
         'dev-portal/source-index',
+        'dev-portal/changelog',
         'dev-portal/graph-explorer',
       ],
     },

--- a/apps/docs/src/components/RelatedLinks.tsx
+++ b/apps/docs/src/components/RelatedLinks.tsx
@@ -2,78 +2,15 @@ import React from 'react'
 import {useDoc} from '@docusaurus/plugin-content-docs/client'
 import {usePluginData} from '@docusaurus/useGlobalData'
 
-type DocRelated = {
-  related_issues?: number[]
-  implemented_in?: number[]
-}
-
-type RelatedLinksGlobalData = {
-  docs?: Record<string, DocRelated>
-}
-
-type DocMetadata = {
-  id?: string
-  source?: string
-  frontMatter?: DocRelated
-}
+import {
+  resolveRelatedLinksData,
+  type DocMetadata,
+  type RelatedLinksGlobalData,
+  type RelatedLinksResolvedData,
+  type ReverseIndexGlobalData,
+} from './relatedLinksData'
 
 const GITHUB_REPO_URL = 'https://github.com/nurockplayer/tachigo'
-
-function uniquePositiveNumbers(values: number[] | undefined): number[] {
-  if (!values) {
-    return []
-  }
-
-  return [...new Set(values.filter((value) => Number.isInteger(value) && value > 0))]
-}
-
-function normalizeSourceKey(source: string): string {
-  return source
-    .replace(/^@site\//, '')
-    .replace(/^(\.\.\/)+docs\//, '')
-    .replace(/^docs\//, '')
-}
-
-function candidateDocKeys(metadata: DocMetadata): string[] {
-  const candidates = new Set<string>()
-
-  if (metadata.source) {
-    candidates.add(normalizeSourceKey(metadata.source))
-  }
-
-  if (metadata.id) {
-    candidates.add(`${metadata.id}.md`)
-    candidates.add(`${metadata.id}/index.md`)
-  }
-
-  return [...candidates]
-}
-
-function findPluginRelated(
-  data: RelatedLinksGlobalData | undefined,
-  metadata: DocMetadata,
-): DocRelated | undefined {
-  const docs = data?.docs
-
-  if (!docs) {
-    return undefined
-  }
-
-  for (const key of candidateDocKeys(metadata)) {
-    if (docs[key]) {
-      return docs[key]
-    }
-  }
-
-  return undefined
-}
-
-export function resolveDocRelated(
-  data: RelatedLinksGlobalData | undefined,
-  metadata: DocMetadata,
-): DocRelated {
-  return findPluginRelated(data, metadata) ?? metadata.frontMatter ?? {}
-}
 
 function RelatedChip({href, number}: {href: string; number: number}): JSX.Element {
   return (
@@ -84,6 +21,27 @@ function RelatedChip({href, number}: {href: string; number: number}): JSX.Elemen
       rel="noreferrer"
     >
       #{number}
+    </a>
+  )
+}
+
+function InferredPrChip({
+  entry,
+}: {
+  entry: RelatedLinksResolvedData['inferredPullRequests'][number]
+}): JSX.Element {
+  const title = `${entry.title} · weight ${entry.weight.toFixed(2)} · ${entry.reasons.join(', ')}`
+
+  return (
+    <a
+      className="tachigo-related-links__chip tachigo-related-links__chip--inferred"
+      href={`${GITHUB_REPO_URL}/pull/${entry.pr}`}
+      target="_blank"
+      rel="noreferrer"
+      title={title}
+    >
+      #{entry.pr}
+      <span>{entry.weight.toFixed(2)}</span>
     </a>
   )
 }
@@ -113,16 +71,45 @@ function RelatedGroup({
   )
 }
 
+function InferredPrGroup({
+  entries,
+}: {
+  entries: RelatedLinksResolvedData['inferredPullRequests']
+}): JSX.Element | null {
+  if (entries.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="tachigo-related-links__group">
+      <h3>推論關聯 PR</h3>
+      <div className="tachigo-related-links__chips">
+        {entries.map((entry) => (
+          <InferredPrChip key={entry.pr} entry={entry} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export default function RelatedLinks(): JSX.Element | null {
   const {metadata} = useDoc()
   const pluginData = usePluginData('tachigo-related-links') as
     | RelatedLinksGlobalData
     | undefined
-  const related = resolveDocRelated(pluginData, metadata as DocMetadata)
-  const relatedIssues = uniquePositiveNumbers(related.related_issues)
-  const implementedIn = uniquePositiveNumbers(related.implemented_in)
+  const reverseIndexData = usePluginData('tachigo-reverse-index') as
+    | ReverseIndexGlobalData
+    | undefined
+  const related = resolveRelatedLinksData({
+    relatedLinks: pluginData,
+    reverseIndex: reverseIndexData,
+    metadata: metadata as DocMetadata,
+  })
+  const relatedIssues = related.authoritative.relatedIssues
+  const implementedIn = related.authoritative.implementedIn
+  const inferredPrs = related.inferredPullRequests
 
-  if (relatedIssues.length === 0 && implementedIn.length === 0) {
+  if (relatedIssues.length === 0 && implementedIn.length === 0 && inferredPrs.length === 0) {
     return null
   }
 
@@ -138,6 +125,7 @@ export default function RelatedLinks(): JSX.Element | null {
         hrefBase={`${GITHUB_REPO_URL}/pull`}
         numbers={implementedIn}
       />
+      <InferredPrGroup entries={inferredPrs} />
     </section>
   )
 }

--- a/apps/docs/src/components/ReverseIndexChangelog.tsx
+++ b/apps/docs/src/components/ReverseIndexChangelog.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import {usePluginData} from '@docusaurus/useGlobalData'
+
+type ReverseIndexEntry = {
+  pr: number
+  title: string
+  mergedAt: string
+  additions: number
+  deletions: number
+  weight: number
+  reasons: string[]
+  paths: string[]
+}
+
+type ReverseIndexData = {
+  generatedAt?: string
+  stale?: boolean
+  warning?: string
+  entries?: Record<string, ReverseIndexEntry[]>
+}
+
+type ChangelogItem = ReverseIndexEntry & {
+  docPath: string
+}
+
+const GITHUB_REPO_URL = 'https://github.com/nurockplayer/tachigo'
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function toTime(value: string | undefined): number {
+  const timestamp = Date.parse(value ?? '')
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+export function createChangelogItems(
+  data: ReverseIndexData | undefined,
+  windowDays = 90,
+): ChangelogItem[] {
+  const entries = data?.entries ?? {}
+  const generatedAt = toTime(data?.generatedAt) || Date.now()
+  const cutoff = generatedAt - windowDays * DAY_MS
+
+  return Object.entries(entries)
+    .flatMap(([docPath, docEntries]) =>
+      docEntries.map((entry) => ({
+        ...entry,
+        docPath,
+      })),
+    )
+    .filter((entry) => toTime(entry.mergedAt) >= cutoff)
+    .sort((a, b) => toTime(b.mergedAt) - toTime(a.mergedAt) || b.pr - a.pr)
+}
+
+function formatDate(value: string): string {
+  const timestamp = toTime(value)
+
+  if (!timestamp) {
+    return 'unknown date'
+  }
+
+  return new Date(timestamp).toISOString().slice(0, 10)
+}
+
+function formatDocPath(docPath: string): string {
+  return docPath.replace(/^docs\//, '').replace(/\.md$/, '')
+}
+
+function formatReasons(reasons: string[]): string {
+  if (reasons.length === 0) {
+    return 'reason unavailable'
+  }
+
+  return reasons
+    .map((reason) =>
+      reason
+        .replace(/^body:/, 'body: ')
+        .replace(/^changedFiles:/, 'changedFiles: ')
+        .replace('title:doc-slug', 'title: doc slug'),
+    )
+    .join(', ')
+}
+
+export default function ReverseIndexChangelog(): JSX.Element {
+  const data = usePluginData('tachigo-reverse-index') as ReverseIndexData | undefined
+  const items = createChangelogItems(data)
+
+  if (items.length === 0) {
+    return (
+      <div className="tachigo-reverse-index-empty">
+        committed cache 目前沒有可顯示的 reverse-index entries。
+      </div>
+    )
+  }
+
+  return (
+    <section className="tachigo-reverse-index" aria-label="Reverse index changelog">
+      {data?.stale ? (
+        <p className="tachigo-reverse-index__warning">
+          Cache is stale{data.warning ? `: ${data.warning}` : '。'}
+        </p>
+      ) : null}
+      <div className="tachigo-reverse-index__list">
+        {items.map((item) => (
+          <article
+            className="tachigo-reverse-index__item"
+            key={`${item.docPath}-${item.pr}`}
+          >
+            <div className="tachigo-reverse-index__meta">
+              <a href={`${GITHUB_REPO_URL}/pull/${item.pr}`} target="_blank" rel="noreferrer">
+                #{item.pr}
+              </a>
+              <span>{formatDate(item.mergedAt)}</span>
+              <span>weight {item.weight.toFixed(2)}</span>
+            </div>
+            <h3>{item.title}</h3>
+            <p>
+              <strong>{formatDocPath(item.docPath)}</strong>
+              <span> — {formatReasons(item.reasons)}</span>
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/docs/src/components/relatedLinksData.ts
+++ b/apps/docs/src/components/relatedLinksData.ts
@@ -1,0 +1,151 @@
+export type DocRelated = {
+  related_issues?: number[]
+  implemented_in?: number[]
+}
+
+export type ReverseIndexDocMatch = {
+  path: string
+  title: string
+  mergedAt: string
+  additions: number
+  deletions: number
+  weight: number
+  reasons: string[]
+  paths: string[]
+}
+
+export type ReverseIndexByPr = Record<
+  number,
+  {
+    pr: number
+    title: string
+    mergedAt: string
+    docs: ReverseIndexDocMatch[]
+  }
+>
+
+export type RelatedLinksGlobalData = {
+  docs?: Record<string, DocRelated>
+}
+
+export type ReverseIndexGlobalData = {
+  byPr?: ReverseIndexByPr
+}
+
+export type DocMetadata = {
+  id?: string
+  source?: string
+  frontMatter?: DocRelated
+}
+
+export type RelatedLinksResolvedData = {
+  authoritative: {
+    relatedIssues: number[]
+    implementedIn: number[]
+  }
+  inferredPullRequests: Array<{
+    pr: number
+    title: string
+    mergedAt: string
+    weight: number
+    reasons: string[]
+  }>
+}
+
+function uniquePositiveNumbers(values: number[] | undefined): number[] {
+  if (!values) {
+    return []
+  }
+
+  return [...new Set(values.filter((value) => Number.isInteger(value) && value > 0))]
+}
+
+function normalizeSourceKey(source: string): string {
+  return source
+    .replace(/^@site\//, '')
+    .replace(/^(\.\.\/)+docs\//, '')
+    .replace(/^docs\//, '')
+}
+
+function candidateDocKeys(metadata: DocMetadata): string[] {
+  const candidates = new Set<string>()
+
+  if (metadata.source) {
+    candidates.add(normalizeSourceKey(metadata.source))
+  }
+
+  if (metadata.id) {
+    candidates.add(`${metadata.id}.md`)
+    candidates.add(`${metadata.id}/index.md`)
+  }
+
+  return [...candidates]
+}
+
+function findPluginRelated(
+  data: RelatedLinksGlobalData | undefined,
+  metadata: DocMetadata,
+): DocRelated | undefined {
+  const docs = data?.docs
+
+  if (!docs) {
+    return undefined
+  }
+
+  for (const key of candidateDocKeys(metadata)) {
+    if (docs[key]) {
+      return docs[key]
+    }
+  }
+
+  return undefined
+}
+
+export function resolveDocRelated(
+  data: RelatedLinksGlobalData | undefined,
+  metadata: DocMetadata,
+): DocRelated {
+  return findPluginRelated(data, metadata) ?? metadata.frontMatter ?? {}
+}
+
+export function resolveRelatedLinksData(options: {
+  relatedLinks?: RelatedLinksGlobalData
+  reverseIndex?: ReverseIndexGlobalData
+  metadata: DocMetadata
+}): RelatedLinksResolvedData {
+  const related = resolveDocRelated(options.relatedLinks, options.metadata)
+  const authoritative = {
+    relatedIssues: uniquePositiveNumbers(related.related_issues),
+    implementedIn: uniquePositiveNumbers(related.implemented_in),
+  }
+
+  const inferredByPr = new Map<number, RelatedLinksResolvedData['inferredPullRequests'][number]>()
+  const docKeys = new Set(candidateDocKeys(options.metadata))
+
+  for (const entry of Object.values(options.reverseIndex?.byPr ?? {})) {
+    const matchingDoc = entry.docs.find((doc) => docKeys.has(normalizeSourceKey(doc.path)))
+
+    if (!matchingDoc) {
+      continue
+    }
+
+    if (authoritative.implementedIn.includes(entry.pr)) {
+      continue
+    }
+
+    inferredByPr.set(entry.pr, {
+      pr: entry.pr,
+      title: entry.title,
+      mergedAt: entry.mergedAt,
+      weight: matchingDoc.weight,
+      reasons: matchingDoc.reasons,
+    })
+  }
+
+  return {
+    authoritative,
+    inferredPullRequests: [...inferredByPr.values()].sort(
+      (a, b) => Date.parse(b.mergedAt) - Date.parse(a.mergedAt) || b.pr - a.pr,
+    ),
+  }
+}

--- a/apps/docs/src/components/relatedLinksData.ts
+++ b/apps/docs/src/components/relatedLinksData.ts
@@ -129,6 +129,12 @@ export function resolveRelatedLinksData(options: {
       continue
     }
 
+    const weight = Number.isFinite(matchingDoc.weight) ? matchingDoc.weight : 0
+
+    if (weight < 0.5) {
+      continue
+    }
+
     if (authoritative.implementedIn.includes(entry.pr)) {
       continue
     }
@@ -137,7 +143,7 @@ export function resolveRelatedLinksData(options: {
       pr: entry.pr,
       title: entry.title,
       mergedAt: entry.mergedAt,
-      weight: matchingDoc.weight,
+      weight,
       reasons: matchingDoc.reasons,
     })
   }

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -533,6 +533,62 @@
   text-decoration: none;
 }
 
+.tachigo-related-links__chip--inferred {
+  gap: 0.4rem;
+  border-color: color-mix(in srgb, var(--tachigo-violet), var(--tachigo-line) 40%);
+  background: color-mix(in srgb, var(--tachigo-violet), transparent 88%);
+}
+
+.tachigo-related-links__chip--inferred span {
+  color: var(--tachigo-muted);
+  font-size: 0.72rem;
+}
+
+.tachigo-reverse-index {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.tachigo-reverse-index__warning,
+.tachigo-reverse-index-empty {
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--tachigo-line);
+  border-radius: 8px;
+  background: var(--tachigo-panel);
+  color: var(--tachigo-muted);
+}
+
+.tachigo-reverse-index__list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tachigo-reverse-index__item {
+  padding: 0.95rem;
+  border: 1px solid var(--tachigo-line);
+  border-radius: 8px;
+  background: var(--tachigo-panel);
+}
+
+.tachigo-reverse-index__item h3 {
+  margin: 0.4rem 0;
+  font-size: 1rem;
+}
+
+.tachigo-reverse-index__item p {
+  margin: 0;
+  color: var(--tachigo-muted);
+}
+
+.tachigo-reverse-index__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  color: var(--tachigo-muted);
+  font-size: 0.78rem;
+  font-weight: 760;
+}
+
 @media (max-width: 1120px) {
   .tachigo-hero {
     grid-template-columns: 1fr;

--- a/docs/dev-portal/changelog.md
+++ b/docs/dev-portal/changelog.md
@@ -1,0 +1,22 @@
+---
+title: Reverse Index Changelog
+sidebar_position: 6
+status: active
+owner: engineering
+last_reviewed: 2026-05-15
+source_of_truth: true
+code_areas:
+  - apps/docs
+  - docs
+related_repos:
+  - tachigo
+reverse_index_mode: explicit_only
+---
+
+import ReverseIndexChangelog from '@site/src/components/ReverseIndexChangelog'
+
+# Reverse Index Changelog
+
+這頁列出 committed reverse-index cache 中，近 90 天 merged PR 對應到的文件。Frontmatter 仍是 authoritative source；這裡顯示的是 build-time GitHub metadata 推論結果。
+
+<ReverseIndexChangelog />

--- a/docs/dev-portal/changelog.md
+++ b/docs/dev-portal/changelog.md
@@ -3,7 +3,7 @@ title: Reverse Index Changelog
 sidebar_position: 6
 status: active
 owner: engineering
-last_reviewed: 2026-05-15
+last_reviewed: 2026-05-14
 source_of_truth: true
 code_areas:
   - apps/docs


### PR DESCRIPTION
## 什麼改動
新增 Dev Portal reverse-index plugin，將 committed `apps/docs/.cache/pr-to-doc.json` 注入 Docusaurus global data；新增 reverse-index changelog 頁，並在 RelatedLinks 補上「推論關聯 PR」分區。

## 為什麼
#696 PR3a 已完成 reverse-index cache 產生，#706 已完成 frontmatter authoritative links。這張 PR3b 把 cache 接到 Dev Portal UI，讓文件頁和 changelog 能顯示 PR ↔ doc 推論結果。

closes #696

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#696; #693 spec `docs/superpowers/specs/2026-05-14-dev-portal-link-layer-design.md` PR 3 section
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 PR3a reverse-index scoring / GitHub API 規則。
  - 不新增 dependency 或 lockfile change。
  - 不接 graphify。
  - 不做 #699 deployment / hosting。
  - 不把 reverse-index cache 變成 required CI check。
  - 不修改 backend / extension / dashboard runtime。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - https://github.com/nurockplayer/tachigo/issues/696#issuecomment-4452525571
- routing_evidence_status: pass
- routing_evidence_ref: https://github.com/nurockplayer/tachigo/issues/696#issuecomment-4452525571
- spark_readback_evidence: https://github.com/nurockplayer/tachigo/issues/696#issuecomment-4452525571
- worker_5_4_evidence: https://github.com/nurockplayer/tachigo/issues/696#issuecomment-4452525571
- Actual worker profile(s)：
  - ops_spark / frontend_worker / review_worker / controller
- Model strength：
  - ops_spark = GPT-5.3-Codex-Spark medium；frontend_worker = GPT-5.4 medium；review_worker = GPT-5.4 medium；controller = GPT-5.5 high
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=frontend_worker model=gpt-5.4 reasoning=medium controller_fallback=allowed fallback_reason=worker_timeout_after_initial_dispatch_no_shared_diff_then_partial_readback
  - profile=review_worker model=gpt-5.4 reasoning=medium controller_fallback=allowed fallback_reason=review_worker_timeout_after_dispatch
- Verification evidence：
  - `spec workflow-check --phase start --issue 696 --repo .` pass in clean worktree
  - `pnpm --filter ./apps/docs test:reverse-index` pass, 10/10
  - `pnpm --filter ./apps/docs test:related-links` pass, 4/4
  - `pnpm --filter ./apps/docs test:frontmatter-validator` pass, 7/7
  - `pnpm --filter ./apps/docs test:llms-txt` pass, 4/4
  - `pnpm --filter ./apps/docs build:reverse-index -- --cache /tmp/tachigo-pr3b-pr-to-doc.json --limit 1` pass, stale fallback expected without token
  - `pnpm build:docs` pass
  - `git diff --check` pass
  - review remediation on latest head `a21d1eed7412182839a1caee0fa128977977ab28`: `test:related-links` pass 4/4, `test:reverse-index` pass 10/10, `test:frontmatter-validator` pass 7/7, `test:llms-txt` pass 4/4, `pnpm build:docs` pass, `git diff --check` pass
- Self-review / exception reason：
  - Controller self-review checked scope, cache cleanliness, and PR3b split boundary after frontend/review worker timeouts.
- Worker session closeout：
  - Initial ops_spark completed read-only metadata task. frontend_worker was closed after timeout; partial shared diff was read back and integrated. review_worker was closed after timeout with no findings returned. Follow-up ops_spark readback hit context limit, so controller fallback handled metadata readback with `controller_fallback_reason=ops_spark_context_length_exceeded`. Follow-up GPT-5.4 remediation worker fixed validated CodeRabbit findings and ran focused tests.
- Workflow friction / follow-up split：
  - PR3 was already split into PR3a/PR3b. This PR keeps PR3b as one UI integration slice; threshold calibration will be logged to #664 after merge.

## Review conversation closeout
- Unresolved threads：
  - 0; CodeRabbit inline threads were replied to and resolved via GraphQL.
- CodeRabbit：
  - pass/readback: latest `gh pr checks` shows CodeRabbit `pass` / review skipped on current head after fixes.
  - findings handled:
    - `apps/docs/src/components/relatedLinksData.ts`: adopted. Added `weight >= 0.5` guard; missing/non-finite weight is treated as 0.
    - `docs/dev-portal/changelog.md`: adopted. `last_reviewed` changed from `2026-05-15` to `2026-05-14`.
    - `apps/docs/plugins/related-links/index.test.ts`: adopted. Added 0.49 regression fixture.
- chatgpt-codex-connector：
  - skipped/not requested; controller self-review and CodeRabbit thread readback used instead.
- review_triage_ref：
  - CodeRabbit review: https://github.com/nurockplayer/tachigo/pull/711#pullrequestreview-4291635579
  - weight thread reply: https://github.com/nurockplayer/tachigo/pull/711#discussion_r3242833834
  - date thread reply: https://github.com/nurockplayer/tachigo/pull/711#discussion_r3242834894
- root_cause_gate_ref：
  - root cause was missing UI-layer threshold filtering after cache-builder already enforced the threshold; fixed at `resolveRelatedLinksData` and covered by test.
- finding_disposition_ref：
  - all actionable current-head findings adopted and resolved.
- Final reviewer action：
  - blocked: GitHub rejected author self-approval with `Review Can not approve your own pull request`; waiting for non-author review/approval.

## Final merge gate
- Ready-to-merge decision：
  - blocked until non-author approval. Current head has green checks, resolved review threads, and no known code blocker.
- Latest head SHA：
  - `a21d1eed7412182839a1caee0fa128977977ab28`
- Required checks：
  - pass by `gh pr checks 711`: Scope police, Workflow regression tests, Supply-chain guardrails, PR commit messages, PR metadata check regression tests, Commit message regression tests, Backend CI (gate), CodeRabbit, and auto-ready/label workflows are green or intentionally skipped for non-product surfaces.
- spec workflow-check evidence：
  - start=pass; commit=pass local with /tmp/tachigo-696-* evidence; routing_evidence_status=pass; threshold_ledger_ref=https://github.com/nurockplayer/tachigo/issues/664; merge=manual because final approval is blocked by GitHub self-approval policy.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/696#issuecomment-4452525571
  - https://github.com/nurockplayer/tachigo/issues/664#issuecomment-4452587974

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Connect reverse-index cache to Dev Portal UI as plugin global data, changelog page, and inferred PR chips.
- Approx changed lines：~770; exceeds 600 warning but below 1000 hard limit.
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #696 PR3b is the already-split UI integration slice after PR3a; plugin global data, changelog page, sidebar entry, and RelatedLinks inferred section are one reviewable behavior.
- 若已拆分，相關 PR：
  - PR3a: #707; related prerequisites: #706, #703, #709

## Acceptance Criteria
- [x] 新增 reverse-index plugin，讀取 `apps/docs/.cache/pr-to-doc.json` 並注入 global data。
- [x] `docs/dev-portal/changelog.md` 列出近 90 天 PR + doc + weight + reason。
- [x] sidebar 加入 `dev-portal/changelog`。
- [x] RelatedLinks 分開顯示 frontmatter authoritative links 與 reverse-index inferred PRs。
- [x] GitHub API failure / missing cache path 不讓 docs build fail；plugin publishes stale empty data。
- [x] 不新增依賴、不更動 lockfile、不改 backend / extension / dashboard。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
pnpm install --frozen-lockfile
PASS

pnpm --filter ./apps/docs test:reverse-index
PASS: 10/10

pnpm --filter ./apps/docs test:related-links
PASS: 4/4

pnpm --filter ./apps/docs test:frontmatter-validator
PASS: 7/7

pnpm --filter ./apps/docs test:llms-txt
PASS: 4/4

Review remediation rerun on head a21d1eed7412182839a1caee0fa128977977ab28
PASS: test:related-links 4/4; test:reverse-index 10/10; test:frontmatter-validator 7/7; test:llms-txt 4/4; pnpm build:docs; git diff --check

pnpm --filter ./apps/docs build:reverse-index -- --cache /tmp/tachigo-pr3b-pr-to-doc.json --limit 1
PASS: no-token stale fallback produced valid cache output

pnpm build:docs
PASS

git diff --check
PASS
```

## 備註
- Build warning about untracked docs files appeared before commit because new PR files were not tracked yet; production build still succeeded.
- Local no-token reverse-index verification used a temp cache path, so committed `apps/docs/.cache/pr-to-doc.json` stayed unchanged.

## Notes for Claude Code Review
- Please review the reverse-index global data shape and RelatedLinks duplicate suppression for `implemented_in` PRs.
- The PR is intentionally over the 600-line warning because #696 was already split into PR3a/PR3b, and this is the single UI integration slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 新增变更日志页面，展示最近90天内合并的PR及其相关文件更改
  * 增强相关链接组件，新增推论关联PR分组展示，包含权重和链接信息

* **Tests**
  * 新增反向索引插件及相关链接组件的测试用例

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/711)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
