### PR TITLE
[infra] dev-portal: document deployment tracker

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -17,6 +17,7 @@ const sidebars: SidebarsConfig = {
         'dev-portal/daily-dev-guide',
         'dev-portal/flows',
         'dev-portal/source-index',
+        'dev-portal/deployment',
         'dev-portal/changelog',
         'dev-portal/graph-explorer',
       ],

--- a/docs/dev-portal/deployment.md
+++ b/docs/dev-portal/deployment.md
@@ -1,0 +1,122 @@
+---
+title: Deployment Tracker
+status: active
+owner: engineering
+last_reviewed: 2026-05-14
+source_of_truth: true
+code_areas:
+  - docs
+  - apps/docs
+related_repos:
+  - tachigo
+related_issues:
+  - 699
+---
+
+# Deployment Tracker
+
+這頁記錄 `tachigo` Dev Portal 部署到 Cloudflare Pages 的 repo-side 設定與 readback checklist。範圍只涵蓋靜態 docs hosting，不擴張成 backend runtime 或其他 Cloudflare 產品導入。
+
+## Scope
+
+- 手動在 Cloudflare Pages 後台連接 GitHub repo
+- 記錄 docs build 所需的 install / build / output / root 設定
+- 定義 `develop` / `main` branch deploy 與 PR preview 的預期行為
+- 保留公開 URL 驗證、rollback 與 readback checklist
+
+## Manual setup values
+
+| 欄位 | 值 |
+|---|---|
+| Provider | Cloudflare Pages |
+| Production branch | `main` |
+| Root directory | repo root (`/`) |
+| Install command | `pnpm install --frozen-lockfile --ignore-scripts` |
+| Build command | `pnpm build:docs` |
+| Build output directory | `apps/docs/build` |
+| Node / package manager | 依 repo 既有 `pnpm` / lockfile，不額外加 dependency |
+
+Cloudflare 後台操作重點：
+
+1. 選擇 `nurockplayer/tachigo` repo。
+2. Framework preset 可維持 generic static site，只手動覆蓋 `Production branch`、`Root directory`、`Install command`、`Build command` 與 `Build output directory`。
+3. Install command 必須加上 `--ignore-scripts`，避免 hosted deploy 在 install phase 執行 dependency lifecycle script。
+4. Root 必須是 repo root，不是 `apps/docs`，因為 build script 定義在 workspace root。
+5. 第一次連線完成後，先確認 Cloudflare 讀到的 branch 與 build config 都和這頁一致，再觸發初次 deploy。
+
+## Preview readback
+
+Cloudflare Pages 的 preview 行為不能只靠填一個欄位宣稱完成。連 repo 後必須從 Pages dashboard 與實際 URL 讀回：
+
+| 讀回項目 | 預期 |
+|---|---|
+| Production deployment | branch 是 `main`，commit SHA 對得上 GitHub 的 `main` head |
+| Branch deployment | `develop` 有獨立 preview / staging deployment，commit SHA 對得上 GitHub 的 `develop` head |
+| PR preview | 新開 PR 後會產生 preview URL，URL 對應該 PR branch / commit |
+| Build config | root、install、build、output 值與上表一致 |
+
+若 `develop` branch deploy 或 PR preview 沒有出現在 dashboard，先不要把 #699 關成完成；補 Cloudflare Pages 設定或另開 issue 追蹤。
+
+## Branch deploy model
+
+| 分支 / 情境 | 預期 |
+|---|---|
+| `main` | production docs URL；對外穩定入口 |
+| `develop` | branch preview / staging URL；用來驗證 develop 最新整合狀態 |
+| PR branch | 每個 PR 自動產生 preview URL，供 reviewer 驗證 docs、搜尋與靜態資產 |
+
+實務上要把 `main` 視為穩定公開入口，把 `develop` 視為 release 前 readback 環境；不要反過來。
+
+## Domain gate
+
+預設先接受 Cloudflare 提供的 `*.pages.dev` URL，等下列條件滿足後再由人類決定是否綁 custom domain（例如 `wiki.tachigo.dev`）：
+
+- Cloudflare 帳號歸屬已確認是 org 或明確可交接的個人帳號
+- `main` / `develop` / PR preview 的 deploy 與 rollback 流程已走通一次
+- DNS owner、TLS、子網域命名是否要對外長期承諾，已有明確結論
+
+在這個 gate 完成前，`pages.dev` 已足以支撐 `/tachigo/llms.txt`、`/tachigo/manifest.json`、搜尋與 docs 頁面的公開驗證。
+
+## Public URL verification checklist
+
+每次首次上線、重大 docs pipeline 調整，或切換 custom domain 前，至少 readback 這些項目：
+
+- [ ] `main` production URL 可開啟首頁與 [Start Here](/tachigo/dev-portal/start-here)
+- [ ] `develop` branch URL 可讀到同一批最新 docs
+- [ ] 任一 PR preview URL 可正常載入，且不指向舊 build
+- [ ] `/tachigo/llms.txt` 可公開存取
+- [ ] `/tachigo/manifest.json` 回傳合法 JSON
+- [ ] 搜尋框可開啟並命中至少一份核心 doc（例如 `watch points`）
+- [ ] [Source Index](/tachigo/dev-portal/source-index) 與至少一份 root source-of-truth doc 可正常導覽
+- [ ] 頁面資產、樣式與站內連結沒有 base path 錯位
+
+若 production URL 尚未綁 custom domain，以上檢查在 `pages.dev` URL 完成即可；切 custom domain 後再完整重跑一次。
+
+## Rollback and readback
+
+Cloudflare Pages rollback 以後台 deployment history 為主，repo 端只記錄必要 readback：
+
+1. 在 Pages deployments 清單選定上一個已知正常版本並 rollback。
+2. 讀回 rollback 後的 deployment commit SHA、branch、建立時間與 URL。
+3. 重新跑一次上面的 public URL checklist，至少驗證首頁、`llms.txt`、`manifest.json`、搜尋。
+4. 若 rollback 只影響 `develop` 或單一 PR preview，也要記錄 production 是否未受影響。
+
+建議每次 rollback 都補一段簡短 readback 紀錄，至少包含：
+
+- rollback 目標 deployment id / commit SHA
+- rollback 前後 URL
+- 重新驗證結果
+- 是否需要後續 issue 追蹤 build config、內容或 domain 問題
+
+## Explicit non-goals
+
+這張票與這份文件明確不做：
+
+- Cloudflare Workers
+- Cloudflare Functions
+- Cloudflare Access / Zero Trust
+- backend runtime、API、database 或其他 server-side deployment
+- `.github/workflows/deploy-docs.yml`
+- GitHub Pages 自動部署流程
+
+若未來真的要改成 GitHub Pages、補 deploy workflow，或引入其他 Cloudflare 能力，應拆成新 issue / PR。

--- a/docs/dev-portal/source-index.md
+++ b/docs/dev-portal/source-index.md
@@ -65,6 +65,12 @@ related_repos:
 | [feature-discussion.md](/tachigo/feature-discussion) | 早期產品討論紀錄；仍保留供背景參考，不得單獨視為 implementation source of truth |
 | [tachimint-loyalty-claim-boundary.md](/tachigo/tachimint-loyalty-claim-boundary) | Tachimint / claim flow 邊界討論短文件，不是正式 architecture source of truth |
 
+## Dev Portal operations
+
+| 文件 | 定位 |
+|---|---|
+| [deployment.md](/tachigo/dev-portal/deployment) | Cloudflare Pages 手動連 repo、branch deploy / PR preview、公開 URL 驗證與 rollback/readback checklist |
+
 ## Code source map
 
 | Area | Source |


### PR DESCRIPTION
## 什麼改動
新增 Dev Portal Deployment Tracker，記錄 Cloudflare Pages 手動部署設定、preview/readback、public URL 驗證與 rollback checklist，並把文件掛進 Dev Portal sidebar / Source Index。

## 為什麼
refs #699

Phase 1 Link Layer 已完成，Dev Portal 需要 repo-side deployment tracker，讓後續 Cloudflare Pages 手動設定、公開 URL 驗證與 rollback readback 有一致 source of truth。這張 PR 不登入 Cloudflare、不建立外部資源，只把可審核的 repo 文件落地；#699 應保留到人類完成 Cloudflare setup / domain gate 後再關閉。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#699；`docs/superpowers/specs/2026-05-14-dev-portal-link-layer-design.md`
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不登入或修改 Cloudflare 後台
  - 不新增 `.github/workflows/deploy-docs.yml`
  - 不導入 GitHub Pages 自動部署
  - 不導入 Cloudflare Workers / Functions / Access / Zero Trust
  - 不新增 backend runtime、API、database、dependency 或 lockfile 變更

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #699 Issue Delegation Plan: https://github.com/nurockplayer/tachigo/issues/699#issuecomment-4452785529
- Actual worker profile(s)：
  - controller / ops_spark / docs_worker / review_worker
- Model strength：
  - controller = 5.5 high; ops_spark = gpt-5.3-codex-spark medium; docs_worker = gpt-5.4 medium; review_worker = gpt-5.4 medium
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=medium controller_fallback=allowed fallback_reason=metadata_readback_only
  - profile=docs_worker model=gpt-5.4 reasoning=medium controller_fallback=allowed fallback_reason=worker_timeout_or_review_integration_only
  - profile=review_worker model=gpt-5.4 reasoning=medium controller_fallback=allowed fallback_reason=review_worker_timeout_after_dispatch
- Verification evidence：
- routing_evidence_status: pass
- routing_evidence_ref: https://github.com/nurockplayer/tachigo/issues/699#issuecomment-4452785529
- spark_readback_evidence: workflow-check:spark:ops-readback-699
- worker_5_4_evidence: workflow-check:worker:docs-worker-readback-699
- finding_disposition_status: pass
- finding_disposition_ref: workflow-check:finding-disposition-699
- threshold_evidence_status: pass
- threshold_ledger_ref: https://github.com/nurockplayer/tachigo/issues/664
  - `spec workflow-check --phase start --issue 699 --repo .` pass
  - `pnpm --filter ./apps/docs test:frontmatter-validator` pass 7/7
  - `pnpm build:docs` pass
  - `git diff --check --cached && git diff --check` pass
  - `make pr-meta-check TITLE="[infra] dev-portal: document deployment tracker" BODY_FILE=/tmp/tachigo-699-pr-body.md` pass
  - `spec workflow-check --phase commit ...` pass
- Self-review / exception reason：
  - Self-review complete. Adopted review_worker major/nit about preview readback precision before PR creation.
- Worker session closeout：
  - ops_spark, docs_worker, and review_worker results were read back; completed worker sessions closed.
- Workflow friction / follow-up split：
  - Thread limit caused one spawn retry; controller recorded fallback evidence. Cloudflare account/domain execution remains a human gate, not a workflow failure. threshold calibration will be recorded in #664 after PR is stable/merged.

## Review conversation closeout
- Unresolved threads：
  - 0 pre-PR
- CodeRabbit：
  - no CodeRabbit review posted at latest readback
- chatgpt-codex-connector：
  - n/a pre-PR
- review_triage_ref：
  - /tmp/tachigo-699-finding-disposition.json
- root_cause_gate_ref：
  - #699 Issue Delegation Plan: https://github.com/nurockplayer/tachigo/issues/699#issuecomment-4452785529
- finding_disposition_ref：
  - /tmp/tachigo-699-finding-disposition.json
- Final reviewer action：
  - pre-PR review finding adopted; waiting for non-author / repo review

## Final merge gate
- Ready-to-merge decision：
  - blocked by review required
- Latest head SHA：
  - 1682911eeb83e2fca7d38dcc7e318e55c15eeae5
- Required checks：
  - remote CI / Scope Police pass; review required remains
- spec workflow-check evidence：
  - start=pass; commit=pass; merge=blocked by review required at latest readback
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/699#issuecomment-4452903787

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Document the Dev Portal Cloudflare Pages deployment tracker and expose it in Dev Portal navigation.
- Approx changed lines：~129
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 文件化 Cloudflare Pages 手動 setup：repo root、install command、build command、output directory
- [x] 文件化 develop/main branch deploy 與 PR preview readback
- [x] 文件化 `pages.dev` vs custom domain 的 human gate
- [x] 文件化 `/tachigo/llms.txt`、`/tachigo/manifest.json`、搜尋與核心 docs page 的 public URL checklist
- [x] 文件化 rollback / readback checklist
- [x] 明確不做 Workers / Functions / Access / backend runtime / GitHub Pages workflow

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
spec workflow-check --phase start --issue 699 --repo .
phase=start
status=pass

pnpm --filter ./apps/docs test:frontmatter-validator
pass 7 / fail 0

pnpm build:docs
[SUCCESS] Generated static files in "build".

 git diff --check --cached && git diff --check
pass

make pr-meta-check TITLE="[infra] dev-portal: document deployment tracker" BODY_FILE=/tmp/tachigo-699-pr-body.md
pass

spec workflow-check --phase commit --repo . --pr-body /tmp/tachigo-699-pr-body.md --routing-evidence /tmp/tachigo-699-routing-evidence.json --finding-disposition /tmp/tachigo-699-finding-disposition.json --threshold-evidence /tmp/tachigo-699-threshold-evidence.json
phase=commit
status=pass
```

## 備註
Cloudflare 帳號歸屬與 custom domain / `pages.dev` 決策仍是 human gate。這張 PR 只落地 repo-side tracker，不宣稱外部部署已完成。

## Notes for Claude Code Review
- 請特別看 `docs/dev-portal/deployment.md` 的 Cloudflare Pages readback wording 是否足夠可執行。
- Install command 已使用 `pnpm install --frozen-lockfile --ignore-scripts`，對齊 repo supply-chain guardrails。
