### PR TITLE
[frontend] Dev Portal weight formatting runtime guard

### DIFF
--- a/apps/docs/plugins/related-links/index.test.ts
+++ b/apps/docs/plugins/related-links/index.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {fileURLToPath} from 'node:url'
 
+import * as relatedLinksData from '../../src/components/relatedLinksData.ts'
 import {
   collectRelatedLinks,
   default as relatedLinksPlugin,
@@ -144,4 +145,11 @@ test('resolved related links keep authoritative and inferred PRs separate', () =
       reasons: ['changedFiles:services/api/internal/watchtime'],
     },
   ])
+})
+
+test('formats missing or non-number link weight without throwing', () => {
+  assert.equal(typeof relatedLinksData.formatLinkWeight, 'function')
+  assert.equal(relatedLinksData.formatLinkWeight?.(undefined), '0.00')
+  assert.equal(relatedLinksData.formatLinkWeight?.('not-a-number'), '0.00')
+  assert.equal(relatedLinksData.formatLinkWeight?.(0.625), '0.63')
 })

--- a/apps/docs/src/components/RelatedLinks.tsx
+++ b/apps/docs/src/components/RelatedLinks.tsx
@@ -3,6 +3,7 @@ import {useDoc} from '@docusaurus/plugin-content-docs/client'
 import {usePluginData} from '@docusaurus/useGlobalData'
 
 import {
+  formatLinkWeight,
   resolveRelatedLinksData,
   type DocMetadata,
   type RelatedLinksGlobalData,
@@ -30,7 +31,8 @@ function InferredPrChip({
 }: {
   entry: RelatedLinksResolvedData['inferredPullRequests'][number]
 }): JSX.Element {
-  const title = `${entry.title} · weight ${entry.weight.toFixed(2)} · ${entry.reasons.join(', ')}`
+  const formattedWeight = formatLinkWeight(entry.weight)
+  const title = `${entry.title} · weight ${formattedWeight} · ${entry.reasons.join(', ')}`
 
   return (
     <a
@@ -41,7 +43,7 @@ function InferredPrChip({
       title={title}
     >
       #{entry.pr}
-      <span>{entry.weight.toFixed(2)}</span>
+      <span>{formattedWeight}</span>
     </a>
   )
 }

--- a/apps/docs/src/components/ReverseIndexChangelog.tsx
+++ b/apps/docs/src/components/ReverseIndexChangelog.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import {usePluginData} from '@docusaurus/useGlobalData'
 
+import {formatLinkWeight} from './relatedLinksData'
+
 type ReverseIndexEntry = {
   pr: number
   title: string
@@ -109,7 +111,7 @@ export default function ReverseIndexChangelog(): JSX.Element {
                 #{item.pr}
               </a>
               <span>{formatDate(item.mergedAt)}</span>
-              <span>weight {item.weight.toFixed(2)}</span>
+              <span>weight {formatLinkWeight(item.weight)}</span>
             </div>
             <h3>{item.title}</h3>
             <p>

--- a/apps/docs/src/components/relatedLinksData.ts
+++ b/apps/docs/src/components/relatedLinksData.ts
@@ -52,6 +52,11 @@ export type RelatedLinksResolvedData = {
   }>
 }
 
+export function formatLinkWeight(weight: unknown): string {
+  const normalized = Number(weight)
+  return Number.isFinite(normalized) ? normalized.toFixed(2) : '0.00'
+}
+
 function uniquePositiveNumbers(values: number[] | undefined): number[] {
   if (!values) {
     return []


### PR DESCRIPTION
## 什麼改動
- 新增 `formatLinkWeight()`，讓 Dev Portal link weight 在 missing / non-number runtime data 下安全顯示 `0.00`。
- RelatedLinks 與 ReverseIndexChangelog 改用安全 formatter，避免 `weight.toFixed(2)` 崩潰。
- 補 regression test 覆蓋 missing / non-number weight 格式化行為。

## 為什麼
修正本機 Dev Portal 桌面瀏覽器進入 Docusaurus error boundary 的 runtime crash：`Cannot read properties of undefined (reading 'toFixed')`。

closes #714

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#714
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 Cloudflare Pages 實際部署；後續部署仍由 #699 追蹤。
  - 不調整 Dev Portal link layer schema。
  - 不新增 hosted search / backend service。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - routing_evidence_ref: workflow-check:start:issue-714
  - spark_readback_evidence: workflow-check:start:issue-714-ops-spark-readback
  - worker_5_4_evidence: workflow-check:start:issue-714-worker-5-4-tdd
  - #714 bugfix：metadata/readback 交給 ops_spark；窄範圍 docs frontend patch 交給 5.4 worker；controller 做 scope/root-cause/review/PR gate。
- Actual worker profile(s)：
  - ops_spark：GitHub duplicate issue/PR readback + #699 Cloudflare scope check。
  - frontend_5_4_worker：TDD regression test + formatter patch。
  - 5.5 controller：root-cause review、validation、commit/PR gate。
- Model strength：
  - ops_spark = low-cost Spark；frontend_5_4_worker = medium；controller = high。
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=frontend_5_4_worker model=gpt-5.4 reasoning=medium controller_fallback=allowed fallback_reason=initial spawn hit `agent_thread_limit_reached`; after closing completed Spark worker, 5.4 worker completed patch
- Verification evidence：
  - `spec plan 714 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 714`
  - `spec workflow-check --repo . --phase commit --pr-body /tmp/.../pr-body.md --routing-evidence /tmp/.../routing-evidence.json --finding-disposition /tmp/.../finding-disposition.json --threshold-evidence /tmp/.../threshold-evidence.json`
  - `pnpm --filter ./apps/docs test:related-links`
  - `pnpm --filter ./apps/docs test:reverse-index`
  - `pnpm --filter ./apps/docs build`
  - `git diff --check`
- Self-review / exception reason：
  - Controller reviewed worker diff; no scope expansion beyond #714.
- Worker session closeout：
  - ops_spark worker closed after metadata readback。
  - 5.4 worker completed and controller read back modified files/tests。
- Workflow friction / follow-up split：
  - Cloudflare Pages deployment remains #699; this PR stays runtime bugfix-only。

## Workflow-check evidence
- spec_evidence_status: pass
- workflow-check evidence: workflow-check:commit:issue-714
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-714
- finding_disposition_status: manual
- finding_disposition_ref: workflow-check:finding-disposition:issue-714-pr-creation
- threshold_evidence_status: pass
- threshold_ledger_ref: workflow-check:threshold:issue-714

## Review conversation closeout
- Unresolved threads：
  - 0; GraphQL reviewThreads readback on latest head confirmed no open threads.
- CodeRabbit：
  - pass / review skipped; two low-value nits were evaluated and intentionally not adopted because they do not affect behavior and would only churn CI.
- chatgpt-codex-connector：
  - Codex comment-only review posted latest-head no-change-needed evidence.
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/715#pullrequestreview-4292229649
- root_cause_gate_ref：
  - #714 runtime root cause: display components directly formatted runtime `weight` values with `toFixed(2)`; fixed by `formatLinkWeight()` and regression test.
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/715#pullrequestreview-4292229649
- Final reviewer action：
  - Approved and merged; all actionable findings resolved or intentionally not adopted with rationale.

## Final merge gate
- Ready-to-merge decision：
  - merged
- Latest head SHA：
  - 30b9af2daf47bb52a305ebd08d7ef0199a78f645
- Required checks：
  - pass or scope-skipped as expected: Scope Police pass, Scope gate pass, PR metadata check regression tests pass, PR commit messages pass, Workflow regression tests pass, Supply-chain guardrails pass, Backend CI gate pass, CodeRabbit pass / review skipped.
- spec workflow-check evidence：
  - start gate: pass, local-only
  - commit gate: pass, local-only
  - merge gate: manual fallback readback; spec workflow-check read PR #715 but gh checks field drift required manual verification
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/715#pullrequestreview-4292229649
  - https://github.com/nurockplayer/tachigo/issues/714#issuecomment-4453417029
- Merge commit：
  - 34d7408e1d8049058229772403f35794eac405c6

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 防止 Dev Portal link weight runtime data 缺值時觸發 `toFixed` crash。
- Approx changed lines：~23
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - bugfix 需要同 PR 加 regression test 以防止 `toFixed` crash 回歸。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `pnpm --filter ./apps/docs test:related-links` pass
- [x] `pnpm --filter ./apps/docs test:reverse-index` pass
- [x] `pnpm --filter ./apps/docs build` pass
- [x] `git diff --check` pass
- [x] 本機 Dev Portal smoke readback 不再顯示 `Cannot read properties of undefined (reading 'toFixed')`；#715 merged to `develop`

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
pnpm --filter ./apps/docs test:related-links: pass (5 tests)
pnpm --filter ./apps/docs test:reverse-index: pass (10 tests)
pnpm --filter ./apps/docs build: pass
git diff --check: pass
```

## 備註
Cloudflare Pages 後續部署仍由 #699 追蹤；目前 `127.0.0.1:3000` 仍是本機 dev server，不是雲端站台。

## Notes for Claude Code Review
- 請特別看 `formatLinkWeight()` 是否符合 Dev Portal 對 malformed runtime data 的防禦策略。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 添加权重值统一格式化功能，确保相关链接和变更日志中的权重显示保持一致性。

* **Tests**
  * 新增单元测试，验证权重格式化函数在各种输入场景下的正确性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/715)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

