### PR TITLE
[frontend] Guard Dev Portal inferred link reasons

### DIFF
--- a/apps/docs/plugins/related-links/index.test.ts
+++ b/apps/docs/plugins/related-links/index.test.ts
@@ -147,6 +147,69 @@ test('resolved related links keep authoritative and inferred PRs separate', () =
   ])
 })
 
+test('resolved inferred PR reasons normalize missing or non-array values', () => {
+  const resolved = resolveRelatedLinksData({
+    metadata: {
+      id: 'watch-to-points-design',
+      source: '@site/docs/watch-to-points-design.md',
+    },
+    reverseIndex: {
+      byPr: {
+        710: {
+          pr: 710,
+          title: 'Missing reasons should not crash related links rendering',
+          mergedAt: '2026-05-15T08:00:00Z',
+          docs: [
+            {
+              path: 'docs/watch-to-points-design.md',
+              title: 'Missing reasons should not crash related links rendering',
+              mergedAt: '2026-05-15T08:00:00Z',
+              additions: 18,
+              deletions: 3,
+              weight: 0.8,
+              paths: ['services/api/internal/watchtime/session.go'],
+            },
+          ],
+        },
+        711: {
+          pr: 711,
+          title: 'String reasons should be ignored',
+          mergedAt: '2026-05-15T09:00:00Z',
+          docs: [
+            {
+              path: 'docs/watch-to-points-design.md',
+              title: 'String reasons should be ignored',
+              mergedAt: '2026-05-15T09:00:00Z',
+              additions: 12,
+              deletions: 1,
+              weight: 0.9,
+              reasons: 'changedFiles:services/api/internal/watchtime',
+              paths: ['services/api/internal/watchtime/summary.go'],
+            },
+          ],
+        },
+      },
+    } as unknown as Parameters<typeof resolveRelatedLinksData>[0]['reverseIndex'],
+  })
+
+  assert.deepEqual(resolved.inferredPullRequests, [
+    {
+      pr: 711,
+      title: 'String reasons should be ignored',
+      mergedAt: '2026-05-15T09:00:00Z',
+      weight: 0.9,
+      reasons: [],
+    },
+    {
+      pr: 710,
+      title: 'Missing reasons should not crash related links rendering',
+      mergedAt: '2026-05-15T08:00:00Z',
+      weight: 0.8,
+      reasons: [],
+    },
+  ])
+})
+
 test('formats missing or non-number link weight without throwing', () => {
   assert.equal(typeof relatedLinksData.formatLinkWeight, 'function')
   assert.equal(relatedLinksData.formatLinkWeight?.(undefined), '0.00')

--- a/apps/docs/src/components/RelatedLinks.tsx
+++ b/apps/docs/src/components/RelatedLinks.tsx
@@ -4,6 +4,7 @@ import {usePluginData} from '@docusaurus/useGlobalData'
 
 import {
   formatLinkWeight,
+  normalizeLinkReasons,
   resolveRelatedLinksData,
   type DocMetadata,
   type RelatedLinksGlobalData,
@@ -32,7 +33,8 @@ function InferredPrChip({
   entry: RelatedLinksResolvedData['inferredPullRequests'][number]
 }): JSX.Element {
   const formattedWeight = formatLinkWeight(entry.weight)
-  const title = `${entry.title} · weight ${formattedWeight} · ${entry.reasons.join(', ')}`
+  const reasons = normalizeLinkReasons(entry.reasons).join(', ')
+  const title = `${entry.title} · weight ${formattedWeight} · ${reasons}`
 
   return (
     <a

--- a/apps/docs/src/components/relatedLinksData.ts
+++ b/apps/docs/src/components/relatedLinksData.ts
@@ -57,6 +57,14 @@ export function formatLinkWeight(weight: unknown): string {
   return Number.isFinite(normalized) ? normalized.toFixed(2) : '0.00'
 }
 
+export function normalizeLinkReasons(reasons: unknown): string[] {
+  if (!Array.isArray(reasons)) {
+    return []
+  }
+
+  return reasons.filter((reason): reason is string => typeof reason === 'string')
+}
+
 function uniquePositiveNumbers(values: number[] | undefined): number[] {
   if (!values) {
     return []
@@ -149,7 +157,7 @@ export function resolveRelatedLinksData(options: {
       title: entry.title,
       mergedAt: entry.mergedAt,
       weight,
-      reasons: matchingDoc.reasons,
+      reasons: normalizeLinkReasons(matchingDoc.reasons),
     })
   }
 


### PR DESCRIPTION
## 什麼改動

修正 Dev Portal related-links runtime guard：inferred PR 的 `reasons` 若缺失或不是陣列，會被 normalize 成安全陣列，避免頁面在 `join(', ')` 崩潰。

## 為什麼

Closes #716。#715 修掉 `weight.toFixed(2)` 後，本機瀏覽器 readback 又暴露另一個 malformed reverse-index data 路徑：`Cannot read properties of undefined (reading 'join')`。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊

- Source of truth：#716
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 Cloudflare Pages 實際部署；仍由 #699 追蹤。
  - 不改 reverse-index schema 或資料產生格式。
  - 不新增 backend / API / hosted service。
  - 不做 Dev Portal 視覺調色或版面改版。

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：
  - #716 bounded runtime bugfix；保持 single-surface docs/frontend runtime guard。
- Actual worker profile(s)：
  - ops_spark equivalent = controller fallback for trivial GitHub/readback metadata
  - 5.4 worker = Descartes for narrow docs/frontend/test implementation
  - 5.5 controller = scope / architecture / review decision / merge gate
- Model strength：
  - ops_spark equivalent = n/a, controller fallback for sub-3-minute metadata checks
  - 5.4 worker = medium/high narrow implementation
  - 5.5 controller = high for scope and final decision
- Spawn directive(s)：
  - profile=5.4-worker model=gpt-5.4 reasoning=medium controller_fallback=allowed fallback_reason=worker_timeout_after_initial_wait_on_narrow_runtime_bug
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=medium controller_fallback=allowed fallback_reason=trivial_issue_readback_and_runtime_repro_under_3_minutes
- Verification evidence：
  - `spec plan 716 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 716`
  - `spec workflow-check --repo . --phase commit --pr-body /tmp/tachigo-716-evidence.06lnDf/pr-body.md --routing-evidence /tmp/tachigo-716-evidence.06lnDf/routing.json --finding-disposition /tmp/tachigo-716-evidence.06lnDf/finding.json --threshold-evidence /tmp/tachigo-716-evidence.06lnDf/threshold.json`
  - `pnpm --filter ./apps/docs test:related-links`
  - `pnpm --filter ./apps/docs test:reverse-index`
  - `pnpm --filter ./apps/docs build`
  - `git diff --check`
- Self-review / exception reason：
  - Completed self-review. Visual color question was not adopted because this diff touches no CSS/theme files and the difference disappeared after preview refresh.
- Worker session closeout：
  - 5.4 worker Descartes returned matching summary for the three touched files; no extra task needed.
- Workflow friction / follow-up split：
  - Runtime crash fix stays in #716 / #717. Cloudflare deployment remains split to #699 because it requires account/config/public URL readback.

controller_fallback=allowed
controller_fallback_reason=worker_timeout_after_initial_wait_on_narrow_runtime_bug; controller kept critical path moving, worker later confirmed the same scoped patch.
worker_5_4_evidence: workflow-check:worker-5-4:issue-716-descartes

## Review conversation closeout

- Unresolved threads：
  - 0 at PR creation readback.
- CodeRabbit：
  - Rate limit comment only; status context reports success but no actionable finding was available at initial readback.
- chatgpt-codex-connector：
  - n/a at PR creation.
- review_triage_ref：
  - workflow-check:finding-disposition:issue-716-pr-creation
- root_cause_gate_ref：
  - workflow-check:finding-disposition:issue-716-pr-creation
- finding_disposition_ref：
  - workflow-check:finding-disposition:issue-716-pr-creation
- Final reviewer action：
  - No actionable findings at latest readback; waiting for required reviewer action.

## Final merge gate

- Ready-to-merge decision：
  - blocked by required human/Codex review; checks are green, not merge-ready until reviewer action.
- Latest head SHA：
  - e3c8f921ccb9f1393e65a74a236a965ccc4ecfe7
- Required checks：
  - Local validation pass; GitHub CI pass; latest Scope Police run pass; review still required.
- spec workflow-check evidence：
  - status=pass; ref=workflow-check:commit:issue-716
- Evidence URL：
  - CI/Scope Police readback on PR #717; final closeout comment n/a until merge.

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - Prevent Dev Portal from crashing when inferred related-link reasons are missing or malformed.
- Approx changed lines：~77
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #699 tracks Cloudflare Pages deployment separately.

## Acceptance Criteria

- [x] `pnpm --filter ./apps/docs test:related-links` pass
- [x] `pnpm --filter ./apps/docs test:reverse-index` pass
- [x] `pnpm --filter ./apps/docs build` pass
- [x] `git diff --check` pass
- [x] 本機 Dev Portal 不再顯示 `Cannot read properties of undefined (reading 'join')`

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**

```text
spec plan 716 --repo . --dry-run --format prompt --verbose: pass
spec workflow-check --repo . --phase start --issue 716: pass
spec workflow-check --repo . --phase commit ...: pass
pnpm --filter ./apps/docs test:related-links: pass (6 tests)
pnpm --filter ./apps/docs test:reverse-index: pass (10 tests)
pnpm --filter ./apps/docs build: pass
git diff --check: pass
Browser readback: http://127.0.0.1:3003/tachigo/ renders Dev Portal without join crash.
```

## 備註

Cloudflare Pages deployment should continue through #699 after this runtime guard lands.

## Notes for Claude Code Review

- 請特別看 malformed `reasons` 同時在 resolver 與 component 兩層被防護，避免未來 plugin data 繞過 resolver 時又 crash。
