### PR TITLE
[backend] 傳遞 streamer request context

### DIFF
--- a/services/api/internal/handlers/airdrop_handler.go
+++ b/services/api/internal/handlers/airdrop_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -47,7 +48,7 @@ func (h *AirdropHandler) Airdrop(c *gin.Context) {
 	}
 
 	claims := middleware.MustClaims(c)
-	allowed, err := h.authorize(claims, channelID)
+	allowed, err := h.authorize(c.Request.Context(), claims, channelID)
 	if err != nil {
 		internal(c)
 		return
@@ -93,7 +94,7 @@ func (h *AirdropHandler) Airdrop(c *gin.Context) {
 	ok(c, result)
 }
 
-func (h *AirdropHandler) authorize(claims *services.Claims, channelID string) (bool, error) {
+func (h *AirdropHandler) authorize(ctx context.Context, claims *services.Claims, channelID string) (bool, error) {
 	switch claims.Role {
 	case models.RoleAdmin:
 		return true, nil
@@ -103,9 +104,9 @@ func (h *AirdropHandler) authorize(claims *services.Claims, channelID string) (b
 			return false, err
 		}
 		if claims.Role == models.RoleStreamer {
-			return h.streamerSvc.OwnsChannel(userID, channelID)
+			return h.streamerSvc.OwnsChannelContext(ctx, userID, channelID)
 		}
-		return h.agencySvc.OwnsChannel(userID, channelID)
+		return h.agencySvc.OwnsChannelContext(ctx, userID, channelID)
 	default:
 		return false, nil
 	}

--- a/services/api/internal/handlers/channel_config_handler.go
+++ b/services/api/internal/handlers/channel_config_handler.go
@@ -87,7 +87,7 @@ func (h *ChannelConfigHandler) authorizeChannelAccess(c *gin.Context) (string, b
 			badRequest(c, "invalid user id")
 			return "", false
 		}
-		owns, err := h.streamerSvc.OwnsAgencyChannel(agencyUserID, channelID)
+		owns, err := h.streamerSvc.OwnsAgencyChannelContext(c.Request.Context(), agencyUserID, channelID)
 		if err != nil {
 			internal(c)
 			return "", false
@@ -103,7 +103,7 @@ func (h *ChannelConfigHandler) authorizeChannelAccess(c *gin.Context) (string, b
 			badRequest(c, "invalid user id")
 			return "", false
 		}
-		owns, err := h.streamerSvc.OwnsChannel(userID, channelID)
+		owns, err := h.streamerSvc.OwnsChannelContext(c.Request.Context(), userID, channelID)
 		if err != nil {
 			internal(c)
 			return "", false

--- a/services/api/internal/handlers/streamer_handler.go
+++ b/services/api/internal/handlers/streamer_handler.go
@@ -37,7 +37,7 @@ func (h *StreamerHandler) Register(c *gin.Context) {
 		return
 	}
 
-	streamer, err := h.streamerSvc.Register(userID, body.ChannelID, body.DisplayName)
+	streamer, err := h.streamerSvc.RegisterContext(c.Request.Context(), userID, body.ChannelID, body.DisplayName)
 	if err != nil {
 		if errors.Is(err, services.ErrChannelNotOwned) {
 			c.JSON(http.StatusForbidden, Response{Success: false, Error: "channel_id does not match your Twitch account"})
@@ -77,7 +77,7 @@ func (h *StreamerHandler) Create(c *gin.Context) {
 		agencyUserID = &aid
 	}
 
-	streamer, err := h.streamerSvc.Create(userID, agencyUserID, body.ChannelID)
+	streamer, err := h.streamerSvc.CreateContext(c.Request.Context(), userID, agencyUserID, body.ChannelID)
 	if err != nil {
 		if errors.Is(err, services.ErrChannelNotOwned) {
 			c.JSON(http.StatusForbidden, Response{Success: false, Error: "channel_id does not match user's Twitch account"})
@@ -102,7 +102,7 @@ func (h *StreamerHandler) ListChannels(c *gin.Context) {
 		return
 	}
 
-	channels, err := h.streamerSvc.ListChannels(userID)
+	channels, err := h.streamerSvc.ListChannelsContext(c.Request.Context(), userID)
 	if err != nil {
 		internal(c)
 		return
@@ -120,14 +120,14 @@ func (h *StreamerHandler) List(c *gin.Context) {
 	)
 	switch claims.Role {
 	case models.RoleAdmin:
-		streamers, err = h.streamerSvc.ListAll()
+		streamers, err = h.streamerSvc.ListAllContext(c.Request.Context())
 	case models.RoleAgency:
 		agencyUserID, parseErr := uuid.Parse(claims.UserID)
 		if parseErr != nil {
 			badRequest(c, "invalid user id")
 			return
 		}
-		streamers, err = h.streamerSvc.ListByAgencyUserID(agencyUserID)
+		streamers, err = h.streamerSvc.ListByAgencyUserIDContext(c.Request.Context(), agencyUserID)
 	default:
 		c.JSON(http.StatusForbidden, Response{Success: false, Error: "forbidden"})
 		return
@@ -143,7 +143,7 @@ func (h *StreamerHandler) List(c *gin.Context) {
 		channelIDs = append(channelIDs, s.ChannelID)
 	}
 
-	summaryMap, err := h.streamerSvc.GetSummaryStats(channelIDs)
+	summaryMap, err := h.streamerSvc.GetSummaryStatsContext(c.Request.Context(), channelIDs)
 	if err != nil {
 		internal(c)
 		return
@@ -184,7 +184,7 @@ func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
 			badRequest(c, "invalid user id")
 			return
 		}
-		owns, err := h.streamerSvc.OwnsChannel(userID, channelID)
+		owns, err := h.streamerSvc.OwnsChannelContext(c.Request.Context(), userID, channelID)
 		if err != nil {
 			internal(c)
 			return
@@ -195,7 +195,7 @@ func (h *StreamerHandler) GetChannelStats(c *gin.Context) {
 		}
 	}
 
-	stats, err := h.streamerSvc.GetChannelStats(channelID)
+	stats, err := h.streamerSvc.GetChannelStatsContext(c.Request.Context(), channelID)
 	if err != nil {
 		if errors.Is(err, services.ErrStreamerNotFound) {
 			notFound(c, "streamer not found")
@@ -215,7 +215,7 @@ func (h *StreamerHandler) GetStats(c *gin.Context) {
 		return
 	}
 
-	streamer, err := h.streamerSvc.GetByID(streamerID)
+	streamer, err := h.streamerSvc.GetByIDContext(c.Request.Context(), streamerID)
 	if err != nil {
 		if errors.Is(err, services.ErrStreamerNotFound) {
 			notFound(c, "streamer not found")
@@ -240,7 +240,7 @@ func (h *StreamerHandler) GetStats(c *gin.Context) {
 			badRequest(c, "invalid user id")
 			return
 		}
-		owns, ownErr := h.streamerSvc.OwnsStreamer(agencyUserID, streamerID)
+		owns, ownErr := h.streamerSvc.OwnsStreamerContext(c.Request.Context(), agencyUserID, streamerID)
 		if ownErr != nil {
 			internal(c)
 			return
@@ -255,7 +255,7 @@ func (h *StreamerHandler) GetStats(c *gin.Context) {
 		return
 	}
 
-	stats, err := h.streamerSvc.GetStats(streamer.ID)
+	stats, err := h.streamerSvc.GetStatsContext(c.Request.Context(), streamer.ID)
 	if err != nil {
 		if errors.Is(err, services.ErrStreamerNotFound) {
 			notFound(c, "streamer not found")

--- a/services/api/internal/handlers/streamer_handler_test.go
+++ b/services/api/internal/handlers/streamer_handler_test.go
@@ -116,6 +116,9 @@ func dashboardRequestWithContext(
 ) *httptest.ResponseRecorder {
 	t.Helper()
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	req := httptest.NewRequestWithContext(ctx, method, path, bytes.NewBufferString(body))
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")

--- a/services/api/internal/handlers/streamer_handler_test.go
+++ b/services/api/internal/handlers/streamer_handler_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,12 +10,43 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/middleware"
 	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
 )
+
+type streamerHandlerContextKey struct{}
+
+func installStreamerHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:streamer_handler_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", probe); err != nil {
+		t.Fatalf("register raw context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name + ":query")
+		_ = db.Callback().Raw().Remove(name + ":raw")
+	})
+
+	return func() int {
+		return seen
+	}
+}
 
 func newStreamerDashboardEnv(t *testing.T) *dashboardEnv {
 	t.Helper()
@@ -61,6 +93,30 @@ func dashboardRequest(t *testing.T, router *gin.Engine, method, path, token, bod
 	t.Helper()
 
 	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func dashboardRequestWithContext(
+	t *testing.T,
+	router *gin.Engine,
+	ctx context.Context,
+	method,
+	path,
+	token,
+	body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(ctx, method, path, bytes.NewBufferString(body))
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -338,6 +394,31 @@ func TestCreate_RejectsUnknownAgencyUserID(t *testing.T) {
 	w := dashboardRequest(t, env.router, http.MethodPost, "/api/v1/dashboard/streamers", adminToken, body)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestList_PassesRequestContextToStreamerQueries(t *testing.T) {
+	env := newStreamerDashboardEnv(t)
+	_, adminToken := createDashboardUser(t, env, models.RoleAdmin, "list_context_admin")
+	streamerUser, _ := createDashboardUser(t, env, models.RoleStreamer, "list_context_streamer")
+	seedStreamerRow(t, env, streamerUser.ID, nil, "list_context_channel")
+	key := streamerHandlerContextKey{}
+	seen := installStreamerHandlerDBContextProbe(t, env.db, key, "streamer-list")
+
+	w := dashboardRequestWithContext(
+		t,
+		env.router,
+		context.WithValue(context.Background(), key, "streamer-list"),
+		http.MethodGet,
+		"/api/v1/dashboard/streamers",
+		adminToken,
+		"",
+	)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected List handler to pass request context to streamer GORM queries")
 	}
 }
 

--- a/services/api/internal/services/context_probe_test.go
+++ b/services/api/internal/services/context_probe_test.go
@@ -30,12 +30,16 @@ func installDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int 
 	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", probe); err != nil {
 		t.Fatalf("register raw context probe: %v", err)
 	}
+	if err := db.Callback().Row().Before("gorm:row").Register(name+":row", probe); err != nil {
+		t.Fatalf("register row context probe: %v", err)
+	}
 
 	t.Cleanup(func() {
 		_ = db.Callback().Create().Remove(name + ":create")
 		_ = db.Callback().Query().Remove(name + ":query")
 		_ = db.Callback().Update().Remove(name + ":update")
 		_ = db.Callback().Raw().Remove(name + ":raw")
+		_ = db.Callback().Row().Remove(name + ":row")
 	})
 
 	return func() int {

--- a/services/api/internal/services/points_service.go
+++ b/services/api/internal/services/points_service.go
@@ -324,14 +324,19 @@ func (s *PointsService) AddHeartbeatTimeContext(ctx context.Context, userID uuid
 // daily / monthly / yearly are derived from broadcast_time_logs (per-heartbeat increments).
 // current_session_seconds is approximated from active viewer watch_sessions in the channel.
 func (s *PointsService) GetBroadcastStats(streamerID uuid.UUID, channelID string) (*BroadcastStats, error) {
+	return s.GetBroadcastStatsContext(context.Background(), streamerID, channelID)
+}
+
+func (s *PointsService) GetBroadcastStatsContext(ctx context.Context, streamerID uuid.UUID, channelID string) (*BroadcastStats, error) {
 	now := time.Now()
+	db := s.dbWithContext(ctx)
 
 	// current_session_seconds: sum of accumulated_seconds across all active viewer sessions
 	// in the channel — used as a proxy for the ongoing broadcast session duration.
 	var currentSession struct {
 		AccumulatedSeconds int64
 	}
-	if err := s.db.Raw(`
+	if err := db.Raw(`
 		SELECT COALESCE(SUM(accumulated_seconds), 0) AS accumulated_seconds
 		FROM watch_sessions
 		WHERE channel_id = ? AND is_active = true
@@ -352,7 +357,7 @@ func (s *PointsService) GetBroadcastStats(streamerID uuid.UUID, channelID string
 
 	fetch := func(label string, since time.Time) (int64, error) {
 		var r struct{ Total int64 }
-		if err := s.db.Raw(logQuery, streamerID, channelID, since).Scan(&r).Error; err != nil {
+		if err := db.Raw(logQuery, streamerID, channelID, since).Scan(&r).Error; err != nil {
 			return 0, fmt.Errorf("query %s broadcast seconds: %w", label, err)
 		}
 		return r.Total, nil

--- a/services/api/internal/services/points_service_test.go
+++ b/services/api/internal/services/points_service_test.go
@@ -656,6 +656,21 @@ func TestPointsService_GetBroadcastStats_TimeWindows(t *testing.T) {
 	}
 }
 
+func TestPointsService_GetBroadcastStatsContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	channelID := "ch_broadcast_context"
+	streamerID := seedStreamer(t, svc, channelID)
+	key := pointsContextKey("broadcast-stats-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-broadcast")
+
+	if _, err := svc.GetBroadcastStatsContext(context.WithValue(context.Background(), key, "points-broadcast"), streamerID, channelID); err != nil {
+		t.Fatalf("get broadcast stats with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetBroadcastStatsContext DB operations to carry request context")
+	}
+}
+
 func TestGetBroadcastStats_ReturnsCurrentSessionQueryError(t *testing.T) {
 	svc, _ := newPointsSvc(t)
 

--- a/services/api/internal/services/streamer_service.go
+++ b/services/api/internal/services/streamer_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -36,10 +37,22 @@ func NewStreamerService(db *gorm.DB, pointsSvc *PointsService) *StreamerService 
 	return &StreamerService{db: db, pointsSvc: pointsSvc}
 }
 
+func (s *StreamerService) dbWithContext(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.db.WithContext(ctx)
+}
+
 func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName string) (*models.Streamer, error) {
+	return s.RegisterContext(context.Background(), userID, channelID, displayName)
+}
+
+func (s *StreamerService) RegisterContext(ctx context.Context, userID uuid.UUID, channelID, displayName string) (*models.Streamer, error) {
+	db := s.dbWithContext(ctx)
 	// Verify the channelID matches the user's Twitch auth_provider entry.
 	var count int64
-	if err := s.db.Model(&models.AuthProvider{}).
+	if err := db.Model(&models.AuthProvider{}).
 		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderTwitch, channelID).
 		Count(&count).Error; err != nil {
 		return nil, err
@@ -54,7 +67,7 @@ func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName stri
 		DisplayName: displayName,
 	}
 
-	if err := s.db.
+	if err := db.
 		Where("user_id = ? AND channel_id = ?", userID, channelID).
 		Assign(models.Streamer{DisplayName: displayName}).
 		FirstOrCreate(streamer).Error; err != nil {
@@ -65,8 +78,13 @@ func (s *StreamerService) Register(userID uuid.UUID, channelID, displayName stri
 }
 
 func (s *StreamerService) Create(userID uuid.UUID, agencyUserID *uuid.UUID, channelID string) (*models.Streamer, error) {
+	return s.CreateContext(context.Background(), userID, agencyUserID, channelID)
+}
+
+func (s *StreamerService) CreateContext(ctx context.Context, userID uuid.UUID, agencyUserID *uuid.UUID, channelID string) (*models.Streamer, error) {
+	db := s.dbWithContext(ctx)
 	var count int64
-	if err := s.db.Model(&models.AuthProvider{}).
+	if err := db.Model(&models.AuthProvider{}).
 		Where("user_id = ? AND provider = ? AND provider_id = ?", userID, models.ProviderTwitch, channelID).
 		Count(&count).Error; err != nil {
 		return nil, err
@@ -77,7 +95,7 @@ func (s *StreamerService) Create(userID uuid.UUID, agencyUserID *uuid.UUID, chan
 
 	if agencyUserID != nil {
 		var agency models.User
-		if err := s.db.Select("id", "role").Where("id = ?", *agencyUserID).First(&agency).Error; err != nil {
+		if err := db.Select("id", "role").Where("id = ?", *agencyUserID).First(&agency).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, ErrAgencyUserInvalid
 			}
@@ -94,7 +112,7 @@ func (s *StreamerService) Create(userID uuid.UUID, agencyUserID *uuid.UUID, chan
 		ChannelID:    channelID,
 	}
 
-	if err := s.db.
+	if err := db.
 		Where("user_id = ? AND channel_id = ?", userID, channelID).
 		Assign(models.Streamer{AgencyUserID: agencyUserID}).
 		FirstOrCreate(streamer).Error; err != nil {
@@ -105,8 +123,12 @@ func (s *StreamerService) Create(userID uuid.UUID, agencyUserID *uuid.UUID, chan
 }
 
 func (s *StreamerService) OwnsChannel(userID uuid.UUID, channelID string) (bool, error) {
+	return s.OwnsChannelContext(context.Background(), userID, channelID)
+}
+
+func (s *StreamerService) OwnsChannelContext(ctx context.Context, userID uuid.UUID, channelID string) (bool, error) {
 	var count int64
-	if err := s.db.Model(&models.Streamer{}).
+	if err := s.dbWithContext(ctx).Model(&models.Streamer{}).
 		Where("user_id = ? AND channel_id = ?", userID, channelID).
 		Count(&count).Error; err != nil {
 		return false, err
@@ -115,8 +137,12 @@ func (s *StreamerService) OwnsChannel(userID uuid.UUID, channelID string) (bool,
 }
 
 func (s *StreamerService) OwnsAgencyChannel(agencyUserID uuid.UUID, channelID string) (bool, error) {
+	return s.OwnsAgencyChannelContext(context.Background(), agencyUserID, channelID)
+}
+
+func (s *StreamerService) OwnsAgencyChannelContext(ctx context.Context, agencyUserID uuid.UUID, channelID string) (bool, error) {
 	var count int64
-	if err := s.db.Model(&models.Streamer{}).
+	if err := s.dbWithContext(ctx).Model(&models.Streamer{}).
 		Where("agency_user_id = ? AND channel_id = ?", agencyUserID, channelID).
 		Count(&count).Error; err != nil {
 		return false, err
@@ -125,8 +151,12 @@ func (s *StreamerService) OwnsAgencyChannel(agencyUserID uuid.UUID, channelID st
 }
 
 func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, error) {
+	return s.ListChannelsContext(context.Background(), userID)
+}
+
+func (s *StreamerService) ListChannelsContext(ctx context.Context, userID uuid.UUID) ([]models.Streamer, error) {
 	var streamers []models.Streamer
-	if err := s.db.
+	if err := s.dbWithContext(ctx).
 		Where("user_id = ?", userID).
 		Order("created_at ASC").
 		Find(&streamers).Error; err != nil {
@@ -139,8 +169,12 @@ func (s *StreamerService) ListChannels(userID uuid.UUID) ([]models.Streamer, err
 }
 
 func (s *StreamerService) GetByID(id uuid.UUID) (*models.Streamer, error) {
+	return s.GetByIDContext(context.Background(), id)
+}
+
+func (s *StreamerService) GetByIDContext(ctx context.Context, id uuid.UUID) (*models.Streamer, error) {
 	var streamer models.Streamer
-	if err := s.db.Where("id = ?", id).First(&streamer).Error; err != nil {
+	if err := s.dbWithContext(ctx).Where("id = ?", id).First(&streamer).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrStreamerNotFound
 		}
@@ -159,6 +193,10 @@ type StreamerSummary struct {
 // GetSummaryStats returns list-level summary metrics for the given channel IDs
 // using three batch queries to avoid N+1.
 func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*StreamerSummary, error) {
+	return s.GetSummaryStatsContext(context.Background(), channelIDs)
+}
+
+func (s *StreamerService) GetSummaryStatsContext(ctx context.Context, channelIDs []string) (map[string]*StreamerSummary, error) {
 	result := make(map[string]*StreamerSummary, len(channelIDs))
 	for _, id := range channelIDs {
 		result[id] = &StreamerSummary{}
@@ -169,12 +207,13 @@ func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*Stre
 
 	now := time.Now().UTC()
 	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	db := s.dbWithContext(ctx)
 
 	var dailyRows []struct {
 		ChannelID string `gorm:"column:channel_id"`
 		Total     int64  `gorm:"column:total"`
 	}
-	if err := s.db.Raw(`
+	if err := db.Raw(`
 		SELECT channel_id, COALESCE(SUM(seconds), 0) AS total
 		FROM broadcast_time_logs
 		WHERE channel_id IN ? AND recorded_at >= ?
@@ -192,7 +231,7 @@ func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*Stre
 		ChannelID    string `gorm:"column:channel_id"`
 		UniqueMiners int64  `gorm:"column:unique_miners"`
 	}
-	if err := s.db.Raw(`
+	if err := db.Raw(`
 		SELECT channel_id, COUNT(DISTINCT user_id) AS unique_miners
 		FROM watch_sessions
 		WHERE channel_id IN ?
@@ -210,7 +249,7 @@ func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*Stre
 		ChannelID        string `gorm:"column:channel_id"`
 		TotalTokenMinted int64  `gorm:"column:total_token_minted"`
 	}
-	if err := s.db.Raw(`
+	if err := db.Raw(`
 		SELECT channel_id, COALESCE(SUM(cumulative_total), 0) AS total_token_minted
 		FROM points_ledgers
 		WHERE channel_id IN ?
@@ -228,16 +267,24 @@ func (s *StreamerService) GetSummaryStats(channelIDs []string) (map[string]*Stre
 }
 
 func (s *StreamerService) ListAll() ([]models.Streamer, error) {
+	return s.ListAllContext(context.Background())
+}
+
+func (s *StreamerService) ListAllContext(ctx context.Context) ([]models.Streamer, error) {
 	var streamers []models.Streamer
-	if err := s.db.Order("created_at ASC").Find(&streamers).Error; err != nil {
+	if err := s.dbWithContext(ctx).Order("created_at ASC").Find(&streamers).Error; err != nil {
 		return nil, err
 	}
 	return streamers, nil
 }
 
 func (s *StreamerService) ListByAgencyUserID(agencyUserID uuid.UUID) ([]models.Streamer, error) {
+	return s.ListByAgencyUserIDContext(context.Background(), agencyUserID)
+}
+
+func (s *StreamerService) ListByAgencyUserIDContext(ctx context.Context, agencyUserID uuid.UUID) ([]models.Streamer, error) {
 	var streamers []models.Streamer
-	if err := s.db.
+	if err := s.dbWithContext(ctx).
 		Where("agency_user_id = ?", agencyUserID).
 		Order("created_at ASC").
 		Find(&streamers).Error; err != nil {
@@ -247,8 +294,12 @@ func (s *StreamerService) ListByAgencyUserID(agencyUserID uuid.UUID) ([]models.S
 }
 
 func (s *StreamerService) OwnsStreamer(agencyUserID uuid.UUID, streamerID uuid.UUID) (bool, error) {
+	return s.OwnsStreamerContext(context.Background(), agencyUserID, streamerID)
+}
+
+func (s *StreamerService) OwnsStreamerContext(ctx context.Context, agencyUserID uuid.UUID, streamerID uuid.UUID) (bool, error) {
 	var count int64
-	if err := s.db.Model(&models.Streamer{}).
+	if err := s.dbWithContext(ctx).Model(&models.Streamer{}).
 		Where("id = ? AND agency_user_id = ?", streamerID, agencyUserID).
 		Count(&count).Error; err != nil {
 		return false, err
@@ -257,8 +308,12 @@ func (s *StreamerService) OwnsStreamer(agencyUserID uuid.UUID, streamerID uuid.U
 }
 
 func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, error) {
+	return s.GetChannelStatsContext(context.Background(), channelID)
+}
+
+func (s *StreamerService) GetChannelStatsContext(ctx context.Context, channelID string) (*BroadcastStats, error) {
 	var provider models.AuthProvider
-	if err := s.db.
+	if err := s.dbWithContext(ctx).
 		Where("provider = ? AND provider_id = ?", models.ProviderTwitch, channelID).
 		First(&provider).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -267,12 +322,17 @@ func (s *StreamerService) GetChannelStats(channelID string) (*BroadcastStats, er
 		return nil, err
 	}
 
-	return s.pointsSvc.GetBroadcastStats(provider.UserID, channelID)
+	return s.pointsSvc.GetBroadcastStatsContext(ctx, provider.UserID, channelID)
 }
 
 func (s *StreamerService) GetStats(streamerID uuid.UUID) (*StreamerStats, error) {
+	return s.GetStatsContext(context.Background(), streamerID)
+}
+
+func (s *StreamerService) GetStatsContext(ctx context.Context, streamerID uuid.UUID) (*StreamerStats, error) {
+	db := s.dbWithContext(ctx)
 	var streamer models.Streamer
-	if err := s.db.Where("id = ?", streamerID).First(&streamer).Error; err != nil {
+	if err := db.Where("id = ?", streamerID).First(&streamer).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrStreamerNotFound
 		}
@@ -280,7 +340,7 @@ func (s *StreamerService) GetStats(streamerID uuid.UUID) (*StreamerStats, error)
 	}
 	channelID := streamer.ChannelID
 
-	broadcast, err := s.pointsSvc.GetBroadcastStats(streamer.UserID, channelID)
+	broadcast, err := s.pointsSvc.GetBroadcastStatsContext(ctx, streamer.UserID, channelID)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +349,7 @@ func (s *StreamerService) GetStats(streamerID uuid.UUID) (*StreamerStats, error)
 		UniqueMiners      int64   `gorm:"column:unique_miners"`
 		AvgSessionSeconds float64 `gorm:"column:avg_session_seconds"`
 	}
-	if err := s.db.Raw(`
+	if err := db.Raw(`
 		SELECT
 			COUNT(DISTINCT user_id) AS unique_miners,
 			COALESCE(AVG(accumulated_seconds), 0) AS avg_session_seconds
@@ -303,7 +363,7 @@ func (s *StreamerService) GetStats(streamerID uuid.UUID) (*StreamerStats, error)
 		TotalTokenMinted       int64 `gorm:"column:total_token_minted"`
 		SpendableInCirculation int64 `gorm:"column:spendable_in_circulation"`
 	}
-	if err := s.db.Raw(`
+	if err := db.Raw(`
 		SELECT
 			COALESCE(SUM(cumulative_total), 0) AS total_token_minted,
 			COALESCE(SUM(spendable_balance), 0) AS spendable_in_circulation

--- a/services/api/internal/services/streamer_service_test.go
+++ b/services/api/internal/services/streamer_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+type streamerContextKey string
 
 func seedStreamerUserRow(t *testing.T, db *gorm.DB, role models.UserRole) uuid.UUID {
 	t.Helper()
@@ -32,6 +35,22 @@ func seedTwitchAuthProvider(t *testing.T, db *gorm.DB, userID uuid.UUID, channel
 		uuid.New(), userID, models.ProviderTwitch, channelID,
 	).Error; err != nil {
 		t.Fatalf("seed auth provider: %v", err)
+	}
+}
+
+func TestRegisterContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedTwitchAuthProvider(t, db, userID, "ch_ctx_register")
+	key := streamerContextKey("register-context")
+	seen := installDBContextProbe(t, db, key, "streamer-register")
+
+	if _, err := svc.RegisterContext(context.WithValue(context.Background(), key, "streamer-register"), userID, "ch_ctx_register", "Ctx"); err != nil {
+		t.Fatalf("register with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected RegisterContext DB operations to carry request context")
 	}
 }
 
@@ -78,6 +97,29 @@ func TestRegister_UpdateDisplayName(t *testing.T) {
 	}
 }
 
+func TestOwnsChannelContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedTwitchAuthProvider(t, db, userID, "ch_ctx_owns")
+	if _, err := svc.Register(userID, "ch_ctx_owns", "Ctx Owns"); err != nil {
+		t.Fatalf("register owned channel: %v", err)
+	}
+	key := streamerContextKey("owns-channel-context")
+	seen := installDBContextProbe(t, db, key, "streamer-owns")
+
+	owns, err := svc.OwnsChannelContext(context.WithValue(context.Background(), key, "streamer-owns"), userID, "ch_ctx_owns")
+	if err != nil {
+		t.Fatalf("owns channel with context: %v", err)
+	}
+	if !owns {
+		t.Fatal("expected streamer to own channel")
+	}
+	if seen() == 0 {
+		t.Fatal("expected OwnsChannelContext DB operations to carry request context")
+	}
+}
+
 func TestListChannels_Empty(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
@@ -116,6 +158,47 @@ func TestListChannels_MultipleChannels(t *testing.T) {
 	}
 }
 
+func TestListAllContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedTwitchAuthProvider(t, db, userID, "ch_ctx_list_all")
+	if _, err := svc.Register(userID, "ch_ctx_list_all", "Ctx List"); err != nil {
+		t.Fatalf("register list row: %v", err)
+	}
+	key := streamerContextKey("list-all-context")
+	seen := installDBContextProbe(t, db, key, "streamer-list-all")
+
+	streamers, err := svc.ListAllContext(context.WithValue(context.Background(), key, "streamer-list-all"))
+	if err != nil {
+		t.Fatalf("list all with context: %v", err)
+	}
+	if len(streamers) != 1 {
+		t.Fatalf("expected 1 streamer, got %d", len(streamers))
+	}
+	if seen() == 0 {
+		t.Fatal("expected ListAllContext DB operations to carry request context")
+	}
+}
+
+func TestGetSummaryStatsContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
+	key := streamerContextKey("summary-context")
+	seen := installDBContextProbe(t, db, key, "streamer-summary")
+
+	stats, err := svc.GetSummaryStatsContext(context.WithValue(context.Background(), key, "streamer-summary"), []string{"ch_ctx_summary"})
+	if err != nil {
+		t.Fatalf("summary stats with context: %v", err)
+	}
+	if _, ok := stats["ch_ctx_summary"]; !ok {
+		t.Fatal("expected initialized summary entry for channel")
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetSummaryStatsContext DB operations to carry request context")
+	}
+}
+
 func TestGetChannelStats_NoStreamer(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewStreamerService(db, NewPointsService(db, NewWatchService(db)))
@@ -123,6 +206,28 @@ func TestGetChannelStats_NoStreamer(t *testing.T) {
 	_, err := svc.GetChannelStats("missing_channel")
 	if !errors.Is(err, ErrStreamerNotFound) {
 		t.Fatalf("want ErrStreamerNotFound, got %v", err)
+	}
+}
+
+func TestGetStatsContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	watchSvc := NewWatchService(db)
+	pointsSvc := NewPointsService(db, watchSvc)
+	svc := NewStreamerService(db, pointsSvc)
+	userID := seedStreamerUserRow(t, db, models.RoleStreamer)
+	seedTwitchAuthProvider(t, db, userID, "ch_ctx_stats")
+	streamer, err := svc.Register(userID, "ch_ctx_stats", "Ctx Stats")
+	if err != nil {
+		t.Fatalf("register stats row: %v", err)
+	}
+	key := streamerContextKey("stats-context")
+	seen := installDBContextProbe(t, db, key, "streamer-stats")
+
+	if _, err := svc.GetStatsContext(context.WithValue(context.Background(), key, "streamer-stats"), streamer.ID); err != nil {
+		t.Fatalf("get stats with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetStatsContext DB operations to carry request context")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動

讓 StreamerService 相關 DB 查詢支援 request context，並讓 dashboard streamer、channel config ownership、airdrop ownership call site 將 `c.Request.Context()` 傳入 GORM。

## 為什麼

`request timeout middleware` 已經會在 request context 設 deadline；#645 追蹤 service/repository 層 DB query 是否實際收到該 context。這個 PR 是 #645 的 StreamerService 小切片。

refs #645

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 Extension receipt / TPoint credit path。
  - 不處理 Claim / Spend / Wallet / Auth context 化。
  - 不修改 schema / migration / timeout policy。
  - 不做完整 repo audit 或 permission policy redesign。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 StreamerService request-context slice；GitHub issue comment attempted twice but GitHub API returned connectivity errors, so initial public issue-plan evidence is in this PR body + automation thread memory.
- Actual worker profile(s)：
  - repo_scout = gpt-5.3-codex-spark high read-only scan for remaining #645 candidates.
  - controller = implementation, scope decision, review/merge gate.
- Model strength：
  - repo_scout = Spark high.
  - controller = GPT-5.5 xhigh.
- Spawn directive(s)：
  - profile=repo_scout model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a
  - profile=controller model=gpt-5.5 reasoning=xhigh controller_fallback=allowed fallback_reason=schema_or_data_risk: rejected ExtensionService because it touches receipt/TPoint credit semantics; impact=selected lower-risk StreamerService slice; evidence=local readback
- Verification evidence：
  - `go test ./internal/services -run 'Test(RegisterContext|OwnsChannelContext|ListAllContext|GetSummaryStatsContext|GetStatsContext|PointsService_GetBroadcastStatsContext)'` red before implementation.
  - `go test ./internal/services ./internal/handlers -count=1` pass.
  - `git diff --check` pass.
- Self-review / exception reason：
  - Self-review complete; diff is backend-only and under 400 changed lines. Extension/TPoint path intentionally deferred due points credit semantics.
- Worker session closeout：
  - repo_scout result read back; no public action delegated to worker; worker completed.
- Workflow friction / follow-up split：
  - `spec` CLI is unavailable in this environment, so workflow-check used manual checklist fallback. Remaining #645 services should continue as separate small PRs.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: new PR, waiting for reviewer / CodeRabbit.
- CodeRabbit：
  - pending with reason: new PR.
- chatgpt-codex-connector：
  - n/a at PR creation.
- review_triage_ref：
  - pending with reason: no review findings yet.
- root_cause_gate_ref：
  - pending with reason: no repeated finding yet.
- finding_disposition_ref：
  - pending with reason: no review findings yet.
- Final reviewer action：
  - pending with reason: new PR.

## Final merge gate
- Ready-to-merge decision：
  - blocked by required review and GitHub CI.
- Latest head SHA：
  - 9842ad636318ac839385fb749e3275297278f5d6
- Required checks：
  - local focused tests pass; GitHub checks pending.
- spec workflow-check evidence：
  - tool_gap=spec-injector #242 workflow-check unavailable; manual checklist fallback.
- Evidence URL：
  - n/a before PR creation.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through StreamerService DB queries and its direct handler call sites.
- Approx changed lines：~351
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit（n/a：未修改 router 或 swagger annotation）
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler 必須傳入 `c.Request.Context()`，service context variants 才能接到 request timeout cancellation；tests 驗證同一個 #645 行為切片。
- 若已拆分，相關 PR：
  - Prior #645 slices: #685 / #686 / #690 / #691.

## Acceptance Criteria
- [x] StreamerService DB calls have context-aware variants.
- [x] Existing non-Context StreamerService and PointsService methods remain backward compatible via `context.Background()`.
- [x] Dashboard streamer handler passes request context into StreamerService.
- [x] Channel config and airdrop ownership checks pass request context into ownership lookups.
- [x] Focused regression tests verify request context reaches GORM.

## 超出範圍內容

無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
go test ./internal/services -run 'Test(RegisterContext|OwnsChannelContext|ListAllContext|GetSummaryStatsContext|GetStatsContext|PointsService_GetBroadcastStatsContext)': red before implementation, then pass
go test -count=1 ./internal/services ./internal/handlers: pass
git diff --check: pass
```

## 備註

本 PR 不宣稱完成 #645；Extension/TPoint、Claim、Spend、Auth、Wallet 等剩餘路徑需依風險拆成後續 PR。

## Notes for Claude Code Review
- 請特別看 `GetChannelStatsContext` / `GetStatsContext` 是否正確把 context 繼續傳到 `PointsService.GetBroadcastStatsContext`。
- `AirdropHandler` 只更新 ownership authorization query 的 context；`AirdropService.Execute` 本身仍是 #645 後續切片。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 强化请求上下文在各处理流程中的传递，改善权限与数据查询的上下文一致性。

* **测试**
  * 新增多项测试，验证请求上下文在 API、服务和数据库操作链路中的正确传播与使用，提升可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/718)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->