### PR TITLE
[frontend] Patch docs npm dependency advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,11 @@
   "bugs": {
     "url": "https://github.com/nurockplayer/tachigo/issues"
   },
-  "homepage": "https://github.com/nurockplayer/tachigo#readme"
+  "homepage": "https://github.com/nurockplayer/tachigo#readme",
+  "pnpm": {
+    "overrides": {
+      "copy-webpack-plugin": "14.0.0",
+      "serialize-javascript": "7.0.5"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  copy-webpack-plugin: 14.0.0
+  serialize-javascript: 7.0.5
+
 importers:
 
   .: {}
@@ -3298,9 +3302,9 @@ packages:
     resolution: {integrity: sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==}
     engines: {node: '>=12'}
 
-  copy-webpack-plugin@11.0.0:
-    resolution: {integrity: sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==}
-    engines: {node: '>= 14.15.0'}
+  copy-webpack-plugin@14.0.0:
+    resolution: {integrity: sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==}
+    engines: {node: '>= 20.9.0'}
     peerDependencies:
       webpack: ^5.1.0
 
@@ -4207,10 +4211,6 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
-
-  globby@13.2.2:
-    resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -5935,9 +5935,6 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -6262,8 +6259,9 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
@@ -6346,10 +6344,6 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
-
-  slash@4.0.0:
-    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
-    engines: {node: '>=12'}
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
@@ -8438,7 +8432,7 @@ snapshots:
       '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.12))(html-minifier-terser@7.2.0)(postcss@8.5.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2(postcss@8.5.12))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.106.2(postcss@8.5.12))
+      copy-webpack-plugin: 14.0.0(webpack@5.106.2(postcss@8.5.12))
       css-loader: 6.11.0(webpack@5.106.2(postcss@8.5.12))
       css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.106.2(postcss@8.5.12))
       cssnano: 6.1.2(postcss@8.5.12)
@@ -11398,14 +11392,13 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.106.2(postcss@8.5.12)):
+  copy-webpack-plugin@14.0.0(webpack@5.106.2(postcss@8.5.12)):
     dependencies:
-      fast-glob: 3.3.3
       glob-parent: 6.0.2
-      globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
+      tinyglobby: 0.2.16
       webpack: 5.106.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.12))(html-minifier-terser@7.2.0)(postcss@8.5.12)
 
   core-js-compat@3.49.0:
@@ -11479,7 +11472,7 @@ snapshots:
       jest-worker: 29.7.0
       postcss: 8.5.12
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       webpack: 5.106.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.12))(html-minifier-terser@7.2.0)(postcss@8.5.12)
     optionalDependencies:
       clean-css: 5.3.3
@@ -12398,14 +12391,6 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
-
-  globby@13.2.2:
-    dependencies:
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 4.0.0
 
   gopd@1.2.0: {}
 
@@ -14497,10 +14482,6 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.0: {}
 
   range-parser@1.2.1: {}
@@ -14921,9 +14902,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   serve-handler@6.1.7:
     dependencies:
@@ -15035,8 +15014,6 @@ snapshots:
       unicode-emoji-modifier-base: 1.0.0
 
   slash@3.0.0: {}
-
-  slash@4.0.0: {}
 
   snake-case@3.0.4:
     dependencies:


### PR DESCRIPTION
## 什麼改動
更新 root pnpm overrides 與 lockfile，讓 Docusaurus docs build chain 使用已修補的 `serialize-javascript@7.0.5`，並把 `copy-webpack-plugin` 提升到已修安全相依的 `14.0.0`。

## 為什麼
`pnpm audit --prod` 在 docs workspace dependency graph 中回報 `serialize-javascript@6.0.2` 的 high / moderate advisories。單純升 `copy-webpack-plugin` 只能修掉其中一條 transitive path，`css-minimizer-webpack-plugin` 仍會拉到舊版 `serialize-javascript`，所以這裡同時加入底層 override 以保持 CSS minifier blast radius 最小。

closes #723

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#723
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不導入新的 dependency scanner gate
  - 不調整 Node runtime policy；該工作在 #722
  - 不更新 Docusaurus 本身

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #723 controller-only dependency advisory fix；trivial/self-only exception：單一 lockfile/package override 修補，沒有可平行切出的 worker 任務。
- Actual worker profile(s)：
  - controller
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller model=gpt-5 reasoning=high controller_fallback=allowed fallback_reason=trivial/self-only-dependency-advisory-fix
- Verification evidence：
  - `fnm exec --using 24.15.0 pnpm install --frozen-lockfile`
  - `fnm exec --using 24.15.0 pnpm audit --prod --json`
  - `fnm exec --using 24.15.0 pnpm build:docs`
- Self-review / exception reason：
  - self-review completed; trivial/self-only exception for this scoped dependency lockfile fix.
- Worker session closeout：
  - controller-only work was re-reviewed; no external worker sessions were opened, so there are no worker handles left to close.
- Workflow friction / follow-up split：
  - #722 merged and this branch has been rebased onto latest develop; no remaining follow-up split.

## Review conversation closeout
- Unresolved threads：
  - 0 known unresolved review threads at latest head.
- CodeRabbit：
  - latest CodeRabbit check passed; no blocking finding recorded.
- chatgpt-codex-connector：
  - not requested for this scoped PR; controller self-review completed.
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/724
- root_cause_gate_ref：
  - https://github.com/nurockplayer/tachigo/pull/724
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/724
- Final reviewer action：
  - no review findings pending; latest-head closeout documented for latest head.

## Final merge gate
- Ready-to-merge decision：
  - waiting for GitHub checks after rebase onto develop; local validation passed.
- Latest head SHA：
  - ff5876e3
- Required checks：
  - waiting for GitHub checks after rebase; local install, audit, and docs build passed.
- spec workflow-check evidence：
  - n/a
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 修正 docs npm production dependency audit 中的 `serialize-javascript` advisory。
- Approx changed lines：~63
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #722 handled Node 24 runtime policy first and is merged.

## Acceptance Criteria
- [x] `pnpm audit --prod --json` 回報 0 vulnerabilities
- [x] `pnpm build:docs` 成功
- [x] dependency fix 在 Node 24 runtime 下驗證

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
fnm exec --using 24.15.0 pnpm install --frozen-lockfile
pass; lockfile up to date; only existing core-js build-script approval warning

fnm exec --using 24.15.0 pnpm audit --prod --json
pass: 0 vulnerabilities

fnm exec --using 24.15.0 pnpm build:docs
pass
```

## 備註
#722 已合併；此 PR 已 rebase 到最新 `develop`，目前只包含 dependency advisory fix。

## Notes for Claude Code Review
- 請確認 `copy-webpack-plugin@14.0.0` + `serialize-javascript@7.0.5` override 是可接受的最小修補組合。
- 曾測試 `css-minimizer-webpack-plugin@8.0.0`，但它帶入 cssnano 7 / PostCSS peer warning，blast radius 較大，因此未採用。




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 更新了项目依赖版本管理配置，确保构建环境的稳定性和一致性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/724)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->