### PR TITLE
[frontend] 中獎者領獎頁面 /claim/:token

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import TransactionsPage from '@/pages/TransactionsPage'
 import SettingsPage from '@/pages/SettingsPage'
 import RafflesPage from '@/pages/RafflesPage'
 import RaffleDetailPage from '@/pages/RaffleDetailPage'
+import ClaimPage from '@/pages/ClaimPage'
 import { authProvider } from '@/providers/authProvider'
 import { dataProvider } from '@/providers/dataProvider'
 
@@ -41,6 +42,10 @@ const router = createBrowserRouter([
             ],
           },
         ],
+      },
+      {
+        path: 'claim/:token',
+        element: <ClaimPage />,
       },
       {
         path: '*',

--- a/apps/dashboard/src/pages/ClaimPage.tsx
+++ b/apps/dashboard/src/pages/ClaimPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { restoreSession, isAuthenticated } from '@/services/auth'
+import { apiBaseURL } from '@/services/api'
 import { getClaim, submitClaim, type ClaimDraw, type ClaimInput } from '@/services/claim'
 
 type ViewState =
@@ -179,7 +180,7 @@ export default function ClaimPage() {
           <Button
             className="w-full"
             onClick={() => {
-              window.location.href = `/api/v1/auth/twitch?redirect_to=/claim/${token}`
+              window.location.href = `${apiBaseURL}/api/v1/auth/twitch?redirect_to=${encodeURIComponent(`/claim/${token}`)}`
             }}
           >
             用 Twitch 帳號登入領獎

--- a/apps/dashboard/src/pages/ClaimPage.tsx
+++ b/apps/dashboard/src/pages/ClaimPage.tsx
@@ -48,11 +48,14 @@ export default function ClaimPage() {
       setState({ phase: 'not_found' })
       return
     }
+    let cancelled = false
     Promise.all([restoreSession(), getClaim(token)]).then(
       ([, draw]) => {
+        if (cancelled) return
         setState(isAuthenticated() ? { phase: 'form', draw } : { phase: 'unauthenticated', draw })
       },
       (err) => {
+        if (cancelled) return
         if (isAxiosError(err)) {
           const status = err.response?.status
           if (status === 404) setState({ phase: 'not_found' })
@@ -64,10 +67,14 @@ export default function ClaimPage() {
         }
       },
     )
+    return () => {
+      cancelled = true
+    }
   }, [token])
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
+    if (submitting) return
     setSubmitting(true)
     setFormError(null)
     try {
@@ -180,7 +187,9 @@ export default function ClaimPage() {
           <Button
             className="w-full"
             onClick={() => {
-              window.location.href = `${apiBaseURL}/api/v1/auth/twitch?redirect_to=${encodeURIComponent(`/claim/${token}`)}`
+              const url = new URL('/api/v1/auth/twitch', apiBaseURL)
+              url.searchParams.set('redirect_to', `/claim/${token}`)
+              window.location.href = url.toString()
             }}
           >
             用 Twitch 帳號登入領獎

--- a/apps/dashboard/src/pages/ClaimPage.tsx
+++ b/apps/dashboard/src/pages/ClaimPage.tsx
@@ -1,0 +1,220 @@
+import { type FormEvent, type ReactNode, useEffect, useState } from 'react'
+import { useParams } from 'react-router'
+import { isAxiosError } from 'axios'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { restoreSession, isAuthenticated } from '@/services/auth'
+import { getClaim, submitClaim, type ClaimDraw, type ClaimInput } from '@/services/claim'
+
+type ViewState =
+  | { phase: 'loading' }
+  | { phase: 'not_found' }
+  | { phase: 'expired' }
+  | { phase: 'forbidden' }
+  | { phase: 'unauthenticated'; draw: ClaimDraw }
+  | { phase: 'form'; draw: ClaimDraw }
+  | { phase: 'submitted' }
+  | { phase: 'load_error' }
+
+const initialForm: ClaimInput = {
+  recipient_name: '',
+  phone: '',
+  address_line1: '',
+  address_line2: '',
+  city: '',
+  postal_code: '',
+  country: '',
+}
+
+function Shell({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col items-center justify-center px-4 py-12">
+      {children}
+    </div>
+  )
+}
+
+export default function ClaimPage() {
+  const { token = '' } = useParams<{ token: string }>()
+  const [state, setState] = useState<ViewState>({ phase: 'loading' })
+  const [form, setForm] = useState<ClaimInput>(initialForm)
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) {
+      setState({ phase: 'not_found' })
+      return
+    }
+    Promise.all([restoreSession(), getClaim(token)]).then(
+      ([, draw]) => {
+        setState(isAuthenticated() ? { phase: 'form', draw } : { phase: 'unauthenticated', draw })
+      },
+      (err) => {
+        if (isAxiosError(err)) {
+          const status = err.response?.status
+          if (status === 404) setState({ phase: 'not_found' })
+          else if (status === 410) setState({ phase: 'expired' })
+          else if (status === 403) setState({ phase: 'forbidden' })
+          else setState({ phase: 'load_error' })
+        } else {
+          setState({ phase: 'load_error' })
+        }
+      },
+    )
+  }, [token])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setFormError(null)
+    try {
+      await submitClaim(token, form)
+      setState({ phase: 'submitted' })
+    } catch (err) {
+      if (isAxiosError(err)) {
+        const status = err.response?.status
+        if (status === 403) setFormError('此帳號非中獎者，無法領取獎品')
+        else if (status === 409) setFormError('此獎品已完成領取')
+        else setFormError('送出失敗，請稍後再試')
+      } else {
+        setFormError('送出失敗，請稍後再試')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function field(key: keyof ClaimInput, label: string, required = false) {
+    return (
+      <div className="space-y-1">
+        <Label htmlFor={key}>
+          {label}
+          {required && <span className="text-destructive ml-1">*</span>}
+        </Label>
+        <Input
+          id={key}
+          value={form[key]}
+          onChange={e => setForm(f => ({ ...f, [key]: e.target.value }))}
+          required={required}
+        />
+      </div>
+    )
+  }
+
+  if (state.phase === 'loading') {
+    return (
+      <Shell>
+        <p className="text-muted-foreground">載入中…</p>
+      </Shell>
+    )
+  }
+
+  if (state.phase === 'not_found') {
+    return (
+      <Shell>
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold">找不到此領獎連結</h1>
+          <p className="text-muted-foreground">連結可能有誤，請確認 Email 中的連結是否完整。</p>
+        </div>
+      </Shell>
+    )
+  }
+
+  if (state.phase === 'expired') {
+    return (
+      <Shell>
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold">領獎連結已過期</h1>
+          <p className="text-muted-foreground">領獎期限已過，請聯絡主辦單位。</p>
+        </div>
+      </Shell>
+    )
+  }
+
+  if (state.phase === 'load_error') {
+    return (
+      <Shell>
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold">載入失敗</h1>
+          <p className="text-muted-foreground">請稍後再試，或聯絡主辦單位。</p>
+        </div>
+      </Shell>
+    )
+  }
+
+  if (state.phase === 'forbidden') {
+    return (
+      <Shell>
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold">無法領取此獎品</h1>
+          <p className="text-muted-foreground">此帳號並非此獎項的中獎者。</p>
+        </div>
+      </Shell>
+    )
+  }
+
+  if (state.phase === 'submitted') {
+    return (
+      <Shell>
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold">領獎資料已送出！</h1>
+          <p className="text-muted-foreground">我們將盡快安排寄送，感謝您的參與。</p>
+        </div>
+      </Shell>
+    )
+  }
+
+  if (state.phase === 'unauthenticated') {
+    const { draw } = state
+    const name = draw.entry.display_name || draw.entry.twitch_login
+    const expires = new Date(draw.claim_expires_at).toLocaleDateString('zh-TW')
+    return (
+      <Shell>
+        <div className="text-center space-y-4 max-w-sm">
+          <h1 className="text-3xl font-bold">恭喜中獎！</h1>
+          <p className="text-lg">{name}，您已抽中獎品</p>
+          <p className="text-sm text-muted-foreground">領獎截止：{expires}</p>
+          <Button
+            className="w-full"
+            onClick={() => {
+              window.location.href = `/api/v1/auth/twitch?redirect_to=/claim/${token}`
+            }}
+          >
+            用 Twitch 帳號登入領獎
+          </Button>
+        </div>
+      </Shell>
+    )
+  }
+
+  // phase === 'form'
+  const { draw } = state
+  const name = draw.entry.display_name || draw.entry.twitch_login
+  const expires = new Date(draw.claim_expires_at).toLocaleDateString('zh-TW')
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col items-center py-12 px-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center space-y-1">
+          <h1 className="text-2xl font-bold">填寫領獎資料</h1>
+          <p className="text-sm text-muted-foreground">以 {name} 身份登入・領獎截止：{expires}</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {field('recipient_name', '收件人姓名', true)}
+          {field('phone', '電話')}
+          {field('address_line1', '地址第一行', true)}
+          {field('address_line2', '地址第二行')}
+          {field('city', '城市', true)}
+          {field('postal_code', '郵遞區號')}
+          {field('country', '國家')}
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? '送出中…' : '送出領獎資料'}
+          </Button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/services/api.ts
+++ b/apps/dashboard/src/services/api.ts
@@ -1,10 +1,12 @@
 import axios, { type AxiosRequestConfig } from 'axios'
 
-const BASE_URL =
+export const apiBaseURL: string =
   import.meta.env.VITE_TACHIGO_API_URL ??
   // Temporary fallback for existing local env files during the key migration.
   import.meta.env.VITE_API_URL ??
   'http://localhost:8080'
+
+const BASE_URL = apiBaseURL
 
 const client = axios.create({
   baseURL: BASE_URL,

--- a/apps/dashboard/src/services/claim.ts
+++ b/apps/dashboard/src/services/claim.ts
@@ -1,0 +1,42 @@
+import client from '@/services/api'
+
+type ApiResponse<T> = { success: boolean; data: T }
+
+export interface ClaimEntry {
+  id: string
+  raffle_id: string
+  user_id: string | null
+  twitch_login: string
+  display_name: string
+  created_at: string
+}
+
+export interface ClaimDraw {
+  id: string
+  raffle_id: string
+  entry_id: string
+  claim_expires_at: string
+  drawn_at: string
+  entry: ClaimEntry
+}
+
+export interface ClaimInput {
+  recipient_name: string
+  phone: string
+  address_line1: string
+  address_line2: string
+  city: string
+  postal_code: string
+  country: string
+}
+
+export async function getClaim(token: string): Promise<ClaimDraw> {
+  const { data } = await client.get<ApiResponse<{ draw: ClaimDraw }>>(
+    `/api/v1/claim/${token}`,
+  )
+  return data.data.draw
+}
+
+export async function submitClaim(token: string, input: ClaimInput): Promise<void> {
+  await client.post(`/api/v1/claim/${token}`, input)
+}

--- a/apps/dashboard/src/services/claim.ts
+++ b/apps/dashboard/src/services/claim.ts
@@ -32,11 +32,11 @@ export interface ClaimInput {
 
 export async function getClaim(token: string): Promise<ClaimDraw> {
   const { data } = await client.get<ApiResponse<{ draw: ClaimDraw }>>(
-    `/api/v1/claim/${token}`,
+    `/api/v1/claim/${encodeURIComponent(token)}`,
   )
   return data.data.draw
 }
 
 export async function submitClaim(token: string, input: ClaimInput): Promise<void> {
-  await client.post(`/api/v1/claim/${token}`, input)
+  await client.post(`/api/v1/claim/${encodeURIComponent(token)}`, input)
 }


### PR DESCRIPTION
## 什麼改動

新增公開路由 `/claim/:token` 的領獎頁面，供抽獎中獎者填寫收件資訊：

- `apps/dashboard/src/pages/ClaimPage.tsx`：公開頁面（無 Layout 側欄），自行管理三種視圖：未登入（顯示中獎資訊 + Twitch 登入按鈕）、已登入（7 欄位領獎表單）、送出確認；錯誤狀態覆蓋 404 / 410 / 403 / 409
- `apps/dashboard/src/services/claim.ts`：封裝 `getClaim`（GET /api/v1/claim/:token）與 `submitClaim`（POST）及對應型別
- `apps/dashboard/src/App.tsx`：在 `<Authenticated>` 守衛外側新增 `/claim/:token` 路由
- `services/api/.env.example`：補充 `FRONTEND_URL=http://localhost:5174` 本機預設值說明

## 為什麼

後端 claim flow（GET/POST /api/v1/claim/:token）與 Email 通知已完整（#704 已 merge），但前端缺少對應頁面，email 連結點開是 404。

closes #705
refs #704

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium

## Scope 對齊
- Source of truth：#705
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Google OAuth 登入按鈕
  - 已領取狀態的查詢頁面
  - 管理後台的 claim 管理介面
  - Email/password 登入流程的 redirect 支援

## Delegation Execution Log（非 Codex autonomous PR 可略過）
n/a

## Review conversation closeout
- Unresolved threads：0
- CodeRabbit：pending（新 PR）
- chatgpt-codex-connector：n/a
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：n/a
- Final reviewer action：pending

## Final merge gate
- Ready-to-merge decision：pending CI
- Latest head SHA：fe94aaa
- Required checks：CI pass；PR Scope Police pass；Frontend build pass
- spec workflow-check evidence：tsc --noEmit 通過（零錯誤）
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：新增中獎者公開領獎頁面，讓 email 中的 /claim/:token 連結不再是 404
- Approx changed lines：~271
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [ ] tests
  - [x] docs（.env.example 補充）
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？：frontend + .env.example 說明是同一個功能交付的必要面，diff < 400 行
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] 中獎者點擊 email 連結後能看到中獎資訊頁面（不需登入）
- [x] 點擊「用 Twitch 登入」完成 OAuth 後自動回到 claim 頁面並顯示表單
- [x] 填寫並送出表單後顯示確認訊息
- [x] 404 / 410 / 403 各有對應的錯誤提示（另補 GET 403 forbidden 狀態）

## 超出範圍內容
無

## 測試方式
- [ ] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
cd apps/dashboard && npx tsc --noEmit  # 零錯誤
```

## 備註
- ClaimPage 不使用 dashboard Layout（無側欄），是面向中獎者的公開頁面
- 頁面掛載時同時呼叫 `restoreSession()` 與 `getClaim(token)`，Session 還原失敗時靜默忽略（維持未登入）
- GET /claim/:token 的 403（已登入但非中獎者）在載入時直接顯示「無法領取此獎品」頁面

## Notes for Claude Code Review
- `Promise.all([restoreSession(), getClaim(token)])` 是刻意設計：restoreSession 永遠 resolve（內部 swallow error），所以 rejection 只來自 getClaim
- Twitch OAuth redirect URL `/api/v1/auth/twitch?redirect_to=/claim/:token` 使用相對路徑，backend TwitchCallback 會以 `FRONTEND_URL + redirect_to` 組成完整 URL 再 302 redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增领奖页面，用户可通过独特令牌访问
  * 支持表单提交领奖信息及完整的状态管理（加载中、未找到、已过期、禁止访问等）
  * 未登录用户可通过OAuth认证后进行领奖

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/725)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->