### PR TITLE
[frontend] Dev Portal 視覺重塑：CSS 設計系統

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -91,6 +91,7 @@ const config: Config = {
         },
         blog: false,
         theme: {
+          // Fontsource CSS imports live in this file; do not use external font CDNs.
           customCss: './src/css/custom.css',
         },
       } satisfies Preset.Options,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,6 +24,8 @@
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/theme-mermaid": "3.10.1",
     "@easyops-cn/docusaurus-search-local": "0.55.1",
+    "@fontsource/inter": "5.2.8",
+    "@fontsource/jetbrains-mono": "5.2.8",
     "@mdx-js/react": "3.1.1",
     "@mermaid-js/layout-elk": "0.1.9",
     "clsx": "2.1.1",

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -87,14 +87,9 @@
   --ifm-heading-color: var(--dp-text-primary);
 }
 
-html {
-  font-family: var(--ifm-font-family-base);
-}
+html { font-family: var(--ifm-font-family-base); }
 
-body {
-  background: var(--dp-bg-card);
-  color: var(--dp-text-primary);
-}
+body { background: var(--dp-bg-card); color: var(--dp-text-primary); }
 
 .navbar {
   border-bottom: 1px solid var(--dp-border);
@@ -108,9 +103,7 @@ body {
   letter-spacing: 0;
 }
 
-.navbar__link {
-  color: var(--dp-text-primary);
-}
+.navbar__link { color: var(--dp-text-primary); }
 
 .theme-doc-sidebar-container {
   border-right: 1px solid var(--dp-border) !important;
@@ -169,14 +162,11 @@ body {
   transform: translateY(-1px);
 }
 
-.theme-doc-markdown h1,
-.theme-doc-markdown h2,
-.theme-doc-markdown h3 {
-  letter-spacing: 0;
-}
+:is(.theme-doc-markdown, article .markdown) h1,
+:is(.theme-doc-markdown, article .markdown) h2,
+:is(.theme-doc-markdown, article .markdown) h3 { letter-spacing: 0; }
 
-.theme-doc-markdown > h1,
-article .markdown > h1 {
+:is(.theme-doc-markdown, article .markdown) > h1 {
   max-width: 18ch;
   margin-bottom: 0.75rem;
   color: var(--dp-text-primary);
@@ -186,8 +176,7 @@ article .markdown > h1 {
   letter-spacing: 0;
 }
 
-.theme-doc-markdown > h2,
-article .markdown > h2 {
+:is(.theme-doc-markdown, article .markdown) > h2 {
   position: relative;
   margin: 32px 0 12px;
   padding-left: 12px;
@@ -197,8 +186,7 @@ article .markdown > h2 {
   line-height: 1.25;
 }
 
-.theme-doc-markdown > h2::before,
-article .markdown > h2::before {
+:is(.theme-doc-markdown, article .markdown) > h2::before {
   position: absolute;
   top: 0.28rem;
   bottom: 0.28rem;
@@ -209,8 +197,7 @@ article .markdown > h2::before {
   content: "";
 }
 
-.theme-doc-markdown > h3,
-article .markdown > h3 {
+:is(.theme-doc-markdown, article .markdown) > h3 {
   margin: 1.5rem 0 0.55rem;
   color: var(--dp-text-secondary);
   font-size: 13px;
@@ -219,15 +206,13 @@ article .markdown > h3 {
   text-transform: uppercase;
 }
 
-.theme-doc-markdown > h4,
-article .markdown > h4 {
+:is(.theme-doc-markdown, article .markdown) > h4 {
   color: var(--dp-text-primary);
   font-size: 1.05rem;
   font-weight: 600;
 }
 
-article table,
-.theme-doc-markdown table {
+:is(article, .theme-doc-markdown) table {
   display: table;
   width: 100%;
   margin: 1rem 0 1.5rem;
@@ -241,18 +226,13 @@ article table,
   font-size: 0.9rem;
 }
 
-article table thead,
-.theme-doc-markdown table thead {
-  background: var(--dp-bg-board);
-}
+:is(article, .theme-doc-markdown) table thead { background: var(--dp-bg-board); }
 
-[data-theme='dark'] article table thead,
-[data-theme='dark'] .theme-doc-markdown table thead {
+[data-theme='dark'] :is(article, .theme-doc-markdown) table thead {
   background: rgba(255, 255, 255, 0.04);
 }
 
-article table th,
-.theme-doc-markdown table th {
+:is(article, .theme-doc-markdown) table th {
   padding: 0.7rem 0.95rem;
   border: 0;
   border-bottom: 1px solid var(--dp-border);
@@ -265,8 +245,7 @@ article table th,
   text-transform: uppercase;
 }
 
-article table td,
-.theme-doc-markdown table td {
+:is(article, .theme-doc-markdown) table td {
   padding: 0.72rem 0.95rem;
   border: 0;
   border-bottom: 1px solid var(--dp-border-subtle);
@@ -275,34 +254,21 @@ article table td,
   vertical-align: top;
 }
 
-article table tbody tr,
-.theme-doc-markdown table tbody tr {
+:is(article, .theme-doc-markdown) table tbody tr {
   background: transparent;
   transition: background 120ms ease;
 }
 
-article table tbody tr:nth-child(even),
-.theme-doc-markdown table tbody tr:nth-child(even) {
-  background: var(--dp-bg-subtle);
-}
+:is(article, .theme-doc-markdown) table tbody tr:nth-child(even),
+:is(article, .theme-doc-markdown) table tbody tr:hover { background: var(--dp-bg-subtle); }
 
-[data-theme='dark'] article table tbody tr:nth-child(even),
-[data-theme='dark'] .theme-doc-markdown table tbody tr:nth-child(even) {
+[data-theme='dark'] :is(article, .theme-doc-markdown) table tbody tr:nth-child(even) {
   background: rgba(255, 255, 255, 0.02);
 }
 
-article table tbody tr:hover,
-.theme-doc-markdown table tbody tr:hover {
-  background: var(--dp-bg-subtle);
-}
+:is(article, .theme-doc-markdown) table tbody tr:last-child td { border-bottom: 0; }
 
-article table tbody tr:last-child td,
-.theme-doc-markdown table tbody tr:last-child td {
-  border-bottom: 0;
-}
-
-article :not(pre) > code,
-.theme-doc-markdown :not(pre) > code {
+:is(article, .theme-doc-markdown) :not(pre) > code {
   padding: 1px 6px;
   border: 1px solid var(--dp-border-subtle);
   border-radius: var(--dp-radius-sm);
@@ -312,15 +278,13 @@ article :not(pre) > code,
   font-size: 0.88em;
 }
 
-[data-theme='dark'] article :not(pre) > code,
-[data-theme='dark'] .theme-doc-markdown :not(pre) > code {
+[data-theme='dark'] :is(article, .theme-doc-markdown) :not(pre) > code {
   background: rgba(255, 255, 255, 0.06);
   border-color: rgba(255, 255, 255, 0.08);
   color: #ff9d85;
 }
 
-article pre,
-.theme-doc-markdown pre,
+:is(article, .theme-doc-markdown) pre,
 pre.prism-code,
 .theme-code-block {
   border-radius: var(--dp-radius-lg);
@@ -330,19 +294,14 @@ pre.prism-code,
   box-shadow: var(--dp-shadow-card);
 }
 
-article pre,
-.theme-doc-markdown pre {
-  padding: 16px;
-}
+:is(article, .theme-doc-markdown) pre { padding: 16px; }
 
-article pre code,
-.theme-doc-markdown pre code {
+:is(article, .theme-doc-markdown) pre code {
   color: inherit;
   font-family: var(--ifm-font-family-monospace);
 }
 
-article blockquote,
-.theme-doc-markdown > blockquote {
+:is(article, .theme-doc-markdown) blockquote {
   margin: 1.25rem 0;
   padding: 12px 16px;
   border: 0;
@@ -352,42 +311,25 @@ article blockquote,
   color: var(--dp-text-primary);
 }
 
-article blockquote > :first-child,
-.theme-doc-markdown > blockquote > :first-child {
-  margin-top: 0;
-}
+:is(article, .theme-doc-markdown) blockquote > :first-child { margin-top: 0; }
+:is(article, .theme-doc-markdown) blockquote > :last-child { margin-bottom: 0; }
 
-article blockquote > :last-child,
-.theme-doc-markdown > blockquote > :last-child {
-  margin-bottom: 0;
-}
-
-article blockquote.tachigo-callout--idea,
-.theme-doc-markdown > blockquote.tachigo-callout--idea {
+:is(article, .theme-doc-markdown) blockquote:is(.tachigo-callout--idea, .tachigo-callout--warning) {
   border-left-color: var(--dp-warning);
   background: var(--dp-warning-soft);
 }
 
-article blockquote.tachigo-callout--warning,
-.theme-doc-markdown > blockquote.tachigo-callout--warning {
-  border-left-color: var(--dp-warning);
-  background: var(--dp-warning-soft);
-}
-
-article blockquote.tachigo-callout--danger,
-.theme-doc-markdown > blockquote.tachigo-callout--danger {
+:is(article, .theme-doc-markdown) blockquote.tachigo-callout--danger {
   border-left-color: var(--dp-danger);
   background: var(--dp-danger-soft);
 }
 
-article blockquote.tachigo-callout--note,
-.theme-doc-markdown > blockquote.tachigo-callout--note {
+:is(article, .theme-doc-markdown) blockquote.tachigo-callout--note {
   border-left-color: var(--dp-primary);
   background: var(--dp-primary-soft);
 }
 
-article a,
-.theme-doc-markdown a:not(.tachigo-card):not(.tachigo-action):not(.button):not(.card) {
+:is(article, .theme-doc-markdown) a:not(.tachigo-card):not(.tachigo-action):not(.button):not(.card) {
   color: var(--dp-primary);
   text-decoration: underline dotted;
   text-decoration-thickness: 1px;
@@ -395,29 +337,16 @@ article a,
   transition: text-decoration-style 120ms ease;
 }
 
-article a:hover,
-.theme-doc-markdown a:not(.tachigo-card):not(.tachigo-action):not(.button):not(.card):hover {
+:is(article, .theme-doc-markdown) a:not(.tachigo-card):not(.tachigo-action):not(.button):not(.card):hover {
   color: var(--dp-primary);
   text-decoration-style: solid;
 }
 
-.theme-doc-markdown ul,
-.theme-doc-markdown ol {
-  padding-left: 1.2rem;
-}
+.theme-doc-markdown :is(ul, ol) { padding-left: 1.2rem; }
+.theme-doc-markdown li + li { margin-top: 0.25rem; }
 
-.theme-doc-markdown li + li {
-  margin-top: 0.25rem;
-}
-
-.tachigo-home {
-  width: min(100%, 1180px);
-  color: var(--tachigo-ink);
-}
-
-.tachigo-home a {
-  text-decoration: none;
-}
+.tachigo-home { width: min(100%, 1180px); color: var(--tachigo-ink); }
+.tachigo-home a { text-decoration: none; }
 
 .tachigo-hero {
   position: relative;
@@ -428,9 +357,7 @@ article a:hover,
   padding: 0;
 }
 
-.tachigo-hero::before {
-  content: none;
-}
+.tachigo-hero::before { content: none; }
 
 .tachigo-hero__copy {
   display: grid;
@@ -440,10 +367,7 @@ article a:hover,
 }
 
 .tachigo-hero__copy,
-.tachigo-topology {
-  position: relative;
-  z-index: 1;
-}
+.tachigo-topology { position: relative; z-index: 1; }
 
 .tachigo-kicker {
   display: inline-flex;
@@ -480,11 +404,7 @@ article a:hover,
   line-height: 1.72;
 }
 
-.tachigo-status-rail {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
+.tachigo-status-rail { display: flex; flex-wrap: wrap; gap: 0.45rem; }
 
 .tachigo-status-rail span {
   display: inline-flex;
@@ -499,11 +419,7 @@ article a:hover,
   font-weight: 600;
 }
 
-.tachigo-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
+.tachigo-actions { display: flex; flex-wrap: wrap; gap: 0.55rem; }
 
 .tachigo-action {
   display: inline-flex;
@@ -528,15 +444,8 @@ article a:hover,
   transform: translateY(-1px);
 }
 
-.tachigo-action--primary {
-  border-color: var(--dp-primary);
-  background: var(--dp-primary);
-  color: var(--dp-text-inverse);
-}
-
-.tachigo-action--primary:hover {
-  color: var(--dp-text-inverse);
-}
+.tachigo-action--primary { border-color: var(--dp-primary); background: var(--dp-primary); color: var(--dp-text-inverse); }
+.tachigo-action--primary:hover { color: var(--dp-text-inverse); }
 
 .tachigo-topology {
   display: flex;
@@ -637,10 +546,7 @@ article a:hover,
   line-height: 1.42;
 }
 
-.tachigo-node--viewer {
-  grid-column: 1;
-  grid-row: 1;
-}
+.tachigo-node--viewer { grid-column: 1; grid-row: 1; }
 
 .tachigo-node--client {
   grid-column: 1;
@@ -695,12 +601,7 @@ article a:hover,
   transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
 
-.tachigo-card--wide {
-  grid-column: span 2;
-  border-color: var(--dp-border-strong);
-  background: var(--dp-bg-board);
-  color: var(--dp-text-primary);
-}
+.tachigo-card--wide { grid-column: span 2; border-color: var(--dp-border-strong); background: var(--dp-bg-board); color: var(--dp-text-primary); }
 
 .tachigo-card:hover {
   border-color: var(--dp-primary);
@@ -710,9 +611,7 @@ article a:hover,
   transform: translateY(-2px);
 }
 
-.tachigo-card--wide:hover {
-  color: var(--dp-text-primary);
-}
+.tachigo-card--wide:hover { color: var(--dp-text-primary); }
 
 .tachigo-card__eyebrow {
   color: var(--dp-primary);
@@ -767,16 +666,8 @@ article a:hover,
   line-height: 1.25;
 }
 
-.tachigo-flow strong {
-  background: var(--dp-primary-soft);
-  color: var(--dp-primary);
-  font-weight: 600;
-}
-
-.tachigo-flow span {
-  background: var(--dp-bg-subtle);
-  color: var(--dp-text-secondary);
-}
+.tachigo-flow strong { background: var(--dp-primary-soft); color: var(--dp-primary); font-weight: 600; }
+.tachigo-flow span { background: var(--dp-bg-subtle); color: var(--dp-text-secondary); }
 
 .tachigo-band {
   margin: 1.25rem 0 1.8rem;
@@ -810,14 +701,8 @@ article a:hover,
   font-size: 1rem;
 }
 
-.tachigo-checklist h2::before {
-  content: none;
-}
-
-.tachigo-checklist__body {
-  color: var(--dp-text-secondary);
-  line-height: 1.6;
-}
+.tachigo-checklist h2::before { content: none; }
+.tachigo-checklist__body { color: var(--dp-text-secondary); line-height: 1.6; }
 
 .tachigo-status {
   display: inline-flex;
@@ -843,10 +728,7 @@ article a:hover,
   box-shadow: var(--dp-shadow-card);
 }
 
-.tachigo-related-links__group {
-  display: grid;
-  gap: 0.45rem;
-}
+.tachigo-related-links__group { display: grid; gap: 0.45rem; }
 
 .tachigo-related-links__group h3 {
   margin: 0;
@@ -855,11 +737,7 @@ article a:hover,
   font-weight: 700;
 }
 
-.tachigo-related-links__chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
+.tachigo-related-links__chips { display: flex; flex-wrap: wrap; gap: 0.5rem; }
 
 .tachigo-related-links__chip {
   display: inline-flex;
@@ -877,11 +755,7 @@ article a:hover,
   text-decoration: none;
 }
 
-.tachigo-related-links__chip:hover {
-  border-color: var(--dp-primary);
-  color: var(--dp-primary);
-  text-decoration: none;
-}
+.tachigo-related-links__chip:hover { border-color: var(--dp-primary); color: var(--dp-primary); text-decoration: none; }
 
 .tachigo-related-links__chip--inferred {
   gap: 0.4rem;
@@ -890,15 +764,9 @@ article a:hover,
   color: var(--tachigo-violet);
 }
 
-.tachigo-related-links__chip--inferred span {
-  color: var(--dp-text-secondary);
-  font-size: 0.72rem;
-}
+.tachigo-related-links__chip--inferred span { color: var(--dp-text-secondary); font-size: 0.72rem; }
 
-.tachigo-reverse-index {
-  display: grid;
-  gap: 0.9rem;
-}
+.tachigo-reverse-index { display: grid; gap: 0.9rem; }
 
 .tachigo-reverse-index__warning,
 .tachigo-reverse-index-empty,
@@ -910,18 +778,11 @@ article a:hover,
 }
 
 .tachigo-reverse-index__warning,
-.tachigo-reverse-index-empty {
-  padding: 0.8rem 1rem;
-}
+.tachigo-reverse-index-empty { padding: 0.8rem 1rem; }
 
-.tachigo-reverse-index__list {
-  display: grid;
-  gap: 0.75rem;
-}
+.tachigo-reverse-index__list { display: grid; gap: 0.75rem; }
 
-.tachigo-reverse-index__item {
-  padding: 0.95rem;
-}
+.tachigo-reverse-index__item { padding: 0.95rem; }
 
 .tachigo-reverse-index__item h3 {
   margin: 0.4rem 0;
@@ -930,9 +791,7 @@ article a:hover,
 }
 
 .tachigo-reverse-index__item p,
-.tachigo-reverse-index__meta {
-  color: var(--dp-text-secondary);
-}
+.tachigo-reverse-index__meta { color: var(--dp-text-secondary); }
 
 .tachigo-reverse-index__meta {
   display: flex;

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -1,4 +1,4 @@
-/* Dev Portal Visual System: Trello-primary structure with Notion-like callouts. */
+/* Dev Portal Visual System: engineering console / atlas workbook. */
 @import "@fontsource/inter/400.css";
 @import "@fontsource/inter/500.css";
 @import "@fontsource/inter/600.css";
@@ -9,11 +9,11 @@
 :root {
   --dp-primary: #0052cc;
   --dp-primary-strong: #0747a6;
-  --dp-primary-soft: #deebff;
+  --dp-primary-soft: #e7f0ff;
   --dp-success: #00875a;
-  --dp-success-soft: #e3fcef;
+  --dp-success-soft: #e4f7ef;
   --dp-warning: #ff8b00;
-  --dp-warning-soft: #fff0b3;
+  --dp-warning-soft: #fff3d6;
   --dp-neutral: #6b778c;
   --dp-neutral-soft: #ebecf0;
   --dp-danger: #de350b;
@@ -31,19 +31,19 @@
   --dp-radius-sm: 3px;
   --dp-radius-md: 6px;
   --dp-radius-lg: 8px;
-  --dp-shadow-card: 0 1px 0 rgba(9, 30, 66, 0.25);
-  --dp-shadow-card-hover: 0 4px 12px rgba(9, 30, 66, 0.15);
+  --dp-shadow-card: 0 1px 0 rgba(9, 30, 66, 0.18);
+  --dp-shadow-card-hover: 0 6px 18px rgba(9, 30, 66, 0.12);
 
   --ifm-color-primary: var(--dp-primary);
   --ifm-color-primary-dark: #0747a6;
   --ifm-color-primary-darker: #053780;
   --ifm-color-primary-darkest: #042c66;
-  --ifm-color-primary-light: #2684ff;
+  --ifm-color-primary-light: #1d7afc;
   --ifm-color-primary-lighter: #4c9aff;
   --ifm-color-primary-lightest: #b3d4ff;
   --ifm-background-color: var(--dp-bg-card);
   --ifm-background-surface-color: var(--dp-bg-board);
-  --ifm-navbar-background-color: rgba(255, 255, 255, 0.94);
+  --ifm-navbar-background-color: rgba(255, 255, 255, 0.96);
   --ifm-font-family-base: "Inter", "Noto Sans TC", system-ui, sans-serif;
   --ifm-heading-font-family: "Inter", "Noto Sans TC", system-ui, sans-serif;
   --ifm-font-family-monospace: "JetBrains Mono", SFMono-Regular, Consolas, monospace;
@@ -72,18 +72,18 @@
   --dp-text-primary: #f9fafb;
   --dp-text-secondary: #9ca3af;
   --dp-text-muted: #6b7280;
-  --dp-text-inverse: #172b4d;
+  --dp-text-inverse: #ffffff;
   --dp-border: #1f2937;
   --dp-border-strong: #374151;
-  --dp-border-subtle: #1f2937;
-  --dp-primary-soft: rgba(0, 82, 204, 0.22);
+  --dp-border-subtle: #232a35;
+  --dp-primary-soft: rgba(76, 154, 255, 0.14);
   --dp-success-soft: rgba(0, 135, 90, 0.18);
-  --dp-warning-soft: rgba(255, 139, 0, 0.18);
+  --dp-warning-soft: rgba(255, 139, 0, 0.16);
   --dp-danger-soft: rgba(222, 53, 11, 0.18);
 
   --ifm-background-color: var(--dp-bg-card);
   --ifm-background-surface-color: var(--dp-bg-board);
-  --ifm-navbar-background-color: rgba(26, 29, 36, 0.94);
+  --ifm-navbar-background-color: rgba(26, 29, 36, 0.96);
   --ifm-heading-color: var(--dp-text-primary);
 }
 
@@ -99,13 +99,17 @@ body {
 .navbar {
   border-bottom: 1px solid var(--dp-border);
   box-shadow: none;
-  backdrop-filter: blur(18px);
+  backdrop-filter: blur(16px);
 }
 
 .navbar__title {
   color: var(--dp-text-primary);
   font-weight: 700;
   letter-spacing: 0;
+}
+
+.navbar__link {
+  color: var(--dp-text-primary);
 }
 
 .theme-doc-sidebar-container {
@@ -128,13 +132,14 @@ body {
 
 .menu__link--active,
 .menu__link--active:hover {
-  background: var(--dp-primary-soft);
-  color: var(--dp-primary-strong);
-  font-weight: 600;
+  background: var(--dp-neutral-soft);
+  color: var(--dp-primary);
+  font-weight: 700;
 }
 
 [data-theme='dark'] .menu__link--active,
 [data-theme='dark'] .menu__link--active:hover {
+  background: rgba(255, 255, 255, 0.05);
   color: var(--ifm-color-primary-lighter);
 }
 
@@ -147,7 +152,7 @@ body {
 .table-of-contents__link--active,
 .table-of-contents__link:hover {
   color: var(--dp-primary);
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .pagination-nav__link {
@@ -172,11 +177,13 @@ body {
 
 .theme-doc-markdown > h1,
 article .markdown > h1 {
+  max-width: 18ch;
   margin-bottom: 0.75rem;
   color: var(--dp-text-primary);
-  font-size: 1.95rem;
+  font-size: clamp(2rem, 3vw, 2.85rem);
   font-weight: 700;
-  letter-spacing: -0.02em;
+  line-height: 1.08;
+  letter-spacing: 0;
 }
 
 .theme-doc-markdown > h2,
@@ -187,13 +194,14 @@ article .markdown > h2 {
   color: var(--dp-text-primary);
   font-size: 1.45rem;
   font-weight: 700;
+  line-height: 1.25;
 }
 
 .theme-doc-markdown > h2::before,
 article .markdown > h2::before {
   position: absolute;
-  top: 0.35rem;
-  bottom: 0.35rem;
+  top: 0.28rem;
+  bottom: 0.28rem;
   left: 0;
   width: 4px;
   border-radius: 2px;
@@ -240,7 +248,7 @@ article table thead,
 
 [data-theme='dark'] article table thead,
 [data-theme='dark'] .theme-doc-markdown table thead {
-  background: rgba(76, 154, 255, 0.10);
+  background: rgba(255, 255, 255, 0.04);
 }
 
 article table th,
@@ -257,14 +265,9 @@ article table th,
   text-transform: uppercase;
 }
 
-[data-theme='dark'] article table th,
-[data-theme='dark'] .theme-doc-markdown table th {
-  color: var(--ifm-color-primary-lighter);
-}
-
 article table td,
 .theme-doc-markdown table td {
-  padding: 0.7rem 0.95rem;
+  padding: 0.72rem 0.95rem;
   border: 0;
   border-bottom: 1px solid var(--dp-border-subtle);
   background: transparent;
@@ -290,7 +293,7 @@ article table tbody tr:nth-child(even),
 
 article table tbody tr:hover,
 .theme-doc-markdown table tbody tr:hover {
-  background: var(--dp-primary-soft);
+  background: var(--dp-bg-subtle);
 }
 
 article table tbody tr:last-child td,
@@ -419,98 +422,77 @@ article a:hover,
 .tachigo-hero {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
-  gap: 1.2rem;
-  align-items: stretch;
-  min-height: 560px;
-  margin: -1.2rem -0.2rem 1.4rem;
-  padding: 1rem;
-  overflow: hidden;
-  border: 1px solid var(--dp-border);
-  border-radius: var(--dp-radius-lg);
-  background:
-    linear-gradient(var(--dp-border-subtle) 1px, transparent 1px),
-    linear-gradient(90deg, var(--dp-border-subtle) 1px, transparent 1px),
-    linear-gradient(135deg, color-mix(in srgb, var(--dp-primary), transparent 88%), transparent 42%),
-    linear-gradient(315deg, color-mix(in srgb, var(--dp-success), transparent 90%), transparent 38%),
-    var(--dp-bg-board);
-  background-size: 32px 32px, 32px 32px, auto, auto, auto;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  margin: -0.6rem 0 1.25rem;
+  padding: 0;
 }
 
 .tachigo-hero::before {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    linear-gradient(90deg, transparent 0 68%, color-mix(in srgb, var(--dp-border-strong), transparent 70%) 68% 68.2%, transparent 68.2%),
-    linear-gradient(180deg, transparent 0 18%, color-mix(in srgb, var(--dp-border-strong), transparent 74%) 18% 18.2%, transparent 18.2%);
-  content: "";
+  content: none;
+}
+
+.tachigo-hero__copy {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem 0 1rem;
+  border-bottom: 1px solid var(--dp-border);
 }
 
 .tachigo-hero__copy,
 .tachigo-topology {
   position: relative;
   z-index: 1;
-  border: 1px solid var(--dp-border);
-  border-radius: var(--dp-radius-lg);
-  background: color-mix(in srgb, var(--dp-bg-card), transparent 6%);
-  box-shadow: var(--dp-shadow-card);
-}
-
-.tachigo-hero__copy {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 1.5rem;
-  padding: 1.35rem;
 }
 
 .tachigo-kicker {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
-  margin: 0 0 1rem;
-  padding: 0.2rem 0.55rem;
-  border: 1px solid color-mix(in srgb, var(--dp-primary), var(--dp-border) 35%);
+  width: fit-content;
+  min-height: 26px;
+  margin: 0 0 0.75rem;
+  padding: 0.18rem 0.52rem;
+  border: 1px solid var(--dp-border-strong);
   border-radius: var(--dp-radius-sm);
-  background: var(--dp-primary-soft);
+  background: var(--dp-bg-card);
   color: var(--dp-primary);
-  font-size: 0.74rem;
+  font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .tachigo-hero h1 {
-  max-width: 12ch;
+  max-width: 18ch;
   margin: 0;
   color: var(--dp-text-primary);
-  font-size: 3.6rem;
-  line-height: 1.05;
+  font-size: clamp(2.35rem, 6vw, 4.25rem);
+  font-weight: 700;
+  line-height: 1.02;
   letter-spacing: 0;
 }
 
 .tachigo-lede {
-  max-width: 38rem;
-  margin: 1.2rem 0 0;
+  max-width: 42rem;
+  margin: 0;
   color: var(--dp-text-secondary);
   font-size: 1.02rem;
   line-height: 1.72;
 }
 
 .tachigo-status-rail {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
 }
 
 .tachigo-status-rail span {
   display: inline-flex;
   align-items: center;
-  min-height: 34px;
-  padding: 0.35rem 0.55rem;
+  min-height: 30px;
+  padding: 0.28rem 0.55rem;
   border: 1px solid var(--dp-border);
-  border-radius: var(--dp-radius-md);
+  border-radius: var(--dp-radius-sm);
   background: var(--dp-bg-subtle);
   color: var(--dp-text-secondary);
   font-size: 0.78rem;
@@ -520,15 +502,15 @@ article a:hover,
 .tachigo-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.55rem;
 }
 
 .tachigo-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 44px;
-  padding: 0.72rem 0.95rem;
+  min-height: 40px;
+  padding: 0.62rem 0.85rem;
   border: 1px solid var(--dp-border);
   border-radius: var(--dp-radius-md);
   color: var(--dp-text-primary);
@@ -559,7 +541,11 @@ article a:hover,
 .tachigo-topology {
   display: flex;
   flex-direction: column;
-  padding: 0.95rem;
+  padding: 1rem;
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  box-shadow: var(--dp-shadow-card);
 }
 
 .tachigo-topology__header {
@@ -567,8 +553,8 @@ article a:hover,
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
-  min-height: 48px;
-  margin-bottom: 0.8rem;
+  min-height: 44px;
+  margin-bottom: 0.9rem;
   border-bottom: 1px solid var(--dp-border);
 }
 
@@ -576,7 +562,7 @@ article a:hover,
   color: var(--dp-primary);
   font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -591,17 +577,16 @@ article a:hover,
 .tachigo-topology__grid {
   position: relative;
   display: grid;
-  flex: 1;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  grid-template-rows: repeat(3, minmax(118px, 1fr));
-  gap: 0.8rem;
+  grid-auto-rows: minmax(108px, auto);
+  gap: 0.7rem;
 }
 
 .tachigo-topology__grid::before {
   position: absolute;
-  inset: 12% 10%;
-  z-index: -1;
-  border: 1px dashed color-mix(in srgb, var(--dp-primary), transparent 62%);
+  inset: 13% 9%;
+  z-index: 0;
+  border: 1px dashed color-mix(in srgb, var(--dp-primary), transparent 70%);
   border-radius: var(--dp-radius-lg);
   content: "";
 }
@@ -609,31 +594,32 @@ article a:hover,
 .tachigo-topology__grid::after {
   position: absolute;
   inset: 50% 8% auto;
-  z-index: -1;
+  z-index: 0;
   height: 1px;
   background: linear-gradient(90deg, transparent, var(--dp-primary), var(--dp-success), transparent);
   content: "";
 }
 
 .tachigo-node {
+  position: relative;
+  z-index: 1;
   display: flex;
-  min-height: 112px;
+  min-height: 108px;
   flex-direction: column;
   justify-content: space-between;
-  padding: 0.85rem;
+  padding: 0.78rem;
   border: 1px solid var(--dp-border);
-  border-radius: var(--dp-radius-lg);
+  border-radius: var(--dp-radius-md);
   background: var(--dp-bg-card);
-  box-shadow: var(--dp-shadow-card);
 }
 
 .tachigo-node__tag {
   width: fit-content;
-  padding: 0.1rem 0.4rem;
+  padding: 0.08rem 0.35rem;
   border-radius: var(--dp-radius-sm);
   background: var(--dp-bg-board);
   color: var(--dp-text-secondary);
-  font-size: 0.68rem;
+  font-size: 0.66rem;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -642,12 +628,12 @@ article a:hover,
 .tachigo-node strong {
   margin-top: 0.55rem;
   color: var(--dp-text-primary);
-  font-size: 1rem;
+  font-size: 0.98rem;
 }
 
 .tachigo-node span:last-child {
   color: var(--dp-text-secondary);
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   line-height: 1.42;
 }
 
@@ -659,47 +645,47 @@ article a:hover,
 .tachigo-node--client {
   grid-column: 1;
   grid-row: 2;
-  border-color: color-mix(in srgb, var(--tachigo-violet), var(--dp-border) 45%);
+  border-color: color-mix(in srgb, var(--tachigo-violet), var(--dp-border) 50%);
 }
 
 .tachigo-node--api {
   grid-column: 2;
   grid-row: 2;
-  border-color: color-mix(in srgb, var(--dp-primary), var(--dp-border) 30%);
-  background: color-mix(in srgb, var(--dp-primary), var(--dp-bg-card) 92%);
+  border-color: color-mix(in srgb, var(--dp-primary), var(--dp-border) 35%);
+  background: color-mix(in srgb, var(--dp-primary), var(--dp-bg-card) 94%);
 }
 
 .tachigo-node--ledger {
   grid-column: 2;
   grid-row: 3;
-  border-color: color-mix(in srgb, var(--dp-success), var(--dp-border) 40%);
+  border-color: color-mix(in srgb, var(--dp-success), var(--dp-border) 42%);
 }
 
 .tachigo-node--tachiya {
   grid-column: 3;
   grid-row: 2;
-  border-color: color-mix(in srgb, var(--dp-warning), var(--dp-border) 35%);
+  border-color: color-mix(in srgb, var(--dp-warning), var(--dp-border) 38%);
 }
 
 .tachigo-node--external {
   grid-column: 3;
   grid-row: 3;
-  border-color: color-mix(in srgb, var(--dp-danger), var(--dp-border) 40%);
+  border-color: color-mix(in srgb, var(--dp-danger), var(--dp-border) 42%);
 }
 
 .tachigo-route-board {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.85rem;
-  margin: 1.4rem 0 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin: 1.25rem 0 1rem;
 }
 
 .tachigo-card {
   display: flex;
-  min-height: 184px;
+  min-height: 156px;
   flex-direction: column;
   justify-content: space-between;
-  padding: 1rem;
+  padding: 0.95rem;
   border: 1px solid var(--dp-border);
   border-radius: var(--dp-radius-lg);
   background: var(--dp-bg-card);
@@ -711,9 +697,9 @@ article a:hover,
 
 .tachigo-card--wide {
   grid-column: span 2;
-  border-color: var(--dp-primary);
-  background: linear-gradient(135deg, var(--dp-primary), var(--dp-primary-strong));
-  color: var(--dp-text-inverse);
+  border-color: var(--dp-border-strong);
+  background: var(--dp-bg-board);
+  color: var(--dp-text-primary);
 }
 
 .tachigo-card:hover {
@@ -725,7 +711,7 @@ article a:hover,
 }
 
 .tachigo-card--wide:hover {
-  color: var(--dp-text-inverse);
+  color: var(--dp-text-primary);
 }
 
 .tachigo-card__eyebrow {
@@ -736,38 +722,33 @@ article a:hover,
   text-transform: uppercase;
 }
 
-.tachigo-card--wide .tachigo-card__eyebrow,
-.tachigo-card--wide .tachigo-card__body {
-  color: rgba(255, 255, 255, 0.86);
-}
-
 .tachigo-card h2 {
-  margin: 1.2rem 0 0.55rem;
+  margin: 1rem 0 0.45rem;
   color: inherit;
-  font-size: 1.22rem;
+  font-size: 1.15rem;
   letter-spacing: 0;
 }
 
 .tachigo-card__body {
   color: var(--dp-text-secondary);
-  font-size: 0.92rem;
+  font-size: 0.9rem;
   line-height: 1.58;
 }
 
 .tachigo-flow-strip {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 0.75rem;
   margin: 1rem 0 1.2rem;
 }
 
 .tachigo-flow {
   display: grid;
-  grid-template-columns: minmax(76px, 0.6fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
-  gap: 0.5rem;
+  grid-template-columns: minmax(66px, 0.55fr) repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
   align-items: stretch;
-  min-height: 72px;
-  padding: 0.65rem;
+  min-height: 66px;
+  padding: 0.55rem;
   border: 1px solid var(--dp-border);
   border-radius: var(--dp-radius-lg);
   background: var(--dp-bg-card);
@@ -778,11 +759,11 @@ article a:hover,
 .tachigo-flow strong {
   display: inline-flex;
   align-items: center;
-  min-height: 42px;
-  padding: 0.4rem 0.48rem;
+  min-height: 38px;
+  padding: 0.35rem 0.45rem;
   border: 1px solid var(--dp-border-subtle);
   border-radius: var(--dp-radius-sm);
-  font-size: 0.76rem;
+  font-size: 0.74rem;
   line-height: 1.25;
 }
 
@@ -798,8 +779,8 @@ article a:hover,
 }
 
 .tachigo-band {
-  margin: 1.4rem 0 1.8rem;
-  padding: 1.05rem;
+  margin: 1.25rem 0 1.8rem;
+  padding: 1rem;
   border: 1px solid var(--dp-border);
   border-left: 4px solid var(--dp-primary);
   border-radius: var(--dp-radius-md);
@@ -810,13 +791,13 @@ article a:hover,
 
 .tachigo-checklist {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.75rem;
   margin: 1.2rem 0;
 }
 
 .tachigo-checklist section {
-  padding: 1rem;
+  padding: 0.95rem;
   border: 1px solid var(--dp-border);
   border-radius: var(--dp-radius-lg);
   background: var(--dp-bg-card);
@@ -826,7 +807,7 @@ article a:hover,
 .tachigo-checklist h2 {
   margin-top: 0;
   color: var(--dp-text-primary);
-  font-size: 1.05rem;
+  font-size: 1rem;
 }
 
 .tachigo-checklist h2::before {
@@ -961,27 +942,7 @@ article a:hover,
   font-weight: 600;
 }
 
-@media (max-width: 1120px) {
-  .tachigo-hero {
-    grid-template-columns: 1fr;
-  }
-
-  .tachigo-hero h1 {
-    max-width: 14ch;
-    font-size: 3.1rem;
-  }
-
-  .tachigo-route-board {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 996px) {
-  .tachigo-hero {
-    min-height: auto;
-    padding: 0.8rem;
-  }
-
   .tachigo-route-board,
   .tachigo-checklist,
   .tachigo-flow-strip {
@@ -1000,17 +961,10 @@ article a:hover,
 @media (max-width: 640px) {
   .tachigo-hero {
     margin-top: 0;
-    padding: 0.6rem;
-  }
-
-  .tachigo-hero__copy,
-  .tachigo-topology {
-    padding: 1rem;
   }
 
   .tachigo-hero h1 {
-    max-width: 12ch;
-    font-size: 2.4rem;
+    font-size: 2.45rem;
   }
 
   .tachigo-status-rail,
@@ -1021,8 +975,8 @@ article a:hover,
     grid-template-columns: 1fr;
   }
 
-  .tachigo-topology__grid {
-    grid-template-rows: none;
+  .tachigo-card--wide {
+    grid-column: auto;
   }
 
   .tachigo-node,
@@ -1031,10 +985,14 @@ article a:hover,
   .tachigo-node--api,
   .tachigo-node--ledger,
   .tachigo-node--tachiya,
-  .tachigo-node--external,
-  .tachigo-card--wide {
+  .tachigo-node--external {
     grid-column: auto;
     grid-row: auto;
+  }
+
+  .tachigo-topology__grid::before,
+  .tachigo-topology__grid::after {
+    content: none;
   }
 
   .tachigo-topology__header {

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -1,60 +1,162 @@
+/* Dev Portal Visual System: Trello-primary structure with Notion-like callouts. */
+@import "@fontsource/inter/400.css";
+@import "@fontsource/inter/500.css";
+@import "@fontsource/inter/600.css";
+@import "@fontsource/inter/700.css";
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/500.css";
+
 :root {
-  --ifm-color-primary: #1f6f68;
-  --ifm-color-primary-dark: #1a5d57;
-  --ifm-color-primary-darker: #164f4a;
-  --ifm-color-primary-darkest: #103b37;
-  --ifm-color-primary-light: #2d867d;
-  --ifm-color-primary-lighter: #399a90;
-  --ifm-color-primary-lightest: #65bbb2;
-  --ifm-background-color: #f4f7f1;
-  --ifm-navbar-background-color: rgba(244, 247, 241, 0.94);
-  --ifm-font-family-base: "Avenir Next", "Segoe UI", "Noto Sans TC", sans-serif;
-  --ifm-heading-font-family: "Optima", "Avenir Next", "Noto Sans TC", sans-serif;
-  --ifm-code-font-size: 92%;
-  --tachigo-ink: #17201f;
-  --tachigo-muted: #53625f;
-  --tachigo-line: rgba(23, 32, 31, 0.16);
-  --tachigo-soft-line: rgba(23, 32, 31, 0.08);
-  --tachigo-panel: rgba(255, 255, 250, 0.9);
-  --tachigo-panel-strong: #ffffff;
-  --tachigo-field: #e7ede2;
-  --tachigo-signal: #c74235;
-  --tachigo-amber: #b77b23;
-  --tachigo-cyan: #237f92;
-  --tachigo-violet: #5f5aa2;
+  --dp-primary: #0052cc;
+  --dp-primary-strong: #0747a6;
+  --dp-primary-soft: #deebff;
+  --dp-success: #00875a;
+  --dp-success-soft: #e3fcef;
+  --dp-warning: #ff8b00;
+  --dp-warning-soft: #fff0b3;
+  --dp-neutral: #6b778c;
+  --dp-neutral-soft: #ebecf0;
+  --dp-danger: #de350b;
+  --dp-danger-soft: #ffebe6;
+  --dp-bg-board: #f4f5f7;
+  --dp-bg-card: #ffffff;
+  --dp-bg-subtle: #fafaf9;
+  --dp-text-primary: #172b4d;
+  --dp-text-secondary: #5e6c84;
+  --dp-text-muted: #9b9a97;
+  --dp-text-inverse: #ffffff;
+  --dp-border: #dfe1e6;
+  --dp-border-strong: #c1c7d0;
+  --dp-border-subtle: #ebecf0;
+  --dp-radius-sm: 3px;
+  --dp-radius-md: 6px;
+  --dp-radius-lg: 8px;
+  --dp-shadow-card: 0 1px 0 rgba(9, 30, 66, 0.25);
+  --dp-shadow-card-hover: 0 4px 12px rgba(9, 30, 66, 0.15);
+
+  --ifm-color-primary: var(--dp-primary);
+  --ifm-color-primary-dark: #0747a6;
+  --ifm-color-primary-darker: #053780;
+  --ifm-color-primary-darkest: #042c66;
+  --ifm-color-primary-light: #2684ff;
+  --ifm-color-primary-lighter: #4c9aff;
+  --ifm-color-primary-lightest: #b3d4ff;
+  --ifm-background-color: var(--dp-bg-card);
+  --ifm-background-surface-color: var(--dp-bg-board);
+  --ifm-navbar-background-color: rgba(255, 255, 255, 0.94);
+  --ifm-font-family-base: "Inter", "Noto Sans TC", system-ui, sans-serif;
+  --ifm-heading-font-family: "Inter", "Noto Sans TC", system-ui, sans-serif;
+  --ifm-font-family-monospace: "JetBrains Mono", SFMono-Regular, Consolas, monospace;
+  --ifm-code-font-size: 90%;
+  --ifm-heading-color: var(--dp-text-primary);
+  --ifm-link-color: var(--dp-primary);
+  --ifm-link-hover-color: var(--dp-primary);
+
+  --tachigo-ink: var(--dp-text-primary);
+  --tachigo-muted: var(--dp-text-secondary);
+  --tachigo-line: var(--dp-border);
+  --tachigo-soft-line: var(--dp-border-subtle);
+  --tachigo-panel: var(--dp-bg-card);
+  --tachigo-panel-strong: var(--dp-bg-card);
+  --tachigo-field: var(--dp-bg-board);
+  --tachigo-signal: var(--dp-primary);
+  --tachigo-amber: var(--dp-warning);
+  --tachigo-cyan: var(--dp-primary);
+  --tachigo-violet: #6554c0;
 }
 
 [data-theme='dark'] {
-  --ifm-color-primary: #79d5c8;
-  --ifm-color-primary-dark: #5fcabd;
-  --ifm-color-primary-darker: #4bbcaf;
-  --ifm-color-primary-darkest: #348a81;
-  --ifm-color-primary-light: #a4e3db;
-  --ifm-color-primary-lighter: #bceee8;
-  --ifm-color-primary-lightest: #ddf9f5;
-  --ifm-background-color: #101513;
-  --ifm-navbar-background-color: rgba(16, 21, 19, 0.94);
-  --tachigo-ink: #edf6f2;
-  --tachigo-muted: #aebfba;
-  --tachigo-line: rgba(237, 246, 242, 0.16);
-  --tachigo-soft-line: rgba(237, 246, 242, 0.08);
-  --tachigo-panel: rgba(21, 31, 29, 0.9);
-  --tachigo-panel-strong: #17211f;
-  --tachigo-field: #1d2a27;
-  --tachigo-signal: #ff7d6f;
-  --tachigo-amber: #e5b75d;
-  --tachigo-cyan: #6fc8d9;
-  --tachigo-violet: #ada8ff;
+  --dp-bg-board: #0f1117;
+  --dp-bg-card: #1a1d24;
+  --dp-bg-subtle: #16181f;
+  --dp-text-primary: #f9fafb;
+  --dp-text-secondary: #9ca3af;
+  --dp-text-muted: #6b7280;
+  --dp-text-inverse: #172b4d;
+  --dp-border: #1f2937;
+  --dp-border-strong: #374151;
+  --dp-border-subtle: #1f2937;
+  --dp-primary-soft: rgba(0, 82, 204, 0.22);
+  --dp-success-soft: rgba(0, 135, 90, 0.18);
+  --dp-warning-soft: rgba(255, 139, 0, 0.18);
+  --dp-danger-soft: rgba(222, 53, 11, 0.18);
+
+  --ifm-background-color: var(--dp-bg-card);
+  --ifm-background-surface-color: var(--dp-bg-board);
+  --ifm-navbar-background-color: rgba(26, 29, 36, 0.94);
+  --ifm-heading-color: var(--dp-text-primary);
+}
+
+html {
+  font-family: var(--ifm-font-family-base);
+}
+
+body {
+  background: var(--dp-bg-card);
+  color: var(--dp-text-primary);
 }
 
 .navbar {
-  border-bottom: 1px solid var(--tachigo-line);
+  border-bottom: 1px solid var(--dp-border);
   box-shadow: none;
   backdrop-filter: blur(18px);
 }
 
+.navbar__title {
+  color: var(--dp-text-primary);
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
 .theme-doc-sidebar-container {
-  border-right: 1px solid var(--tachigo-line) !important;
+  border-right: 1px solid var(--dp-border) !important;
+  background: var(--dp-bg-subtle);
+}
+
+.menu__link {
+  border-radius: var(--dp-radius-md);
+  color: var(--dp-text-secondary);
+  font-size: 0.92rem;
+  font-weight: 500;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.menu__link:hover {
+  background: var(--dp-bg-board);
+  color: var(--dp-text-primary);
+}
+
+.menu__link--active,
+.menu__link--active:hover {
+  background: var(--dp-primary-soft);
+  color: var(--dp-primary);
+  font-weight: 600;
+}
+
+.breadcrumbs__link,
+.table-of-contents__link,
+.pagination-nav__sublabel {
+  color: var(--dp-text-secondary);
+}
+
+.table-of-contents__link--active,
+.table-of-contents__link:hover {
+  color: var(--dp-primary);
+  font-weight: 600;
+}
+
+.pagination-nav__link {
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  box-shadow: var(--dp-shadow-card);
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--dp-primary);
+  box-shadow: var(--dp-shadow-card-hover);
+  transform: translateY(-1px);
 }
 
 .theme-doc-markdown h1,
@@ -63,14 +165,220 @@
   letter-spacing: 0;
 }
 
+.theme-doc-markdown > h1,
+article .markdown > h1 {
+  margin-bottom: 0.65rem;
+  color: var(--dp-text-primary);
+  font-size: 2.1rem;
+  font-weight: 700;
+}
+
+.theme-doc-markdown > h2,
+article .markdown > h2 {
+  position: relative;
+  margin: 32px 0 12px;
+  padding-left: 12px;
+  color: var(--dp-text-primary);
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.theme-doc-markdown > h2::before,
+article .markdown > h2::before {
+  position: absolute;
+  top: 0.35rem;
+  bottom: 0.35rem;
+  left: 0;
+  width: 4px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, var(--dp-primary), var(--dp-success));
+  content: "";
+}
+
+.theme-doc-markdown > h3,
+article .markdown > h3 {
+  margin: 1.5rem 0 0.55rem;
+  color: var(--dp-text-secondary);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.theme-doc-markdown > h4,
+article .markdown > h4 {
+  color: var(--dp-text-primary);
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+article table,
 .theme-doc-markdown table {
   display: table;
   width: 100%;
+  margin: 1rem 0 1.5rem;
+  overflow: hidden;
+  border: 1px solid var(--dp-border);
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  font-size: 0.9rem;
+}
+
+article table thead,
+.theme-doc-markdown table thead {
+  background: var(--dp-bg-board);
+}
+
+article table th,
+.theme-doc-markdown table th {
+  padding: 0.65rem 0.9rem;
+  border: 0;
+  border-bottom: 1px solid var(--dp-border);
+  background: transparent;
+  color: var(--dp-text-secondary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+article table td,
+.theme-doc-markdown table td {
+  padding: 0.7rem 0.9rem;
+  border: 0;
+  border-bottom: 1px solid var(--dp-border-subtle);
+  background: transparent;
+  color: var(--dp-text-primary);
+  vertical-align: top;
+}
+
+article table tbody tr,
+.theme-doc-markdown table tbody tr {
+  background: transparent;
+  transition: background 100ms ease;
+}
+
+article table tbody tr:hover,
+.theme-doc-markdown table tbody tr:hover {
+  background: var(--dp-bg-subtle);
+}
+
+article table tbody tr:last-child td,
+.theme-doc-markdown table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+article :not(pre) > code,
+.theme-doc-markdown :not(pre) > code {
+  padding: 1px 5px;
+  border-radius: var(--dp-radius-sm);
+  background: var(--dp-bg-board);
+  color: var(--dp-danger);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.9em;
+}
+
+article pre,
+.theme-doc-markdown pre,
+pre.prism-code,
+.theme-code-block {
+  border-radius: var(--dp-radius-lg);
+  background: #172b4d !important;
+  color: #ffffff;
+  font-family: var(--ifm-font-family-monospace);
+  box-shadow: var(--dp-shadow-card);
+}
+
+article pre,
+.theme-doc-markdown pre {
+  padding: 16px;
+}
+
+article pre code,
+.theme-doc-markdown pre code {
+  color: inherit;
+  font-family: var(--ifm-font-family-monospace);
+}
+
+article blockquote,
+.theme-doc-markdown > blockquote {
+  margin: 1.25rem 0;
+  padding: 12px 16px;
+  border: 0;
+  border-left: 4px solid var(--dp-primary);
+  border-radius: var(--dp-radius-md);
+  background: var(--dp-primary-soft);
+  color: var(--dp-text-primary);
+}
+
+article blockquote > :first-child,
+.theme-doc-markdown > blockquote > :first-child {
+  margin-top: 0;
+}
+
+article blockquote > :last-child,
+.theme-doc-markdown > blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+article blockquote.tachigo-callout--idea,
+.theme-doc-markdown > blockquote.tachigo-callout--idea {
+  border-left-color: var(--dp-warning);
+  background: var(--dp-warning-soft);
+}
+
+article blockquote.tachigo-callout--warning,
+.theme-doc-markdown > blockquote.tachigo-callout--warning {
+  border-left-color: var(--dp-warning);
+  background: var(--dp-warning-soft);
+}
+
+article blockquote.tachigo-callout--danger,
+.theme-doc-markdown > blockquote.tachigo-callout--danger {
+  border-left-color: var(--dp-danger);
+  background: var(--dp-danger-soft);
+}
+
+article blockquote.tachigo-callout--note,
+.theme-doc-markdown > blockquote.tachigo-callout--note {
+  border-left-color: var(--dp-primary);
+  background: var(--dp-primary-soft);
+}
+
+article a,
+.theme-doc-markdown a:not(.tachigo-card):not(.tachigo-action):not(.button):not(.card) {
+  color: var(--dp-primary);
+  text-decoration: underline dotted;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition: text-decoration-style 120ms ease;
+}
+
+article a:hover,
+.theme-doc-markdown a:not(.tachigo-card):not(.tachigo-action):not(.button):not(.card):hover {
+  color: var(--dp-primary);
+  text-decoration-style: solid;
+}
+
+.theme-doc-markdown ul,
+.theme-doc-markdown ol {
+  padding-left: 1.2rem;
+}
+
+.theme-doc-markdown li + li {
+  margin-top: 0.25rem;
 }
 
 .tachigo-home {
   width: min(100%, 1180px);
   color: var(--tachigo-ink);
+}
+
+.tachigo-home a {
+  text-decoration: none;
 }
 
 .tachigo-hero {
@@ -82,35 +390,36 @@
   min-height: 560px;
   margin: -1.2rem -0.2rem 1.4rem;
   padding: 1rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background:
-    linear-gradient(var(--tachigo-soft-line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--tachigo-soft-line) 1px, transparent 1px),
-    linear-gradient(135deg, rgba(35, 127, 146, 0.14), transparent 42%),
-    linear-gradient(315deg, rgba(199, 66, 53, 0.12), transparent 38%),
-    var(--tachigo-field);
-  background-size: 32px 32px, 32px 32px, auto, auto, auto;
   overflow: hidden;
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background:
+    linear-gradient(var(--dp-border-subtle) 1px, transparent 1px),
+    linear-gradient(90deg, var(--dp-border-subtle) 1px, transparent 1px),
+    linear-gradient(135deg, color-mix(in srgb, var(--dp-primary), transparent 88%), transparent 42%),
+    linear-gradient(315deg, color-mix(in srgb, var(--dp-success), transparent 90%), transparent 38%),
+    var(--dp-bg-board);
+  background-size: 32px 32px, 32px 32px, auto, auto, auto;
 }
 
 .tachigo-hero::before {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  content: "";
   background:
-    linear-gradient(90deg, transparent 0 68%, rgba(23, 32, 31, 0.08) 68% 68.2%, transparent 68.2%),
-    linear-gradient(180deg, transparent 0 18%, rgba(23, 32, 31, 0.07) 18% 18.2%, transparent 18.2%);
+    linear-gradient(90deg, transparent 0 68%, color-mix(in srgb, var(--dp-border-strong), transparent 70%) 68% 68.2%, transparent 68.2%),
+    linear-gradient(180deg, transparent 0 18%, color-mix(in srgb, var(--dp-border-strong), transparent 74%) 18% 18.2%, transparent 18.2%);
+  content: "";
 }
 
 .tachigo-hero__copy,
 .tachigo-topology {
   position: relative;
   z-index: 1;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background: var(--tachigo-panel);
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: color-mix(in srgb, var(--dp-bg-card), transparent 6%);
+  box-shadow: var(--dp-shadow-card);
 }
 
 .tachigo-hero__copy {
@@ -127,27 +436,29 @@
   min-height: 28px;
   margin: 0 0 1rem;
   padding: 0.2rem 0.55rem;
-  border: 1px solid color-mix(in srgb, var(--tachigo-signal), var(--tachigo-line) 35%);
-  border-radius: 999px;
-  color: var(--tachigo-signal);
+  border: 1px solid color-mix(in srgb, var(--dp-primary), var(--dp-border) 35%);
+  border-radius: var(--dp-radius-sm);
+  background: var(--dp-primary-soft);
+  color: var(--dp-primary);
   font-size: 0.74rem;
-  font-weight: 800;
-  letter-spacing: 0;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .tachigo-hero h1 {
-  max-width: 9ch;
+  max-width: 12ch;
   margin: 0;
-  font-size: 4.35rem;
-  line-height: 0.96;
+  color: var(--dp-text-primary);
+  font-size: 3.6rem;
+  line-height: 1.05;
   letter-spacing: 0;
 }
 
 .tachigo-lede {
   max-width: 38rem;
   margin: 1.2rem 0 0;
-  color: var(--tachigo-muted);
+  color: var(--dp-text-secondary);
   font-size: 1.02rem;
   line-height: 1.72;
 }
@@ -163,12 +474,12 @@
   align-items: center;
   min-height: 34px;
   padding: 0.35rem 0.55rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--tachigo-panel-strong), transparent 20%);
-  color: var(--tachigo-muted);
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-md);
+  background: var(--dp-bg-subtle);
+  color: var(--dp-text-secondary);
   font-size: 0.78rem;
-  font-weight: 760;
+  font-weight: 600;
 }
 
 .tachigo-actions {
@@ -183,29 +494,31 @@
   justify-content: center;
   min-height: 44px;
   padding: 0.72rem 0.95rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 6px;
-  color: var(--tachigo-ink);
-  font-weight: 780;
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-md);
+  color: var(--dp-text-primary);
+  font-weight: 700;
   line-height: 1.2;
   text-decoration: none;
-  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
 
 .tachigo-action:hover {
-  color: var(--tachigo-ink);
+  border-color: var(--dp-primary);
+  box-shadow: var(--dp-shadow-card-hover);
+  color: var(--dp-text-primary);
   text-decoration: none;
   transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 35%);
 }
 
 .tachigo-action--primary {
-  background: var(--tachigo-ink);
-  color: var(--ifm-background-color);
+  border-color: var(--dp-primary);
+  background: var(--dp-primary);
+  color: var(--dp-text-inverse);
 }
 
 .tachigo-action--primary:hover {
-  color: var(--ifm-background-color);
+  color: var(--dp-text-inverse);
 }
 
 .tachigo-topology {
@@ -221,20 +534,23 @@
   gap: 1rem;
   min-height: 48px;
   margin-bottom: 0.8rem;
-  border-bottom: 1px solid var(--tachigo-line);
+  border-bottom: 1px solid var(--dp-border);
 }
 
 .tachigo-topology__header span {
-  color: var(--tachigo-signal);
+  color: var(--dp-primary);
   font-size: 0.72rem;
-  font-weight: 800;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .tachigo-topology__header strong {
   max-width: 18rem;
-  text-align: right;
+  color: var(--dp-text-primary);
   font-size: 0.92rem;
+  font-weight: 600;
+  text-align: right;
 }
 
 .tachigo-topology__grid {
@@ -250,18 +566,18 @@
   position: absolute;
   inset: 12% 10%;
   z-index: -1;
-  border: 1px dashed color-mix(in srgb, var(--tachigo-cyan), transparent 30%);
-  border-radius: 8px;
+  border: 1px dashed color-mix(in srgb, var(--dp-primary), transparent 62%);
+  border-radius: var(--dp-radius-lg);
   content: "";
 }
 
 .tachigo-topology__grid::after {
   position: absolute;
   inset: 50% 8% auto;
-  height: 1px;
   z-index: -1;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--dp-primary), var(--dp-success), transparent);
   content: "";
-  background: linear-gradient(90deg, transparent, var(--tachigo-signal), var(--tachigo-cyan), transparent);
 }
 
 .tachigo-node {
@@ -270,30 +586,32 @@
   flex-direction: column;
   justify-content: space-between;
   padding: 0.85rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--tachigo-panel-strong), transparent 8%);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  box-shadow: var(--dp-shadow-card);
 }
 
 .tachigo-node__tag {
   width: fit-content;
   padding: 0.1rem 0.4rem;
-  border-radius: 999px;
-  background: var(--tachigo-field);
-  color: var(--tachigo-muted);
+  border-radius: var(--dp-radius-sm);
+  background: var(--dp-bg-board);
+  color: var(--dp-text-secondary);
   font-size: 0.68rem;
-  font-weight: 800;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .tachigo-node strong {
   margin-top: 0.55rem;
+  color: var(--dp-text-primary);
   font-size: 1rem;
 }
 
 .tachigo-node span:last-child {
-  color: var(--tachigo-muted);
+  color: var(--dp-text-secondary);
   font-size: 0.78rem;
   line-height: 1.42;
 }
@@ -306,31 +624,32 @@
 .tachigo-node--client {
   grid-column: 1;
   grid-row: 2;
-  border-color: color-mix(in srgb, var(--tachigo-violet), var(--tachigo-line) 45%);
+  border-color: color-mix(in srgb, var(--tachigo-violet), var(--dp-border) 45%);
 }
 
 .tachigo-node--api {
   grid-column: 2;
   grid-row: 2;
-  border-color: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 24%);
-  background: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-panel-strong) 86%);
+  border-color: color-mix(in srgb, var(--dp-primary), var(--dp-border) 30%);
+  background: color-mix(in srgb, var(--dp-primary), var(--dp-bg-card) 92%);
 }
 
 .tachigo-node--ledger {
   grid-column: 2;
   grid-row: 3;
+  border-color: color-mix(in srgb, var(--dp-success), var(--dp-border) 40%);
 }
 
 .tachigo-node--tachiya {
   grid-column: 3;
   grid-row: 2;
-  border-color: color-mix(in srgb, var(--tachigo-amber), var(--tachigo-line) 26%);
+  border-color: color-mix(in srgb, var(--dp-warning), var(--dp-border) 35%);
 }
 
 .tachigo-node--external {
   grid-column: 3;
   grid-row: 3;
-  border-color: color-mix(in srgb, var(--tachigo-signal), var(--tachigo-line) 36%);
+  border-color: color-mix(in srgb, var(--dp-danger), var(--dp-border) 40%);
 }
 
 .tachigo-route-board {
@@ -346,56 +665,58 @@
   flex-direction: column;
   justify-content: space-between;
   padding: 1rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background: var(--tachigo-panel);
-  color: var(--tachigo-ink);
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  color: var(--dp-text-primary);
+  box-shadow: var(--dp-shadow-card);
   text-decoration: none;
-  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
 
 .tachigo-card--wide {
   grid-column: span 2;
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--tachigo-ink), transparent 4%), color-mix(in srgb, var(--tachigo-ink), transparent 12%));
-  color: var(--ifm-background-color);
+  border-color: var(--dp-primary);
+  background: linear-gradient(135deg, var(--dp-primary), var(--dp-primary-strong));
+  color: var(--dp-text-inverse);
 }
 
 .tachigo-card:hover {
-  color: var(--tachigo-ink);
+  border-color: var(--dp-primary);
+  box-shadow: var(--dp-shadow-card-hover);
+  color: var(--dp-text-primary);
   text-decoration: none;
   transform: translateY(-2px);
-  border-color: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 30%);
 }
 
 .tachigo-card--wide:hover {
-  color: var(--ifm-background-color);
+  color: var(--dp-text-inverse);
 }
 
 .tachigo-card__eyebrow {
-  color: var(--tachigo-signal);
+  color: var(--dp-primary);
   font-size: 0.72rem;
-  font-weight: 800;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.tachigo-card--wide .tachigo-card__eyebrow {
-  color: color-mix(in srgb, var(--tachigo-amber), #ffffff 24%);
+.tachigo-card--wide .tachigo-card__eyebrow,
+.tachigo-card--wide .tachigo-card__body {
+  color: rgba(255, 255, 255, 0.86);
 }
 
 .tachigo-card h2 {
   margin: 1.2rem 0 0.55rem;
+  color: inherit;
   font-size: 1.22rem;
+  letter-spacing: 0;
 }
 
 .tachigo-card__body {
-  color: var(--tachigo-muted);
+  color: var(--dp-text-secondary);
   font-size: 0.92rem;
   line-height: 1.58;
-}
-
-.tachigo-card--wide .tachigo-card__body {
-  color: color-mix(in srgb, var(--ifm-background-color), transparent 18%);
 }
 
 .tachigo-flow-strip {
@@ -412,9 +733,10 @@
   align-items: stretch;
   min-height: 72px;
   padding: 0.65rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background: var(--tachigo-panel);
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  box-shadow: var(--dp-shadow-card);
 }
 
 .tachigo-flow span,
@@ -423,27 +745,31 @@
   align-items: center;
   min-height: 42px;
   padding: 0.4rem 0.48rem;
-  border: 1px solid var(--tachigo-soft-line);
-  border-radius: 6px;
+  border: 1px solid var(--dp-border-subtle);
+  border-radius: var(--dp-radius-sm);
   font-size: 0.76rem;
   line-height: 1.25;
 }
 
 .tachigo-flow strong {
-  color: var(--tachigo-ink);
-  background: color-mix(in srgb, var(--tachigo-cyan), transparent 88%);
+  background: var(--dp-primary-soft);
+  color: var(--dp-primary);
+  font-weight: 600;
 }
 
 .tachigo-flow span {
-  color: var(--tachigo-muted);
+  background: var(--dp-bg-subtle);
+  color: var(--dp-text-secondary);
 }
 
 .tachigo-band {
   margin: 1.4rem 0 1.8rem;
   padding: 1.05rem;
-  border-left: 4px solid var(--tachigo-signal);
-  background: color-mix(in srgb, var(--tachigo-panel), transparent 10%);
-  color: var(--tachigo-muted);
+  border: 1px solid var(--dp-border);
+  border-left: 4px solid var(--dp-primary);
+  border-radius: var(--dp-radius-md);
+  background: var(--dp-bg-subtle);
+  color: var(--dp-text-secondary);
   line-height: 1.65;
 }
 
@@ -456,18 +782,24 @@
 
 .tachigo-checklist section {
   padding: 1rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background: var(--tachigo-panel);
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  box-shadow: var(--dp-shadow-card);
 }
 
 .tachigo-checklist h2 {
   margin-top: 0;
+  color: var(--dp-text-primary);
   font-size: 1.05rem;
 }
 
+.tachigo-checklist h2::before {
+  content: none;
+}
+
 .tachigo-checklist__body {
-  color: var(--tachigo-muted);
+  color: var(--dp-text-secondary);
   line-height: 1.6;
 }
 
@@ -476,11 +808,12 @@
   align-items: center;
   min-height: 28px;
   padding: 0.2rem 0.55rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 999px;
-  color: var(--tachigo-muted);
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-sm);
+  background: var(--dp-bg-subtle);
+  color: var(--dp-text-secondary);
   font-size: 0.78rem;
-  font-weight: 760;
+  font-weight: 600;
 }
 
 .tachigo-related-links {
@@ -488,9 +821,10 @@
   gap: 0.85rem;
   margin: 2rem 0 1.2rem;
   padding: 1rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background: var(--tachigo-panel);
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  box-shadow: var(--dp-shadow-card);
 }
 
 .tachigo-related-links__group {
@@ -500,9 +834,9 @@
 
 .tachigo-related-links__group h3 {
   margin: 0;
-  color: var(--tachigo-muted);
+  color: var(--dp-text-secondary);
   font-size: 0.82rem;
-  font-weight: 800;
+  font-weight: 700;
 }
 
 .tachigo-related-links__chips {
@@ -517,30 +851,31 @@
   justify-content: center;
   min-height: 30px;
   padding: 0.2rem 0.62rem;
-  border: 1px solid color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 45%);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--tachigo-cyan), transparent 88%);
-  color: var(--tachigo-ink);
+  border: 1px solid color-mix(in srgb, var(--dp-primary), var(--dp-border) 45%);
+  border-radius: var(--dp-radius-sm);
+  background: var(--dp-primary-soft);
+  color: var(--dp-primary);
   font-size: 0.84rem;
-  font-weight: 800;
+  font-weight: 600;
   line-height: 1;
   text-decoration: none;
 }
 
 .tachigo-related-links__chip:hover {
-  border-color: color-mix(in srgb, var(--tachigo-cyan), var(--tachigo-line) 18%);
-  color: var(--tachigo-ink);
+  border-color: var(--dp-primary);
+  color: var(--dp-primary);
   text-decoration: none;
 }
 
 .tachigo-related-links__chip--inferred {
   gap: 0.4rem;
-  border-color: color-mix(in srgb, var(--tachigo-violet), var(--tachigo-line) 40%);
+  border-color: color-mix(in srgb, var(--tachigo-violet), var(--dp-border) 40%);
   background: color-mix(in srgb, var(--tachigo-violet), transparent 88%);
+  color: var(--tachigo-violet);
 }
 
 .tachigo-related-links__chip--inferred span {
-  color: var(--tachigo-muted);
+  color: var(--dp-text-secondary);
   font-size: 0.72rem;
 }
 
@@ -550,12 +885,17 @@
 }
 
 .tachigo-reverse-index__warning,
+.tachigo-reverse-index-empty,
+.tachigo-reverse-index__item {
+  border: 1px solid var(--dp-border);
+  border-radius: var(--dp-radius-lg);
+  background: var(--dp-bg-card);
+  color: var(--dp-text-secondary);
+}
+
+.tachigo-reverse-index__warning,
 .tachigo-reverse-index-empty {
   padding: 0.8rem 1rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background: var(--tachigo-panel);
-  color: var(--tachigo-muted);
 }
 
 .tachigo-reverse-index__list {
@@ -565,28 +905,25 @@
 
 .tachigo-reverse-index__item {
   padding: 0.95rem;
-  border: 1px solid var(--tachigo-line);
-  border-radius: 8px;
-  background: var(--tachigo-panel);
 }
 
 .tachigo-reverse-index__item h3 {
   margin: 0.4rem 0;
+  color: var(--dp-text-primary);
   font-size: 1rem;
 }
 
-.tachigo-reverse-index__item p {
-  margin: 0;
-  color: var(--tachigo-muted);
+.tachigo-reverse-index__item p,
+.tachigo-reverse-index__meta {
+  color: var(--dp-text-secondary);
 }
 
 .tachigo-reverse-index__meta {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
-  color: var(--tachigo-muted);
   font-size: 0.78rem;
-  font-weight: 760;
+  font-weight: 600;
 }
 
 @media (max-width: 1120px) {
@@ -596,7 +933,7 @@
 
   .tachigo-hero h1 {
     max-width: 14ch;
-    font-size: 3.8rem;
+    font-size: 3.1rem;
   }
 
   .tachigo-route-board {
@@ -638,7 +975,7 @@
 
   .tachigo-hero h1 {
     max-width: 12ch;
-    font-size: 2.65rem;
+    font-size: 2.4rem;
   }
 
   .tachigo-status-rail,

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -46,7 +46,7 @@
   --ifm-navbar-background-color: rgba(255, 255, 255, 0.96);
   --ifm-font-family-base: "Inter", "Noto Sans TC", system-ui, sans-serif;
   --ifm-heading-font-family: "Inter", "Noto Sans TC", system-ui, sans-serif;
-  --ifm-font-family-monospace: "JetBrains Mono", SFMono-Regular, Consolas, monospace;
+  --ifm-font-family-monospace: "JetBrains Mono", "SFMono-Regular", "Consolas", monospace;
   --ifm-code-font-size: 90%;
   --ifm-heading-color: var(--dp-text-primary);
   --ifm-link-color: var(--dp-primary);

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -129,8 +129,13 @@ body {
 .menu__link--active,
 .menu__link--active:hover {
   background: var(--dp-primary-soft);
-  color: var(--dp-primary);
+  color: var(--dp-primary-strong);
   font-weight: 600;
+}
+
+[data-theme='dark'] .menu__link--active,
+[data-theme='dark'] .menu__link--active:hover {
+  color: var(--ifm-color-primary-lighter);
 }
 
 .breadcrumbs__link,
@@ -167,10 +172,11 @@ body {
 
 .theme-doc-markdown > h1,
 article .markdown > h1 {
-  margin-bottom: 0.65rem;
+  margin-bottom: 0.75rem;
   color: var(--dp-text-primary);
-  font-size: 2.1rem;
+  font-size: 1.95rem;
   font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
 .theme-doc-markdown > h2,
@@ -223,6 +229,7 @@ article table,
   border-spacing: 0;
   border-radius: var(--dp-radius-lg);
   background: var(--dp-bg-card);
+  box-shadow: var(--dp-shadow-card);
   font-size: 0.9rem;
 }
 
@@ -231,23 +238,33 @@ article table thead,
   background: var(--dp-bg-board);
 }
 
+[data-theme='dark'] article table thead,
+[data-theme='dark'] .theme-doc-markdown table thead {
+  background: rgba(76, 154, 255, 0.10);
+}
+
 article table th,
 .theme-doc-markdown table th {
-  padding: 0.65rem 0.9rem;
+  padding: 0.7rem 0.95rem;
   border: 0;
   border-bottom: 1px solid var(--dp-border);
   background: transparent;
   color: var(--dp-text-secondary);
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
   text-align: left;
   text-transform: uppercase;
 }
 
+[data-theme='dark'] article table th,
+[data-theme='dark'] .theme-doc-markdown table th {
+  color: var(--ifm-color-primary-lighter);
+}
+
 article table td,
 .theme-doc-markdown table td {
-  padding: 0.7rem 0.9rem;
+  padding: 0.7rem 0.95rem;
   border: 0;
   border-bottom: 1px solid var(--dp-border-subtle);
   background: transparent;
@@ -258,12 +275,22 @@ article table td,
 article table tbody tr,
 .theme-doc-markdown table tbody tr {
   background: transparent;
-  transition: background 100ms ease;
+  transition: background 120ms ease;
+}
+
+article table tbody tr:nth-child(even),
+.theme-doc-markdown table tbody tr:nth-child(even) {
+  background: var(--dp-bg-subtle);
+}
+
+[data-theme='dark'] article table tbody tr:nth-child(even),
+[data-theme='dark'] .theme-doc-markdown table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
 }
 
 article table tbody tr:hover,
 .theme-doc-markdown table tbody tr:hover {
-  background: var(--dp-bg-subtle);
+  background: var(--dp-primary-soft);
 }
 
 article table tbody tr:last-child td,
@@ -273,12 +300,20 @@ article table tbody tr:last-child td,
 
 article :not(pre) > code,
 .theme-doc-markdown :not(pre) > code {
-  padding: 1px 5px;
+  padding: 1px 6px;
+  border: 1px solid var(--dp-border-subtle);
   border-radius: var(--dp-radius-sm);
   background: var(--dp-bg-board);
   color: var(--dp-danger);
   font-family: var(--ifm-font-family-monospace);
-  font-size: 0.9em;
+  font-size: 0.88em;
+}
+
+[data-theme='dark'] article :not(pre) > code,
+[data-theme='dark'] .theme-doc-markdown :not(pre) > code {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: #ff9d85;
 }
 
 article pre,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,12 @@ importers:
       '@easyops-cn/docusaurus-search-local':
         specifier: 0.55.1
         version: 0.55.1(@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(postcss@8.5.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(postcss@8.5.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(postcss@8.5.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
+      '@fontsource/inter':
+        specifier: 5.2.8
+        version: 5.2.8
+      '@fontsource/jetbrains-mono':
+        specifier: 5.2.8
+        version: 5.2.8
       '@mdx-js/react':
         specifier: 3.1.1
         version: 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -1591,6 +1597,12 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@fontsource/inter@5.2.8':
+    resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
+
+  '@fontsource/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -9436,6 +9448,10 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@fontsource/inter@5.2.8': {}
+
+  '@fontsource/jetbrains-mono@5.2.8': {}
 
   '@hapi/hoek@9.3.0': {}
 


### PR DESCRIPTION
## 什麼改動
Dev Portal 視覺重塑 PR 1/3：CSS 設計系統，方向採 engineering console / atlas workbook。

- 新增 `@fontsource/inter` 與 `@fontsource/jetbrains-mono`，由 `apps/docs/src/css/custom.css` self-hosted import 載入，不使用 Google Fonts CDN。
- 重寫 `apps/docs/src/css/custom.css`：建立 `--dp-*` token、light/dark surface/text/border 對應，並套用 article table / heading / code / pre / blockquote / link 全域樣式。
- 保留首頁既有 `.tachigo-*` JSX class，不改 markup；CSS 內將 legacy token remap 到 `--dp-*`，並重塑首頁為文件導覽 console。

**注意：** 設計 spec（`docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md`）已拆出獨立 PR `#769` review；本 PR 不再包含 spec 文件，只專注 CSS 實作。

## 為什麼
closes #728

#728 要求 Dev Portal 在公開部署前完成 PR 1/3 的 CSS 設計系統，讓內頁不再依賴 Docusaurus 預設樣式。實作過程中人工檢視後認定原 Trello 方向不適合 tachigo Dev Portal，因此本 PR 保留 #728 的硬性 CSS/token/font 範圍，但改採更適合工程文件的 console / workbook 視覺語言。

設計 spec 拆出獨立 PR 是因為原本 #732 包含 CSS + spec 達 1138 行，超過 scope police 1000 行硬限。拆分後 CSS PR 為 ~898 行（黃燈區），spec PR 為 ~237 行。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#728；spec PR `#769`
- Depends on PR：none
  - 備註：spec PR #769 為獨立 source-of-truth doc，本 PR 為實作 PR，兩者不互相 block
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不含 spec 文件（已拆 `#769`）
  - 不新增 MDX 元件；不重組 sidebar；不處理 Coming soon stubs；不搬 reference-notes archive；不部署 Cloudflare Pages；不引入 i18n。

## Delegation Execution Log
- Source issue delegation plan：#728
- Actual worker profile(s)：
  - controller（Claude Code）：實作 + 執行 PR 拆分（git surgery）
  - review_worker（Codex / codex-rescue）：pre-push gate verification（6 項檢查全 PASS）
- Model strength：Claude implementation = high；Codex verification = high
- Spawn directive(s)：profile=codex-rescue model=gpt-5.5 reasoning=xhigh controller_fallback=claude-code
- Verification evidence：
  - `pnpm --filter @tachigo/docs install` pass
  - `pnpm --filter @tachigo/docs build` pass（[SUCCESS] Generated static files in "build"）
  - Codex pre-push gate：CSS scope clean、spec scope clean、CSS content vs snapshot 0-byte diff、build pass、push targets readback
- Self-review / exception reason：已 self-review；CSS 內容自 safety/pr732-snapshot 完整保留
- Worker session closeout：Codex pre-push gate 已 GREEN 並關閉
- Workflow friction / follow-up split：spec 拆出獨立 PR；MDX 元件留 PR 2、sidebar/資料整理留 PR 3（皆未開）

## Review conversation closeout
- Unresolved threads：0（force-push 後 review 重啟）
- CodeRabbit：pending（force-push 後重新觸發）
- chatgpt-codex-connector：pending
- review_triage_ref：https://github.com/nurockplayer/tachigo/pull/732
- root_cause_gate_ref：https://github.com/nurockplayer/tachigo/pull/732
- finding_disposition_ref：https://github.com/nurockplayer/tachigo/pull/732
- Final reviewer action：pending

## Final merge gate
- Ready-to-merge decision：pending（需 spec PR 與本 PR 各自通過 review）
- Latest head SHA：93d3a3a6
- Required checks：pending（force-push 後重跑）
- spec workflow-check evidence：n/a
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/732

## PR 拆分檢查
- 這個 PR 的單一句子目的：建立 Dev Portal CSS 設計系統與 self-hosted font loading（純 CSS 實作）
- Approx changed lines：~898 changed lines against `origin/develop`（553 additions / 345 deletions）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs（self-hosted font import 註解；spec 已拆出）
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - 設計 spec：`#769`
  - PR 2（MDX 元件）：未開
  - PR 3（sidebar 重組 + 資料整理）：未開

## Acceptance Criteria
- [x] `--dp-*` token 變數與 light/dark token 區段已加入 `apps/docs/src/css/custom.css`
- [x] 已加入 self-hosted `@fontsource/inter` 與 `@fontsource/jetbrains-mono`
- [x] article table / h2 / h3 / inline code / pre / blockquote / links 已套用全域 CSS 規格
- [x] 首頁 `.tachigo-*` class 保留，配色改由 CSS token remap 驅動
- [x] `cd apps/docs && pnpm build` 通過
- [x] 總 diff 控制在 1000 行硬限內（898 行）
- [x] 不再依賴 `scope-exception` label

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試（純樣式調整）

**驗證結果**

```
$ pnpm --filter @tachigo/docs build
> docusaurus build
[INFO] [zh-Hant] Creating an optimized production build...
[webpackbar] ✔ Server: Compiled successfully in 11.26s
[webpackbar] ✔ Client: Compiled successfully in 46.80s
[SUCCESS] Generated static files in "build".

$ git diff --stat origin/develop...HEAD
 apps/docs/docusaurus.config.ts |   1 +
 apps/docs/package.json         |   2 +
 apps/docs/src/css/custom.css   | 879 +++++++++++++++++++++++++--
 pnpm-lock.yaml                 |  16 +
 4 files changed, 553 insertions(+), 345 deletions(-)
```

## 備註

- 本 PR 從原 1138-line 版本拆出 spec 文件後，diff 縮為 898 行，不再需要 `scope-exception` label
- CSS 內容自原 branch（safety/pr732-snapshot, `ccdfd4bf`）100% 保留，無 byte 級差異
- 設計 spec 拆至獨立 PR `#769`，建議兩 PR 平行 review

## Notes for Claude Code Review
- `docs/index.md` 沒有 inline hard-coded colors；依 #728 要求保留 `.tachigo-*` markup，首頁換色由 CSS token remap 完成
- Blockquote emoji first-character auto-color 無法用穩定純 CSS selector 精準判斷；目前提供 default callout 與 `.tachigo-callout--idea/warning/danger/note` hooks
- Browser 檢視首頁、Start Here、Domain Maps 的 light/dark 與 375px mobile 已通過
