### PR TITLE
docs: extension 導航架構 + 功能 MVP spec 與實作計劃

### DIFF
--- a/docs/superpowers/specs/2026-05-16-extension-navigation-and-mvp-design.md
+++ b/docs/superpowers/specs/2026-05-16-extension-navigation-and-mvp-design.md
@@ -1,0 +1,365 @@
+# Tachigo Extension — 導航架構 + 功能 MVP 設計
+
+狀態：定稿 v4（已通過三輪 Codex review，第三輪結論「可開工」，**尚未 commit / push**）
+日期：2026-05-16
+相關：[discussion #710](https://github.com/nurockplayer/tachigo/discussions/710)、`plans/ocean-mining-character-system-phase1.md`
+
+> v3 變更摘要：第二輪 Codex review 指出 `claim` 與 `redeem` 一樣需要 wallet +
+> 上鏈（`claim_service.go` 做 on-chain mint）。經對照程式碼驗證屬實。已新增
+> 後端 PR、補上 $TACHI 交易帳本與兌換 idempotency 設計、修正開機分流 UX、
+> 釐清流式佈局的拆分範圍。完整處置見第 11 段。
+
+---
+
+## 1. 背景與目標
+
+`apps/extension` 目前是以 demo state 驅動的原型：畫面用扁平的 `DemoScreen`
+字串 enum 切換，資料來自 `loadDemoState` / `saveDemoState`（chrome storage 假資料）。
+
+本設計做兩件事：
+
+1. **導航骨架**：把扁平 screen enum 重構成兩層導航（全螢幕 scene + 疊層 overlay），
+   讓後續十幾個畫面能逐張掛上、不互相牽動。
+2. **功能 MVP**：把核心循環接成真實後端——Twitch 登入（自動建 tachigo 帳號）→
+   實際挖礦累積點數 → claim 成 $TACHI → 用 $TACHI 換 Tachiya 商城折價券。汰除 demo state。
+
+MVP 定位是「**最簡可用版本，先做內部測試**」：只用螃蟹單一角色、無進化、無其他角色。
+
+**運行型態（已拍板）**：MVP **只支援 Twitch 站內 extension**，登入一律走
+`onAuthorized` extension JWT。standalone（popup / sidepanel）與手機端置後，
+MVP 不做 OAuth redirect 登入路徑。
+
+**設計尺寸（已拍板）**：採**流式響應式佈局**，不寫死 px——寬度設計基準 **360**、
+下限 **320**（吃得下 Twitch Panel 型 extension）、上限約 **430**（大尺寸手機）；
+高度永遠流式（`min-height` + 內容可捲動）。實作用 `%` / `flex` / `clamp()`。
+這樣同一份程式碼在 Twitch panel、瀏覽器側邊欄、手機 360–430 都不需重切。
+
+**MVP $TACHI 經濟（已拍板）**：claim 與 redeem 在 MVP **皆走 DB-only 路徑**，
+不需 Web3 wallet、不上鏈。on-chain mint / burn 是後續迭代，不在 MVP。
+
+非目標：#710 海洋角色系統不在 MVP，獨立 track 排在 MVP 之後；本設計只負責「預留位置」。
+
+---
+
+## 2. 現況
+
+- `apps/extension/src/app/App.tsx`：扁平 `DemoScreen = 'login'|'loading'|'hud'|'claim'|'coupon'|'raffle'`，
+  條件渲染，底部一排 **永遠 render** 的 dev 導航鈕（非 dev-only）。frame 寫死 320。
+- 既有畫面元件：`LoginScreen`、`LoadingScreen`、`MarioHUD`（挖礦主頁，capybara）、
+  `ClaimPanel`、`CouponShopPanel`、`RaffleResultPanel`、`LanguageSwitcher`。
+  → `ClaimPanel` 仍是 demo CPC→TCG 換算；`CouponShopPanel` 用 demo catalog。
+  → `LoginScreen` / `MarioHUD` / `ClaimPanel` 等內部都寫死 `width: 320`（不只 App frame）。
+- 既有 hooks：`useTwitch`（`onAuthorized` JWT → 後端換 token；目前把所有 login
+  失敗都壓成 `Backend unavailable`，未區分 identity 未分享 / JWT 無效）、
+  `useHeartbeat`、`useClickBoost`、`useTPoint`、`useRaffleResult`。
+- 後端（`services/api/internal/`）關鍵事實（已對照程式碼確認）：
+  - `extension_service.go` `LoginWithExtension`：**不會建帳號**，查不到 `ProviderTwitch`
+    連結回 `ErrUserNotFound`；`claims.UserID` 為空（未分享 identity）回 `ErrInvalidExtJWT`。
+  - `auth_service.go` `upsertOAuthUser`（OAuth callback 路線）：**會** find-or-create user。
+    `users.email` / `username` 皆可為 nil。`auth_providers(provider, provider_id)` 的
+    unique index 主要在 migration 建立，AutoMigrate 未必明確建出（須確認 fresh DB）。
+  - `claim_service.go` `Claim`：`resolveWalletAddress` → `MintBroadcastOnChain` →
+    `WaitMintReceiptOnChain` → 寫 `tachi_balances.balance`。**需 wallet + 上鏈 mint**。
+  - `spend_service.go` `Redeem`：`resolveWalletAddress` + `BurnOnChain`。**需 wallet + 上鏈 burn**。
+  - `models/tachi_balance.go` `TachiBalance`：單列 aggregate（`UserID uniqueIndex` + `Balance`），
+    **無 $TACHI 交易流水、無 coupon 兌換記錄**。
+  - 路由：`/extension/auth/login`、`/extension/watch/*`、`/api/v1/users/me/points/claim`、
+    `/api/v1/spend/redeem`。
+- 前端 `redeemCoupon()` 繞過 `runWithAuthRecovery`、手動塞 `Authorization: Bearer ${token}`。
+- Figma `Tachigo Prototype v1`：01 主視覺、02 登入、02-1 註冊、02-2 忘記密碼、
+  03 角色選擇、04 挖礦主頁、05 claim、06 coupon market。
+
+---
+
+## 3. 設計決策：兩層導航（不引入 router）
+
+- **A（採用）兩層導航**：`scene` 狀態機 + `overlayStack` 疊層。自訂 `NavigationProvider`
+  （context + reducer），不引入 router lib。
+- B Hash router：Twitch Extension iframe 無有意義 URL / history，疊層無法乾淨對應 route。
+- C 擴充扁平 enum：無疊層、無 stack、無返回，面板長到 10+ 會腐爛。
+
+採用 A：貼合無 URL 環境、輕量、返回鍵語意清楚、好持久化、好測試。
+
+---
+
+## 4. 畫面盤點
+
+### Scenes（全螢幕流程）
+
+| scene | 對應 | 現況 | MVP? |
+|---|---|---|---|
+| `entry` | 程式入口主視覺（press-to-enter） | 🆕 新增 | ✅ |
+| `login` | 登入（Login with Twitch 為主） | 改造 `LoginScreen` | ✅ |
+| `loading` | 認證 / 串接畫面（含 error / retry） | 沿用 `LoadingScreen`（擴充狀態） | ✅ |
+| `character-select` | 角色選擇畫面 | 🆕 placeholder | ⏸ #710 |
+| `mining` | 挖礦主頁面（螃蟹） | 沿用 `MarioHUD` | ✅ |
+
+### Overlays（疊在當前 scene 上）
+
+| overlay | 對應 | 現況 | MVP? |
+|---|---|---|---|
+| `claim` | 點數 claim → $TACHI | 沿用 `ClaimPanel`（需接線） | ✅ |
+| `shop` | Tachiya 折價券商店 | 沿用 `CouponShopPanel`（需接線） | ✅ |
+| `raffle-result` | 抽獎結果（需 `raffleId` param） | 沿用 `RaffleResultPanel` | ✅（既有） |
+| `menu` | 齒輪 hub 選單 | 🆕 骨架接線、視覺置後 | ⏸ |
+| `account` | 帳號角色資訊 | 🆕 placeholder | ⏸ |
+| `settings` | 語言/畫面/音效/特效/HUD 開關 | 🆕 placeholder | ⏸ |
+| `character-switch` | 角色變換（≈ #710 CharacterMenu） | 🆕 placeholder | ⏸ #710 |
+| `collection` | 圖鑑 | 🆕 placeholder | ⏸ #710 |
+| `missions` | 任務 | 🆕 placeholder | ⏸ #710 Phase 2 |
+| `equipment` | 裝備欄 | 🆕 placeholder | 🧊 Icebox |
+| `onboarding` | 首次 mining 新手導覽 | 🆕 placeholder | ⏸ |
+
+### 已確認的設計細節
+
+- `character-select` (scene) 與 `character-switch` (overlay) 共用 `CharacterPicker` 元件。
+- `entry` 是品牌主視覺，點任意處 → `login`；之後可做動態版（Icebox）。
+- `login` scene 內含登入 / 註冊 / 忘記密碼三子畫面，由 scene 元件 local state 管，
+  不佔全域 scene。MVP 只有「Login with Twitch」功能可用；其餘先 render、不接線。
+- 齒輪 = 選單 hub：點齒輪出 `menu` overlay，`pushOverlay` 到子面板。
+- `mining` 頁的 claim / shop 入口在 MVP 用直接按鈕，不依賴齒輪 hub。
+
+---
+
+## 5. 導航骨架資料結構
+
+```ts
+// src/app/navigation/types.ts
+type Scene   = 'entry' | 'login' | 'loading' | 'character-select' | 'mining'
+type Overlay =
+  | 'claim' | 'shop' | 'raffle-result' | 'menu'
+  | 'account' | 'settings' | 'character-switch'
+  | 'collection' | 'missions' | 'equipment' | 'onboarding'
+
+type OverlayEntry =
+  | { kind: 'raffle-result'; params: { raffleId: string } }
+  | { kind: Exclude<Overlay, 'raffle-result'>; params?: undefined }
+
+interface NavState {
+  scene: Scene
+  overlayStack: OverlayEntry[]          // 後進先出
+  flags: {
+    hasCompletedLogin: boolean          // 曾成功登入 → 開機可略過 entry/login
+    onboardingVersion: number           // 版本化；> 已看版本才重跳 onboarding
+    selectedCharacterOnce: boolean      // 預留給 #710
+  }
+}
+```
+
+- **`NavigationProvider`**（context + `useReducer`）提供
+  `goScene` / `pushOverlay(kind, params?)` / `popOverlay` / `closeAllOverlays` / `setFlag`。
+- **push 去重**：僅當 `kind` **且 `params` 皆相同**、且位於 stack 頂端時才不重複堆疊
+  （防 menu 疊 menu）；同 `kind` 但 `params` 不同 → 視為新 entry 照常 push
+  （例如 raffle A 已在頂端、push raffle B 不可被吃掉）。
+- `goScene` 會清空 `overlayStack`。
+- **渲染**：`App.tsx` → `<SceneRenderer>` 打底 + `<OverlayHost>` 由下往上疊；
+  每個 overlay 自帶半透明 backdrop，點 backdrop / 返回鍵 = `popOverlay`。
+- **持久化**：只把 `flags` 寫進 storage；`scene` / `overlayStack` 不持久化。
+  storage key 從 `tachigo.sidepanel.demo-state.v2` 升為 `tachigo.sidepanel.app-state.v3`，
+  舊資料 sanitize 後丟棄不相容欄位。
+
+### 開機分流（auth 驅動，修正 v2 的 UX 矛盾）
+
+`api.ts` 無持久後端 token（access token 只存 module global、`useTwitch` unmount
+即清）。開機流程依 `flags.hasCompletedLogin` 分兩種：
+
+- **首次使用（`hasCompletedLogin = false`）**：`scene = 'entry'`。背景仍等
+  `onAuthorized` 預熱 extension JWT，但**不自動進 mining**——使用者必須走
+  `entry` → `login` → 按「Login with Twitch」才轉場。即使 identity 已分享、
+  背景已能登入，首次仍要看 entry/login（產品已確認首次需引導）。
+- **回訪（`hasCompletedLogin = true`）**：`scene = 'loading'`，等 `onAuthorized`
+  → 後端 extension 登入：成功 → `goScene('mining')`；失敗 → `loading` 顯示
+  error / retry（沿用 `useTwitch` 15s retry），不退回 entry。
+- 後端登入回 401 / B1 回錯 → `flags.hasCompletedLogin` 清為 false（列入 reducer
+  / storage 測試）。
+- `loading` scene 必須涵蓋 authorizing / error / retry 三種狀態。
+
+### Scene 轉場規則（MVP）
+
+| 從 | 事件 | 到 |
+|---|---|---|
+| `entry` | 點任意處 | `login` |
+| `login` | Login with Twitch 成功（含後端 B1 自動建帳號） | `loading` → `mining`，並設 `hasCompletedLogin=true` |
+| `loading` | extension 登入成功 | `mining` |
+| `mining` | 點 claim / shop 按鈕 | `pushOverlay('claim' \| 'shop')` |
+| `mining` | 點齒輪 | `pushOverlay('menu')` |
+| 任一 overlay | backdrop / 返回 | `popOverlay` |
+
+---
+
+## 6. 骨架實作範圍（F1）
+
+**會寫的：**
+
+1. 新增 `src/app/navigation/`：`types.ts`、`NavigationProvider.tsx`、`useNavigation.ts`。
+2. `SceneRenderer`、`OverlayHost` 兩個渲染元件。
+3. 改寫 `App.tsx`：移除扁平 `screen` state，改用 `NavigationProvider`；
+   **App 外層 shell** 改成流式（寬 320–430、彈性高）。
+4. 擴充 `extension/storage.ts` / `types.ts`：移除 `DemoState.screen`，新增 `flags`；
+   storage key 升 `v3`，舊資料 sanitize。
+5. 既有畫面接線（內容不動）：`LoginScreen`→`login`、`LoadingScreen`→`loading`、
+   `MarioHUD`→`mining`；`ClaimPanel`→`claim`、`CouponShopPanel`→`shop`、
+   `RaffleResultPanel`→`raffle-result`（`onBack`→`popOverlay`，raffle 帶 `raffleId`）。
+6. 新畫面建 placeholder（標題 + 返回鍵；文案走 i18n locale key 或標 dev-only）：
+   `entry`、`character-select`、`account`、`settings`、`collection`、`missions`、
+   `equipment`、`onboarding`。**新 placeholder 一律用流式佈局。**
+7. `menu` 齒輪 hub：骨架就要能動——真按鈕，`pushOverlay` 到對應子面板。
+8. dev 導航列：以 `import.meta.env.DEV` gate，production build 不 render（完成條件）。
+9. 測試：reducer 單元測試（轉場、疊層、push 去重含 params、`goScene` 清疊層、
+   401 清 `hasCompletedLogin`）+ storage 遷移測試。
+
+**流式佈局的範圍界定**：F1 只負責 **App 外層 shell + 新 placeholder** 流式。
+既有元件（`LoginScreen` / `MarioHUD` / `ClaimPanel` / `CouponShopPanel`）內部仍
+寫死 `width: 320`；它們的流式改造**併入各自的 MVP PR**（login→F3、mining→F4、
+claim→F5、shop→F6）一起做，不在 F1 retrofit 全部元件（避免 F1 爆量）。
+
+**內部拆分建議**（避免單 PR 超過 CLAUDE.md 400 行軟門檻）：
+- F1a：`navigation/` reducer + types + storage 遷移 + 測試。
+- F1b：`SceneRenderer` / `OverlayHost` + `App.tsx` 接線 + shell 流式 + placeholder + dev gate。
+
+**不在 F1：** 任何新畫面真實 UI / 內容、真實後端串接、既有元件內部流式改造、#710。
+
+---
+
+## 7. MVP 分期（後端 contract-first，再前端）
+
+依 CLAUDE.md「PR 不得依賴未 merge 的 PR」，後端 PR 須先 merge 進 `develop`。
+
+### 後端
+
+| PR | 標題 | 內容 |
+|---|---|---|
+| B1 | `[backend] extension JWT 登入自動建帳號` | 改 `LoginWithExtension`：查無 `ProviderTwitch` 連結時，用 extension JWT 的 Twitch user_id（需 identity 已分享）自動 find-or-create tachigo user + `AuthProvider`（仿 `upsertOAuthUser`）。**完成條件**：以 transaction + unique constraint 衝突回復處理並發登入；補 concurrent login 測試；確認 fresh dev DB 會建立 `auth_providers(provider, provider_id)` partial unique index——它來自 migration `014_auth_provider_partial_unique.sql`（非 model tag），B1 須確認 runtime migration / fresh setup 真的會跑到它。匿名 user 的 username 用 deterministic 規則（如 `twitch_<userID>`）或保持 nil，不可拿 opaque id 當穩定公開名稱。 |
+| B2 | `[backend] MVP DB-only $TACHI claim 路徑` | 新增**不需 wallet、不上鏈** 的 claim path：扣 `points_ledgers.spendable_balance`、增 `tachi_balances.balance`。新增**可稽核的 $TACHI 交易帳本** `tachi_balance_transactions`（user_id / delta / `source` / balance_after / `reference_type` / `reference_id` / created_at），claim 與日後 redeem 共用。**驗收條件**：鎖 `points_ledgers`、扣 `spendable_balance`、寫 `points_transactions`、upsert `tachi_balances`、寫 `tachi_balance_transactions` 必須在**單一 DB transaction 內原子完成**（參照 `claim_service.go` 既有 `FOR UPDATE` 鎖帳與 `finalizeClaim` upsert）。`source` 定成可稽核 enum（至少分 `claim_db` / `redeem_db` / 未來 on-chain）。與既有 on-chain `Claim` 並存，MVP 走新 path。 |
+| B3 | `[backend] MVP DB-only coupon 兌換 + redemption ledger` | 新增不需 wallet、不上鏈 的兌券 path。新增 `coupon_redemptions` 表（user_id / coupon_id / amount / status / voucher_code / **idempotency_key**），以 unique constraint 擋同券重複扣款。**Tachiya 發券是外部副作用，無法與 DB transaction 原子化**——status flow：先在 DB 建 `pending/reserved` redemption + 扣 `tachi_balances.balance` + 寫 `tachi_balance_transactions(source=redeem_db)`，再 call Tachiya，成功補 `voucher_code` 並標 `completed`，失敗則回補餘額或標記可重試（B3 計劃須拍板）。endpoint 用產品語意（如 `/extension/coupons/redeem`）。 |
+
+### 前端
+
+| PR | 標題 | 內容 | 依賴 |
+|---|---|---|---|
+| F1 | `[frontend] extension 導航骨架` | 第 5、6 段（可內部拆 F1a/F1b） | — |
+| F2 | `[frontend] entry 主視覺畫面` | 01_First page 靜態主視覺 + press-to-enter → `login`；流式 | F1 |
+| F3 | `[frontend] Login with Twitch + identity share` | 02 畫面；「Login with Twitch」主路徑 → 取得 extension JWT → 呼叫 B1 自動建帳號 → 抓 `channelId`。**需補 Twitch helper action 型別（`requestIdShare`）、把 `useTwitch` 的 login 失敗分類（identity 未分享 / JWT 無效 / 後端不可用）並對應 UX**。帳密表單 / Sign Up / Forgot 先 render、不接線。元件流式改造一併做 | F1, B1 |
+| F4 | `[frontend] 真實挖礦（螃蟹單角色）` | `mining` 接真實 heartbeat/click/points/balance；單一螃蟹、無進化；汰除 `HudDemoState`；capybara 美術換螃蟹（正式美術未到位前用 placeholder）；元件流式改造 | F1, B1 |
+| F5 | `[frontend] 真實點數 claim` | `claim` overlay 接 B2 的 DB-only claim path → $TACHI；統一走 `runWithAuthRecovery`；元件流式改造 | F1, B2 |
+| F6 | `[frontend] 真實 Tachiya 折價券兌換` | `shop` overlay 接 B3 的 DB-only 兌換 path；`redeemCoupon()` 改用 tachigo access token + `runWithAuthRecovery`，移除手動 Bearer；元件流式改造 | F1, B3 |
+
+**F4 內部拆分建議**：(a) 真實 balance / 點數顯示接線、(b) click/heartbeat 互動 UI、
+(c) 移除 `HudDemoState`、(d) 螃蟹美術替換 + 流式。
+
+PR 順序即依賴順序；每張預估 < 400 行，超過於 issue 註明再拆。
+
+---
+
+## 8. 置後 / #710 同步 / Icebox
+
+**⏸ 置後 — UI/UX 與帳號功能（MVP 內測後）**
+
+`login` 帳密自訂 / 註冊 / 忘記密碼接線、`onboarding` 新手導覽、`menu` 齒輪 hub
+視覺、`settings` 設定面板、`account` 帳號資訊面板、`entry` 動態化、
+**$TACHI claim / redeem 的 on-chain mint / burn 版本**（MVP 是 DB-only）。
+
+**🌊 #710 海洋角色系統 — 獨立 track，排 MVP 之後**
+
+- MVP 鎖螃蟹單角色；#710 落地才啟用四角色、進化、buff，填上 `character-select`
+  scene、`character-switch` / `collection` overlay、首次選角分流。
+- `missions` 任務面板依 #710 Phase 2。
+- 骨架的 `Scene` / `Overlay` enum 已預留位置。**`flags` 不承諾「#710 完全不動骨架」**
+  ——#710 會需要 server-driven active character、ownership、cooldown 等狀態，
+  屆時 `flags` 與 overlay params 會擴充。骨架保證的是「scene/overlay 不必新增、
+  reducer 形狀穩定」。
+- 既有計劃文件：`plans/ocean-mining-character-system-phase1.md`。
+
+**🧊 Icebox**：`[discussion] 裝備欄系統`、`entry` 主視覺動態化。
+
+---
+
+## 9. 待確認問題
+
+均屬 B1/B2/B3/F3 issue 階段可定的實作細節，不擋 spec 定稿與 writing-plans：
+
+- [ ] B1：extension JWT payload 是否含 Twitch 顯示名稱 / email？若無，自動建立的
+      user 用 `twitch_<userID>` 或保持 nil（issue 階段定）。
+- [ ] B3：同一張 coupon 的兌換頻率政策——一生一次 / 每日一次 / 每個 idempotency key
+      一次 / 依 Tachiya voucher rule？直接決定 `coupon_redemptions` unique 鍵設計。
+- [ ] B2：`tachi_balance_transactions` 是否保留 `balance_before`（v4 只列 `balance_after`，
+      可運作；補 `balance_before` 稽核體驗較佳）——B2 issue 階段定。
+- [ ] B3：Tachiya voucher 發放成功但 DB 回寫失敗時，以 Tachiya 為準還是 tachigo DB
+      為準？需定 rollback / pending / 補償策略。
+- [ ] 使用者未同意 Twitch identity share 時，`login` 的 CTA 文案（F3 issue 定）。
+- [ ] 螃蟹美術資產由設計提供；MVP 內測先用 placeholder。
+- [ ] `extensions/tachigo-demo-sidepanel` 是否同步 / 廢棄，不在本範圍。
+
+---
+
+## 10. 驗證方式
+
+**骨架（F1）**
+1. reducer 單元測試：scene 轉場、疊層、push 去重（含 params 不同不去重）、
+   `goScene` 清疊層、401 清 `hasCompletedLogin`。
+2. storage 遷移測試：舊 `v2`（含 `screen`）可被 sanitize 成新 `v3`。
+3. 手動：dev 導航列走遍所有 scene/overlay；placeholder 返回鍵正常；
+   production build 不出現 dev 導航列。
+
+**MVP（B1/B2/B3 + F2~F6）端到端**
+4. 開啟 extension（首次）→ `entry` → 點擊 → `login`。
+5. 按「Login with Twitch」→ 引導分享 identity → 後端 B1 自動建立 tachigo 帳號
+   → `loading` → `mining`，`hasCompletedLogin` 設為 true。
+6. 回訪重開 → 略過 entry/login，`loading` → `mining`。
+7. `mining` 顯示正在觀看的頻道（`channelId`），螃蟹挖礦。
+8. 掛機 / 點擊 → 真實點數累積（非 demo state），重開 app 數值一致。
+9. 開 `claim` → 經 B2 DB-only path：`spendable_balance` 扣除、`tachi_balances.balance`
+   增加、$TACHI 交易帳本有記錄；**不需 wallet、不上鏈**。
+10. 開 `shop` → 經 B3 DB-only path 兌換 Tachiya 折價券 → $TACHI 扣除、
+    `coupon_redemptions` 有記錄；不需 wallet、不上鏈。
+
+**錯誤路徑（MVP 必測）**
+11. 後端不可用 → `loading` 顯示錯誤 + 重試。
+12. extension JWT 無效 / identity 未分享 → `login` 顯示對應分類 CTA（非籠統「Backend unavailable」）。
+13. claim / 兌換時 $TACHI 餘額不足 → 面板顯示明確錯誤、不扣款。
+14. 同一張 coupon 重複兌換 → `idempotency_key` / unique constraint 擋下、不重複扣款。
+15. Tachiya API 發券失敗 → 依 B3 定的策略 rollback / pending，DB 不出現「已扣款但無 voucher」。
+16. 並發 extension 登入（同一新使用者）→ B1 不建立重複 user / provider。
+
+---
+
+## 11. Codex review 處置紀錄
+
+### 第一輪
+
+| Codex 指出 | 驗證 | 處置 |
+|---|---|---|
+| Blocker：`/extension/auth/login` 不會自動建帳號 | 屬實 | 新增 B1 |
+| Blocker：`spend/redeem` 需 wallet + 上鏈 burn | 屬實 | 新增 DB-only 兌換路徑（v3 為 B3） |
+| Major：iframe OAuth redirect 不宜當主路徑 | 採納 | MVP 只走 `onAuthorized` JWT |
+| Major：`overlayStack` 缺 params | 屬實 | 改 `OverlayEntry` discriminated union |
+| Major：開機分流無持久 token | 屬實 | 改 auth 驅動分流 |
+| Major：F1 / F4 PR 偏大 | 採納 | 加內部拆分建議 |
+| Major：viewport 320 vs 360 | 屬實 | 改流式佈局（320–430） |
+| Major：`flags` 太薄 | 採納 | 加 `onboardingVersion`；改寫骨架保證範圍 |
+| Minor 多項 | 採納 | storage key v3、placeholder i18n、dev gate、錯誤路徑驗證 |
+
+### 第二輪
+
+| Codex 指出 | 驗證 | 處置 |
+|---|---|---|
+| Blocker：`claim` 同樣需 wallet + 上鏈 mint，F5 仍走不通 | 屬實（`claim_service.go` 做 on-chain mint） | claim 改 DB-only，新增 B2；MVP $TACHI 經濟明確全 DB-only（第 1 段） |
+| Major：B2 缺 $TACHI 交易帳本與兌換記錄 | 屬實（`TachiBalance` 僅單列 aggregate） | B2 加 `tachi_balance_transactions`；B3 加 `coupon_redemptions` + `idempotency_key` + unique constraint |
+| Major：B1 並發建帳 race / unique | 屬實 | B1 完成條件加 transaction + 衝突回復 + concurrent 測試 + fresh DB index 確認 |
+| Major：開機分流與 entry/login UX 矛盾 | 採納 | 第 5 段依 `hasCompletedLogin` 分流：首次必看 entry/login |
+| Major：OverlayEntry 去重會吃掉不同 params | 採納 | 去重改為 kind + params 皆同才去重 |
+| Major：F1 仍偏大、元件內部寫死 320 | 屬實 | 第 6 段界定流式範圍：F1 只做 shell + placeholder，元件流式併入各 MVP PR |
+| Major：F3 缺 `requestIdShare` 型別、登入錯誤未分類 | 屬實 | F3 加 Twitch helper 型別 + 錯誤分類 + 重新授權 UX |
+| Minor：deterministic username、401 清 flag、endpoint 命名、Tachiya 失敗 rollback 驗證 | 採納 | 納入 B1 / 第 5 段 / B3 / 第 10 段 |
+
+### 第三輪
+
+結論：**無 blocker，可開工**。剩餘 major 為 B1/B2/B3 計劃文件須鎖死的驗收條件，
+已硬化進第 7 段：
+
+| Codex 指出 | 處置 |
+|---|---|
+| B2 須單一 DB transaction 原子完成 | B2 row 加「驗收條件」明列原子範圍與參照 `claim_service.go` |
+| B3 Tachiya 外部副作用無法原子化，須定 status flow | B3 row 加 `pending/reserved → call Tachiya → completed/補償` 流程 |
+| B1 fresh DB unique index 來自 migration `014_auth_provider_partial_unique.sql` | B1 row 補明 migration 來源與須確認 fresh setup 會跑到 |
+| `tachi_balance_transactions` 應有可稽核 `source` enum + `reference_type`/`reference_id` | B2 row 採納，加入欄位 |

--- a/plans/extension-navigation-mvp.md
+++ b/plans/extension-navigation-mvp.md
@@ -69,7 +69,7 @@ B1/F1 可並行開工（F1 無後端依賴）。F2–F6 需 F1 + 對應後端 me
 **檔案**
 - Create：`services/api/internal/models/tachi_balance_transaction.go`
 - Modify：`services/api/internal/services/claim_service.go`（新增 DB-only path）、
-  `cmd/server/main.go`（AutoMigrate 註冊新 model）、`router/router.go`（若新增路由）
+  `services/api/cmd/server/main.go`（AutoMigrate 註冊新 model）、`router/router.go`（若新增路由）
 - 參照：`claim_service.go` 既有 `FOR UPDATE` 鎖帳、`finalizeClaim` upsert
 - Test：`services/api/internal/services/claim_service_test.go`
 
@@ -98,7 +98,7 @@ B1/F1 可並行開工（F1 無後端依賴）。F2–F6 需 F1 + 對應後端 me
 - Create：`services/api/internal/models/coupon_redemption.go`、
   `services/api/internal/handlers/coupon_handler.go`
 - Modify：`services/api/internal/services/spend_service.go`（新增 DB-only path）、
-  `cmd/server/main.go`、`router/router.go`
+  `services/api/cmd/server/main.go`、`router/router.go`
 - Test：`spend_service_test.go`、handler 測試
 
 **待實作 checklist**

--- a/plans/extension-navigation-mvp.md
+++ b/plans/extension-navigation-mvp.md
@@ -1,0 +1,264 @@
+# Extension 導航架構 + 功能 MVP — 實作計劃
+
+狀態：規劃中
+
+設計來源：[docs/superpowers/specs/2026-05-16-extension-navigation-and-mvp-design.md](../docs/superpowers/specs/2026-05-16-extension-navigation-and-mvp-design.md)（v4 定稿，通過三輪 Codex review）
+
+---
+
+## 背景
+
+把 `apps/extension` 從 demo-state 原型重構成可擴充的兩層導航骨架，並接出功能 MVP：
+Twitch 登入（自動建 tachigo 帳號）→ 螃蟹單角色挖礦累點 → DB-only claim 成 $TACHI →
+DB-only 兌換 Tachiya 折價券。詳細設計、決策依據、Codex review 處置見 spec。
+
+## 架構決策（摘要，完整見 spec）
+
+- 兩層導航：`scene` 狀態機 + `overlayStack` 疊層，自訂 `NavigationProvider`，不引入 router。
+- MVP 只支援 Twitch 站內 panel，登入走 `onAuthorized` extension JWT。
+- MVP $TACHI 經濟全 DB-only（claim / redeem 不上鏈、不需 wallet）。
+- 流式佈局（寬 320–430、彈性高）。
+- 後端 contract-first：B1→B2→B3 須先 merge 進 `develop`，前端 F 系列才開。
+
+## PR 拆分總表
+
+| # | Issue 標題 | 依賴 | 預估行數 |
+|---|---|---|---|
+| B1 | `[backend] extension JWT 登入自動建帳號` | — | ~250 |
+| B2 | `[backend] MVP DB-only $TACHI claim 路徑` | B1 | ~300 |
+| B3 | `[backend] MVP DB-only coupon 兌換 + redemption ledger` | B2 | ~350 |
+| F1 | `[frontend] extension 導航骨架` | — | ~380（可拆 F1a/F1b） |
+| F2 | `[frontend] entry 主視覺畫面` | F1 | ~200 |
+| F3 | `[frontend] Login with Twitch + identity share` | F1, B1 | ~350 |
+| F4 | `[frontend] 真實挖礦（螃蟹單角色）` | F1, B1 | ~380（可拆 a–d） |
+| F5 | `[frontend] 真實點數 claim` | F1, B2 | ~250 |
+| F6 | `[frontend] 真實 Tachiya 折價券兌換` | F1, B3 | ~280 |
+
+B1/F1 可並行開工（F1 無後端依賴）。F2–F6 需 F1 + 對應後端 merge 後才開。
+
+---
+
+## B1 — extension JWT 登入自動建帳號
+
+**目標**：`LoginWithExtension` 查無 Twitch 連結時自動建 tachigo 帳號。
+
+**檔案**
+- Modify：`services/api/internal/services/extension_service.go`（`LoginWithExtension`）
+- 參照：`services/api/internal/services/auth_service.go`（`upsertOAuthUser` find-or-create）
+- Test：`services/api/internal/services/extension_service_test.go`
+
+**待實作 checklist**
+- [ ] `claims.UserID` 為空（未分享 identity）→ 維持回 `ErrInvalidExtJWT`
+- [ ] 查無 `AuthProvider{ProviderTwitch, claims.UserID}` → 在單一 transaction 內
+      find-or-create `User` + `AuthProvider`，再發 token pair
+- [ ] username 用 deterministic 規則（`twitch_<userID>`）或保持 nil；不可用 opaque id
+- [ ] 並發登入：unique constraint 衝突後重新查既有 user（conflict recovery）
+- [ ] 確認 fresh dev DB 會建立 `auth_providers(provider, provider_id)` partial unique
+      index（來自 migration `014_auth_provider_partial_unique.sql`）
+- [ ] 補 concurrent login 測試
+
+**驗證**：`docker compose run --no-deps --rm app go test ./...`；新使用者首次登入成功建帳；
+並發登入不產生重複 user / provider。
+
+---
+
+## B2 — MVP DB-only $TACHI claim 路徑
+
+**目標**：不需 wallet、不上鏈的 claim path。
+
+**檔案**
+- Create：`services/api/internal/models/tachi_balance_transaction.go`
+- Modify：`services/api/internal/services/claim_service.go`（新增 DB-only path）、
+  `cmd/server/main.go`（AutoMigrate 註冊新 model）、`router/router.go`（若新增路由）
+- 參照：`claim_service.go` 既有 `FOR UPDATE` 鎖帳、`finalizeClaim` upsert
+- Test：`services/api/internal/services/claim_service_test.go`
+
+**待實作 checklist**
+- [ ] 新 model `TachiBalanceTransaction`：`user_id` / `delta` / `source`(enum:
+      `claim_db` / `redeem_db` / 預留 on-chain) / `balance_after` / `reference_type` /
+      `reference_id` / `created_at`
+- [ ] 新增 DB-only claim：**單一 DB transaction 內**原子完成——鎖 `points_ledgers`、
+      扣 `spendable_balance`、寫 `points_transactions`、upsert `tachi_balances`、
+      寫 `tachi_balance_transactions`
+- [ ] 餘額不足回明確錯誤、不扣款
+- [ ] 與既有 on-chain `Claim` 並存，MVP 走新 path
+- [ ] swagger annotation + `swag init`（若新增/改路由）
+- [ ] 單元測試：原子性、餘額不足、帳本記錄正確
+
+**驗證**：後端測試全綠；claim 後 `spendable_balance` 減、`tachi_balances.balance` 增、
+`tachi_balance_transactions` 有對應稽核列。
+
+---
+
+## B3 — MVP DB-only coupon 兌換 + redemption ledger
+
+**目標**：不需 wallet、不上鏈的兌券 path。
+
+**檔案**
+- Create：`services/api/internal/models/coupon_redemption.go`、
+  `services/api/internal/handlers/coupon_handler.go`
+- Modify：`services/api/internal/services/spend_service.go`（新增 DB-only path）、
+  `cmd/server/main.go`、`router/router.go`
+- Test：`spend_service_test.go`、handler 測試
+
+**待實作 checklist**
+- [ ] 新 model `CouponRedemption`：`user_id` / `coupon_id` / `amount` / `status`
+      (`pending`/`reserved`/`completed`/`failed`) / `voucher_code` / `idempotency_key`；
+      `idempotency_key` 或 `(user_id, coupon_id)` 加 unique constraint
+- [ ] status flow：先 DB 建 `pending/reserved` redemption + 扣 `tachi_balances.balance`
+      + 寫 `tachi_balance_transactions(source=redeem_db)` → call Tachiya → 成功補
+      `voucher_code` 標 `completed`；失敗回補餘額或標可重試
+- [ ] 同券重複兌換被 unique constraint 擋下、不重複扣款
+- [ ] endpoint 用產品語意（如 `POST /extension/coupons/redeem`）
+- [ ] swagger annotation + `swag init`
+- [ ] 單元測試：idempotency、Tachiya 失敗補償、餘額不足
+
+**驗證**：後端測試全綠；兌換成功有 `coupon_redemptions` 紀錄與 voucher；重複兌換被擋；
+Tachiya 失敗不出現「已扣款無 voucher」。
+
+**B3 計劃須先拍板**（spec §9）：coupon 兌換頻率政策（一生一次 / 每日 / idempotency key）、
+Tachiya 成功但 DB 失敗時的 source of truth。
+
+---
+
+## F1 — extension 導航骨架
+
+**目標**：兩層導航 `NavigationProvider`，既有畫面接線，新畫面 placeholder。
+
+**檔案**
+- Create：`apps/extension/src/app/navigation/{types,NavigationProvider,useNavigation}.ts(x)`、
+  `SceneRenderer.tsx`、`OverlayHost.tsx`、各 placeholder 元件
+- Modify：`apps/extension/src/app/App.tsx`、`apps/extension/src/extension/{types,storage}.ts`
+- Test：navigation reducer 測試、storage 遷移測試
+
+**待實作 checklist**（spec §5、§6）
+- [ ] `types.ts`：`Scene` / `Overlay` / `OverlayEntry`（discriminated union）/ `NavState`
+- [ ] `NavigationProvider`（context + reducer）：`goScene` / `pushOverlay` /
+      `popOverlay` / `closeAllOverlays` / `setFlag`
+- [ ] push 去重：kind + params 皆同且在頂端才去重；`goScene` 清 `overlayStack`
+- [ ] 開機分流：依 `flags.hasCompletedLogin`（首次 `entry`、回訪 `loading`→`mining`）；
+      後端 401 清 `hasCompletedLogin`
+- [ ] `SceneRenderer` + `OverlayHost`（backdrop / 返回 = `popOverlay`）
+- [ ] 改寫 `App.tsx`：移除扁平 `screen` state；App shell 改流式（320–430、彈性高）
+- [ ] `storage.ts`：移除 `DemoState.screen`、新增 `flags`；key 升 `app-state.v3`、舊資料 sanitize
+- [ ] 既有畫面接線：Login/Loading/Mario→scene；Claim/Coupon/Raffle→overlay
+- [ ] 8 個新畫面 placeholder（流式、i18n key 或標 dev-only）
+- [ ] `menu` 齒輪 hub：真按鈕 `pushOverlay` 到子面板
+- [ ] dev 導航列以 `import.meta.env.DEV` gate
+- [ ] reducer 測試（轉場、疊層、去重含 params、清疊層、401 清 flag）+ storage 遷移測試
+
+**內部可拆**：F1a（navigation reducer + types + storage + 測試）、
+F1b（SceneRenderer/OverlayHost + App 接線 + shell 流式 + placeholder + dev gate）。
+
+**驗證**：`pnpm test`；dev 導航列走遍所有 scene/overlay；production build 無 dev 列。
+
+---
+
+## F2 — entry 主視覺畫面
+
+**目標**：01_First page 靜態主視覺 + press-to-enter。
+
+**檔案**：Create `apps/extension/src/app/scenes/EntryScene.tsx`；Modify placeholder 換實作。
+
+**待實作 checklist**
+- [ ] 靜態主視覺（鯨魚 + 水底場景 + TACHIGO logo），流式佈局
+- [ ] 點任意處 → `goScene('login')`
+- [ ] i18n 文案
+
+**驗證**：`pnpm test`；首次開啟顯示 entry、點擊進 login。
+
+---
+
+## F3 — Login with Twitch + identity share
+
+**目標**：02 畫面，Login with Twitch 主路徑。
+
+**檔案**
+- Modify：`apps/extension/src/app/components/LoginScreen.tsx`、
+  `apps/extension/src/hooks/useTwitch.ts`、`apps/extension/src/types/twitch-ext.d.ts`、
+  `apps/extension/src/services/api.ts`
+
+**待實作 checklist**
+- [ ] 「Login with Twitch」按鈕 → 取得 extension JWT → 呼叫 B1 自動建帳號 → 抓 `channelId`
+- [ ] 補 Twitch helper action 型別（`requestIdShare`）到 `twitch-ext.d.ts`
+- [ ] `useTwitch` 登入失敗分類：identity 未分享 / JWT 無效 / 後端不可用，各對應 UX
+- [ ] 成功設 `flags.hasCompletedLogin = true` → `goScene('loading')`
+- [ ] 帳密表單 / Sign Up / Forgot Password render 但不接線
+- [ ] LoginScreen 內部 `width: 320` 改流式
+- [ ] 元件測試
+
+**驗證**：`pnpm test`；按 Login with Twitch → 引導分享 identity → 自動建帳號 → 進 loading。
+
+---
+
+## F4 — 真實挖礦（螃蟹單角色）
+
+**目標**：`mining` 接真實後端，汰除 demo state。
+
+**檔案**：Modify `apps/extension/src/app/components/MarioHUD.tsx`、相關 hooks、
+`apps/extension/src/extension/types.ts`（移除 `HudDemoState`）
+
+**待實作 checklist**
+- [ ] 接真實 heartbeat / click / points / balance（`useHeartbeat` / `useClickBoost` / `useTPoint`）
+- [ ] 單一螃蟹角色、無進化、無其他角色
+- [ ] 汰除 `HudDemoState` 與 demo 累積邏輯
+- [ ] capybara 美術換螃蟹（正式美術未到位前用 placeholder）
+- [ ] MarioHUD 內部 `width: 320` 改流式
+- [ ] 顯示正在觀看的頻道（`channelId`）
+- [ ] 元件測試
+
+**內部可拆**：(a) balance/點數顯示接線、(b) click/heartbeat 互動、(c) 移除 `HudDemoState`、
+(d) 螃蟹美術 + 流式。
+
+**驗證**：`pnpm test`；掛機 / 點擊真實累點，重開數值一致。
+
+---
+
+## F5 — 真實點數 claim
+
+**目標**：`claim` overlay 接 B2 DB-only claim path。
+
+**檔案**：Modify `apps/extension/src/app/components/ClaimPanel.tsx`、`services/api.ts`
+
+**待實作 checklist**
+- [ ] 接 B2 DB-only claim endpoint → $TACHI
+- [ ] 統一走 `runWithAuthRecovery`
+- [ ] 餘額不足顯示明確錯誤、不扣款
+- [ ] ClaimPanel 內部 `width: 320` 改流式
+- [ ] 移除 demo CPC→TCG 換算
+- [ ] 元件測試
+
+**驗證**：`pnpm test`；claim 成功 $TACHI 增加；餘額不足有錯誤。
+
+---
+
+## F6 — 真實 Tachiya 折價券兌換
+
+**目標**：`shop` overlay 接 B3 DB-only 兌換 path。
+
+**檔案**：Modify `apps/extension/src/app/components/CouponShopPanel.tsx`、
+`apps/extension/src/services/api.ts`（`redeemCoupon`）
+
+**待實作 checklist**
+- [ ] 接 B3 `POST /extension/coupons/redeem`
+- [ ] `redeemCoupon()` 改用 tachigo access token + `runWithAuthRecovery`，移除手動 Bearer
+- [ ] 只開放 Tachiya 商城折價券
+- [ ] 重複兌換 / 餘額不足 / Tachiya 失敗的 UX
+- [ ] CouponShopPanel 內部 `width: 320` 改流式
+- [ ] 移除 demo catalog 依賴
+- [ ] 元件測試
+
+**驗證**：`pnpm test`；兌換成功扣 $TACHI、得 voucher；重複兌換被擋。
+
+---
+
+## 端到端驗證（MVP 全部 merge 後）
+
+對照 spec §10：首次 entry→login→自動建帳號→mining；回訪略過 entry/login；
+真實累點；DB-only claim / 兌券；錯誤路徑（後端不可用、identity 未分享、餘額不足、
+重複兌換、Tachiya 失敗、並發登入）。
+
+## 置後 / #710
+
+UI/UX 畫面（settings / account / onboarding / menu 視覺等）、#710 海洋角色系統、
+裝備欄 — 見 spec §8，不在本計劃。

--- a/plans/ocean-mining-character-system-phase1.md
+++ b/plans/ocean-mining-character-system-phase1.md
@@ -117,7 +117,7 @@ F0 / F1 無後端依賴，可與後端並行開工。F2–F4 需等 B6 merge。
 - [ ] 新增 model `models/user_character.go`：`user_id`、`character`（enum: crab/dolphin/turtle/whale/capybara）、`unlocked`、`stage`(1-3)、`xp`、`unlocked_at`
 - [ ] 新增 per-user 全域狀態欄位：`active_character`、`switch_cooldown_until`（放新 model `models/user_character_state.go` 或 `user.go`，二擇一於 PR 說明）
 - [ ] 新增 model `models/streamer_familiarity.go`：`user_id`、`channel_id`、`cumulative_watch_seconds`、`last_watched_at`
-- [ ] 在 `cmd/server/main.go` AutoMigrate 清單註冊新 model + 必要的 unique index `(user_id, character)`、`(user_id, channel_id)`
+- [ ] 在 `services/api/cmd/server/main.go` AutoMigrate 清單註冊新 model + 必要的 unique index `(user_id, character)`、`(user_id, channel_id)`
 - [ ] model 單元測試（BeforeCreate UUID v7、預設值）
 
 **介面／規格**
@@ -150,7 +150,7 @@ F0 / F1 無後端依賴，可與後端並行開工。F2–F4 需等 B6 merge。
 - [ ] 單元測試：曲線插值邊界、衰減、新台 10% 驗證
 
 **介面／規格**
-```
+```text
 T-Points 產出 = 基礎活動值 × familiarity(streamer) × (1 + buffs)
 XP 產出       = 基礎活動值 × (1 + buffs)   // 不套熟悉度
 ```
@@ -234,7 +234,7 @@ XP 產出       = 基礎活動值 × (1 + buffs)   // 不套熟悉度
 
 **任務**
 - [ ] 螃蟹 S1：每 60s tick 10 次有效點擊上限，1.5×；超過上限不累積
-- [ ] 海豚 S1：1 則 +40% / 2-3 則 +60% / 3+ 則 +80%，S1 上限 +100%（品質加成 Phase 2）
+- [ ] 海豚 S1：1 則 +40% / 2 則 +60% / 3 則以上 +80%，S1 上限 +100%（品質加成 Phase 2）
 - [ ] 海龜 S1：連續觀看 30min +10% / 60min +20% / 90min +35%，中斷 >5min 歸零
 - [ ] buff 疊加採加法：`multiplier = 1.0 + Σbuff`
 - [ ] S2/S3 預留 hook（介面留空、回傳 0），不實作

--- a/plans/ocean-mining-character-system-phase1.md
+++ b/plans/ocean-mining-character-system-phase1.md
@@ -1,0 +1,418 @@
+# Ocean Mining 角色系統 — Phase 1 實作計劃
+
+狀態：規劃中（待 Codex review）
+
+來源討論：[discussion #710](https://github.com/nurockplayer/tachigo/discussions/710) — 海洋挖礦角色系統設計
+
+---
+
+## 背景
+
+discussion #710 是 `[discussion]` 設計票，把現有的 capybara 被動挖礦 HUD 擴充成
+「螃蟹 🦀 → 海豚 🐬 / 海龜 🐢 → 鯨魚 🐋」四角色挖礦系統。本計劃只涵蓋設計書的
+**Phase 1 範圍**（設計書第 9 節），把它拆成可獨立 merge 的小 PR，並草擬對應的
+`[backend]` / `[frontend]` GitHub issue。
+
+`[discussion]` 票不直接實作；本計劃的產出是「把討論結論轉成一組 feature issue」。
+
+---
+
+## Repo 現況校正（重要）
+
+設計書「關鍵檔案／模組」段落引用的路徑與實際 repo **不符**，實作時以下表為準：
+
+| 設計書寫的 | 實際 repo |
+|---|---|
+| `tachimint/` sidepanel | **`apps/extension/`**（`tachimint/` 目前是空資料夾） |
+| `tachimint/src/components/MarioHUD/` | `apps/extension/src/app/components/MarioHUD.tsx`（單檔 24KB capybara HUD） |
+| `backend/internal/models/`、`services/` | `services/api/internal/models/`、`services/api/internal/services/` |
+| `migrations/015_*.sql` | 本 repo 用 GORM AutoMigrate，migration 慣例見 `services/api/cmd/server/main.go` |
+
+**後端現況**（`services/api/internal/`）：已有 watch session / click / heartbeat、
+每頻道 points ledger（`PointsLedger.cumulative_total` + `spendable_balance`）、
+claim → $TACHI balance、coupon redeem。**完全沒有**角色、XP、熟悉度、排行榜、任務。
+
+相關現有檔案：
+- `models/points.go`、`models/watch_session.go`、`models/channel_config.go`
+- `services/watch_service.go`（StartSession / Heartbeat / RecordClick / EndSession）
+- `services/points_service.go`（AddWatchTime / AddHeartbeatTime / AddPointsWithMeta）
+- `router/router.go`（`/extension/watch/{start,heartbeat,click,end,balance}`）
+- 前端 `apps/extension/src/app/components/MarioHUD.tsx`、`hooks/useTwitch.ts`
+
+---
+
+## 架構決策
+
+1. **角色資料是 per-user 全域，不是 per-channel。**
+   `PointsLedger` 是 per-channel，但「解鎖即永久擁有」「角色 XP 各自獨立累積」
+   「進化永久保留」都是跨頻道的。→ 新表 `user_characters` 以 `(user_id, character)`
+   為單位；`active_character` 與切換 cooldown 也是 per-user 全域單一狀態。
+
+2. **熟悉度是 per (user × streamer)。** 只影響 T-Points 產出，不影響 XP 產出
+   （設計書第 7 節「水土不服」）。→ 新表 `streamer_familiarity` 記錄跨 session
+   累積觀看秒數。
+
+3. **Contract 變更先行。** 依 CLAUDE.md「PR 不得依賴未 merge 的 PR」，所有後端
+   contract（schema、API、heartbeat payload 欄位）必須先 merge 進 `develop`，
+   前端 PR 才能開。本計劃的 PR 順序已據此排好。
+
+4. **heartbeat payload 需擴充。** 海豚 S1（聊天則數）與海龜 S1（連續觀看秒數）
+   的 buff 計算需要前端把 `chat_count`、`continuous_seconds` 帶進 heartbeat。
+   這是 contract 變更，放在後端 PR-B4。
+
+5. **Phase 1 鯨魚只做 UI 剪影**，不做 buff / 解鎖邏輯（設計書第 9 節）。
+   S2/S3 buff 只預留 hook，UI 顯示「未解鎖」。
+
+6. **美術資產是外部依賴。** 3 角色 × 3 stage 的 Q 版立繪 + 鯨魚剪影需設計提供；
+   程式 PR 先用 placeholder，資產到位後另開小 PR 替換。此依賴需在 issue 標註。
+
+---
+
+## 待 review / 待確認問題
+
+- [ ] 美術資產（角色立繪、剪影、進化特效）由誰、何時提供？Phase 1 是否接受 placeholder 上線？
+- [ ] content script 注入 `*://*.twitch.tv/*` 屬於 Manifest 權限擴張，需確認 extension 審查 / 上架影響。
+- [ ] 進化門檻、解鎖價格、buff 數值皆為設計書「待校準」值；Phase 1 直接採建議預設，OK？
+- [ ] 海龜「中斷 5 分鐘歸零」由後端依 `last_heartbeat_at` 判定 — 與現有 watch session 既有的中斷邏輯是否衝突需確認。
+- [ ] `apps/extension` 與 `extensions/tachigo-demo-sidepanel` 程式幾乎重複；本計劃只動 `apps/extension`，demo 是否同步不在範圍內。
+
+---
+
+## PR 拆分總表
+
+順序即依賴順序；後端 contract 全部 merge 後前端才開。每張預估 < 400 行，
+超過者於該 issue 註明可再拆。
+
+| # | PR | 類型 | 依賴 | 預估行數 |
+|---|---|---|---|---|
+| B1 | 角色 / 熟悉度 schema + model | `[backend]` | — | ~250（含 migration） |
+| B2 | 熟悉度 service + 整合進 T-Points 產出 | `[backend]` | B1 | ~300 |
+| B3 | character service：解鎖 / 切換 / 進化 | `[backend]` | B1 | ~350 |
+| B4 | heartbeat/click contract 擴充 + XP 累積 | `[backend]` | B1 | ~300 |
+| B5 | S1 buff 計算（螃蟹 / 海豚 / 海龜） | `[backend]` | B3, B4 | ~350 |
+| B6 | character handler + routes + swagger | `[backend]` | B3, B5 | ~300 |
+| F0 | characters.ts domain module（純函式） | `[frontend]` | — | ~250 |
+| F1 | content script chatDetector + manifest | `[frontend]` | — | ~150 |
+| F2 | ActiveCharacterDisplay（替換 capybara） | `[frontend]` | B6, F0 | ~350 |
+| F3 | CharacterMenu 抽屜 + 切換 cooldown UI | `[frontend]` | B6, F0 | ~350 |
+| F4 | BuffList + FamiliarityIndicator + EvolutionPrompt + coach marks | `[frontend]` | B6, F0, F2 | ~380 |
+
+F0 / F1 無後端依賴，可與後端並行開工。F2–F4 需等 B6 merge。
+合計 11 PR，與設計書「Phase 1 約 2-3 週」一致。
+
+---
+
+## GitHub Issue 草稿
+
+> 以下為各 PR 對應 issue 的 body 草稿。標題前綴、label、完成條件格式依
+> CLAUDE.md「GitHub Issue 慣例」。target branch 一律 `develop`。
+
+### B1 — `[backend] 角色系統 — user_characters / streamer_familiarity schema`
+
+**背景**
+角色挖礦系統需要 per-user 的角色擁有狀態與 per (user×streamer) 的熟悉度記帳。
+現有 `PointsLedger` 是 per-channel，不適合存全域角色資料。
+
+**任務**
+- [ ] 新增 model `models/user_character.go`：`user_id`、`character`（enum: crab/dolphin/turtle/whale/capybara）、`unlocked`、`stage`(1-3)、`xp`、`unlocked_at`
+- [ ] 新增 per-user 全域狀態欄位：`active_character`、`switch_cooldown_until`（放新 model `models/user_character_state.go` 或 `user.go`，二擇一於 PR 說明）
+- [ ] 新增 model `models/streamer_familiarity.go`：`user_id`、`channel_id`、`cumulative_watch_seconds`、`last_watched_at`
+- [ ] 在 `cmd/server/main.go` AutoMigrate 清單註冊新 model + 必要的 unique index `(user_id, character)`、`(user_id, channel_id)`
+- [ ] model 單元測試（BeforeCreate UUID v7、預設值）
+
+**介面／規格**
+- `Character` 型別為 `string` enum；新使用者預設擁有 crab（unlocked、stage 1、active）
+- capybara 為 dev 專屬角色，enum 保留但不在主流程解鎖
+
+**參考**
+`models/points.go`（GORM 慣例、UUID v7 BeforeCreate）、`models/watch_session.go`
+
+**完成條件**
+- [ ] AutoMigrate 在乾淨 DB 成功建表
+- [ ] `docker compose run --no-deps --rm app go test ./...` 通過
+
+**本票明確不做**：service / handler / router / 前端 / buff 邏輯 / migration 以外的行為。
+
+---
+
+### B2 — `[backend] 熟悉度 service — 水土不服曲線 + T-Points 產出整合`
+
+**背景**
+防炸魚核心機制（設計書第 7 節）：T-Points 產出乘上 per-streamer 熟悉度，
+強角色到新台只能拿 10% 產出。
+
+**任務**
+- [ ] 新增 `services/familiarity_service.go`：依 `cumulative_watch_seconds` 算熟悉度
+  - 0→60min：10%→50% 線性；60→300min：50%→100% 線性
+  - 30 天未觀看後每天 -1%，下限 10%
+- [ ] heartbeat tick 累加 `cumulative_watch_seconds` 並更新 `last_watched_at`
+- [ ] 在 `points_service.go` T-Points 產出路徑套用 `familiarity`（XP 路徑不套）
+- [ ] 單元測試：曲線插值邊界、衰減、新台 10% 驗證
+
+**介面／規格**
+```
+T-Points 產出 = 基礎活動值 × familiarity(streamer) × (1 + buffs)
+XP 產出       = 基礎活動值 × (1 + buffs)   // 不套熟悉度
+```
+
+**參考**
+`services/points_service.go`（AddWatchTime / addPointsWithMetaAt）、`services/watch_service.go`
+
+**完成條件**
+- [ ] 新台熟悉度測試顯示 10%；累積 5hr 顯示 100%
+- [ ] 既有 points / watch 測試不回歸
+- [ ] 後端測試全通過
+
+**本票明確不做**：角色 buff、XP（B4）、handler、前端。
+
+---
+
+### B3 — `[backend] character service — 解鎖 / 切換 / 進化`
+
+**背景**
+角色解鎖（扣 `spendable_balance`）、切換（30 分鐘 cooldown + 海豚例外）、
+進化（XP 門檻 → stage）的核心邏輯。
+
+**任務**
+- [ ] 新增 `services/character_service.go`
+- [ ] `Unlock`：海豚需 `spendable_balance ≥ 50`、海龜 ≥ 1500；扣款後永久擁有；鯨魚回傳「特殊管道」錯誤不可解鎖
+- [ ] `Switch`：切換後 30 分鐘 cooldown；**唯一例外**——切「進入」海豚不受 cooldown 限制，但進入後原 cooldown 繼續倒數、結束前不可從海豚切出
+- [ ] `Evolve`：S1→2 需 1000 XP、S2→3 需 10000 XP（Phase 1 只啟用 S1→2）；使用者主動觸發
+- [ ] 單元測試覆蓋 cooldown 海豚例外的情境範例（設計書第 4 節 5 步驟）
+
+**介面／規格**
+- 解鎖以 `spendable_balance` 是否足夠為準，扣的也是 `spendable_balance`
+- 切換 cooldown 是 per-user 全域單一狀態
+
+**參考**
+`services/spend_service.go`（扣款 / balance 檢查慣例）、設計書第 4、5、6 節
+
+**完成條件**
+- [ ] cooldown 海豚例外的 5 步情境測試全綠
+- [ ] 餘額不足、重複解鎖、鯨魚解鎖皆有對應錯誤
+- [ ] 後端測試全通過
+
+**本票明確不做**：buff 計算、XP 累積（B4）、handler、前端。
+
+---
+
+### B4 — `[backend] heartbeat/click contract 擴充 + 角色 XP 累積`
+
+**背景**
+海豚／海龜 S1 buff 需要前端回傳聊天則數與連續觀看秒數；active 角色每 tick 累積 XP。
+
+**任務**
+- [ ] heartbeat request 擴充：`chat_count`、`continuous_seconds`（向後相容，缺值視為 0）
+- [ ] heartbeat / click tick 對 **active 角色** 累積 XP（離線角色 XP = 0）
+- [ ] 海龜中斷判定：後端 5 分鐘未收到 heartbeat → `continuous_seconds` 視為歸零
+- [ ] 更新 swagger annotation；若改路由則 `swag init`
+- [ ] 單元測試 + 既有 heartbeat/click 測試相容
+
+**介面／規格**
+```jsonc
+// POST /extension/watch/heartbeat
+{ "channel_id": "...", "chat_count": 0, "continuous_seconds": 0 }
+```
+
+**參考**
+`handlers/watch_handler.go`（`watchBody`）、`services/watch_service.go`（Heartbeat / RecordClick）
+
+**完成條件**
+- [ ] 舊 client（無新欄位）heartbeat 仍正常
+- [ ] active 角色 XP 隨 tick 增加，切換後新角色才累積
+- [ ] swagger docs 同 PR 更新
+- [ ] 後端測試全通過
+
+**本票明確不做**：buff 倍率計算（B5）、解鎖／進化（B3）、前端。
+
+---
+
+### B5 — `[backend] S1 buff 計算 — 螃蟹 / 海豚 / 海龜`
+
+**背景**
+3 隻常規角色的 stage 1 buff（波動鉗擊 / 回聲波紋 / 龜養生息），套用到 T-Points/XP 產出。
+
+**任務**
+- [ ] 螃蟹 S1：每 60s tick 10 次有效點擊上限，1.5×；超過上限不累積
+- [ ] 海豚 S1：1 則 +40% / 2-3 則 +60% / 3+ 則 +80%，S1 上限 +100%（品質加成 Phase 2）
+- [ ] 海龜 S1：連續觀看 30min +10% / 60min +20% / 90min +35%，中斷 >5min 歸零
+- [ ] buff 疊加採加法：`multiplier = 1.0 + Σbuff`
+- [ ] S2/S3 預留 hook（介面留空、回傳 0），不實作
+- [ ] 單元測試覆蓋各 buff 邊界與上限
+
+**介面／規格**
+`CharacterBuff(character, stage, tickContext) float64` — 純函式，tickContext 含 clicks/chat/continuousSeconds
+
+**參考**
+設計書第 3 節 buff 矩陣、`channel_config.go`（既有 multiplier 慣例）
+
+**完成條件**
+- [ ] 各角色 S1 上限值（螃蟹 1.5×、海豚 +100%、海龜 1.35×）測試正確
+- [ ] 後端測試全通過
+
+**本票明確不做**：鯨魚 buff、S2/S3 實作、handler、前端。
+
+---
+
+### B6 — `[backend] character handler + routes + swagger`
+
+**背景**
+把 character / familiarity 狀態與操作開成 extension 用的 API。
+
+**任務**
+- [ ] 新增 `handlers/character_handler.go`
+- [ ] `GET /extension/characters` — 回傳擁有角色、stage、XP、active、cooldown 剩餘、熟悉度
+- [ ] `POST /extension/characters/unlock`、`POST /extension/characters/switch`、`POST /extension/characters/evolve`
+- [ ] router 註冊（extension 已驗證群組內）
+- [ ] swagger annotation + `swag init`（docs.go / swagger.json / swagger.yaml 同 PR）
+- [ ] handler 層測試
+
+**參考**
+`handlers/watch_handler.go`、`router/router.go` extension 群組、CLAUDE.md「Swagger Docs 更新規則」
+
+**完成條件**
+- [ ] 4 個 endpoint 可正常回應、錯誤碼正確
+- [ ] swagger docs 已更新並含於 PR
+- [ ] 後端測試全通過
+
+**本票明確不做**：前端、buff 邏輯變更。
+
+---
+
+### F0 — `[frontend] characters.ts domain module（角色定義 + buff/熟悉度曲線）`
+
+**背景**
+前端的純邏輯層：角色定義、buff 計算、熟悉度曲線。無 UI、無 API、可單元測試。
+
+**任務**
+- [ ] 新增 `apps/extension/src/app/features/characters/characters.ts`
+- [ ] 角色定義（4 角 + capybara dev）、解鎖價格、進化門檻常數
+- [ ] buff / 熟悉度曲線純函式（與後端 B2/B5 對齊，用於 UI 預覽顯示）
+- [ ] vitest 單元測試
+
+**參考**
+設計書第 3、5、6、7 節；`apps/extension/src/types/`
+
+**完成條件**
+- [ ] 曲線函式測試與後端值一致
+- [ ] `pnpm test` 通過
+
+**本票明確不做**：任何 UI 元件、API 串接、content script。
+
+---
+
+### F1 — `[frontend] content script — Twitch 聊天偵測 + manifest`
+
+**背景**
+偵測使用者在 twitch.tv 送出聊天，透過 `chrome.runtime` 通知 sidepanel（海豚 buff 用）。
+
+**任務**
+- [ ] 新增 `apps/extension/src/content/chatDetector.ts`：監聽 chat send button / Enter
+- [ ] manifest 新增 `content_scripts`（match `*://*.twitch.tv/*`）與 `tabs` 權限
+- [ ] sidepanel 端接收 `CHAT_SENT` 訊息並計數
+- [ ] selector 失效時 chatCount 自動為 0，不影響其他功能（設計書已註明）
+
+**參考**
+設計書「聊天訊息偵測設計」、`apps/extension` 既有 manifest / `extensions/tachigo-demo-sidepanel/src/extension/content.ts`
+
+**完成條件**
+- [ ] 在 twitch.tv 送訊息能被 sidepanel 計數
+- [ ] selector 失效不報錯、不影響挖礦
+- [ ] manifest 權限變更於 PR body 說明
+
+**本票明確不做**：海豚 buff 數值計算（後端 B5）、UI。
+
+---
+
+### F2 — `[frontend] ActiveCharacterDisplay — 替換 capybara HUD`
+
+**背景**
+把現有 `MarioHUD.tsx` 的 capybara 容器換成 Active Character 顯示區；capybara 改 dev 專屬。
+
+**任務**
+- [ ] 新增 `features/characters/ActiveCharacterDisplay.tsx`：立繪 + 名字 + stage + XP + 進化進度條
+- [ ] 串接 `GET /extension/characters`
+- [ ] capybara 改為僅 dev build 出現的隱藏選項
+- [ ] 角色立繪先用 placeholder（美術資產另開 PR）
+- [ ] 元件測試
+
+**參考**
+`apps/extension/src/app/components/MarioHUD.tsx`、設計書第 8 節
+
+**完成條件**
+- [ ] sidepanel 顯示當前 active 角色與 XP/進化進度
+- [ ] capybara 在 production build 不出現、dev build 可選
+- [ ] `pnpm test` 通過
+
+**本票明確不做**：角色選單、buff list、進化動畫（F3/F4）。
+
+---
+
+### F3 — `[frontend] CharacterMenu 抽屜 + 切換 cooldown UI`
+
+**背景**
+角色選單抽屜：已解鎖角色切換、鎖住角色顯示解鎖條件、cooldown 倒數。
+
+**任務**
+- [ ] 新增 `features/characters/CharacterMenu.tsx`
+- [ ] 已解鎖：縮圖 + stage + 切換按鈕（顯示 cooldown 剩餘）
+- [ ] 鎖住：剪影 + 解鎖條件（缺多少 T-Points）；鯨魚顯示「需透過特別管道解鎖」
+- [ ] 切往海豚按鈕永遠可點；進入海豚後切出按鈕顯示倒數 disabled
+- [ ] 串接 unlock / switch API
+- [ ] 元件測試覆蓋海豚 cooldown 例外 UI 行為
+
+**參考**
+設計書第 4、8 節、F0 `characters.ts`
+
+**完成條件**
+- [ ] cooldown 海豚例外的 UI 行為符合設計書 5 步情境
+- [ ] 解鎖扣款後角色永久可用
+- [ ] `pnpm test` 通過
+
+**本票明確不做**：進化動畫、buff list、coach marks（F4）。
+
+---
+
+### F4 — `[frontend] BuffList / FamiliarityIndicator / EvolutionPrompt / coach marks`
+
+**背景**
+Phase 1 前端收尾：當前 buff 清單、熟悉度徽章、進化提示與最簡動畫、新手引導。
+
+**任務**
+- [ ] `BuffList.tsx`：當前生效 / 未達成 buff 清單（✓ / ✗）
+- [ ] `FamiliarityIndicator.tsx`：當前實況主熟悉度徽章
+- [ ] `EvolutionPrompt.tsx`：XP 足夠時角色頭上「！」+ 進化按鈕 + 最簡視覺升級
+- [ ] 首次開啟 1-2 頁 coach mark，可關閉、不強制
+- [ ] 元件測試
+
+**參考**
+設計書第 5、8 節
+
+**完成條件**
+- [ ] buff list 正確反映後端回傳的生效狀態
+- [ ] 進化按鈕觸發後角色升 stage 並保留
+- [ ] `pnpm test` 通過
+
+**本票明確不做**：S2/S3 buff、進化粒子特效（Phase 2）、排行榜、任務 UI。
+
+---
+
+## 不在 Phase 1（設計書 Phase 2/3，本計劃明確不做）
+
+排行榜系統、競技獎章、里程碑稱號、實況主限時任務、爆擊 → $TACHI、
+鯨魚 buff（S1/S2/S3）、鯊魚角色、進化分支、PvP 食物鏈。
+鯨魚 Phase 1 僅止於選單剪影 +「需透過特別管道解鎖」文案。
+
+---
+
+## 端到端驗證（Phase 1 完成後）
+
+對照設計書第 10 節驗證清單，重點：
+1. 新使用者：螃蟹 active、其他角色鎖住顯示解鎖條件
+2. 累積 50 / 1500 T-Points → 海豚 / 海龜解鎖按鈕亮、扣 `spendable_balance` 後永久擁有
+3. 螃蟹→海豚無 cooldown；海豚→螃蟹 cooldown 中被擋
+4. cooldown 海豚例外 5 步情境
+5. 聊天 / 點擊 / 連續觀看觸發對應 S1 buff
+6. 防炸魚：新台熟悉度 10%，累積 1hr → 50%
+7. 螃蟹累積 1000 XP → 進化提示 → 升 S2 並保留
+8. dev build 可選 capybara、production 不出現


### PR DESCRIPTION
## 摘要

加入 extension 導航架構 + 功能 MVP 的設計 spec 與兩份實作計劃，作為團隊共同方向依據，避免三小時規劃內容遺失。**純文件，無 production code 變更。**

## 變更

- `docs/superpowers/specs/2026-05-16-extension-navigation-and-mvp-design.md` — 導航架構 + MVP spec v4（通過三輪 Codex review，結論「可開工」）
- `plans/extension-navigation-mvp.md` — extension 導航 + MVP 實作計劃（9 PR：B1-B3 後端、F1-F6 前端）
- `plans/ocean-mining-character-system-phase1.md` — #710 海洋角色系統 Phase 1 實作計劃（11 PR）

## Depends on PR：none

純 docs（1047 行），套用 `scope-exception`：非 production code、非 runtime behavior。

refs #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification document for extension navigation architecture and MVP design, outlining two-layer navigation structure and implementation roadmap.
  * Added implementation plan for extension navigation MVP, detailing backend and frontend phases with feature scope and verification standards.
  * Added implementation plan for ocean mining character system phase 1, defining architecture decisions and PR breakdown for role and familiarity features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/733)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->