### PR TITLE
[backend] Align env example with Atlas migration ownership

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -11,9 +11,9 @@ GIN_MODE=debug
 # Enable Swagger UI (default: true in dev, false in prod)
 ENABLE_SWAGGER=true
 
-# Enable GORM AutoMigrate on startup (default: true)
-# NOTE: not yet wired — field exists in config but main.go always runs AutoMigrate (scope: A5-2)
-ENABLE_AUTOMIGRATE=true
+# Legacy AutoMigrate flag. Atlas owns runtime schema migrations; server startup
+# no longer runs GORM AutoMigrate or schema DDL. Use ATLAS_DATABASE_URL + make migrate.
+ENABLE_AUTOMIGRATE=false
 
 # Enable background raffle scheduler (default: true)
 # NOTE: not yet wired — field exists in config but main.go always starts scheduler (scope: A5-2)


### PR DESCRIPTION
## 什麼改動
同步 `services/api/.env.example` 的 `ENABLE_AUTOMIGRATE` 註解，改成目前 Atlas owns runtime schema migrations 的現況，避免 operator 誤以為 API startup 還會跑 GORM AutoMigrate。

## 為什麼
refs #463

`docs/atlas-migration-plan.md`、`services/api/README.md` 與 startup guard tests 已顯示 #588 後 schema DDL 由 Atlas migration path 擁有；但 `.env.example` 仍保留舊註解「main.go always runs AutoMigrate」，會誤導部署與 runbook 讀者。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#463
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 server startup 行為
  - 不改 Atlas migration runner
  - 不改 config parsing
  - 不關閉 #463

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #463 與 `docs/atlas-migration-plan.md` 的 Current Source Of Truth / Issue #463 checklist
- Actual worker profile(s)：
  - controller / ops_spark
- Model strength：
  - controller = GPT-5.5 xhigh；ops_spark = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `rtk git --no-optional-locks diff --check`
  - `rtk rg -n "AutoMigrate|Atlas owns runtime schema migrations|ATLAS_DATABASE_URL|ENABLE_AUTOMIGRATE" services/api/.env.example services/api/README.md services/api/cmd/server/main_test.go`
  - `rtk make pr-meta-check TITLE="[backend] Align env example with Atlas migration ownership" BODY_FILE=/tmp/pr_body_463.md`
  - `rtk go test ./internal/config` attempted; blocked by local Go toolchain download/network restriction, not by test failure
- Self-review / exception reason：
  - Scope is a one-file operator-facing documentation drift fix. No runtime behavior or config parser changes.
- Worker session closeout：
  - Controller read back ops_spark result; worker session closed after final readback.
- Workflow friction / follow-up split：
  - No follow-up split needed for this one-file correction. #463 remains open for broader production/runbook decisions.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: initial PR, no review threads yet
- CodeRabbit：
  - pending with reason: initial PR, waiting for automated review
- chatgpt-codex-connector：
  - pending with reason: initial PR, waiting for automated review/reaction
- review_triage_ref：
  - pending with reason: no review findings yet
- root_cause_gate_ref：
  - `services/api/.env.example` stale text contradicted `services/api/README.md` and `services/api/cmd/server/main_test.go` Atlas startup guard
- finding_disposition_ref：
  - pending with reason: no review findings yet
- Final reviewer action：
  - pending with reason: initial PR

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: initial PR checks/reviews not complete
- Latest head SHA：
  - n/a before PR creation
- Required checks：
  - pending with reason: initial PR checks not complete
- spec workflow-check evidence：
  - unavailable locally; `spec workflow-check --help` returned command not found in this environment, manual checklist used
- Evidence URL：
  - n/a before PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 修正 API `.env.example` 中已過期的 AutoMigrate 說明，對齊 Atlas runtime migration ownership。
- Approx changed lines：~6
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `.env.example` 不再宣稱 server startup 會執行 GORM AutoMigrate
- [x] 說明 Atlas 是 runtime schema migration owner
- [x] 不改 runtime behavior

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk git --no-optional-locks diff --check
# pass

rtk make pr-meta-check TITLE="[backend] Align env example with Atlas migration ownership" BODY_FILE=/tmp/pr_body_463.md
# pass

rtk go test ./internal/config
# blocked: go.mod requires Go 1.26.3; local Go is 1.26.1 and sandbox cannot resolve proxy.golang.org to download toolchain
```

## 備註
此 PR 不關閉 #463；只修正一個已確認的 operator-facing stale note。

## Notes for Claude Code Review
- 請確認 `ENABLE_AUTOMIGRATE=false` 作為 example 值是否符合目前「legacy parsed but runtime ignored」的 operator expectation。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores（项目维护）**
  * 更新了数据库迁移配置策略，由自动模式迁移改为 Atlas 负责运行时模式迁移，并调整了相关环境变量的默认设置。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->