### PR TITLE
[chore] Consolidate PR review state labels

### DIFF
--- a/.github/workflows/auto-ready-pr.yml
+++ b/.github/workflows/auto-ready-pr.yml
@@ -34,7 +34,8 @@ jobs:
             const owner = context.repo.owner
             const repo = context.repo.repo
             const autoReadyLabel = 'auto-ready'
-            const reviewLabel = 'needs-codex-review'
+            const reviewLabel = 'awaiting-review'
+            const staleReviewLabel = 'needs-codex-review'
             const changesLabel = 'changes-requested'
             const targetBaseBranches = new Set(['main', 'develop'])
             const successConclusions = new Set(['success', 'neutral', 'skipped'])
@@ -56,8 +57,10 @@ jobs:
               ],
             }
 
-            const hasAutoReadyLabel = (pr) =>
-              (pr.labels || []).some((label) => label.name === autoReadyLabel)
+            const hasLabel = (pr, name) =>
+              (pr.labels || []).some((label) => label.name === name)
+
+            const hasAutoReadyLabel = (pr) => hasLabel(pr, autoReadyLabel)
 
             const ensureLabel = async (name, color, description) => {
               try {
@@ -76,19 +79,22 @@ jobs:
               }
             }
 
-            const flagForCodexReview = async (pr) => {
+            const flagForReview = async (pr) => {
               await ensureLabel(
                 reviewLabel,
                 '0075ca',
-                'New PR opened or new commits pushed after the latest Codex review — pending Codex review',
+                'New PR opened or new commits pushed after the latest trusted review — pending review',
               )
               await ensureLabel(
                 changesLabel,
                 'd73a4a',
-                'Codex has requested changes — author should update the PR',
+                'Reviewer has requested changes — author should update the PR',
               )
               await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [reviewLabel] })
               await removeLabel(pr.number, changesLabel)
+              if (hasLabel(pr, staleReviewLabel)) {
+                await removeLabel(pr.number, staleReviewLabel)
+              }
             }
 
             const isEligibleAutoReadyPr = (pr) => {
@@ -355,18 +361,18 @@ jobs:
               }
 
               try {
-                await flagForCodexReview(pr)
+                await flagForReview(pr)
               } catch (error) {
                 core.warning(
-                  `Failed to flag PR #${pr.number} for Codex review; ${autoReadyLabel} will retry while the label remains (${error?.message || error}).`,
+                  `Failed to flag PR #${pr.number} for review; ${autoReadyLabel} will retry while the label remains (${error?.message || error}).`,
                 )
                 continue
               }
 
               const readyMessage = markedReady ? 'marked ready for review, ' : ''
               if (workflowFileChanged) {
-                core.notice(`PR #${pr.number} ${readyMessage}skipped auto-merge for workflow-file PR, and flagged for Codex review.`)
+                core.notice(`PR #${pr.number} ${readyMessage}skipped auto-merge for workflow-file PR, and flagged for review.`)
               } else {
-                core.notice(`PR #${pr.number} ${readyMessage}armed auto-merge, and flagged for Codex review.`)
+                core.notice(`PR #${pr.number} ${readyMessage}armed auto-merge, and flagged for review.`)
               }
             }

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -3061,7 +3061,7 @@ test('review label workflow clears changes requested when the last trusted block
   ])
 })
 
-test('review label workflow keeps dismissed PRs in the review queue when another trusted reviewer still blocks', async () => {
+test('review label workflow keeps dismissed PRs out of the review queue when another trusted reviewer still blocks', async () => {
   const result = await runCodexReviewFlagWorkflow({
     action: 'dismissed',
     prOverrides: {
@@ -3096,11 +3096,13 @@ test('review label workflow keeps dismissed PRs in the review queue when another
   })
 
   assert.deepEqual(result.labelsAdded, [
-    { issue_number: 472, labels: ['awaiting-review', 'changes-requested'] },
+    { issue_number: 472, labels: ['changes-requested'] },
   ])
-  assert.deepEqual(result.labelsRemoved, [])
+  assert.deepEqual(result.labelsRemoved, [
+    { issue_number: 472, name: 'awaiting-review' },
+  ])
   assert.deepEqual(result.notices, [
-    'PR #472 flagged for review after dismissal; a trusted reviewer still requests changes.',
+    'PR #472 kept changes-requested because a trusted reviewer still requests changes.',
   ])
 })
 

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -507,7 +507,7 @@ async function runCodexReviewFlagWorkflow({
     draft: false,
     head: { sha: 'head_sha' },
     updated_at: '2026-05-13T11:39:34Z',
-    labels: [{ name: 'needs-codex-review' }],
+    labels: [{ name: 'awaiting-review' }],
   }
   const baseReview = {
     user: { login: 'Erick52106' },
@@ -2571,7 +2571,7 @@ test('auto-ready workflow is opt-in for auto-ready PRs on protected base branche
   assert.match(workflow, /github\.rest\.pulls\.get/)
   assert.match(workflow, /pr\.head\?\.sha !== headSha/)
   assert.match(workflow, /targetBaseBranches\.has\(pr\.base\?\.ref\)/)
-  assert.match(workflow, /const reviewLabel = 'needs-codex-review'/)
+  assert.match(workflow, /const reviewLabel = 'awaiting-review'/)
   assert.match(workflow, /const changesLabel = 'changes-requested'/)
 })
 
@@ -2623,7 +2623,7 @@ test('auto-ready workflow uses routine logs for skipped PRs', async () => {
   assert.doesNotMatch(workflow, /core\.notice\(`Skipping PR #/)
   assert.doesNotMatch(workflow, /core\.notice\(`PR #\$\{pr\.number\} remains draft until checks pass\.`\)/)
   assert.match(workflow, /const readyMessage = markedReady \? 'marked ready for review, ' : ''/)
-  assert.match(workflow, /core\.notice\(`PR #\$\{pr\.number\} \$\{readyMessage\}armed auto-merge, and flagged for Codex review\.`\)/)
+  assert.match(workflow, /core\.notice\(`PR #\$\{pr\.number\} \$\{readyMessage\}armed auto-merge, and flagged for review\.`\)/)
 })
 
 test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', async () => {
@@ -2662,7 +2662,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /pr\.head\?\.sha !== currentHeadSha/)
   assert.match(jobBlock, /targetBaseBranches\.has\(pr\.base\?\.ref\)/)
   assert.match(jobBlock, /hasAutoReadyLabel\(pr\)/)
-  assert.match(jobBlock, /const reviewLabel = 'needs-codex-review'/)
+  assert.match(jobBlock, /const reviewLabel = 'awaiting-review'/)
   assert.match(jobBlock, /const changesLabel = 'changes-requested'/)
   assert.match(jobBlock, /github\.rest\.issues\.addLabels/)
   assert.match(jobBlock, /github\.rest\.issues\.removeLabel/)
@@ -2692,7 +2692,7 @@ test('CI auto-ready job marks ready before arming native auto-merge', async () =
   assert.deepEqual(result.graphqlCalls, ['ready', 'auto-merge'])
   assert.deepEqual(result.autoMergeMutations, [{ pullRequestId: 'PR_node_id' }])
   assert.deepEqual(result.labelsAdded, [
-    { issue_number: 472, labels: ['needs-codex-review'] },
+    { issue_number: 472, labels: ['awaiting-review'] },
   ])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
@@ -2710,7 +2710,7 @@ test('CI auto-ready job retries auto-merge for already-ready auto-ready PRs', as
   assert.equal(result.mutations.length, 0)
   assert.deepEqual(result.autoMergeMutations, [{ pullRequestId: 'PR_node_id' }])
   assert.deepEqual(result.labelsAdded, [
-    { issue_number: 472, labels: ['needs-codex-review'] },
+    { issue_number: 472, labels: ['awaiting-review'] },
   ])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
@@ -2779,7 +2779,7 @@ test('auto-ready workflow retries auto-merge for already-ready auto-ready PRs', 
   assert.equal(result.mutations.length, 0)
   assert.deepEqual(result.autoMergeMutations, [{ pullRequestId: 'PR_node_id' }])
   assert.deepEqual(result.labelsAdded, [
-    { issue_number: 472, labels: ['needs-codex-review'] },
+    { issue_number: 472, labels: ['awaiting-review'] },
   ])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
@@ -2808,10 +2808,10 @@ test('auto-ready workflows skip native auto-merge for workflow-file PRs', async 
   assert.deepEqual(standalone.autoMergeMutations, [])
   assert.deepEqual(ci.autoMergeMutations, [])
   assert.deepEqual(standalone.labelsAdded, [
-    { issue_number: 472, labels: ['needs-codex-review'] },
+    { issue_number: 472, labels: ['awaiting-review'] },
   ])
   assert.deepEqual(ci.labelsAdded, [
-    { issue_number: 472, labels: ['needs-codex-review'] },
+    { issue_number: 472, labels: ['awaiting-review'] },
   ])
 })
 
@@ -2850,14 +2850,14 @@ test('auto-ready workflow treats skipped required checks as passing', async () =
   assert.equal(result.mutations.length, 1)
 })
 
-test('auto-ready workflow flags ready PRs for Codex review', async () => {
+test('auto-ready workflow flags ready PRs for review', async () => {
   const result = await runAutoReadyWorkflow({
     checkRuns: successfulDevelopRequiredCheckRuns(),
   })
 
   assert.equal(result.mutations.length, 1)
   assert.deepEqual(result.labelsAdded, [
-    { issue_number: 472, labels: ['needs-codex-review'] },
+    { issue_number: 472, labels: ['awaiting-review'] },
   ])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
@@ -2976,18 +2976,18 @@ test('auto-ready workflow skips when check/status lookup fails', async () => {
   assert.match(result.warnings[0], /failed to fetch checks\/statuses/)
 })
 
-test('Codex review label workflow clears review labels for collaborator approvals', async () => {
+test('review label workflow clears review labels for collaborator approvals', async () => {
   const result = await runCodexReviewFlagWorkflow()
 
   assert.deepEqual(result.labelsAdded, [])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
-    { issue_number: 472, name: 'needs-codex-review' },
+    { issue_number: 472, name: 'awaiting-review' },
   ])
   assert.deepEqual(result.notices, ['PR #472 cleared review-state labels after approval.'])
 })
 
-test('Codex review label workflow keeps changes requested when another trusted reviewer still blocks', async () => {
+test('review label workflow keeps changes requested when another trusted reviewer still blocks', async () => {
   const result = await runCodexReviewFlagWorkflow({
     reviewOverrides: {
       user: { login: 'reviewer-b' },
@@ -3017,18 +3017,18 @@ test('Codex review label workflow keeps changes requested when another trusted r
     { issue_number: 472, labels: ['changes-requested'] },
   ])
   assert.deepEqual(result.labelsRemoved, [
-    { issue_number: 472, name: 'needs-codex-review' },
+    { issue_number: 472, name: 'awaiting-review' },
   ])
   assert.deepEqual(result.notices, [
     'PR #472 kept changes-requested because a trusted reviewer still requests changes.',
   ])
 })
 
-test('Codex review label workflow clears changes requested when the last trusted blocker is dismissed', async () => {
+test('review label workflow clears changes requested when the last trusted blocker is dismissed', async () => {
   const result = await runCodexReviewFlagWorkflow({
     action: 'dismissed',
     prOverrides: {
-      labels: [{ name: 'needs-codex-review' }, { name: 'changes-requested' }],
+      labels: [{ name: 'awaiting-review' }, { name: 'changes-requested' }],
     },
     reviewOverrides: {
       id: 9001,
@@ -3051,21 +3051,21 @@ test('Codex review label workflow clears changes requested when the last trusted
   })
 
   assert.deepEqual(result.labelsAdded, [
-    { issue_number: 472, labels: ['needs-codex-review'] },
+    { issue_number: 472, labels: ['awaiting-review'] },
   ])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
   ])
   assert.deepEqual(result.notices, [
-    'PR #472 flagged for Codex review after dismissal.',
+    'PR #472 flagged for review after dismissal.',
   ])
 })
 
-test('Codex review label workflow keeps dismissed PRs in the review queue when another trusted reviewer still blocks', async () => {
+test('review label workflow keeps dismissed PRs in the review queue when another trusted reviewer still blocks', async () => {
   const result = await runCodexReviewFlagWorkflow({
     action: 'dismissed',
     prOverrides: {
-      labels: [{ name: 'needs-codex-review' }, { name: 'changes-requested' }],
+      labels: [{ name: 'awaiting-review' }, { name: 'changes-requested' }],
     },
     reviewOverrides: {
       id: 9001,
@@ -3096,22 +3096,22 @@ test('Codex review label workflow keeps dismissed PRs in the review queue when a
   })
 
   assert.deepEqual(result.labelsAdded, [
-    { issue_number: 472, labels: ['needs-codex-review', 'changes-requested'] },
+    { issue_number: 472, labels: ['awaiting-review', 'changes-requested'] },
   ])
   assert.deepEqual(result.labelsRemoved, [])
   assert.deepEqual(result.notices, [
-    'PR #472 flagged for Codex review after dismissal; a trusted reviewer still requests changes.',
+    'PR #472 flagged for review after dismissal; a trusted reviewer still requests changes.',
   ])
 })
 
-test('Codex review label workflow clears review labels when PRs close', async () => {
+test('review label workflow clears review labels when PRs close', async () => {
   const parsedWorkflow = parseYaml(codexReviewFlagWorkflowPath)
   const result = await runCodexReviewFlagWorkflow({
     eventName: 'pull_request',
     action: 'closed',
     prOverrides: {
       state: 'closed',
-      labels: [{ name: 'needs-codex-review' }, { name: 'changes-requested' }],
+      labels: [{ name: 'awaiting-review' }, { name: 'changes-requested' }],
     },
   })
 
@@ -3119,16 +3119,16 @@ test('Codex review label workflow clears review labels when PRs close', async ()
   assert.deepEqual(result.labelsAdded, [])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
-    { issue_number: 472, name: 'needs-codex-review' },
+    { issue_number: 472, name: 'awaiting-review' },
   ])
   assert.deepEqual(result.notices, ['PR #472 cleared review-state labels after close.'])
 })
 
-test('Codex review re-request workflow requests reviewer and notifies Discord', async () => {
+test('PR review re-request workflow requests reviewer and notifies Discord', async () => {
   const workflow = await readFile(codexReviewRerequestWorkflowPath, 'utf8')
   const parsedWorkflow = parseYaml(codexReviewRerequestWorkflowPath)
 
-  assert.equal(parsedWorkflow.name, 'Auto re-request Codex review')
+  assert.equal(parsedWorkflow.name, 'Auto re-request PR review')
   assert.equal(parsedWorkflow.permissions['pull-requests'], 'write')
   assert.match(workflow, /github\.rest\.pulls\.listReviews/)
   assert.match(workflow, /github\.rest\.pulls\.requestReviewers/)

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2687,6 +2687,9 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
 test('CI auto-ready job marks ready before arming native auto-merge', async () => {
   const result = await runCiAutoReadyAfterCiWorkflow({
     checkRuns: successfulDevelopRequiredCheckRuns(),
+    prOverrides: {
+      labels: [{ name: 'auto-ready' }, { name: 'needs-codex-review' }],
+    },
   })
 
   assert.deepEqual(result.graphqlCalls, ['ready', 'auto-merge'])
@@ -2696,6 +2699,7 @@ test('CI auto-ready job marks ready before arming native auto-merge', async () =
   ])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
+    { issue_number: 472, name: 'needs-codex-review' },
   ])
 })
 
@@ -2853,6 +2857,9 @@ test('auto-ready workflow treats skipped required checks as passing', async () =
 test('auto-ready workflow flags ready PRs for review', async () => {
   const result = await runAutoReadyWorkflow({
     checkRuns: successfulDevelopRequiredCheckRuns(),
+    livePrOverrides: {
+      labels: [{ name: 'auto-ready' }, { name: 'needs-codex-review' }],
+    },
   })
 
   assert.equal(result.mutations.length, 1)
@@ -2861,6 +2868,7 @@ test('auto-ready workflow flags ready PRs for review', async () => {
   ])
   assert.deepEqual(result.labelsRemoved, [
     { issue_number: 472, name: 'changes-requested' },
+    { issue_number: 472, name: 'needs-codex-review' },
   ])
 })
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -855,7 +855,8 @@ jobs:
             const owner = context.repo.owner
             const repo = context.repo.repo
             const autoReadyLabel = 'auto-ready'
-            const reviewLabel = 'needs-codex-review'
+            const reviewLabel = 'awaiting-review'
+            const staleReviewLabel = 'needs-codex-review'
             const changesLabel = 'changes-requested'
             const targetBaseBranches = new Set(['main', 'develop'])
             const allowedJobResults = new Set(['success', 'skipped'])
@@ -895,8 +896,10 @@ jobs:
               }
             }
 
-            const hasAutoReadyLabel = (pr) =>
-              (pr.labels || []).some((label) => label.name === autoReadyLabel)
+            const hasLabel = (pr, name) =>
+              (pr.labels || []).some((label) => label.name === name)
+
+            const hasAutoReadyLabel = (pr) => hasLabel(pr, autoReadyLabel)
 
             const ensureLabel = async (name, color, description) => {
               try {
@@ -915,19 +918,22 @@ jobs:
               }
             }
 
-            const flagForCodexReview = async (pr) => {
+            const flagForReview = async (pr) => {
               await ensureLabel(
                 reviewLabel,
                 '0075ca',
-                'New PR opened or new commits pushed after the latest Codex review — pending Codex review',
+                'New PR opened or new commits pushed after the latest trusted review — pending review',
               )
               await ensureLabel(
                 changesLabel,
                 'd73a4a',
-                'Codex has requested changes — author should update the PR',
+                'Reviewer has requested changes — author should update the PR',
               )
               await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [reviewLabel] })
               await removeLabel(pr.number, changesLabel)
+              if (hasLabel(pr, staleReviewLabel)) {
+                await removeLabel(pr.number, staleReviewLabel)
+              }
             }
 
             const enableAutoMerge = async (pr) => {
@@ -1156,19 +1162,19 @@ jobs:
             }
 
             try {
-              await flagForCodexReview(pr)
+              await flagForReview(pr)
             } catch (error) {
               core.warning(
-                `Failed to flag PR #${pr.number} for Codex review; ${autoReadyLabel} will retry while the label remains (${error?.message || error}).`,
+                `Failed to flag PR #${pr.number} for review; ${autoReadyLabel} will retry while the label remains (${error?.message || error}).`,
               )
               return
             }
 
             const readyMessage = markedReady ? 'marked ready for review, ' : ''
             if (workflowFileChanged) {
-              core.notice(`PR #${pr.number} ${readyMessage}skipped auto-merge for workflow-file PR, and flagged for Codex review.`)
+              core.notice(`PR #${pr.number} ${readyMessage}skipped auto-merge for workflow-file PR, and flagged for review.`)
             } else {
-              core.notice(`PR #${pr.number} ${readyMessage}armed auto-merge, and flagged for Codex review.`)
+              core.notice(`PR #${pr.number} ${readyMessage}armed auto-merge, and flagged for review.`)
             }
 
   notify-discord:

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -194,9 +194,10 @@ jobs:
 
               if (context.payload.action === 'dismissed') {
                 if (trustedReviewSummary.hasChangesRequested) {
-                  await addLabels(pr.number, [reviewLabel, changesLabel])
+                  await addLabels(pr.number, [changesLabel])
+                  await removeLabel(pr.number, reviewLabel)
                   await removeStaleReviewLabel(pr)
-                  core.notice(`PR #${pr.number} flagged for review after dismissal; a trusted reviewer still requests changes.`)
+                  core.notice(`PR #${pr.number} kept ${changesLabel} because a trusted reviewer still requests changes.`)
                   return
                 }
 

--- a/.github/workflows/codex-review-flag.yml
+++ b/.github/workflows/codex-review-flag.yml
@@ -1,4 +1,4 @@
-name: Flag PR for Codex review
+name: Flag PR for review
 
 on:
   schedule:
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   label-state:
-    name: Manage Codex review labels
+    name: Manage PR review labels
     runs-on: ubuntu-latest
     steps:
       - name: Sync labels
@@ -24,12 +24,15 @@ jobs:
           script: |
             const owner = context.repo.owner
             const repo = context.repo.repo
-            const reviewLabel = 'needs-codex-review'
+            const reviewLabel = 'awaiting-review'
+            const staleReviewLabel = 'needs-codex-review'
             const changesLabel = 'changes-requested'
             const trustedAuthorAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR'])
             const targetBaseBranches = new Set(['main', 'develop'])
 
             const isTargetBase = (pr) => targetBaseBranches.has(pr.base?.ref)
+            const hasLabel = (pr, name) =>
+              (pr.labels || []).some((label) => label.name === name)
 
             const isTrustedReview = (review) => {
               const login = review.user?.login || ''
@@ -115,6 +118,12 @@ jobs:
               }
             }
 
+            const removeStaleReviewLabel = async (pr) => {
+              if (hasLabel(pr, staleReviewLabel)) {
+                await removeLabel(pr.number, staleReviewLabel)
+              }
+            }
+
             // For schedule cron: find the last trusted review (any state)
             // to detect whether new commits have been pushed since the last review.
             const getLastTrustedReview = async (pr) => {
@@ -126,9 +135,9 @@ jobs:
             // It re-evaluates:
             // 1. PRs stuck with `changes-requested` that have received new commits
             //    since the last review.
-            // 2. PRs with no Codex review history yet, as a fallback if the
+            // 2. PRs with no review history yet, as a fallback if the
             //    original `opened` event was missed.
-            // 3. PRs previously reviewed by Codex that have new commits since
+            // 3. PRs previously reviewed that have new commits since
             //    that review, but currently lack the review label because a
             //    `synchronize` event was missed.
             const shouldFlag = async (pr) => {
@@ -137,7 +146,7 @@ jobs:
 
               const lastReview = await getLastTrustedReview(pr)
 
-              // No prior Codex review means the PR likely missed the original
+              // No prior trusted review means the PR likely missed the original
               // flagging event and should be put into the review queue.
               if (!lastReview) {
                 return !labels.includes(changesLabel)
@@ -157,12 +166,12 @@ jobs:
             await ensureLabel(
               reviewLabel,
               '0075ca',
-              'New PR opened or new commits pushed after the latest Codex review — pending Codex review',
+              'New PR opened or new commits pushed after the latest trusted review — pending review',
             )
             await ensureLabel(
               changesLabel,
               'd73a4a',
-              'Codex has requested changes — author should update the PR',
+              'Reviewer has requested changes — author should update the PR',
             )
 
             if (context.eventName === 'pull_request_review') {
@@ -186,19 +195,22 @@ jobs:
               if (context.payload.action === 'dismissed') {
                 if (trustedReviewSummary.hasChangesRequested) {
                   await addLabels(pr.number, [reviewLabel, changesLabel])
-                  core.notice(`PR #${pr.number} flagged for Codex review after dismissal; a trusted reviewer still requests changes.`)
+                  await removeStaleReviewLabel(pr)
+                  core.notice(`PR #${pr.number} flagged for review after dismissal; a trusted reviewer still requests changes.`)
                   return
                 }
 
                 await addLabels(pr.number, [reviewLabel])
                 await removeLabel(pr.number, changesLabel)
-                core.notice(`PR #${pr.number} flagged for Codex review after dismissal.`)
+                await removeStaleReviewLabel(pr)
+                core.notice(`PR #${pr.number} flagged for review after dismissal.`)
                 return
               }
 
               if (trustedReviewSummary.hasChangesRequested) {
                 await addLabels(pr.number, [changesLabel])
                 await removeLabel(pr.number, reviewLabel)
+                await removeStaleReviewLabel(pr)
                 core.notice(`PR #${pr.number} kept ${changesLabel} because a trusted reviewer still requests changes.`)
                 return
               }
@@ -206,6 +218,7 @@ jobs:
               if (reviewState(review) === 'approved') {
                 await removeLabel(pr.number, changesLabel)
                 await removeLabel(pr.number, reviewLabel)
+                await removeStaleReviewLabel(pr)
                 core.notice(`PR #${pr.number} cleared review-state labels after approval.`)
                 return
               }
@@ -234,6 +247,7 @@ jobs:
               if (action === 'closed') {
                 await removeLabel(pr.number, changesLabel)
                 await removeLabel(pr.number, reviewLabel)
+                await removeStaleReviewLabel(pr)
                 core.notice(`PR #${pr.number} cleared review-state labels after close.`)
                 continue
               }
@@ -254,7 +268,8 @@ jobs:
               ) {
                 await addLabels(pr.number, [reviewLabel])
                 await removeLabel(pr.number, changesLabel)
-                core.notice(`PR #${pr.number} flagged for Codex review (${action}).`)
+                await removeStaleReviewLabel(pr)
+                core.notice(`PR #${pr.number} flagged for review (${action}).`)
                 continue
               }
 
@@ -263,6 +278,9 @@ jobs:
               if (await shouldFlag(pr)) {
                 await addLabels(pr.number, [reviewLabel])
                 await removeLabel(pr.number, changesLabel)
-                core.notice(`PR #${pr.number} flagged for Codex review (schedule catch-up).`)
+                await removeStaleReviewLabel(pr)
+                core.notice(`PR #${pr.number} flagged for review (schedule catch-up).`)
+              } else {
+                await removeStaleReviewLabel(pr)
               }
             }

--- a/.github/workflows/codex-review-rerequest.yml
+++ b/.github/workflows/codex-review-rerequest.yml
@@ -1,4 +1,4 @@
-name: Auto re-request Codex review
+name: Auto re-request PR review
 
 on:
   workflow_run:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   evaluate:
-    name: Evaluate Codex review re-request
+    name: Evaluate PR review re-request
     runs-on: ubuntu-latest
     outputs:
       has_review_requests: ${{ steps.evaluate.outputs.has_review_requests }}
@@ -27,7 +27,7 @@ jobs:
           script: |
             const owner = context.repo.owner
             const repo = context.repo.repo
-            const reviewLabel = 'needs-codex-review'
+            const reviewLabel = 'awaiting-review'
             const changesLabel = 'changes-requested'
             const targetBaseBranches = new Set(['main', 'develop'])
             async function getFullPr(pullNumber) {
@@ -82,7 +82,7 @@ jobs:
             function buildDiscordPayload(fullPr, sourceRun, reviewers) {
               const shortSha = (fullPr.head?.sha || sourceRun.head_sha || '').slice(0, 7)
               const lines = [
-                `Codex review re-requested for PR #${fullPr.number}`,
+                `PR review re-requested for PR #${fullPr.number}`,
                 `**${fullPr.title}**`,
                 fullPr.html_url,
                 `Author: ${fullPr.user?.login || 'unknown'}`,
@@ -192,7 +192,7 @@ jobs:
             core.setOutput('review_requests', JSON.stringify(reviewRequests))
 
   rerequest:
-    name: Re-request Codex review and notify Discord
+    name: Re-request PR review and notify Discord
     needs: evaluate
     if: needs.evaluate.outputs.has_review_requests == 'true'
     runs-on: ubuntu-latest
@@ -208,7 +208,7 @@ jobs:
           path: ${{ runner.temp }}/codex-review-rerequest/${{ matrix.review_request.dedup_key }}
           key: codex-review-rerequest-${{ github.repository }}-${{ matrix.review_request.dedup_key }}
 
-      - name: Re-request Codex review
+      - name: Re-request PR review
         id: rerequest-review
         if: steps.dedup-cache.outputs.cache-hit != 'true'
         uses: actions/github-script@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,8 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 
 | Label | 用途 |
 |---|---|
-| `needs-codex-review` | PR 有新 commit，輪到 Codex 重新審查 |
-| `changes-requested` | Codex 已提出 blocker，輪到作者修正 |
+| `awaiting-review` | PR 等待 reviewer 審查或複查 |
+| `changes-requested` | Reviewer 已提出 blocker，輪到作者修正 |
 | `auto-ready` | Codex task draft PR 的 opt-in label；required checks 全綠後由 workflow 自動轉 ready |
 
 ## Scope 邊界

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@
 |---|---|
 | `feature` | 開發任務 |
 | `discussion` | 討論票（搭配 `[discussion]` 前綴使用） |
-| `needs-codex-review` | PR 有新 commit，輪到 Codex 重新審查 |
-| `changes-requested` | Codex 已提出 blocker，輪到作者修正 |
+| `awaiting-review` | PR 等待 reviewer 審查或複查 |
+| `changes-requested` | Reviewer 已提出 blocker，輪到作者修正 |
 | `auto-ready` | Codex task draft PR 的 opt-in label；required checks 全綠後由 workflow 自動轉 ready |
 
 ### Issue 內容格式

--- a/docs/draft-pr-auto-ready.md
+++ b/docs/draft-pr-auto-ready.md
@@ -25,7 +25,7 @@ review, while auto-merge happens after approval.
 4. The auto-ready job verifies the PR is still eligible and all required checks
    in the maintained snapshot for the base branch are successful.
 5. The workflow marks the PR ready for review.
-6. The same workflow adds `needs-codex-review` and removes `changes-requested`
+6. The same workflow adds `awaiting-review` and removes `changes-requested`
    because events emitted by `GITHUB_TOKEN` do not trigger the separate
    `ready_for_review` label workflow.
 
@@ -144,7 +144,7 @@ only where the ready-for-review mutation can run.
 The ready-for-review mutation is executed with `GITHUB_TOKEN`, so the resulting
 `ready_for_review` event does not trigger `.github/workflows/codex-review-flag.yml`.
 The auto-ready paths therefore also use `issues: write` to add
-`needs-codex-review` and remove stale `changes-requested` in the same guarded
+`awaiting-review` and remove stale `changes-requested` in the same guarded
 mutation path.
 
 ## PR creation default

--- a/plans/github-actions-enhancements.md
+++ b/plans/github-actions-enhancements.md
@@ -12,8 +12,8 @@ repo 目前已有 9 個 `.github/workflows` 檔案，其中 8 個是 GitHub Acti
 | `.github/workflows/ci.yml` | 主要 CI、scope gate、backend/frontend/dashboard/contracts 測試、workflow regression、commit message regression |
 | `.github/workflows/ci.test.mjs` | `ci.yml` / scope policy / auto-merge 等 workflow 行為的 Node regression test |
 | `.github/workflows/pr-scope-police.yml` | PR metadata、diff 大小、product surface、dependency gate 檢查 |
-| `.github/workflows/codex-review-flag.yml` | 管理 `needs-codex-review` / `changes-requested` label |
-| `.github/workflows/codex-review-slack.yml` | CI 成功且 PR 有 `needs-codex-review` label 時通知 Slack review queue |
+| `.github/workflows/codex-review-flag.yml` | 管理 `awaiting-review` / `changes-requested` label |
+| `.github/workflows/codex-review-slack.yml` | CI 成功且 PR 有 `awaiting-review` label 時通知 Slack review queue |
 | `.github/workflows/auto-merge.yml` | 非 Dependabot PR opened/reopened/ready_for_review 時啟用 GitHub auto-merge |
 | `.github/workflows/dependabot-automerge.yml` | Dependabot PR 的保守 auto-merge policy |
 | `.github/workflows/notify-rebase-needed.yml` | PR merge 後通知其他有 conflict 的 PR rebase |
@@ -30,7 +30,7 @@ repo 目前已有 9 個 `.github/workflows` 檔案，其中 8 個是 GitHub Acti
 - Contract CI：Foundry install、build、test、format check。
 - Workflow regression：用 `.github/workflows/ci.test.mjs` 固定 workflow policy 不被誤改。
 - Commit message 檢查：`ci.yml` 已有 `commit-message-regression` 與 `pr-commit-messages` job。
-- Review label lifecycle：PR opened/synchronize/ready_for_review、Codex review submitted/dismissed、scheduled fallback。
+- Review label lifecycle：PR opened/synchronize/ready_for_review、trusted reviewer submitted/dismissed、scheduled fallback。
 - Auto-merge：一般 PR 與 Dependabot 分流處理。
 - Release PR：定期從 `develop` promote 到 `main`。
 
@@ -75,7 +75,7 @@ PR A 已處理：
 
 **優先級：P1 / workflow completed**
 
-目的：讓 Codex task PR 可以先用 draft 發出跑 CI，CI 綠後自動轉 ready for review，並在同一條受 guard 的 auto-ready path 加上 `needs-codex-review`。
+目的：讓 Codex task PR 可以先用 draft 發出跑 CI，CI 綠後自動轉 ready for review，並在同一條受 guard 的 auto-ready path 加上 `awaiting-review`。
 
 Repo 內設計 / rollout 文件：
 
@@ -100,7 +100,7 @@ rollout PR 補上：
   或 `ci.yml` 的 `auto-ready-after-ci` job。
 - review label：rollout validation 發現由 `GITHUB_TOKEN` 觸發的
   `ready_for_review` 不會喚醒 `codex-review-flag.yml`，因此 auto-ready
-  path 在 mark ready 後直接加 `needs-codex-review` 並移除 stale
+  path 在 mark ready 後直接加 `awaiting-review` 並移除 stale
   `changes-requested`。
 
 目前 workflow 觸發：
@@ -120,7 +120,7 @@ rollout PR 補上：
 - 以 workflow 內 required-check snapshot 作為 readiness gate，並用 regression tests 固定。
 - 不讀 fork 產物、不 checkout PR head。
 - mark ready 前再次驗證 PR number、head SHA、base branch、draft state、label state、author deny-list。
-- mark ready 後在同一個 guarded path 加上 `needs-codex-review`，並移除 stale `changes-requested`。
+- mark ready 後在同一個 guarded path 加上 `awaiting-review`，並移除 stale `changes-requested`。
 - CI completion hook 只在 `scope-gate`、`backend-ci`、`frontend`、`dashboard`、`contracts`
   都是 `success` 或 `skipped` 後執行，且仍以 required-check snapshot 作為最後 gate。
 
@@ -178,14 +178,14 @@ rollout PR 補上：
 | Workflow | Write permission | 必要 guard |
 |---|---|---|
 | `pr-scope-police.yml` | `pull-requests: write` / `issues: write` | 只跑 `pull_request` 到 `main` / `develop`，sticky comment、label、嚴重違規 close 都必須基於同一份 scope evaluation |
-| `ci.yml` | `contents: write` / `pull-requests: write` / `issues: write` / `checks: read` / `statuses: read` | 只限 `auto-ready-after-ci` job；只跑 `pull_request`；必須等 protected CI gate jobs 完成，並驗證同 repo draft PR、`auto-ready` label、非 dependency bot、live head SHA 與 snapshot required checks 全部成功；`contents: write` 只用於 ready-for-review mutation 權限需求；`issues: write` 只用於加 `needs-codex-review` 與移除 stale `changes-requested` |
+| `ci.yml` | `contents: write` / `pull-requests: write` / `issues: write` / `checks: read` / `statuses: read` | 只限 `auto-ready-after-ci` job；只跑 `pull_request`；必須等 protected CI gate jobs 完成，並驗證同 repo draft PR、`auto-ready` label、非 dependency bot、live head SHA 與 snapshot required checks 全部成功；`contents: write` 只用於 ready-for-review mutation 權限需求；`issues: write` 只用於加 `awaiting-review` 與移除 stale `changes-requested` |
 | `codex-review-flag.yml` | `pull-requests: write` / `issues: write` | 只處理 `main` / `develop` PR；review event 只接受指定 reviewer；draft PR 不加 review label |
-| `codex-review-slack.yml` | `actions: write` | 只在 CI success 或 `needs-codex-review` label 後通知 Slack；必須驗證 PR open、非 draft、base branch、label、head SHA、dedup cache |
+| `codex-review-slack.yml` | `actions: write` | 只在 CI success 或 `awaiting-review` label 後通知 Slack；必須驗證 PR open、非 draft、base branch、label、head SHA、dedup cache |
 | `auto-merge.yml` | `contents: write` / `pull-requests: write` | 排除 draft 與 Dependabot；只啟用 GitHub auto-merge，不直接 merge |
 | `dependabot-automerge.yml` | `contents: write` / `pull-requests: write` | 只允許 `dependabot[bot]` actor；必須通過 metadata policy 或 `safe-to-automerge` label |
 | `notify-rebase-needed.yml` | `pull-requests: write` / `issues: write` | 只在 merge 到 `develop` 後留言；不得修改 PR branch |
 | `weekly-release-pr.yml` | `pull-requests: write` / `actions: write` | 只建立 `develop -> main` release PR；若已存在 open release PR 就 no-op |
-| `auto-ready-pr.yml` | `contents: write` / `pull-requests: write` / `issues: write` / `checks: read` / `statuses: read` | 只處理同 repo draft PR、`auto-ready` label、非 dependency bot、live head SHA 與 snapshot required checks 全部成功；`contents: write` 只用於 ready-for-review mutation 權限需求；`issues: write` 只用於加 `needs-codex-review` 與移除 stale `changes-requested` |
+| `auto-ready-pr.yml` | `contents: write` / `pull-requests: write` / `issues: write` / `checks: read` / `statuses: read` | 只處理同 repo draft PR、`auto-ready` label、非 dependency bot、live head SHA 與 snapshot required checks 全部成功；`contents: write` 只用於 ready-for-review mutation 權限需求；`issues: write` 只用於加 `awaiting-review` 與移除 stale `changes-requested` |
 
 明確禁止第一版 workflow health check 接受未審查的 `pull_request_target`、repo-wide `contents: write`，或沒有 base branch / actor / label guard 的 public mutation workflow。
 


### PR DESCRIPTION
## 什麼改動
將 PR review queue 狀態 label 從 `needs-codex-review` 收斂為 `awaiting-review`，並同步 auto-ready、review-state、re-request workflow、regression tests 與文件。

## 為什麼
`needs-codex-review` 讀起來像 Codex-only signal，實際 reviewer 都是人時會削弱「現在輪到 reviewer 處理」的急迫感。

closes #767

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#767
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不變更 auto-merge policy
  - 不自動 approve PR
  - 不移除 stale `needs-codex-review` label 的相容清理

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - n/a
- Actual worker profile(s)：
  - controller
- Model strength：
  - controller = GPT-5
- Spawn directive(s)：
  - profile=controller model=gpt-5 reasoning=medium controller_fallback=denied fallback_reason=self-only
- Verification evidence：
  - `rtk node --test .github/workflows/ci.test.mjs`
  - `rtk node --test --test-name-pattern "CI auto-ready job marks ready before arming native auto-merge|auto-ready workflow flags ready PRs for review" .github/workflows/ci.test.mjs`
  - `rtk git --no-optional-locks diff --check`
- Self-review / exception reason：
  - self-only quick workflow change; no autonomous implementation worker used
- Worker session closeout：
  - self-only closeout complete for implementation; sprint readback worker result was read by controller and did not identify a code blocker
- Workflow friction / follow-up split：
  - CodeRabbit latest-head review was rate-limited after the final test-coverage commit; controller used GitHub readback plus local regression tests as fallback evidence.

## Review conversation closeout
- Unresolved threads：
  - 0 blocking threads by GraphQL readback; CodeRabbit blocker discussion_r3251587780 is resolved
- CodeRabbit：
  - blocker adopted in commit 68a16ff8; stale-label regression coverage note adopted in commit 45878bd4; latest CodeRabbit attempt for 45878bd4 was rate-limited
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - PR #768 CodeRabbit review, discussion_r3251587780, plus CodeRabbit rate-limit comment on latest head
- root_cause_gate_ref：
  - commit 68a16ff8 fixes dismissed-with-remaining-blocker review-state model; commit 45878bd4 covers stale-label cleanup regression
- finding_disposition_ref：
  - adopted blocker and adopted stale-label cleanup coverage note; CodeRabbit latest-head review deferred by rate-limit fallback
- Final reviewer action：
  - actionable findings fixed; remaining gate is human review approval

## Final merge gate
- Ready-to-merge decision：
  - blocked by REVIEW_REQUIRED / human approval; not blocked by CI or merge conflict
- Latest head SHA：
  - 45878bd4e381afef438139ec6ab2fd4b9811c9f2
- Required checks：
  - CI, Scope Police, workflow regression tests, Backend CI gate, Cloudflare Pages, and CodeRabbit status are success; `Notify Discord on failure` is skipped/non-blocking
- spec workflow-check evidence：
  - n/a; local `spec workflow-check` unavailable in sprint environment, manual checklist used
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/actions/runs/25947915884

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Rename the active PR review queue label to `awaiting-review` while preserving stale label cleanup.
- Approx changed lines：~207
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Workflow behavior, regression tests, and docs must stay aligned so the label state machine remains understandable and guarded.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Auto-ready PRs are labeled `awaiting-review` after CI passes.
- [x] `changes-requested` continues to mean author action is needed.
- [x] Approval and close events clear review-state labels.
- [x] Workflow regression tests pass.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk node --test .github/workflows/ci.test.mjs
tests 85
pass 85
fail 0

rtk node --test --test-name-pattern "CI auto-ready job marks ready before arming native auto-merge|auto-ready workflow flags ready PRs for review" .github/workflows/ci.test.mjs
tests 2
pass 2
fail 0
```

## 備註
Workflow keeps `staleReviewLabel = 'needs-codex-review'` only to remove old labels from existing PRs when review-state automation runs.

## Notes for Claude Code Review
- 請特別看 `.github/workflows/codex-review-flag.yml` 的狀態轉換：`awaiting-review` 表示輪到 reviewer，`changes-requested` 表示輪到作者。
- Auto-ready 仍保留 workflow-file PR 不自動 arm auto-merge 的既有保護。
- CodeRabbit 對 latest head `45878bd4` 回報 rate limit；請以已通過的 CI/workflow regression tests 與 resolved review thread 作為替代 closeout evidence。
