### PR TITLE
[discussion] Dev Portal 視覺重塑：設計 spec

### DIFF
--- a/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
+++ b/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
@@ -24,16 +24,16 @@ Phase 1 Link Layer（#694–#698）已將 Dev Portal 內容層建置完成，#69
 1. **內頁完全沒有自訂樣式**。首頁有 573 行 `custom.css`（拓撲圖、卡片網格），但 `start-here`、`domain-maps`、`flows` 等內頁直接使用 Docusaurus 預設樣式，table 是無底色邊框、heading 沒有層次、整體質感顯著低於首頁。使用者實測後反映「沒有質感」。
 2. **資料殘片散落**。`domain-maps.md` 有 5 個「Coming soon」字串、`flows.md` 有 1 個未完成流程，且 sidebar 結構扁平（5 個分類），P0 onboarding 路徑與 reference / archive 條目混雜。
 
-本次工作將以 **Trello 鮮明色彩 × Notion 卡片堆疊** 為視覺方向，全面重塑 Dev Portal 的 CSS 系統、補上 3 個 MDX 元件、並重新組織 sidebar 與資料殘片。目標是讓 Dev Portal 在 `*.pages.dev` 公開部署前達到「人類與 AI agent 都覺得有質感且可掃讀」的狀態。
+本次工作將以 **engineering console × atlas workbook** 為視覺方向，全面重塑 Dev Portal 的 CSS 系統、補上 3 個 MDX 元件、並重新組織 sidebar 與資料殘片。目標是讓 Dev Portal 在 `*.pages.dev` 公開部署前達到「人類與 AI agent 都覺得有質感且可掃讀」的狀態。
 
 ## 視覺方向
 
-採用 **方向 B（Trello-primary）+ 部分 Notion 元素**：
+採用 **engineering console / atlas workbook**：
 
-- 看板灰底（`#f4f5f7`）+ 白色卡片（`box-shadow: 0 1px 0 rgba(9,30,66,.25)`）
-- 鮮明彩色 pill badge（藍/綠/橘）標示狀態
-- 卡片堆疊 list 取代部分 markdown table
-- Notion 的 callout 樣式（左側色條 + emoji）用於提示塊
+- 安靜的文件工作台：灰底 board、白色 card、薄 border、低陰影
+- 以藍/綠/橘/紅 token 做狀態與拓撲提示，但避免整頁變成高彩度看板
+- 首頁像專案導覽 console；內頁像可掃讀的 engineering runbook
+- Callout 保留左側色條語彙，PR2/PR3 若導入 MDX markup 再補更精準的狀態型別
 
 ## 設計系統
 

--- a/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
+++ b/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
@@ -1,0 +1,236 @@
+---
+title: Dev Portal 視覺重塑與資料整理
+status: draft
+owner: engineering
+last_reviewed: 2026-05-15
+source_of_truth: true
+code_areas:
+  - apps/docs
+  - docs/dev-portal
+  - docs
+related_repos:
+  - tachigo
+related_issues:
+  - "#699"
+---
+
+# Dev Portal 視覺重塑與資料整理
+
+## Context
+
+Phase 1 Link Layer（#694–#698）已將 Dev Portal 內容層建置完成，#699 也將 Cloudflare Pages 部署 repo-side 準備就緒。但目前 Dev Portal 的呈現有兩個顯著問題：
+
+1. **內頁完全沒有自訂樣式**。首頁有 573 行 `custom.css`（拓撲圖、卡片網格），但 `start-here`、`domain-maps`、`flows` 等內頁直接使用 Docusaurus 預設樣式，table 是無底色邊框、heading 沒有層次、整體質感顯著低於首頁。使用者實測後反映「沒有質感」。
+2. **資料殘片散落**。`domain-maps.md` 有 5 個「Coming soon」字串、`flows.md` 有 1 個未完成流程，且 sidebar 結構扁平（5 個分類），P0 onboarding 路徑與 reference / archive 條目混雜。
+
+本次工作將以 **Trello 鮮明色彩 × Notion 卡片堆疊** 為視覺方向，全面重塑 Dev Portal 的 CSS 系統、補上 3 個 MDX 元件、並重新組織 sidebar 與資料殘片。目標是讓 Dev Portal 在 `*.pages.dev` 公開部署前達到「人類與 AI agent 都覺得有質感且可掃讀」的狀態。
+
+## 視覺方向
+
+採用 **方向 B（Trello-primary）+ 部分 Notion 元素**：
+
+- 看板灰底（`#f4f5f7`）+ 白色卡片（`box-shadow: 0 1px 0 rgba(9,30,66,.25)`）
+- 鮮明彩色 pill badge（藍/綠/橘）標示狀態
+- 卡片堆疊 list 取代部分 markdown table
+- Notion 的 callout 樣式（左側色條 + emoji）用於提示塊
+
+## 設計系統
+
+### 色彩 token
+
+```css
+:root {
+  --dp-primary: #0052cc;
+  --dp-success: #00875a;
+  --dp-warning: #ff8b00;
+  --dp-neutral: #6b778c;
+  --dp-danger: #de350b;
+
+  --dp-bg-board: #f4f5f7;
+  --dp-bg-card: #ffffff;
+  --dp-bg-subtle: #fafaf9;
+
+  --dp-text-primary: #172b4d;
+  --dp-text-secondary: #5e6c84;
+  --dp-text-muted: #9b9a97;
+
+  --dp-border: #dfe1e6;
+  --dp-border-strong: #c1c7d0;
+
+  --dp-radius-sm: 3px;
+  --dp-radius-md: 6px;
+  --dp-radius-lg: 8px;
+
+  --dp-shadow-card: 0 1px 0 rgba(9, 30, 66, 0.25);
+  --dp-shadow-card-hover: 0 4px 12px rgba(9, 30, 66, 0.15);
+}
+
+[data-theme='dark'] {
+  --dp-bg-board: #0f1117;
+  --dp-bg-card: #1a1d24;
+  --dp-text-primary: #f9fafb;
+  --dp-text-secondary: #9ca3af;
+  --dp-border: #1f2937;
+}
+```
+
+### 字型
+
+- 內文：`Inter`（既有，移除 Avenir Next / Optima）
+- 中文 fallback：`Noto Sans TC`（保留）
+- 代碼：`JetBrains Mono`（取代現有 SFMono）
+
+## CSS 元件（自動套用）
+
+| Selector | 樣式 |
+|---|---|
+| `article table` | 白底、表頭 `--dp-bg-board` 灰底、表格邊框 `1px solid var(--dp-border)`、`border-radius: var(--dp-radius-lg)`、`overflow: hidden`、tbody row `:hover` 加 `background: var(--dp-bg-subtle)` |
+| `article h2` | 左側 `4px` 漸層色條（`linear-gradient(180deg, var(--dp-primary), var(--dp-success))`）、`padding-left: 12px`、margin `32px 0 12px` |
+| `article h3` | uppercase label 風格（`font-size: 13px; letter-spacing: .08em; color: var(--dp-text-secondary)`） |
+| `article :not(pre) > code` | `background: var(--dp-bg-board); color: var(--dp-danger); padding: 1px 5px; border-radius: var(--dp-radius-sm)` |
+| `article pre` | 深底 `#172b4d` + 白字、`JetBrains Mono`、`border-radius: var(--dp-radius-lg)` |
+| `article blockquote` | 左側 4px 色條（依首字 emoji 變色：💡 黃、⚠️ 橘、🚨 紅、📝 藍）、淡底色 |
+| `article a` | `color: var(--dp-primary)` + 點線下底（`text-decoration: underline dotted`），hover 變實線 |
+
+## MDX 元件
+
+### `<StatusBadge status="..." />`
+
+```tsx
+type StatusBadgeProps = {
+  status: 'complete' | 'draft' | 'planned' | 'blocker' | 'in-progress';
+  children?: React.ReactNode;
+};
+```
+
+對應色彩：complete = `--dp-success`、draft = `--dp-warning`、planned = `--dp-neutral`、blocker = `--dp-danger`、in-progress = `--dp-primary`。
+
+位置：`apps/docs/src/components/StatusBadge/`
+
+### `<DomainCard title="..." status="..." sources={[]} issues={[]} />`
+
+替換 `domain-maps.md` 的 P0/P1 markdown table，以卡片堆疊呈現。每張卡顯示：
+
+- 標題（h3 級別）
+- 狀態 badge（用 `<StatusBadge>`）
+- Source 連結清單（GitHub blob URLs）
+- 相關 issues（GitHub issue links）
+
+位置：`apps/docs/src/components/DomainCard/`
+
+### `<RoadmapStub title="..." status="planned" eta="..." owner="..." />`
+
+取代 `domain-maps.md` 與 `flows.md` 的 5 個 + 1 個「Coming soon」字串，明確顯示狀態、ETA、owner，並提供 placeholder 連結（可連到 issue 或 source entry point）。
+
+位置：`apps/docs/src/components/RoadmapStub/`
+
+## 資料整理
+
+### Sidebar 重組
+
+`apps/docs/sidebars.ts` 改為 4 群組：
+
+```
+🚀 Getting Started (expanded)
+  ├─ start-here
+  ├─ domain-maps
+  ├─ daily-dev-guide
+  └─ deployment-tracker (來自 #699，標 in-progress)
+
+🗺️ Architecture & Flows
+  ├─ architecture
+  ├─ sequence-diagram
+  ├─ flows
+  ├─ source-index
+  ├─ graph-explorer
+  ├─ watch-to-points-design
+  ├─ auth-architecture
+  ├─ tokenomics
+  └─ backend-permissions
+
+⚙️ Daily Work
+  ├─ AI Workflow（README、autonomous-pr-gates、cheatsheet…）
+  └─ Policies（auto-merge、dependabot、scope policy…）
+
+📦 Reference & Archive
+  ├─ extension-ui-prompts
+  ├─ feature-discussion
+  ├─ loyalty-claim-boundary
+  ├─ Plans and Proposals
+  └─ archive/（搬入 reference-notes 中的 6 個 2026-04-xx ~ 2026-05-xx history）
+```
+
+### 「Coming soon」處理
+
+`domain-maps.md` 的 5 個 stub 用 `<RoadmapStub>` 取代：
+
+| Domain | status | 補充說明 |
+|---|---|---|
+| Raffle / airdrop | `planned` | 標示 Phase 2 |
+| Claim / spend / coupon redemption | `draft` | 連結到 cross-repo flow |
+| Dashboard | `draft` | 連結到 `apps/dashboard` README |
+| Tachiya commerce | `draft` | 連結到 tachiya repo README |
+| AI workflow / PR scope policy | `complete` | 連結到 sidebar 既有條目 |
+
+`flows.md` 的 streamer / agency 流程：保留為 `<RoadmapStub status="draft">`，補上 `source-index.md` 已記錄的 entry points 連結。
+
+### History 條目搬移
+
+`docs/reference-notes/` 內 6 個 `2026-04-XX-*.md` 與 `2026-05-XX-*.md` 搬到 `docs/reference-notes/archive/`，避免 sidebar 雜訊。
+
+## 實作分階段
+
+### PR 1：CSS 設計系統（~400-500 行）
+
+- 重寫 `apps/docs/src/css/custom.css`
+- 移除 `.tachigo-*` 系列 class（首頁 markdown 改用通用 class 或 MDX 元件）
+- 加入 `--dp-*` token、字型載入（Google Fonts: Inter + JetBrains Mono）
+- 套用全域 selector（table、h2、h3、code、blockquote、a）
+
+**驗證**：本機 `pnpm start` 跑起來，每頁逐一檢視 light/dark mode，截首頁 + Start Here + Domain Maps 三張圖。
+
+### PR 2：MDX 元件 + high-value 頁面套用（~300-400 行）
+
+- 建立 `apps/docs/src/components/{StatusBadge,DomainCard,RoadmapStub}/`
+- 套用到 `docs/index.md`（首頁 status row）
+- 套用到 `docs/dev-portal/domain-maps.md`（P0/P1 卡片）
+- 套用到 `docs/dev-portal/flows.md`（streamer/agency stub）
+
+**驗證**：本機 build + render，確認 3 個元件在 light/dark mode 都正常。
+
+### PR 3：Sidebar 重組 + 資料整理（~200-300 行）
+
+- 重寫 `apps/docs/sidebars.ts`
+- `git mv` history 條目到 `docs/reference-notes/archive/`
+- 補完 5 個 Coming soon 的 `<RoadmapStub>` 內容
+- `flows.md` streamer/agency stub 補 source entry points
+
+**驗證**：本機 build pass（`onBrokenLinks: 'throw'`），每個 sidebar 群組展開檢查、所有 RoadmapStub 連結有效。
+
+## 驗證流程
+
+1. **本機渲染**：`cd apps/docs && pnpm start`，逐頁檢視
+2. **Light / Dark**：每頁切換 theme，確認對比可讀
+3. **斷點**：DevTools 切 375px / 768px / 1024px，確認 sidebar collapse、卡片堆疊
+4. **Build**：`pnpm build` 通過（內含 broken link check）
+5. **Screenshot**：PR description 附首頁 + Start Here + Domain Maps before/after
+6. **AI agent fetch**：確認 `/tachigo/llms.txt`、`/tachigo/manifest.json` 內容未被視覺改動破壞
+
+## 不在本次 scope
+
+- 不部署到 Cloudflare Pages（#699 account-side / human gate）
+- 不引入 i18n（單一 zh-Hant locale 維持）
+- 不重寫拓撲圖 SVG（保留現有 grid layout，僅換配色）
+- 不改 markdown content（除 5 個 Coming soon + flows streamer stub）
+- 不引入新的搜尋引擎（保留 EasyOps local search）
+
+## 風險
+
+- **首頁 markdown 內嵌大量 `.tachigo-*` class JSX**：PR 1 移除這些 class 時可能漏改首頁 markdown，需在 PR 1 同步更新 `docs/index.md`
+- **字型載入影響 Cloudflare Pages 部署**：Google Fonts 改用 self-hosted 或保留 system font，避免外部依賴延遲。建議 PR 1 用 `@fontsource/inter` + `@fontsource/jetbrains-mono`
+- **Dark mode 對比測試成本**：建議 PR 1 PR description 附 dark mode 截圖
+
+## 相關 issue
+
+- `#699` — Dev Portal 部署追蹤（本 spec 為其 prerequisite，但不互相 block）
+- 待開新 issue：`[frontend] Dev Portal 視覺重塑與資料整理` 作為 epic，三個 PR 各自 closes 子 issue

--- a/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
+++ b/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
@@ -158,7 +158,7 @@ type StatusBadgeProps = {
   ├─ feature-discussion
   ├─ loyalty-claim-boundary
   ├─ Plans and Proposals
-  └─ archive/（搬入 reference-notes 中的 6 個 2026-04-xx ~ 2026-05-xx history）
+  └─ History（引用 `docs/history/` 中的 2026-04-xx ~ 2026-05-xx history）
 ```
 
 ### 「Coming soon」處理
@@ -177,7 +177,7 @@ type StatusBadgeProps = {
 
 ### History 條目搬移
 
-`docs/reference-notes/` 內 6 個 `2026-04-XX-*.md` 與 `2026-05-XX-*.md` 搬到 `docs/reference-notes/archive/`，避免 sidebar 雜訊。
+保留既有 `docs/history/` 目錄，不搬移檔案；PR 3 只在 sidebar 的 Reference & Archive 群組中引用這些 history 條目，避免指向不存在的 `docs/reference-notes/` 路徑。
 
 ## 實作分階段
 
@@ -202,7 +202,7 @@ type StatusBadgeProps = {
 ### PR 3：Sidebar 重組 + 資料整理（~200-300 行）
 
 - 重寫 `apps/docs/sidebars.ts`
-- `git mv` history 條目到 `docs/reference-notes/archive/`
+- 在 sidebar 的 Reference & Archive 群組中引用既有 `docs/history/` 條目，不執行 history 檔案搬移
 - 補完 5 個 Coming soon 的 `<RoadmapStub>` 內容
 - `flows.md` streamer/agency stub 補 source entry points
 

--- a/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
+++ b/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
@@ -131,7 +131,7 @@ type StatusBadgeProps = {
 
 `apps/docs/sidebars.ts` 改為 4 群組：
 
-```
+```text
 🚀 Getting Started (expanded)
   ├─ start-here
   ├─ domain-maps
@@ -184,8 +184,8 @@ type StatusBadgeProps = {
 ### PR 1：CSS 設計系統（~400-500 行）
 
 - 重寫 `apps/docs/src/css/custom.css`
-- 移除 `.tachigo-*` 系列 class（首頁 markdown 改用通用 class 或 MDX 元件）
-- 加入 `--dp-*` token、字型載入（Google Fonts: Inter + JetBrains Mono）
+- 保留 `.tachigo-*` 結構，將顏色與樣式映射到 `--dp-*`；PR 1 只允許 token remap，不移除首頁 DOM / class，以避免首頁樣式回歸
+- 加入 `--dp-*` token、字型載入（self-hosted `@fontsource/inter` + `@fontsource/jetbrains-mono`）
 - 套用全域 selector（table、h2、h3、code、blockquote、a）
 
 **驗證**：本機 `pnpm start` 跑起來，每頁逐一檢視 light/dark mode，截首頁 + Start Here + Domain Maps 三張圖。
@@ -227,8 +227,8 @@ type StatusBadgeProps = {
 
 ## 風險
 
-- **首頁 markdown 內嵌大量 `.tachigo-*` class JSX**：PR 1 移除這些 class 時可能漏改首頁 markdown，需在 PR 1 同步更新 `docs/index.md`
-- **字型載入影響 Cloudflare Pages 部署**：Google Fonts 改用 self-hosted 或保留 system font，避免外部依賴延遲。建議 PR 1 用 `@fontsource/inter` + `@fontsource/jetbrains-mono`
+- **首頁 markdown 內嵌大量 `.tachigo-*` class JSX**：PR 1 必須保留既有 class / DOM 結構，只做 token remap；若要移除 class 或重組 markup，需另拆 PR 2/PR 3 範圍
+- **字型載入影響 Cloudflare Pages 部署**：外部字型服務改用 self-hosted 或保留 system font，避免外部依賴延遲。建議 PR 1 用 `@fontsource/inter` + `@fontsource/jetbrains-mono`
 - **Dark mode 對比測試成本**：建議 PR 1 PR description 附 dark mode 截圖
 
 ## 相關 issue

--- a/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
+++ b/docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md
@@ -1,6 +1,6 @@
 ---
 title: Dev Portal 視覺重塑與資料整理
-status: draft
+status: proposed
 owner: engineering
 last_reviewed: 2026-05-15
 source_of_truth: true
@@ -11,7 +11,8 @@ code_areas:
 related_repos:
   - tachigo
 related_issues:
-  - "#699"
+  - 699
+  - 728
 ---
 
 # Dev Portal 視覺重塑與資料整理


### PR DESCRIPTION
## 什麼改動

新增 Dev Portal 視覺重塑與資料整理的 design spec（PR #732 epic 的設計依據）。

- `docs/superpowers/specs/2026-05-15-dev-portal-visual-redesign.md`：237 行 spec，定義 `--dp-*` design token 體系、全域 article 樣式、MDX 元件（`<StatusBadge>` / `<DomainCard>` / `<RoadmapStub>`）、sidebar 重組、3-PR 拆分計畫
- frontmatter 已調整為 `status: proposed`、`related_issues: [699, 728]`，通過 frontmatter validator

不在本 PR 範圍：
- CSS 設計系統實作 → #732
- MDX 元件實作 → 後續 PR 2
- Sidebar 重組與資料整理 → 後續 PR 3

## 為什麼

refs #728

Dev Portal 視覺重塑屬於跨 3 個 PR 的 epic（CSS → MDX → 資料整理），需要 source of truth 文件作為三個 PR 的設計依據。本 PR 把 spec 文件從 #732 拆出來獨立 review，避免 #732 同時混 CSS 實作 + design 文件造成 scope 過大（先前 #732 達 1138 行被 scope police 自動關閉）。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#728
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不含任何 CSS / 程式碼實作
  - 不含 MDX 元件
  - 不含 sidebar / 資料調整

## Delegation Execution Log
- Source issue delegation plan：#728 delegation plan
- Actual worker profile(s)：
  - controller（Claude Code 執行 PR 拆分 + spec 從原 #732 提出）
  - review_worker（Codex 執行 pre-push gate 驗證）
- Model strength：Claude split = medium、Codex verification = high
- Spawn directive(s)：profile=codex-rescue model=gpt-5.5 reasoning=xhigh controller_fallback=claude-code
- Verification evidence：`pnpm --filter @tachigo/docs build` pass（spec 是純 markdown，frontmatter validator 通過）
- Self-review / exception reason：已 self-review；spec 內容自 #732 原始 commits cherry-pick + 混合 commit ccdfd4bf 的 spec hunk
- Worker session closeout：Codex pre-push gate 已關閉並回報 GREEN
- Workflow friction / follow-up split：本 PR 即為 #732 scope 問題的 split follow-up

## Review conversation closeout
- Unresolved threads：0（initial open，尚無 review thread）
- CodeRabbit：not yet triggered（initial open）
- chatgpt-codex-connector：not yet triggered（initial open）
- review_triage_ref：https://github.com/nurockplayer/tachigo/pull/769
- root_cause_gate_ref：https://github.com/nurockplayer/tachigo/pull/769
- finding_disposition_ref：https://github.com/nurockplayer/tachigo/pull/769
- Final reviewer action：not-ready — fresh open, no reviewer action yet

## Final merge gate
- Ready-to-merge decision：not-ready — fresh open, awaiting CodeRabbit / Codex review
- Latest head SHA：e13b949c
- Required checks：pending
- spec workflow-check evidence：n/a
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/769

## PR 拆分檢查
- 這個 PR 的單一句子目的：建立 Dev Portal 視覺重塑 epic 的設計 spec 作為 source of truth
- Approx changed lines：~237 insertions / 0 deletions
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是（spec 是 source of truth，反過來 #732 引用本 PR）
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs（spec）
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a（只一項）
- 若已拆分，相關 PR：
  - #732（CSS 實作，本 PR 為其設計依據）

## Acceptance Criteria
- [x] AC 1：spec 文件包含完整 `--dp-*` token、全域樣式 selector、MDX 元件規格
- [x] AC 2：frontmatter 通過 validator（status: proposed、related_issues 為 numeric array）
- [x] AC 3：3-PR 拆分計畫明確
- [x] AC 4：`pnpm --filter @tachigo/docs build` pass

## 超出範圍內容

無。

## 測試方式
- [x] 本地測試過（pnpm build pass）
- [ ] 有寫 / 更新測試（spec 為 markdown 文件，無新測試需求）

**驗證結果**

```
$ pnpm --filter @tachigo/docs build
> docusaurus build
[INFO] [zh-Hant] Creating an optimized production build...
[webpackbar] ✔ Server: Compiled successfully in 10.09s
[webpackbar] ✔ Client: Compiled successfully in 31.90s
[SUCCESS] Generated static files in "build".
```

## 備註

- spec 內容直接 cherry-pick 自 #732 原始 commits（`a8d379d5`、`607cbe36`、`391df194`），加上混合 commit `ccdfd4bf` 的 spec hunk
- CSS 實作部分留在 #732，移除非授權的 `scope-exception` label 後重新提交 review

## Notes for Claude Code Review

- 確認 frontmatter `related_issues: [699, 728]` 為 numeric array（不是 string）
- 確認 spec 提到的 3-PR 拆分計畫與當前 epic 進度一致
