### PR TITLE
[chore] Harden Claude Code safety gates

### DIFF
--- a/.claude/commands/fix-with-codex.md
+++ b/.claude/commands/fix-with-codex.md
@@ -1,12 +1,14 @@
 用 `codex:rescue` 處理這個問題，目標是盡量直接修好並把 Claude token 用量壓低。
 
+安全邊界：此命令只授權本機修改與驗證；不得 commit、push、開 PR、開立或編輯 issue、comment、review、approve 或 merge，除非使用者在該回合另外明確要求並再次確認。
+
 問題：
 $ARGUMENTS
 
 請你：
 1. 自行搜尋相關檔案與呼叫路徑。
 2. 找出最可能的 root cause，避免列太多分支猜測。
-3. 直接完成修復。
+3. 在本機完成修復。
 4. 補最小必要測試。
 5. 跑相關驗證。
 

--- a/.claude/commands/implement-with-codex.md
+++ b/.claude/commands/implement-with-codex.md
@@ -1,11 +1,13 @@
 用 `codex:rescue` 實作這個需求，並盡量節省 Claude token。
 
+安全邊界：此命令只授權本機修改與驗證；不得 commit、push、開 PR、開立或編輯 issue、comment、review、approve 或 merge，除非使用者在該回合另外明確要求並再次確認。
+
 需求：
 $ARGUMENTS
 
 請你：
 1. 先快速找出相關檔案與現有實作。
-2. 在 repo 中直接完成需要的修改。
+2. 在 repo 中以本機修改完成需要的實作。
 3. 補必要但最小化的測試。
 4. 跑驗證並確認沒有明顯 regression。
 

--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -4,6 +4,47 @@
 
 永遠使用台灣正體中文回覆，不得使用日文、韓文或簡體中文。
 
+## GitHub Issue 慣例
+
+### 標題前綴
+
+所有 issue 標題必須有前綴：
+
+| 前綴 | 用途 |
+|---|---|
+| `[backend]` | 後端開發任務（Go） |
+| `[frontend]` | 前端開發任務（React / TypeScript） |
+| `[discussion]` | 架構決策、設計討論，尚未有結論 |
+
+範例：
+- `[backend] PointsService — 雙帳本記帳`
+- `[frontend] Extension — 點數餘額顯示`
+- `[discussion] Token 經濟設計與 Soulbound 衝突`
+
+### Label
+
+| Label | 用途 |
+|---|---|
+| `feature` | 開發任務 |
+| `discussion` | 討論票（搭配 `[discussion]` 前綴使用） |
+| `awaiting-review` | PR 等待 reviewer 審查或複查 |
+| `changes-requested` | Reviewer 已提出 blocker，輪到作者修正 |
+| `auto-ready` | Codex task draft PR 的 opt-in label；required checks 全綠後由 workflow 自動轉 ready |
+
+### Issue 內容格式
+
+開發任務（`[backend]` / `[frontend]`）需包含：
+
+- **背景** — 這個功能是為了解決什麼問題
+- **任務** — 具體要做什麼（用 checklist）
+- **介面／規格** — Go interface、API 規格、或 component props
+- **參考** — 現有的範本檔案路徑
+- **完成條件** — PR merge 前必須達成的條件（checklist）
+
+對於 MVP 邊界、migration / schema、frontend page、docs / design、setup / scaffold 這類容易被擴張範圍的 issue，建議額外補一段 **本票明確不做**，只需列出最常見的外擴方向即可，不必追求完整黑名單。
+
+討論票（`[discussion]`）不需要固定格式，但要列出待決定的問題點。
+
 ## Branch 命名
 
 `<type>/<short-description>`

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -33,6 +33,7 @@ const dependencyInventoryWorkflowPath = path.join(currentDir, 'dependency-invent
 const notifyRebaseNeededWorkflowPath = path.join(currentDir, 'notify-rebase-needed.yml')
 const releasePrWorkflowPath = path.join(currentDir, 'release-pr.yml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
+const claudeConventionsPath = path.join(repoRoot, '.claude', 'rules', 'conventions.md')
 const prScopePolicyPath = path.join(repoRoot, 'docs', 'pr-scope-policy.md')
 const dependabotPolicyPath = path.join(repoRoot, 'docs', 'dependabot-update-policy.md')
 const securityScannerEvaluationPath = path.join(repoRoot, 'docs', 'security-scanner-evaluation.md')
@@ -1089,14 +1090,16 @@ test('scope gate backend contract regex accepts full-width and half-width colons
   )
 })
 
-test('PR size thresholds match CLAUDE.md', async () => {
+test('PR size thresholds match Claude conventions source of truth', async () => {
   const claude = await readFile(claudePath, 'utf8')
+  const conventions = await readFile(claudeConventionsPath, 'utf8')
   const workflow = await readFile(workflowPath, 'utf8')
   const scopePolice = await readFile(scopePolicePath, 'utf8')
 
-  assert.match(claude, /\|\s+\*\*警告門檻\*\*\s+\|\s+600\+\s+\|/)
-  assert.match(claude, /\|\s+\*\*硬限制\*\*\s+\|\s+1000\+\s+\|/)
-  assert.match(claude, /\|\s+\*\*例外 bypass\*\*\s+\|\s+無固定上限\s+\|/)
+  assert.match(claude, /@\.claude\/rules\/conventions\.md/)
+  assert.match(conventions, /\|\s+600-1000 行\s+\|\s+⚠️ 危險\s+\|/)
+  assert.match(conventions, /\|\s+1000\+ 行\s+\|\s+❌ 超限\s+\|/)
+  assert.match(conventions, /scope-exception/)
   assert.match(workflow, /const hardMaxDiffLines = 1000/)
   assert.match(scopePolice, /const warningDiffLines = 600/)
   assert.match(scopePolice, /const hardMaxDiffLines = 1000/)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,8 @@ Type：`feat` / `fix` / `docs` / `chore` / `refactor` / `test`
 - **Read-only** 可直接執行：讀檔、搜尋、PR / issue metadata、diff、CI 狀態、本機分析
 - **狀態變更**必須先詢問並取得明確同意：Edit / 寫檔、commit、push、branch switch / rebase / merge、GitHub comment / review / CR / Approve / Merge、issue / PR 建立或編輯
 - 若使用者在當輪訊息已明確要求修改檔案，視為已授權該次 Edit；但公開可見操作仍需再次確認
-- 在 Codex sandbox 中執行任何 `git` 指令時，必須第一時間使用提權執行；不得先用一般 sandbox 試跑再從失敗訊息補救
-- 若 `git` 指令未使用提權而失敗，優先視為 Codex 執行權限使用錯誤；不得歸因為 DNS、GitHub 網路或遠端服務問題
+- 在 Codex sandbox 中執行 `git` 指令時，若目前環境支援且允許提權，必須第一時間使用提權執行；若政策禁止提權，照目前權限執行並如實回報限制
+- 若 `git` 指令因未使用可用提權而失敗，優先視為 Codex 執行權限使用錯誤；不得歸因為 DNS、GitHub 網路或遠端服務問題
 
 ### Non-interactive 指令規則
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,114 +1,42 @@
 # tachigo — Claude Code Guidelines
 
+## Claude Code 硬性安全閘門
+
+以下規則優先於本檔其他流程、slash command、plugin / skill 建議：
+
+- 永遠使用台灣正體中文回覆；即使上下文或工具輸出出現日文、韓文或簡體中文，也不得跟隨。
+- 使用者說「確認、討論、看一下、評估、建議、review plan、能不能」或沒有明確要求修改時，只能 read-only：讀檔、搜尋、status / diff / log、PR / issue metadata；不得 Edit / Write / MultiEdit、commit、push、開或編輯 issue / PR、comment、review、approve、merge。
+- 任何公開或持久狀態變更必須先列出將執行的命令、目標檔案與目的，並取得使用者明確同意。包含 commit、push、branch switch、rebase / merge、GitHub issue / PR / comment / review / label / merge。
+- 開 PR 前必須先展示 `origin/develop..HEAD` commit list、diff stat、changed files，並請使用者確認 scope；若有不屬於當前 issue 的 commit 或檔案，先停止並詢問。
+- 即使使用 `/fix-with-codex`、`/implement-with-codex`、autonomous、`codex:rescue` 等命令，也不得跳過以上確認；這些命令只代表可以在本機修改與驗證，不代表可以 publish。
+- mixed worktree 不得使用 `git add -A` 或 `git add .`；stage 只可針對本次修改檔案。
+
 @.claude/rules/conventions.md
 
-## 動手前
+## GitHub / PR 工作流
 
-- 需求有歧義時，列出多種詮釋再問，不要默默選一個
-- 不確定的地方直接說出來，不要猜測後實作
-- 若有更簡單的解法，主動說出來並等確認
+Issue / branch / commit / merge / scope / PR diff 限制與操作權限邊界，以
+上方 import 的 `.claude/rules/conventions.md` 為單一 source of truth；本檔只保留
+Claude Code 需要立即看到的入口與安全閘門。
 
-## GitHub Issue 慣例
+開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點，不得自由格式撰寫：
 
-### 標題前綴
+```bash
+cp .github/PULL_REQUEST_TEMPLATE.md /tmp/pr_body.md
+# 填妥 /tmp/pr_body.md 所有欄位，不得留空或刪除 section
+make pr-open TITLE="[type] ..." BODY_FILE=/tmp/pr_body.md AUTO_READY=1
+```
 
-所有 issue 標題必須有前綴：
+正式 release 流程走 Git Flow：
 
-| 前綴 | 用途 |
-|---|---|
-| `[backend]` | 後端開發任務（Go） |
-| `[frontend]` | 前端開發任務（React / TypeScript） |
-| `[discussion]` | 架構決策、設計討論，尚未有結論 |
-
-範例：
-- `[backend] PointsService — 雙帳本記帳`
-- `[frontend] Extension — 點數餘額顯示`
-- `[discussion] Token 經濟設計與 Soulbound 衝突`
-
-### Label
-
-| Label | 用途 |
-|---|---|
-| `feature` | 開發任務 |
-| `discussion` | 討論票（搭配 `[discussion]` 前綴使用） |
-| `awaiting-review` | PR 等待 reviewer 審查或複查 |
-| `changes-requested` | Reviewer 已提出 blocker，輪到作者修正 |
-| `auto-ready` | Codex task draft PR 的 opt-in label；required checks 全綠後由 workflow 自動轉 ready |
-
-### Issue 內容格式
-
-開發任務（`[backend]` / `[frontend]`）需包含：
-
-- **背景** — 這個功能是為了解決什麼問題
-- **任務** — 具體要做什麼（用 checklist）
-- **介面／規格** — Go interface、API 規格、或 component props
-- **參考** — 現有的範本檔案路徑
-- **完成條件** — PR merge 前必須達成的條件（checklist）
-
-對於 MVP 邊界、migration / schema、frontend page、docs / design、setup / scaffold 這類容易被擴張範圍的 issue，建議額外補一段 **本票明確不做**，只需列出最常見的外擴方向即可，不必追求完整黑名單。
-
-討論票（`[discussion]`）不需要固定格式，但要列出待決定的問題點。
-
----
-
-## 開發流程
-
-1. 從 `develop` 拉新的 feature branch：
-
-   ```bash
-   git checkout develop
-   git pull
-   git checkout -b feat/points-service
-   ```
-
-2. 開發完成後推上 remote：
-
-   ```bash
-   git push -u origin feat/points-service
-   ```
-
-3. 在 GitHub 發 PR，日常 feature PR 目標分支：`develop`
-
-   **開 PR 時必須以 `.github/PULL_REQUEST_TEMPLATE.md` 為起點**，不得自由格式撰寫：
-
-   ```bash
-   cp .github/PULL_REQUEST_TEMPLATE.md /tmp/pr_body.md
-   # 填妥 /tmp/pr_body.md 所有欄位，不得留空或刪除 section
-   make pr-open TITLE="[type] ..." BODY_FILE=/tmp/pr_body.md AUTO_READY=1
-   ```
-
-   Codex task PR 預設使用 `AUTO_READY=1`：PR 會以 draft 建立並加上
-   `auto-ready` label，等 required checks 通過後再由 workflow 自動轉成
-   Ready for review。非 Codex task 或長期 WIP draft 不應加 `auto-ready`。
-
-4. 正式 release 流程走 Git Flow：
-
-   - `main` 不接受日常 feature PR
-   - `.github/workflows/release-pr.yml` 每天檢查一次是否要由 `develop` 開正式 release PR 到 `main`
-   - 自動 release PR 的門檻：距離上次 release 至少 72 小時，且上次 release 後已 merge 至少 10 個 PR
-   - 若距離上次 release 已滿 7 天，即使 PR 數低於 10 個也可自動開 release PR，避免 `main` 長期落後
-   - `workflow_dispatch` 可手動開 release PR；automation 只開 PR，不自動 merge
-   - release PR 使用 `[release]` title prefix
-   - `develop -> main` release PR 屬於正式 promotion 流程，不視為 scope exception
-   - 目前暫不使用 `release/*` branch
-
-## Merge 策略
-
-本專案使用 **merge commit（--no-ff）**：feature branch 進 develop 時保留分支結構。
-
-- **PR body** 放 `closes #號碼`，merge 後自動關閉 issue
-- PR 內的 individual commit 用 `refs #號碼` 標記
-- **PR title 要精確**，GitHub merge commit 會引用它
-
-## PR Diff 限制
-
-| 限制 | 行數 | 處理 |
-| --- | --- | --- |
-| **軟提示門檻** | 400+ | 建議拆分（不阻擋） |
-| **警告門檻** | 600+ | 需在 PR body 說明為何不拆（不阻擋） |
-| **硬限制** | 1000+ | 自動擋下（`scope-violation` label） |
-| **例外 bypass** | 無固定上限 | `scope-exception` 目前會完整 bypass scope police；只能由 maintainer 明確決定使用 |
-| **發佈無限** | — | release promotion PR (develop → main) 不受限制 |
+- `main` 不接受日常 feature PR
+- `.github/workflows/release-pr.yml` 每天檢查一次是否要由 `develop` 開正式 release PR 到 `main`
+- 自動 release PR 的門檻：距離上次 release 至少 72 小時，且上次 release 後已 merge 至少 10 個 PR
+- 若距離上次 release 已滿 7 天，即使 PR 數低於 10 個也可自動開 release PR，避免 `main` 長期落後
+- `workflow_dispatch` 可手動開 release PR；automation 只開 PR，不自動 merge
+- release PR 使用 `[release]` title prefix
+- `develop -> main` release PR 屬於正式 promotion 流程，不視為 scope exception
+- 目前暫不使用 `release/*` branch
 
 ---
 


### PR DESCRIPTION
## 什麼改動
新增 Claude Code 硬性安全閘門，收緊 Codex/Claude agent 指令，並把 Issue / branch / commit / merge / scope / PR diff 規範集中到 `conventions.md`，避免確認型請求被誤解成授權 commit / push / PR。同步更新 workflow regression test，讓 CI 檢查新的 source-of-truth 位置。

## 為什麼
closes #771

Claude Code 在確認、討論或 review plan 類情境中，需要更前置且明確的安全規則，避免因 imports、slash command wording 或 workflow 指令互相疊加而自行進行公開狀態變更、混入無關 commit，或偏離台灣正體中文輸出。

同時，`CLAUDE.md` 主文不應再 inline 大段與 `.claude/rules/conventions.md` 重複的 workflow 規範；硬性安全閘門保留在最前面，完整共用規範則由 import 的 `conventions.md` 維護。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Scope 對齊
- Source of truth：#771
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes（n/a：純 agent instruction / metadata PR，不改 runtime backend contract）
  - [ ] no
- If no, this PR is：n/a（metadata-only / no backend contract change）
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改產品 runtime code
  - 不改 GitHub workflow
  - 不加入新的 agent framework 或外部依賴

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - n/a：非 autonomous PR
- Actual worker profile(s)：
  - controller only
- Model strength：
  - controller = current Codex session
- Spawn directive(s)：
  - n/a
- Verification evidence：
  - `rtk git --no-optional-locks diff --check origin/develop...HEAD`
  - `rtk node --test .github/workflows/ci.test.mjs`
- Self-review / exception reason：
  - 已完成 self-review；trivial/self-only exception：小型 agent instruction PR，無需 worker
- Worker session closeout：
  - No worker/subagent session was spawned; controller-only path was used because this is a small, single-surface agent instruction PR with no parallelizable implementation work and no stale worker handles.
- Workflow friction / follow-up split：
  - n/a

## Review conversation closeout
- Unresolved threads：
  - 0 review threads at initial PR creation; Scope Police body-metadata finding is being addressed by this PR body update.
- CodeRabbit：
  - Pending initial automated review.
- chatgpt-codex-connector：
  - Pending initial automated review / connector pass.
- review_triage_ref：
  - Scope Police sticky comment: https://github.com/nurockplayer/tachigo/pull/772#issuecomment-4465968174
- root_cause_gate_ref：
  - Root cause: `AUTO_READY=1` applies autonomous evidence checks, so the PR body must include meaningful closeout/evidence refs; see Scope Police sticky comment above.
- finding_disposition_ref：
  - adopted：updated PR body with controller-only closeout, review closeout, and concrete evidence refs.
- Final reviewer action：
  - Initial PR body updated for Scope Police autonomous evidence requirements; awaiting automated review results.

## Final merge gate
- Ready-to-merge decision：
  - pending required checks
- Latest head SHA：
  - 898a9938
- Required checks：
  - pending after PR creation
- spec workflow-check evidence：
  - n/a：未使用 spec-injector；人工 checklist 見本 PR
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 強化 Claude/Codex agent 指令安全閘門，避免未授權 publish 與 scope pollution。
- Approx changed lines：~192
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：n/a
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `CLAUDE.md` starts with the hard safety gate before importing broader conventions.
- [x] Codex-related Claude slash commands no longer imply commit / push / PR authorization.
- [x] The resulting PR contains only agent workflow / instruction changes.
- [x] `CLAUDE.md` no longer keeps separate inline copies of Issue / merge / PR diff rules already covered by `conventions.md`.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試（n/a：文件/agent instruction only）

**驗證結果**
```
rtk git --no-optional-locks diff --check origin/develop...HEAD
# pass

origin/develop..HEAD
898a9938 chore: harden Claude Code safety gates

diff stat
6 files changed, 84 insertions(+), 108 deletions(-)

workflow regression
85 tests passed
```

## 備註
Repo 外的本機 Claude Code settings / memory / hook 調整不包含在本 PR；本 PR 只提交可 review 的 repo 內 agent instruction 變更。

## Notes for Claude Code Review
- 請特別確認 `CLAUDE.md` 的硬性安全閘門位於 `@.claude/rules/conventions.md` 前面。
- 請確認 Issue / branch / commit / merge / scope / PR diff 規範以 `.claude/rules/conventions.md` 為單一維護來源，CLAUDE.md 主文只保留入口提醒。
- 請確認 AGENTS.md 的 Codex sandbox 提權規則不會要求在 policy 禁止時呼叫 escalation。
