### PR TITLE
[infra] Mark generated release PRs as R4 risk

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2620,6 +2620,18 @@ test('release PR workflow includes grouped PR summaries in generated body', asyn
   assert.match(jobBlock, /\$\(cat \/tmp\/release-pr-summary\.md\)/)
 })
 
+test('release PR workflow marks generated release PRs as R4 risk', async () => {
+  const workflow = await readFile(releasePrWorkflowPath, 'utf8')
+  const jobBlock = workflowJobBlock(workflow, 'create-release-pr')
+
+  assert.match(jobBlock, /## PR Risk Class/)
+  assert.match(jobBlock, /- \[ \] R0 docs \/ template \/ metadata only/)
+  assert.match(jobBlock, /- \[ \] R1 tests \/ CI \/ tooling only/)
+  assert.match(jobBlock, /- \[ \] R2 frontend behavior/)
+  assert.match(jobBlock, /- \[ \] R3 backend \/ API behavior/)
+  assert.match(jobBlock, /- \[x\] R4 auth \/ permissions \/ security \/ schema \/ migration \/ secrets \/ payments \/ wallet \/ workflow \/ release/)
+})
+
 test('release cadence documentation matches the automated gate', async () => {
   const claude = await readFile(claudePath, 'utf8')
   const policy = await readFile(prScopePolicyPath, 'utf8')

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -250,6 +250,13 @@ jobs:
           - [ ] Test-Driven / Debug Loop
           - [x] Architecture / High Risk
 
+          ## PR Risk Class
+          - [ ] R0 docs / template / metadata only
+          - [ ] R1 tests / CI / tooling only
+          - [ ] R2 frontend behavior
+          - [ ] R3 backend / API behavior
+          - [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release
+
           ## Scope 對齊
           - Source of truth：develop release promotion on $DATE
           - Depends on PR：none


### PR DESCRIPTION
## 什麼改動
讓 `.github/workflows/release-pr.yml` 產生的 `develop -> main` release PR body 自動包含 `PR Risk Class` 區塊，並勾選 `R4`。

## 為什麼
closes #774

#770 暴露 release PR generator 仍會產出缺少 risk class 的 body，導致 `PR Scope Police` 曾經失敗。#774 已把這個 follow-up 明確收斂為 release PR generator guardrail；#647 是上游 PR risk governance policy。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#774
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 #770 PR body、不 dismiss review、不 merge release PR、不調整 Scope Police 邏輯、不變更 R4 定義、不修改 PR template 本身。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #774 release PR generator guardrail；本輪由 retrospective safety mode 限定為 narrow governance/guardrail fix。
- Actual worker profile(s)：
  - controller / ops_spark sidecar
- Model strength：
  - controller = GPT-5.5 xhigh；ops_spark = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a task=read-only PR/issue/CI capacity audit
- Verification evidence：
  - `rtk node --test --test-name-pattern 'release PR workflow marks generated release PRs as R4 risk' .github/workflows/ci.test.mjs` pass 1/1
  - `rtk node --test .github/workflows/ci.test.mjs` pass 93/93
  - `rtk git --no-optional-locks diff --check origin/develop...HEAD` pass
- Self-review / exception reason：
  - Controller verified diff scope is limited to release PR generator body and workflow regression coverage.
- Worker session closeout：
  - Read-only ops_spark result was read back in the Codex thread; no additional worker action needed before PR creation.
- Workflow friction / follow-up split：
  - Narrow follow-up to #770 blocker and #774 AC; no product implementation. Threshold ledger: n/a for this small governance fix.

## Review conversation closeout
- Unresolved threads：
  - 0 at latest readback; CodeRabbit produced no actionable comments.
- CodeRabbit：
  - reviewed latest head `4a13eb1dac78767dc4ab4ae688ba61c3d6bf3772`; no actionable comments.
- chatgpt-codex-connector：
  - not_applicable_initial: awaiting connector/human review.
- review_triage_ref：
  - latest_head_no_actionable_coderabbit_comments
- root_cause_gate_ref：
  - root_cause_latest_head: release PR generator omitted PR Risk Class, while Scope Police now requires exactly one risk class.
- finding_disposition_ref：
  - not_applicable_no_actionable_findings
- Final reviewer action：
  - R4 workflow/release governance PR; requires human review.

## Final merge gate
- Ready-to-merge decision：
  - blocked_by_human_review: R4 workflow/release governance PR.
- Latest head SHA：
  - 4a13eb1dac78767dc4ab4ae688ba61c3d6bf3772
- Required checks：
  - PR Scope Police pass；CI pass；CodeRabbit success/no actionable comments；Cloudflare Pages success
- spec workflow-check evidence：
  - manual fallback: `spec` unavailable locally (`which spec` empty; `spec workflow-check --help` command missing)
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/775

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 release PR generator 產生的 body 自動勾選 R4 risk class。
- Approx changed lines：~19
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 下次由 workflow 自動產生的 release PR body 包含正確的 `## PR Risk Class` section，且預設勾選 R4
- [x] 有 regression test 驗證 PR body 格式正確
- [ ] Scope Police 在新 release PR 開出後自動通過（需下一次 release PR 驗證）

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
rtk node --test --test-name-pattern 'release PR workflow marks generated release PRs as R4 risk' .github/workflows/ci.test.mjs
pass 1/1

rtk node --test .github/workflows/ci.test.mjs
pass 93/93

rtk git --no-optional-locks diff --check origin/develop...HEAD
pass
```

## 備註
這張 PR 不帶 `auto-ready`；R4 release/workflow governance 必須由 human reviewer 明確 review。

## Notes for Claude Code Review
- 請特別確認 release PR generator 的 body 與 PR template / Scope Police 的 `PR Risk Class` 文案完全對齊。
