### PR TITLE
[backend] Wire ENABLE_SCHEDULER into raffle scheduler startup

### DIFF
--- a/services/api/cmd/server/main_test.go
+++ b/services/api/cmd/server/main_test.go
@@ -12,6 +12,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/tachigo/tachigo/internal/config"
+	"github.com/tachigo/tachigo/internal/services"
 )
 
 func TestServerStartupDoesNotRunSchemaDDL(t *testing.T) {
@@ -101,7 +104,7 @@ func TestServerStartupIsSplitByResponsibility(t *testing.T) {
 		"func wire(db *gorm.DB, cfg *config.Config, ctx context.Context) *gin.Engine",
 		"services.NewAuthService(db, cfg)",
 		"context.WithTimeout(ctx, 10*time.Second)",
-		"services.NewRaffleScheduler(raffleSvc).Start(ctx)",
+		"startRaffleSchedulerIfEnabled(ctx, cfg, raffleSvc)",
 		"router.New(",
 	} {
 		if !strings.Contains(wiringSource, want) {
@@ -111,6 +114,53 @@ func TestServerStartupIsSplitByResponsibility(t *testing.T) {
 	if strings.Contains(wiringSource, "context.WithTimeout(context.Background(), 10*time.Second)") {
 		t.Fatalf("Sepolia RPC dial timeout should inherit the server context")
 	}
+}
+
+func TestStartRaffleSchedulerIfEnabledRespectsConfig(t *testing.T) {
+	originalFactory := raffleSchedulerFactory
+	defer func() { raffleSchedulerFactory = originalFactory }()
+
+	var starts atomic.Int32
+	raffleSchedulerFactory = func(_ *services.RaffleService) raffleSchedulerStarter {
+		return fakeRaffleSchedulerStarter{starts: &starts}
+	}
+
+	startRaffleSchedulerIfEnabled(context.Background(), &config.Config{
+		Server: config.ServerConfig{EnableScheduler: false},
+	}, nil)
+	if got := starts.Load(); got != 0 {
+		t.Fatalf("disabled scheduler starts: want 0, got %d", got)
+	}
+
+	startRaffleSchedulerIfEnabled(context.Background(), &config.Config{
+		Server: config.ServerConfig{EnableScheduler: true},
+	}, nil)
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("enabled scheduler starts: want 1, got %d", got)
+	}
+}
+
+func TestStartRaffleSchedulerIfEnabledDefaultsToEnabledForNilConfig(t *testing.T) {
+	originalFactory := raffleSchedulerFactory
+	defer func() { raffleSchedulerFactory = originalFactory }()
+
+	var starts atomic.Int32
+	raffleSchedulerFactory = func(_ *services.RaffleService) raffleSchedulerStarter {
+		return fakeRaffleSchedulerStarter{starts: &starts}
+	}
+
+	startRaffleSchedulerIfEnabled(context.Background(), nil, nil)
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("nil config scheduler starts: want 1, got %d", got)
+	}
+}
+
+type fakeRaffleSchedulerStarter struct {
+	starts *atomic.Int32
+}
+
+func (f fakeRaffleSchedulerStarter) Start(context.Context) {
+	f.starts.Add(1)
 }
 
 func TestHTTPServerConfiguresProductionTimeouts(t *testing.T) {

--- a/services/api/cmd/server/wiring.go
+++ b/services/api/cmd/server/wiring.go
@@ -49,7 +49,7 @@ func wire(db *gorm.DB, cfg *config.Config, ctx context.Context) *gin.Engine {
 		oauthTokenSecret = cfg.JWT.RefreshSecret
 	}
 	raffleSvc := services.NewRaffleService(db, cfg.OAuth.Twitch.ClientID, cfg.App.FrontendURL, mailer, oauthTokenSecret)
-	services.NewRaffleScheduler(raffleSvc).Start(ctx)
+	startRaffleSchedulerIfEnabled(ctx, cfg, raffleSvc)
 	agencyH := handlers.NewAgencyHandler(agencySvc, emailAuthSvc)
 
 	return router.New(
@@ -71,4 +71,19 @@ func wire(db *gorm.DB, cfg *config.Config, ctx context.Context) *gin.Engine {
 		cfg.Server.AllowedOrigins,
 		router.InternalRouterConfig{DB: db, Config: cfg},
 	)
+}
+
+type raffleSchedulerStarter interface {
+	Start(context.Context)
+}
+
+var raffleSchedulerFactory = func(raffleSvc *services.RaffleService) raffleSchedulerStarter {
+	return services.NewRaffleScheduler(raffleSvc)
+}
+
+func startRaffleSchedulerIfEnabled(ctx context.Context, cfg *config.Config, raffleSvc *services.RaffleService) {
+	if cfg != nil && !cfg.Server.EnableScheduler {
+		return
+	}
+	raffleSchedulerFactory(raffleSvc).Start(ctx)
 }


### PR DESCRIPTION
## 什麼改動
讓 API server wiring 尊重 `cfg.Server.EnableScheduler`，只有啟用時才啟動 `RaffleScheduler`。新增可測的 scheduler startup helper，並補上 enabled / disabled / nil config 預設行為測試。

## 為什麼
`ENABLE_SCHEDULER` 已存在於 config 與 `.env.example`，但實際 server wiring 仍無條件啟動 raffle scheduler。這會讓 staging、read-only smoke、one-off command 或 blue/green deployment 無法關閉背景 job。

closes #782

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#782
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 raffle scheduler timing / business behavior
  - 不改 raffle service
  - 不改 deployment workflow
  - 不改 config parsing
  - 不改 schema / migration

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #782 issue comment: https://github.com/nurockplayer/tachigo/issues/782#issuecomment-4469249635
- Actual worker profile(s)：
  - controller direct implementation with worker fallback recorded
- Model strength：
  - controller = GPT-5.5 medium
- Spawn directive(s)：
  - profile=controller model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=tool_unavailable: Gemini worker lacked shell tool access and hit quota retry; impact=first-pass review unavailable; evidence=#782 issue comment
- Verification evidence：
  - RED: `go test ./cmd/server -run 'TestStartRaffleSchedulerIfEnabled'` failed with missing helper/factory
  - GREEN: `go test ./cmd/server -run 'TestStartRaffleSchedulerIfEnabled|TestServerStartupIsSplitByResponsibility'` passed, 3 tests
  - FULL: `go test ./...` passed, 732 tests / 13 packages
  - `gofmt -w services/api/cmd/server/wiring.go services/api/cmd/server/main_test.go`
  - `git diff --check` passed
- Self-review / exception reason：
  - Small backend-only startup wiring slice; Gemini worker route was unavailable, so controller completed TDD implementation and diff readback.
- Worker session closeout：
  - Gemini worker attempt was stopped after unavailable tool/quota retry; no active worker session remains.
- Workflow friction / follow-up split：
  - Workflow friction was limited to spec/gemini tool availability; implementation stayed inside #782 and no follow-up split is needed.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: PR just opened; no review threads yet
- CodeRabbit：
  - status context: success; no review findings observed in readback
- chatgpt-codex-connector：
  - pending with reason: PR just opened
- review_triage_ref：
  - pending with reason: no review findings yet
- root_cause_gate_ref：
  - pending with reason: no repeated finding/root-cause gate triggered
- finding_disposition_ref：
  - pending with reason: no review findings yet
- Final reviewer action：
  - pending with reason: awaiting automated/human review

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: PR just opened; waiting for remote checks/review
- Latest head SHA：
  - 75fc2dc9aa8248d00f0c6ae88d8cfa367c4b47f1
- Required checks：
  - pending with reason: remote checks still running at readback; completed successful checks include Scope gate, Supply-chain guardrails, PR commit messages, PR metadata regression tests, PR Scope Police, and CodeRabbit status context. In-progress checks include Backend tests, Backend security scanners, Build backend image, Atlas migration tooling, Workflow regression tests, Auto-ready draft PR, and Cloudflare Pages.
- spec workflow-check evidence：
  - manual fallback: global `spec` command unavailable; using PR template/manual checklist
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/782#issuecomment-4469249635

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 raffle scheduler startup 尊重 `ENABLE_SCHEDULER` config。
- Approx changed lines：~69
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試是 #782 行為變更的 TDD coverage，與 server wiring helper 必須同 PR 驗證。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `ENABLE_SCHEDULER=false` prevents raffle scheduler startup.
- [x] Default config still starts scheduler.
- [x] Tests cover both enabled and disabled paths.
- [x] Backend tests pass.

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
go test ./cmd/server -run 'TestStartRaffleSchedulerIfEnabled'
FAIL (expected RED): undefined helper/factory before implementation

go test ./cmd/server -run 'TestStartRaffleSchedulerIfEnabled|TestServerStartupIsSplitByResponsibility'
PASS: 3 tests

go test ./...
PASS: 732 tests / 13 packages

git diff --check
PASS
```

## 備註
`spec workflow-check` 未執行，因為此環境沒有全域 `spec` command；已以 PR template/manual checklist 記錄 fallback。

## Notes for Claude Code Review
- 請特別看 `raffleSchedulerFactory` 是否是可接受的 test seam；它只在 `cmd/server` package 內使用，目的是避免測試真的啟動 goroutine。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 新增调度器配置条件的测试用例，验证启用/禁用行为

* **重构**
  * 优化调度器启动逻辑，支持基于配置进行条件启用

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->