### PR TITLE
[backend] Harden production secret validation

### DIFF
--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -236,6 +236,34 @@ func ValidateProductionSecrets(cfg *Config) error {
 		return fmt.Errorf("SMTP_HOST must be configured when email-dependent production flows are enabled")
 	}
 
+	// These launch flows are mounted unconditionally in production, so fail fast
+	// before starting with OAuth, extension, or server-to-server credentials missing.
+	requiredValues := []struct {
+		name  string
+		value string
+		flow  string
+	}{
+		{"TWITCH_CLIENT_ID", cfg.OAuth.Twitch.ClientID, "Twitch OAuth and raffle snapshot flows are enabled"},
+		{"TWITCH_CLIENT_SECRET", cfg.OAuth.Twitch.ClientSecret, "Twitch OAuth is enabled"},
+		{"TWITCH_EXTENSION_SECRET", cfg.OAuth.Twitch.ExtensionSecret, "Twitch Extension auth is enabled"},
+		{"GOOGLE_CLIENT_ID", cfg.OAuth.Google.ClientID, "Google OAuth is enabled"},
+		{"GOOGLE_CLIENT_SECRET", cfg.OAuth.Google.ClientSecret, "Google OAuth is enabled"},
+		{"TACHIYA_INTERNAL_SHARED_SECRET", cfg.Internal.TachiyaSharedSecret, "Tachiya coupon handoff is enabled"},
+		{"OAUTH_TOKEN_ENCRYPTION_KEY", cfg.OAuth.TokenEncryptionKey, "OAuth token persistence is enabled"},
+	}
+	for _, required := range requiredValues {
+		if err := validateRequiredProductionValue(required.name, required.value, required.flow); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateRequiredProductionValue(name, value, flow string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s must be configured when %s in production", name, flow)
+	}
 	return nil
 }
 

--- a/services/api/internal/config/config_test.go
+++ b/services/api/internal/config/config_test.go
@@ -9,130 +9,159 @@ import (
 func TestValidateProductionSecrets(t *testing.T) {
 	validAccess := "access-secret-with-at-least-32-chars!"
 	validRefresh := "refresh-secret-with-at-least-32-char"
+	validConfig := func() *Config {
+		return &Config{
+			JWT: JWTConfig{
+				AccessSecret:  validAccess,
+				RefreshSecret: validRefresh,
+			},
+			SMTP: SMTPConfig{
+				Host: "smtp.example.com",
+			},
+			OAuth: OAuthConfig{
+				TokenEncryptionKey: "oauth-token-encryption-secret",
+				Twitch: TwitchConfig{
+					ClientID:        "twitch-client-id",
+					ClientSecret:    "twitch-client-secret",
+					ExtensionSecret: "twitch-extension-secret",
+				},
+				Google: GoogleConfig{
+					ClientID:     "google-client-id",
+					ClientSecret: "google-client-secret",
+				},
+			},
+			Internal: InternalConfig{
+				TachiyaSharedSecret: "tachiya-shared-secret",
+			},
+		}
+	}
+	withConfig := func(mutate func(*Config)) func() *Config {
+		return func() *Config {
+			cfg := validConfig()
+			mutate(cfg)
+			return cfg
+		}
+	}
 
 	tests := []struct {
 		name    string
-		cfg     *Config
+		cfg     func() *Config
 		wantErr string
 	}{
 		{
 			name: "accepts valid production secrets",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  validAccess,
-					RefreshSecret: validRefresh,
-				},
-				SMTP: SMTPConfig{
-					Host: "smtp.example.com",
-				},
-			},
+			cfg:  validConfig,
 		},
 		{
 			name: "rejects empty access secret",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  "",
-					RefreshSecret: validRefresh,
-				},
-				SMTP: SMTPConfig{
-					Host: "smtp.example.com",
-				},
-			},
+			cfg: withConfig(func(cfg *Config) {
+				cfg.JWT.AccessSecret = ""
+			}),
 			wantErr: "JWT_ACCESS_SECRET",
 		},
 		{
 			name: "rejects empty refresh secret",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  validAccess,
-					RefreshSecret: "",
-				},
-				SMTP: SMTPConfig{
-					Host: "smtp.example.com",
-				},
-			},
+			cfg: withConfig(func(cfg *Config) {
+				cfg.JWT.RefreshSecret = ""
+			}),
 			wantErr: "JWT_REFRESH_SECRET",
 		},
 		{
 			name: "rejects default access secret",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  defaultJWTAccessSecret,
-					RefreshSecret: validRefresh,
-				},
-				SMTP: SMTPConfig{
-					Host: "smtp.example.com",
-				},
-			},
+			cfg: withConfig(func(cfg *Config) {
+				cfg.JWT.AccessSecret = defaultJWTAccessSecret
+			}),
 			wantErr: "default",
 		},
 		{
 			name: "rejects default refresh secret",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  validAccess,
-					RefreshSecret: defaultJWTRefreshSecret,
-				},
-				SMTP: SMTPConfig{
-					Host: "smtp.example.com",
-				},
-			},
+			cfg: withConfig(func(cfg *Config) {
+				cfg.JWT.RefreshSecret = defaultJWTRefreshSecret
+			}),
 			wantErr: "default",
 		},
 		{
 			name: "rejects short access secret",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  "short-secret",
-					RefreshSecret: validRefresh,
-				},
-				SMTP: SMTPConfig{
-					Host: "smtp.example.com",
-				},
-			},
+			cfg: withConfig(func(cfg *Config) {
+				cfg.JWT.AccessSecret = "short-secret"
+			}),
 			wantErr: "at least 32 characters",
 		},
 		{
 			name: "rejects short refresh secret",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  validAccess,
-					RefreshSecret: "short-secret",
-				},
-				SMTP: SMTPConfig{
-					Host: "smtp.example.com",
-				},
-			},
+			cfg: withConfig(func(cfg *Config) {
+				cfg.JWT.RefreshSecret = "short-secret"
+			}),
 			wantErr: "at least 32 characters",
 		},
 		{
 			name: "rejects identical secrets",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  validAccess,
-					RefreshSecret: validAccess,
-				},
-				SMTP: SMTPConfig{
-					Host: "smtp.example.com",
-				},
-			},
+			cfg: withConfig(func(cfg *Config) {
+				cfg.JWT.RefreshSecret = cfg.JWT.AccessSecret
+			}),
 			wantErr: "must be different",
 		},
 		{
 			name: "rejects missing SMTP host",
-			cfg: &Config{
-				JWT: JWTConfig{
-					AccessSecret:  validAccess,
-					RefreshSecret: validRefresh,
-				},
-			},
+			cfg: withConfig(func(cfg *Config) {
+				cfg.SMTP.Host = ""
+			}),
 			wantErr: "SMTP_HOST",
+		},
+		{
+			name: "rejects missing Twitch OAuth client id",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.OAuth.Twitch.ClientID = ""
+			}),
+			wantErr: "TWITCH_CLIENT_ID",
+		},
+		{
+			name: "rejects missing Twitch OAuth client secret",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.OAuth.Twitch.ClientSecret = ""
+			}),
+			wantErr: "TWITCH_CLIENT_SECRET",
+		},
+		{
+			name: "rejects missing Twitch extension secret",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.OAuth.Twitch.ExtensionSecret = ""
+			}),
+			wantErr: "TWITCH_EXTENSION_SECRET",
+		},
+		{
+			name: "rejects missing Google OAuth client id",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.OAuth.Google.ClientID = ""
+			}),
+			wantErr: "GOOGLE_CLIENT_ID",
+		},
+		{
+			name: "rejects missing Google OAuth client secret",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.OAuth.Google.ClientSecret = ""
+			}),
+			wantErr: "GOOGLE_CLIENT_SECRET",
+		},
+		{
+			name: "rejects missing Tachiya shared secret",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.Internal.TachiyaSharedSecret = ""
+			}),
+			wantErr: "TACHIYA_INTERNAL_SHARED_SECRET",
+		},
+		{
+			name: "rejects missing OAuth token encryption key",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.OAuth.TokenEncryptionKey = ""
+			}),
+			wantErr: "OAUTH_TOKEN_ENCRYPTION_KEY",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateProductionSecrets(tc.cfg)
+			err := ValidateProductionSecrets(tc.cfg())
 			if tc.wantErr == "" {
 				if err != nil {
 					t.Fatalf("expected nil error, got %v", err)


### PR DESCRIPTION
## 什麼改動
強化 production startup secret validation，讓 API server 在啟用生產環境檢查時，除了既有 JWT / SMTP 之外，也會 fail-fast 驗證 OAuth、Twitch Extension、Tachiya handoff 與 OAuth token encryption 所需設定。

## 為什麼
Launch audit 發現 `ValidateProductionSecrets` 只檢查 JWT secrets 與 SMTP host；production 仍可能在 Twitch / Google OAuth、Twitch Extension auth、Tachiya coupon handoff 或 OAuth token persistence 缺少必要 secret 的情況下啟動。

closes #781

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#781
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 config flag
  - 不改 router / route gating
  - 不改 deployment workflow
  - 不改 development default startup path
  - 不改 OAuth token crypto implementation

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #781 issue comment: https://github.com/nurockplayer/tachigo/issues/781#issuecomment-4469274960
- Actual worker profile(s)：
  - controller self-only
- Model strength：
  - controller = GPT-5.5 medium
- Spawn directive(s)：
  - profile=controller model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=developer_tool_constraints:no_subagent_spawn_without_explicit_user_request self_only_exception=small_config_test_slice
- Verification evidence：
  - RED: `go test ./internal/config -run TestValidateProductionSecrets` failed as expected; new OAuth / Extension / Tachiya / token-encryption missing-secret cases were not yet rejected
  - GREEN: `go test ./internal/config -run TestValidateProductionSecrets` passed, 17 tests
  - FULL: `go test ./...` passed, 737 tests / 13 packages
  - `git diff --check` passed
- Self-review / exception reason：
  - R4 scope was kept to config validation and table tests; mandatory production values are listed explicitly in code/test and issue evidence.
- Worker session closeout：
  - n/a; no worker session opened for this small config-only slice
- Workflow friction / follow-up split：
  - `spec` command unavailable locally, so workflow-check uses manual issue evidence. No follow-up split needed for this PR.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: PR not opened yet
- CodeRabbit：
  - status context: success; no review findings observed in readback
- chatgpt-codex-connector：
  - pending with reason: PR not opened yet
- review_triage_ref：
  - pending with reason: PR not opened yet
- root_cause_gate_ref：
  - pending with reason: no repeated finding/root-cause gate triggered
- finding_disposition_ref：
  - pending with reason: no review findings yet
- Final reviewer action：
  - pending with reason: R4 PR requires human review before merge

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: R4 PR requires remote checks and human review; auto-ready intentionally not used
- Latest head SHA：
  - 196e67ae66fcfd3833878628f1c9306c1df9915d
- Required checks：
  - pending with reason: remote checks still running at readback; in-progress checks include Scope gate, Scope police, Workflow regression tests, Supply-chain guardrails, Commit message regression tests, PR metadata check regression tests, PR commit messages, and Cloudflare Pages. Completed successful statuses include CodeRabbit, draft PR marker, automerge noop, and review label manager.
- spec workflow-check evidence：
  - manual fallback: global `spec` command unavailable; using PR template/manual checklist
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/781#issuecomment-4469274960

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 production startup 對 non-Web3 closed beta 必要 secret fail-fast。
- Approx changed lines：~217
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試是 #781 production validation 行為的 TDD coverage，必須和 config validation 同 PR。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Production config fails fast for missing secrets required by enabled launch flows.
- [x] Development defaults remain usable because production validation still only runs through `ShouldValidateProductionSecrets`.
- [x] Tests document conditional validation behavior and each missing-secret failure.
- [x] Error messages identify the missing variable name.

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
go test ./internal/config -run TestValidateProductionSecrets
FAIL (expected RED): new OAuth / Extension / Tachiya / token-encryption missing-secret cases were not rejected

go test ./internal/config -run TestValidateProductionSecrets
PASS: 17 tests

go test ./...
PASS: 737 tests / 13 packages

git diff --check
PASS
```

## 備註
R4 PR：依 template 規則不使用 `AUTO_READY=1`。Production 會要求明確設定 `OAUTH_TOKEN_ENCRYPTION_KEY`，不再把 JWT refresh secret fallback 視為可接受的 production posture。

## Notes for Claude Code Review
- 請特別確認 production mandatory list 是否符合 non-Web3 closed beta：Twitch OAuth、Google OAuth、Twitch Extension、Tachiya shared secret、OAuth token encryption key 都因目前 routes/flows 可用而被列為必填。
