### PR TITLE
[backend] Make OAuth upsert atomic

### DIFF
--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -422,43 +422,81 @@ type googleUserInfo struct {
 }
 
 func (s *AuthService) upsertOAuthUser(
-	_ context.Context,
+	ctx context.Context,
 	provider models.ProviderType,
 	providerID, username, email string,
 	avatarURL *string,
 	token *oauth2.Token,
 ) (*models.User, *TokenPair, error) {
-
-	var ap models.AuthProvider
-	err := s.db.Where("provider = ? AND provider_id = ?", provider, providerID).First(&ap).Error
-
-	if err == nil {
-		// Already linked – update tokens, return user
-		if token != nil {
-			if err := s.assignProviderTokens(&ap, provider, token); err != nil {
-				return nil, nil, err
-			}
-			if err := s.db.Save(&ap).Error; err != nil {
-				return nil, nil, err
-			}
-		}
-		var user models.User
-		if err := s.db.First(&user, "id = ?", ap.UserID).Error; err != nil {
-			return nil, nil, ErrUserNotFound
-		}
-		tokens, err := s.issueTokenPair(&user)
-		return &user, tokens, err
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	// New provider – find or create user
-	var user models.User
+	user, tokens, err := s.upsertOAuthUserInTransaction(s.db.WithContext(ctx), provider, providerID, username, email, avatarURL, token)
+	if err == nil {
+		return user, tokens, nil
+	}
+	if !isDuplicatedKeyError(err) {
+		return nil, nil, err
+	}
 
+	user, tokens, recoverErr := s.recoverOAuthProviderConflict(ctx, provider, providerID, token)
+	if recoverErr == nil {
+		return user, tokens, nil
+	}
+	if !errors.Is(recoverErr, gorm.ErrRecordNotFound) {
+		return nil, nil, recoverErr
+	}
+
+	return nil, nil, s.mapOAuthUserUniqueError(ctx, username, email, err)
+}
+
+func (s *AuthService) upsertOAuthUserInTransaction(
+	db *gorm.DB,
+	provider models.ProviderType,
+	providerID, username, email string,
+	avatarURL *string,
+	token *oauth2.Token,
+) (*models.User, *TokenPair, error) {
+	var user *models.User
+	var tokens *TokenPair
+	err := db.Transaction(func(tx *gorm.DB) error {
+		txUser, txTokens, err := s.upsertOAuthUserTx(tx, provider, providerID, username, email, avatarURL, token)
+		if err != nil {
+			return err
+		}
+		user = txUser
+		tokens = txTokens
+		return nil
+	})
+	return user, tokens, err
+}
+
+func (s *AuthService) upsertOAuthUserTx(
+	tx *gorm.DB,
+	provider models.ProviderType,
+	providerID, username, email string,
+	avatarURL *string,
+	token *oauth2.Token,
+) (*models.User, *TokenPair, error) {
+	var ap models.AuthProvider
+	err := tx.Where("provider = ? AND provider_id = ?", provider, providerID).First(&ap).Error
+	if err == nil {
+		return s.finishExistingOAuthProviderTx(tx, &ap, provider, token)
+	}
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil, err
+	}
+
+	var user models.User
 	if email != "" {
-		s.db.Where("email = ?", email).First(&user)
+		err := tx.Where("email = ?", email).First(&user).Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil, err
+		}
 	}
 
 	if user.ID == uuid.Nil {
-		// Brand-new user
 		if email != "" {
 			user.Email = &email
 		}
@@ -467,12 +505,11 @@ func (s *AuthService) upsertOAuthUser(
 		}
 		user.AvatarURL = avatarURL
 		user.Role = models.RoleViewer
-		if err := s.db.Create(&user).Error; err != nil {
+		if err := tx.Create(&user).Error; err != nil {
 			return nil, nil, err
 		}
 	}
 
-	// Link provider
 	newAP := models.AuthProvider{
 		UserID:     user.ID,
 		Provider:   provider,
@@ -483,12 +520,88 @@ func (s *AuthService) upsertOAuthUser(
 			return nil, nil, err
 		}
 	}
-	if err := s.db.Create(&newAP).Error; err != nil {
+	if err := tx.Create(&newAP).Error; err != nil {
 		return nil, nil, err
 	}
 
-	tokens, err := s.issueTokenPair(&user)
+	tokens, err := s.issueTokenPairTx(tx, &user)
 	return &user, tokens, err
+}
+
+func (s *AuthService) finishExistingOAuthProviderTx(tx *gorm.DB, ap *models.AuthProvider, provider models.ProviderType, token *oauth2.Token) (*models.User, *TokenPair, error) {
+	if token != nil {
+		if err := s.assignProviderTokens(ap, provider, token); err != nil {
+			return nil, nil, err
+		}
+		if err := tx.Save(ap).Error; err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var user models.User
+	if err := tx.First(&user, "id = ?", ap.UserID).Error; err != nil {
+		return nil, nil, ErrUserNotFound
+	}
+	tokens, err := s.issueTokenPairTx(tx, &user)
+	return &user, tokens, err
+}
+
+func (s *AuthService) recoverOAuthProviderConflict(ctx context.Context, provider models.ProviderType, providerID string, token *oauth2.Token) (*models.User, *TokenPair, error) {
+	var user *models.User
+	var tokens *TokenPair
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var ap models.AuthProvider
+		if err := tx.Where("provider = ? AND provider_id = ?", provider, providerID).First(&ap).Error; err != nil {
+			return err
+		}
+
+		txUser, txTokens, err := s.finishExistingOAuthProviderTx(tx, &ap, provider, token)
+		if err != nil {
+			return err
+		}
+		user = txUser
+		tokens = txTokens
+		return nil
+	})
+	return user, tokens, err
+}
+
+func isDuplicatedKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "duplicated key")
+}
+
+func (s *AuthService) mapOAuthUserUniqueError(ctx context.Context, username, email string, fallback error) error {
+	db := s.db.WithContext(ctx)
+	if email != "" {
+		var count int64
+		if err := db.Model(&models.User{}).Where("email = ?", email).Count(&count).Error; err == nil && count > 0 {
+			return ErrEmailExists
+		}
+	}
+	if username != "" {
+		var count int64
+		if err := db.Model(&models.User{}).Where("username = ?", username).Count(&count).Error; err == nil && count > 0 {
+			return ErrUsernameExists
+		}
+	}
+
+	msg := fallback.Error()
+	if strings.Contains(msg, "email") {
+		return ErrEmailExists
+	}
+	if strings.Contains(msg, "username") {
+		return ErrUsernameExists
+	}
+	return fallback
 }
 
 func (s *AuthService) assignProviderTokens(ap *models.AuthProvider, provider models.ProviderType, token *oauth2.Token) error {

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/models"
 )
@@ -138,6 +139,119 @@ func TestOAuthUser_DoesNotPersistUnusedGoogleTokens(t *testing.T) {
 	}
 	if ap.TokenExpiresAt != nil {
 		t.Fatalf("google token expiry should not be persisted, got %v", ap.TokenExpiresAt)
+	}
+}
+
+func TestRecoverOAuthProviderConflictReturnsExistingAccount(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	email := "oauth-race@example.com"
+	username := "oauth-race"
+	seededUser := models.User{
+		Email:    &email,
+		Username: &username,
+		Role:     models.RoleViewer,
+	}
+	if err := db.Create(&seededUser).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	const providerID = "google-race-provider"
+	if err := db.Create(&models.AuthProvider{
+		UserID:     seededUser.ID,
+		Provider:   models.ProviderGoogle,
+		ProviderID: providerID,
+	}).Error; err != nil {
+		t.Fatalf("seed auth provider: %v", err)
+	}
+
+	user, tokens, err := svc.recoverOAuthProviderConflict(
+		context.Background(),
+		models.ProviderGoogle,
+		providerID,
+		&oauth2.Token{AccessToken: "google-access-token"},
+	)
+	if err != nil {
+		t.Fatalf("recoverOAuthProviderConflict: %v", err)
+	}
+	if user == nil || tokens == nil || tokens.RefreshToken == "" {
+		t.Fatalf("expected user and tokens, got user=%#v tokens=%#v", user, tokens)
+	}
+	if user.ID != seededUser.ID {
+		t.Fatalf("expected callback to return seeded user %s, got %s", seededUser.ID, user.ID)
+	}
+
+	var providerCount int64
+	db.Model(&models.AuthProvider{}).Where("provider = ? AND provider_id = ?", models.ProviderGoogle, providerID).Count(&providerCount)
+	if providerCount != 1 {
+		t.Fatalf("expected one auth provider row, got %d", providerCount)
+	}
+
+	var userCount int64
+	db.Model(&models.User{}).Where("email = ?", email).Count(&userCount)
+	if userCount != 1 {
+		t.Fatalf("expected one logical user, got %d", userCount)
+	}
+
+	var tokenCount int64
+	db.Model(&models.RefreshToken{}).Where("user_id = ?", seededUser.ID).Count(&tokenCount)
+	if tokenCount != 1 {
+		t.Fatalf("expected one refresh token for recovered callback, got %d", tokenCount)
+	}
+}
+
+func TestUpsertOAuthUser_DuplicateUsernameCreateReturnsStableError(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	takenUsername := "oauth-taken"
+	existingEmail := "oauth-taken@example.com"
+	if err := db.Create(&models.User{
+		Username: &takenUsername,
+		Email:    &existingEmail,
+		Role:     models.RoleViewer,
+	}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	user, tokens, err := svc.upsertOAuthUser(
+		context.Background(),
+		models.ProviderGoogle,
+		"google-duplicate-username",
+		takenUsername,
+		"oauth-new@example.com",
+		nil,
+		&oauth2.Token{AccessToken: "google-access-token"},
+	)
+	if !errors.Is(err, ErrUsernameExists) {
+		t.Fatalf("want ErrUsernameExists, got %v (user=%#v tokens=%#v)", err, user, tokens)
+	}
+
+	var providerCount int64
+	db.Model(&models.AuthProvider{}).Where("provider_id = ?", "google-duplicate-username").Count(&providerCount)
+	if providerCount != 0 {
+		t.Fatalf("auth provider should not be created after username conflict, got %d rows", providerCount)
+	}
+}
+
+func TestMapOAuthUserUniqueErrorReturnsStableEmailError(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	email := "oauth-email-race@example.com"
+	username := "oauth-email-race"
+	if err := db.Create(&models.User{
+		Username: &username,
+		Email:    &email,
+		Role:     models.RoleViewer,
+	}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	err := svc.mapOAuthUserUniqueError(context.Background(), "new-oauth-user", email, gorm.ErrDuplicatedKey)
+	if !errors.Is(err, ErrEmailExists) {
+		t.Fatalf("want ErrEmailExists, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
讓 OAuth provider upsert 走交易式流程：provider lookup/create、user lookup/create、provider token update、refresh token issue 會包在 transaction 內；duplicate provider conflict 會 reload 既有 provider/user 後恢復成同一個邏輯帳號。

## 為什麼
Launch audit 發現 `AuthService.upsertOAuthUser` 原本在 transaction 外分段執行。並發 OAuth callback 或 provider create race 可能留下部分狀態，或把 DB unique constraint 原樣丟給呼叫端。

closes #783

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#783
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 OAuth route / handler
  - 不改 JWT payload 或 token format
  - 不改 schema / migration
  - 不新增 provider linking policy
  - 不調整 Web3 nonce 驗證流程本身

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #783 issue comment: https://github.com/nurockplayer/tachigo/issues/783#issuecomment-4469316844
- Actual worker profile(s)：
  - controller self-only
- Model strength：
  - controller = GPT-5.5 medium
- Spawn directive(s)：
  - profile=controller model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=developer_tool_constraints:no_subagent_spawn_without_explicit_user_request self_only_exception=focused_service_test_slice
- Verification evidence：
  - RED: focused tests failed before implementation with raw duplicated-key behavior
  - GREEN: focused tests passed, 3 tests
  - SERVICE: `go test ./internal/services` passed, 317 tests / 1 package
  - FULL: `go test ./...` passed, 733 tests / 13 packages
  - `git diff --check` passed
- Self-review / exception reason：
  - R4 scope was kept inside `AuthService` and tests. Existing provider token update behavior now uses the same transaction path as token issue.
- Worker session closeout：
  - n/a; no worker session opened for this focused slice
- Workflow friction / follow-up split：
  - `spec` command unavailable locally, so workflow-check uses manual issue evidence. No follow-up split needed for this PR.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: PR not opened yet
- CodeRabbit：
  - pending with reason: PR not opened yet
- chatgpt-codex-connector：
  - pending with reason: PR not opened yet
- review_triage_ref：
  - pending with reason: PR not opened yet
- root_cause_gate_ref：
  - pending with reason: no repeated finding/root-cause gate triggered
- finding_disposition_ref：
  - pending with reason: no review findings yet
- Final reviewer action：
  - pending with reason: R4 PR requires human review before merge

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: R4 PR requires remote checks and human review; auto-ready intentionally not used
- Latest head SHA：
  - 7849abb1adf078c02a03de09ebb60497a51f6939
- Required checks：
  - pending with reason: PR not opened yet
- spec workflow-check evidence：
  - manual fallback: global `spec` command unavailable; using PR template/manual checklist
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/783#issuecomment-4469316844

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 OAuth upsert 對 duplicate provider race 與 token issue 具備交易式一致性。
- Approx changed lines：~279
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試是 #783 transaction/conflict recovery 行為的 TDD coverage，必須和 service 變更同 PR。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Duplicate provider conflict can recover to one logical account by reloading existing provider/user.
- [x] OAuth upsert and refresh token issue are wrapped in transactions.
- [x] Existing provider token update behavior still works through the transactional path.
- [x] User uniqueness conflicts map to stable auth errors where applicable.
- [x] Backend tests pass.

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
go test ./internal/services -run 'Test(RecoverOAuthProviderConflictReturnsExistingAccount|UpsertOAuthUser_DuplicateUsernameCreateReturnsStableError|MapOAuthUserUniqueErrorReturnsStableEmailError)'
PASS: 3 tests

go test ./internal/services
PASS: 317 tests / 1 package

go test ./...
PASS: 733 tests / 13 packages

git diff --check
PASS
```

## 備註
R4 PR：依 template 規則不使用 `AUTO_READY=1`。SQLite unit test 無法可靠模擬真正的 concurrent provider insert，因此 provider conflict recovery 以 reload helper 測試固定；Postgres 層的 unique constraint 仍是 production recovery trigger。

## Notes for Claude Code Review
- 請特別看 nested transaction 對 `Web3Verify` 的 nonce transaction 是否維持原有 rollback 行為；本地 `internal/services` suite 已覆蓋 nonce delete/provider create/refresh token failure rollback cases。
