### PR TITLE
[backend] Add observability baseline

### DIFF
--- a/docs/backend-observability.md
+++ b/docs/backend-observability.md
@@ -1,0 +1,48 @@
+# Backend Observability Baseline
+
+## Current baseline
+
+The first production baseline is vendor-neutral structured logging:
+
+- HTTP requests get an `X-Request-ID` response header. Incoming safe request IDs are preserved; otherwise the API generates one.
+- Request logs emit `event=http_request`, `request_id`, `method`, matched `route`, sanitized `path`, `status`, `duration_ms`, `client_ip`, and Gin error count.
+- Request logs intentionally do not include query strings, request bodies, `Authorization`, cookies, OAuth tokens, signer keys, vouchers, or receipt payloads.
+- Raffle scheduled snapshot jobs emit start, per-raffle error, query-error, and completion events with `job=raffle_scheduled_snapshots`, counts, IDs, source, and redacted error text.
+
+## Local readback
+
+1. Start the API locally.
+2. Send a request with a known request ID:
+
+   ```bash
+   curl -i -H 'X-Request-ID: local-readback-1' 'http://localhost:8080/health?access_token=should-not-log'
+   ```
+
+3. Confirm the response contains `X-Request-ID: local-readback-1`.
+4. Confirm the API log contains `event=http_request request_id=local-readback-1`.
+5. Confirm the same log line does not contain `access_token`, `Authorization`, `Bearer`, cookies, or request body content.
+
+## Staging readback
+
+1. Deploy the backend to staging with normal production-like logging enabled.
+2. Run a health request with a known request ID and verify the ID appears in both response headers and centralized logs.
+3. Exercise one authenticated route and verify logs show route/status/duration without tokens or cookies.
+4. Trigger or simulate a raffle scheduled snapshot window in staging.
+5. Verify scheduler logs include `event=raffle_scheduled_snapshots_start` and `event=raffle_scheduled_snapshots_complete`.
+6. If a staging raffle snapshot fails, verify `event=raffle_scheduled_snapshot_error` includes `raffle_id`, `user_id`, and `source`, but does not include OAuth tokens.
+
+## Owner
+
+Backend production owner: backend/on-call release owner for the deployment window.
+
+Review cadence:
+
+- During staging deploy: verify request logs and scheduler logs before promoting.
+- During production launch: keep the log stream open for first request traffic and first scheduled job window.
+- After launch: move request metrics and tracing/error reporting into dedicated follow-up work.
+
+## Deferred follow-ups
+
+- #792: backend metrics and alerting baseline.
+- #793: backend tracing and error reporting integration.
+

--- a/services/api/internal/middleware/observability.go
+++ b/services/api/internal/middleware/observability.go
@@ -1,0 +1,126 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	RequestIDHeader = "X-Request-ID"
+	requestIDKey    = "request_id"
+)
+
+func RequestID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := ""
+		if c.Request != nil {
+			requestID = c.Request.Header.Get(RequestIDHeader)
+		}
+		if !isSafeRequestID(requestID) {
+			requestID = newRequestID()
+		}
+
+		c.Set(requestIDKey, requestID)
+		c.Header(RequestIDHeader, requestID)
+		c.Next()
+	}
+}
+
+func RequestIDFromGin(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	value, ok := c.Get(requestIDKey)
+	if !ok {
+		return ""
+	}
+	requestID, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return requestID
+}
+
+func StructuredRequestLogger(logger *log.Logger) gin.HandlerFunc {
+	if logger == nil {
+		logger = log.Default()
+	}
+
+	return func(c *gin.Context) {
+		start := time.Now()
+		method := ""
+		path := ""
+		if c.Request != nil {
+			method = c.Request.Method
+			if c.Request.URL != nil {
+				path = c.Request.URL.Path
+			}
+		}
+
+		c.Next()
+
+		route := c.FullPath()
+		if route == "" {
+			route = path
+		}
+		logger.Printf(
+			"event=http_request request_id=%s method=%s route=%s path=%s status=%d duration_ms=%d client_ip=%s errors=%d",
+			RequestIDFromGin(c),
+			safeLogToken(method),
+			safeLogToken(route),
+			safeLogToken(path),
+			c.Writer.Status(),
+			time.Since(start).Milliseconds(),
+			safeLogToken(c.ClientIP()),
+			len(c.Errors),
+		)
+	}
+}
+
+func newRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return hex.EncodeToString([]byte(time.Now().UTC().Format("20060102150405.000000000")))
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func isSafeRequestID(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' ||
+			r == '-' || r == '_' || r == '.' || r == ':' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func safeLogToken(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	value = strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\t', '\n', '\r', '"', '\'':
+			return '_'
+		default:
+			return r
+		}
+	}, value)
+	if len(value) > 256 {
+		return value[:256]
+	}
+	return value
+}

--- a/services/api/internal/middleware/observability_test.go
+++ b/services/api/internal/middleware/observability_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRequestIDAndStructuredRequestLogger(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var logs bytes.Buffer
+	r := gin.New()
+	r.Use(RequestID())
+	r.Use(StructuredRequestLogger(log.New(&logs, "", 0)))
+	r.GET("/api/v1/things/:id", func(c *gin.Context) {
+		c.Status(http.StatusAccepted)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/things/123?access_token=secret-token", nil)
+	req.Header.Set(RequestIDHeader, "req-safe-123")
+	req.Header.Set("Authorization", "Bearer super-secret-token")
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Header().Get(RequestIDHeader) != "req-safe-123" {
+		t.Fatalf("expected request id header to be preserved, got %q", rec.Header().Get(RequestIDHeader))
+	}
+
+	line := logs.String()
+	for _, want := range []string{
+		"event=http_request",
+		"request_id=req-safe-123",
+		"method=GET",
+		"route=/api/v1/things/:id",
+		"status=202",
+		"duration_ms=",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected log to contain %q, got %q", want, line)
+		}
+	}
+	for _, leaked := range []string{"secret-token", "super-secret-token", "access_token", "Bearer"} {
+		if strings.Contains(line, leaked) {
+			t.Fatalf("request log leaked %q: %s", leaked, line)
+		}
+	}
+}
+
+func TestRequestIDGeneratesHeaderWhenMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(RequestID())
+	r.GET("/health", func(c *gin.Context) {
+		if RequestIDFromGin(c) == "" {
+			t.Fatal("expected request id in gin context")
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Header().Get(RequestIDHeader) == "" {
+		t.Fatal("expected generated request id response header")
+	}
+}

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -57,7 +57,7 @@ func New(
 	}
 
 	r := gin.New()
-	r.Use(gin.Logger(), gin.Recovery())
+	r.Use(middleware.RequestID(), middleware.StructuredRequestLogger(log.Default()), gin.Recovery())
 	if cfg != nil {
 		r.Use(middleware.RequestTimeout(cfg.Server.RequestTimeout))
 	}

--- a/services/api/internal/services/raffle_scheduler.go
+++ b/services/api/internal/services/raffle_scheduler.go
@@ -21,13 +21,15 @@ func (rs *RaffleScheduler) Start(ctx context.Context) {
 		for {
 			now := time.Now().UTC()
 			next := nextSchedulerRun(now)
+			log.Printf("event=raffle_scheduler_wait job=raffle_scheduled_snapshots next_run=%s", next.Format(time.RFC3339))
 			select {
 			case <-ctx.Done():
+				log.Printf("event=raffle_scheduler_stop job=raffle_scheduled_snapshots")
 				return
 			case <-time.After(next.Sub(now)):
 				runCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 				if err := rs.svc.RunScheduledSnapshots(runCtx, time.Now().UTC()); err != nil {
-					log.Printf("raffle scheduler: batch error: %v", err)
+					log.Printf("event=raffle_scheduler_batch_error job=raffle_scheduled_snapshots err=%q", err)
 				}
 				cancel()
 			}

--- a/services/api/internal/services/raffle_scheduler_test.go
+++ b/services/api/internal/services/raffle_scheduler_test.go
@@ -1,8 +1,12 @@
 package services
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,6 +139,62 @@ func TestRunScheduledSnapshots_TwitchTokenMissing_StaysDraft(t *testing.T) {
 	db.First(&r, "id = ?", raffle.ID)
 	if r.Status != models.RaffleStatusDraft {
 		t.Errorf("expected draft after failed snapshot, got %s", r.Status)
+	}
+}
+
+func TestRunScheduledSnapshots_LogsSafeJobEvents(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "test-client-id", "", nil)
+
+	user := insertRaffleTestUser(t, db)
+	scheduledAt := time.Now().UTC().Add(5 * time.Minute)
+	raffle := insertScheduledRaffle(t, db, user.ID, scheduledAt, models.RaffleSourceTwitchAPI)
+
+	var logs bytes.Buffer
+	previousOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() {
+		log.SetOutput(previousOutput)
+	})
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected batch error: %v", err)
+	}
+
+	line := logs.String()
+	for _, want := range []string{
+		"event=raffle_scheduled_snapshots_start",
+		"event=raffle_scheduled_snapshot_error",
+		"event=raffle_scheduled_snapshots_complete",
+		"job=raffle_scheduled_snapshots",
+		"candidate_count=1",
+		"failed=1",
+		"raffle_id=" + raffle.ID.String(),
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected scheduler log to contain %q, got %q", want, line)
+		}
+	}
+	for _, leaked := range []string{"access_token", "refresh_token", "Authorization", "Bearer"} {
+		if strings.Contains(line, leaked) {
+			t.Fatalf("scheduler log leaked %q: %s", leaked, line)
+		}
+	}
+}
+
+func TestSafeScheduledJobErrorRedactsSensitiveMaterial(t *testing.T) {
+	for _, err := range []error{
+		errors.New("upstream failed with access_token=secret"),
+		errors.New("Authorization: Bearer secret"),
+		errors.New("client_secret leaked"),
+	} {
+		if got := safeScheduledJobError(err); got != "[redacted]" {
+			t.Fatalf("expected redacted error, got %q", got)
+		}
+	}
+
+	if got := safeScheduledJobError(errors.New("twitch token missing")); got != `"twitch token missing"` {
+		t.Fatalf("expected safe operational error to remain visible, got %q", got)
 	}
 }
 

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -685,14 +685,77 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 		"status = ? AND source != ? AND scheduled_at IS NOT NULL AND scheduled_at >= ? AND scheduled_at <= ?",
 		models.RaffleStatusDraft, models.RaffleSourceCSV, now, window,
 	).Find(&raffles).Error; err != nil {
+		log.Printf(
+			"event=raffle_scheduled_snapshots_query_error job=raffle_scheduled_snapshots run_at=%s window_end=%s err=%q",
+			now.Format(time.RFC3339),
+			window.Format(time.RFC3339),
+			err,
+		)
 		return err
 	}
+	log.Printf(
+		"event=raffle_scheduled_snapshots_start job=raffle_scheduled_snapshots run_at=%s window_end=%s candidate_count=%d",
+		now.Format(time.RFC3339),
+		window.Format(time.RFC3339),
+		len(raffles),
+	)
+	failed := 0
 	for _, r := range raffles {
 		if err := s.snapshotOne(ctx, r); err != nil {
-			log.Printf("raffle %s snapshot error: %v", r.ID, err)
+			failed++
+			log.Printf(
+				"event=raffle_scheduled_snapshot_error job=raffle_scheduled_snapshots raffle_id=%s user_id=%s source=%s err=%s",
+				r.ID,
+				r.UserID,
+				r.Source,
+				safeScheduledJobError(err),
+			)
 		}
 	}
+	log.Printf(
+		"event=raffle_scheduled_snapshots_complete job=raffle_scheduled_snapshots run_at=%s window_end=%s candidate_count=%d processed=%d failed=%d",
+		now.Format(time.RFC3339),
+		window.Format(time.RFC3339),
+		len(raffles),
+		len(raffles),
+		failed,
+	)
 	return nil
+}
+
+func safeScheduledJobError(err error) string {
+	if err == nil {
+		return "-"
+	}
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+	for _, marker := range []string{
+		"access_token",
+		"refresh_token",
+		"authorization",
+		"bearer ",
+		"client_secret",
+		"private_key",
+		"signer_key",
+		"voucher",
+		"receipt",
+	} {
+		if strings.Contains(lower, marker) {
+			return "[redacted]"
+		}
+	}
+	msg = strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t':
+			return ' '
+		default:
+			return r
+		}
+	}, msg)
+	if len(msg) > 512 {
+		return msg[:512]
+	}
+	return fmt.Sprintf("%q", msg)
 }
 
 func (s *RaffleService) snapshotOne(ctx context.Context, r models.Raffle) error {


### PR DESCRIPTION
## 什麼改動
新增 backend observability baseline：request ID middleware、安全結構化 request log、raffle scheduler/job structured events，並補 staging readback 文件。

## 為什麼
#784 指出上線前需要最小可用的 production debugging signal。這個 PR 先選擇 vendor-neutral logging baseline，避免一開始就引入 metrics/tracing/Sentry/OpenTelemetry 等深度整合。

closes #784

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#784
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 metrics endpoint
  - 不引入 Sentry / OpenTelemetry / vendor SDK
  - 不改 schema / migration
  - 不改 frontend
  - 不記錄 request body、query string、Authorization、cookies、OAuth tokens、signer keys、vouchers 或 receipt payloads

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #784 issue comment: https://github.com/nurockplayer/tachigo/issues/784#issuecomment-4469352996
- Actual worker profile(s)：
  - controller self-only
- Model strength：
  - controller = GPT-5.5 medium
- Spawn directive(s)：
  - profile=controller model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=developer_tool_constraints:no_subagent_spawn_without_explicit_user_request self_only_exception=focused_logging_docs_slice
- Verification evidence：
  - RED: middleware tests failed on missing request ID/logger; scheduler log test failed on missing structured job events
  - GREEN: focused tests passed
  - PACKAGE: `go test ./internal/middleware ./internal/services ./internal/router` passed, 349 tests / 3 packages
  - FULL: `go test ./...` passed, 734 tests / 13 packages
  - `git diff --check` passed
- Self-review / exception reason：
  - Scope is intentionally vendor-neutral logging plus readback docs; metrics/tracing split to #792/#793.
- Worker session closeout：
  - n/a; no worker session opened for this focused slice
- Workflow friction / follow-up split：
  - `spec` command unavailable locally, so workflow-check uses manual issue evidence. Follow-up splits created as #792 and #793.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: PR not opened yet
- CodeRabbit：
  - pending with reason: PR not opened yet
- chatgpt-codex-connector：
  - pending with reason: PR not opened yet
- review_triage_ref：
  - pending with reason: PR not opened yet
- root_cause_gate_ref：
  - pending with reason: no repeated finding/root-cause gate triggered
- finding_disposition_ref：
  - pending with reason: no review findings yet
- Final reviewer action：
  - pending with reason: awaiting automated/human review

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: PR not opened yet
- Latest head SHA：
  - 6392c6dd0cfd1e85e6f920816e8b065b481190ac
- Required checks：
  - pending with reason: PR not opened yet
- spec workflow-check evidence：
  - manual fallback: global `spec` command unavailable; using PR template/manual checklist
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/784#issuecomment-4469352996

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 backend request/job logging baseline 與 staging readback 文件。
- Approx changed lines：~210
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - logging baseline、safe-log tests、scheduler job visibility 與 staging readback 是 #784 同一個可驗證交付面。
- 若已拆分，相關 PR：
  - #792 metrics/alerting follow-up
  - #793 tracing/error-reporting follow-up

## Acceptance Criteria
- [x] Backend emits structured signal for failed requests and background jobs.
- [x] Logs avoid request bodies, query strings, headers, cookies, tokens, signer keys, vouchers, and receipts.
- [x] Staging readback checklist is documented.
- [x] Follow-up issues exist for deferred metrics/tracing/vendor integration.

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
go test ./internal/middleware -run 'TestRequestID'
PASS: 2 tests

go test ./internal/services -run 'TestRunScheduledSnapshots_LogsSafeJobEvents|TestSafeScheduledJobErrorRedactsSensitiveMaterial'
PASS: 2 tests

go test ./internal/middleware ./internal/services ./internal/router
PASS: 349 tests / 3 packages

go test ./...
PASS: 734 tests / 13 packages

git diff --check
PASS
```

## 備註
Follow-up issues created: #792 for metrics/alerting, #793 for tracing/error reporting. This PR intentionally avoids new dependencies.

## Notes for Claude Code Review
- 請特別看 log fields 是否足夠 debug，但仍不含 query/header/body/token 類資料；scheduler error redaction 只做 baseline marker redaction，深度 PII/token redaction policy 留給 #793。
