### PR TITLE
[frontend] Add extension production package manifest

### DIFF
--- a/apps/extension/.env.production.example
+++ b/apps/extension/.env.production.example
@@ -1,0 +1,1 @@
+VITE_TACHIGO_API_URL=https://api.tachigo.io

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -29,6 +29,9 @@ http://localhost:5173
 ```bash
 pnpm dev
 pnpm build
+pnpm build:local
+pnpm package:production
+pnpm package:readback
 pnpm test
 pnpm lint
 pnpm check:i18n
@@ -53,15 +56,33 @@ cp apps/extension/.env.example apps/extension/.env
 | --- | --- |
 | `VITE_TACHIGO_API_URL` | Tachigo API origin，例如 `http://localhost:8080` |
 
-Chrome manifest 目前允許 `http://localhost:8080/*` host permission；若本機 API origin 改變，請同步檢查 [`public/manifest.json`](public/manifest.json)。
+本機 dev manifest 允許 `http://localhost:8080/*` host permission，並讓 content script 只匹配 `http://localhost:3000/*`。
+若本機 API origin 改變，請同步檢查 [`manifests/dev.json`](manifests/dev.json) 與 `src/extension/runtime-config.test.ts`。
+
+Production package 使用 [`manifests/production.json`](manifests/production.json)：
+
+| 設定 | Production 值 |
+| --- | --- |
+| API origin | `https://api.tachigo.io` |
+| API host permission | `https://api.tachigo.io/*` |
+| Content script match | `https://www.twitch.tv/*` |
+
+Production env 範例在 [`.env.production.example`](.env.production.example)。正式送審前，release owner 必須確認 `https://api.tachigo.io` 的 DNS、TLS、CORS allowlist 與後端部署已可用。
 
 ## Chrome Extension 載入方式
 
-先產出 `dist/`：
+Production package 的 `pnpm build` 預設會把 production manifest 複製成 `dist/manifest.json`。正式 package/readback 請跑：
 
 ```bash
 cd apps/extension
-pnpm build
+pnpm package:production
+```
+
+如果只是要用 localhost API 載入本機 unpacked extension，請改跑：
+
+```bash
+cd apps/extension
+pnpm build:local
 ```
 
 在 Chrome 載入 unpacked extension：
@@ -72,11 +93,25 @@ pnpm build
 4. 選擇 `apps/extension/dist`
 5. 點擊 Tachimint extension action，或從 Chrome side panel 開啟
 
-目前 Manifest V3 設定在 [`public/manifest.json`](public/manifest.json)：
+Manifest V3 template 位於 [`manifests/`](manifests/)：
 
 - `side_panel.default_path` 指向 `sidepanel.html`
 - background service worker 由 `src/extension/background.ts` build 成 `assets/background.js`
 - content script 由 `src/extension/content.ts` build 成 `assets/content.js`
+
+`pnpm package:readback` 會檢查 `dist/manifest.json`、`assets/background.js`、`assets/content.js`、`sidepanel.html`，並確認 production package 沒有 `localhost` / `127.0.0.1` / `0.0.0.0` 權限。
+
+## Chrome Web Store / sideload release checklist
+
+Owner：當次 Chrome Web Store submission 的 extension release owner。
+
+- 跑 `pnpm package:production`，確認 readback 通過。
+- 用 Chrome `Load unpacked` 載入 `apps/extension/dist`。
+- 開啟 Twitch channel 頁面，點擊 Tachimint extension action，確認 side panel 可開啟。
+- 走一次 login flow，確認請求打到 `https://api.tachigo.io`，沒有連到 localhost。
+- 確認後端 production `ALLOWED_ORIGINS` / CORS 已允許 extension 需要的 origin。
+- 在 Chrome Web Store permission review 中說明 `sidePanel`、`storage`、`activeTab`、`https://www.twitch.tv/*` 與 `https://api.tachigo.io/*` 的用途。
+- 記錄 package SHA、送審帳號、Chrome Web Store draft/review 狀態到 release ticket。
 
 ## `sidepanel.html` 與 `index.html`
 

--- a/apps/extension/manifests/dev.json
+++ b/apps/extension/manifests/dev.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "name": "Tachimint",
-  "description": "Tachimint Chrome sidepanel extension.",
+  "name": "Tachimint Dev",
+  "description": "Tachimint Chrome sidepanel extension for local development.",
   "version": "0.0.1",
   "permissions": ["sidePanel", "storage", "activeTab"],
   "background": {

--- a/apps/extension/manifests/production.json
+++ b/apps/extension/manifests/production.json
@@ -1,0 +1,24 @@
+{
+  "manifest_version": 3,
+  "name": "Tachimint",
+  "description": "Tachimint Chrome sidepanel extension.",
+  "version": "0.0.1",
+  "permissions": ["sidePanel", "storage", "activeTab"],
+  "background": {
+    "service_worker": "assets/background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.twitch.tv/*"],
+      "js": ["assets/content.js"]
+    }
+  ],
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
+  "action": {
+    "default_title": "Open Tachimint"
+  },
+  "host_permissions": ["https://api.tachigo.io/*"]
+}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -10,8 +10,11 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:local": "TACHIGO_EXTENSION_MANIFEST_TARGET=dev pnpm build",
     "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",
     "lint": "eslint .",
+    "package:production": "pnpm build && pnpm package:readback",
+    "package:readback": "node --experimental-strip-types scripts/verify-production-package.ts",
     "test": "vitest run",
     "preview": "vite preview"
   },

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -8,12 +8,12 @@
     "node": ">=24.0.0 <25"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "VITE_TACHIGO_API_URL=http://localhost:8080 vite",
     "build": "tsc -b && vite build",
-    "build:local": "TACHIGO_EXTENSION_MANIFEST_TARGET=dev pnpm build",
+    "build:local": "TACHIGO_EXTENSION_MANIFEST_TARGET=dev VITE_TACHIGO_API_URL=http://localhost:8080 pnpm build",
     "check:i18n": "node --experimental-strip-types scripts/check-i18n.ts",
     "lint": "eslint .",
-    "package:production": "pnpm build && pnpm package:readback",
+    "package:production": "TACHIGO_EXTENSION_MANIFEST_TARGET=production VITE_TACHIGO_API_URL=https://api.tachigo.io pnpm build && pnpm package:readback",
     "package:readback": "node --experimental-strip-types scripts/verify-production-package.ts",
     "test": "vitest run",
     "preview": "vite preview"

--- a/apps/extension/scripts/verify-production-package.ts
+++ b/apps/extension/scripts/verify-production-package.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 interface ExtensionManifest {
@@ -17,10 +18,14 @@ interface ExtensionManifest {
 }
 
 const distUrl = new URL('../dist/', import.meta.url)
+const distPath = fileURLToPath(distUrl)
 const manifestUrl = new URL('manifest.json', distUrl)
-const productionApiPermission = 'https://api.tachigo.io/*'
+const productionApiUrl = 'https://api.tachigo.io'
+const productionApiPermission = `${productionApiUrl}/*`
 const productionTwitchMatch = 'https://www.twitch.tv/*'
 const localOnlyPattern = /localhost|127\.0\.0\.1|0\.0\.0\.0/
+const localApiPattern = /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):8080\b/
+const scannedBundleExtensions = new Set(['.css', '.html', '.js'])
 
 function readManifest(): ExtensionManifest {
   assert.ok(
@@ -42,6 +47,27 @@ function collectManifestUrls(manifest: ExtensionManifest) {
     ...(manifest.host_permissions ?? []),
     ...(manifest.content_scripts ?? []).flatMap((script) => script.matches ?? []),
   ]
+}
+
+function collectBundleFiles(directoryPath = distPath): Array<{ relativePath: string; contents: string }> {
+  return readdirSync(directoryPath, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directoryPath, entry.name)
+
+    if (entry.isDirectory()) {
+      return collectBundleFiles(entryPath)
+    }
+
+    if (!entry.isFile() || !scannedBundleExtensions.has(path.extname(entry.name))) {
+      return []
+    }
+
+    return [
+      {
+        relativePath: path.relative(distPath, entryPath),
+        contents: readFileSync(entryPath, 'utf8'),
+      },
+    ]
+  })
 }
 
 const manifest = readManifest()
@@ -68,5 +94,20 @@ assert.ok(
 assertDistFile('assets/background.js', 'background service worker')
 assertDistFile('assets/content.js', 'content script')
 assertDistFile('sidepanel.html', 'side panel entry')
+
+const bundleFiles = collectBundleFiles()
+const localApiBundleFiles = bundleFiles
+  .filter(({ contents }) => localApiPattern.test(contents))
+  .map(({ relativePath }) => relativePath)
+
+assert.deepEqual(
+  localApiBundleFiles,
+  [],
+  `Production bundle must not include local API URLs: ${localApiBundleFiles.join(', ')}`,
+)
+assert.ok(
+  bundleFiles.some(({ contents }) => contents.includes(productionApiUrl)),
+  `Production bundle must include ${productionApiUrl}`,
+)
 
 console.log('Production extension package readback passed.')

--- a/apps/extension/scripts/verify-production-package.ts
+++ b/apps/extension/scripts/verify-production-package.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+interface ExtensionManifest {
+  background?: {
+    service_worker?: string
+  }
+  content_scripts?: Array<{
+    matches?: string[]
+    js?: string[]
+  }>
+  host_permissions?: string[]
+  side_panel?: {
+    default_path?: string
+  }
+}
+
+const distUrl = new URL('../dist/', import.meta.url)
+const manifestUrl = new URL('manifest.json', distUrl)
+const productionApiPermission = 'https://api.tachigo.io/*'
+const productionTwitchMatch = 'https://www.twitch.tv/*'
+const localOnlyPattern = /localhost|127\.0\.0\.1|0\.0\.0\.0/
+
+function readManifest(): ExtensionManifest {
+  assert.ok(
+    existsSync(manifestUrl),
+    `Missing production manifest at ${fileURLToPath(manifestUrl)}. Run pnpm build first.`,
+  )
+
+  return JSON.parse(readFileSync(manifestUrl, 'utf8')) as ExtensionManifest
+}
+
+function assertDistFile(relativePath: string, label: string) {
+  const fileUrl = new URL(relativePath, distUrl)
+
+  assert.ok(existsSync(fileUrl), `Missing ${label}: ${relativePath}`)
+}
+
+function collectManifestUrls(manifest: ExtensionManifest) {
+  return [
+    ...(manifest.host_permissions ?? []),
+    ...(manifest.content_scripts ?? []).flatMap((script) => script.matches ?? []),
+  ]
+}
+
+const manifest = readManifest()
+
+assert.ok(
+  manifest.host_permissions?.includes(productionApiPermission),
+  `Production manifest must include ${productionApiPermission}`,
+)
+assert.ok(
+  manifest.content_scripts?.some((script) => script.matches?.includes(productionTwitchMatch)),
+  `Production manifest must target ${productionTwitchMatch}`,
+)
+
+const localOnlyUrls = collectManifestUrls(manifest).filter((url) => localOnlyPattern.test(url))
+assert.deepEqual(localOnlyUrls, [], `Production manifest must not include local-only URLs: ${localOnlyUrls.join(', ')}`)
+
+assert.equal(manifest.background?.service_worker, 'assets/background.js')
+assert.equal(manifest.side_panel?.default_path, 'sidepanel.html')
+assert.ok(
+  manifest.content_scripts?.some((script) => script.js?.includes('assets/content.js')),
+  'Production manifest must include assets/content.js as a content script.',
+)
+
+assertDistFile('assets/background.js', 'background service worker')
+assertDistFile('assets/content.js', 'content script')
+assertDistFile('sidepanel.html', 'side panel entry')
+
+console.log('Production extension package readback passed.')

--- a/apps/extension/src/extension/runtime-config.test.ts
+++ b/apps/extension/src/extension/runtime-config.test.ts
@@ -17,7 +17,7 @@ interface ExtensionManifest {
 }
 
 async function readManifest(target: 'dev' | 'production') {
-  const raw = await readFile(new URL(`../../../manifests/${target}.json`, import.meta.url), 'utf8')
+  const raw = await readFile(new URL(`../../manifests/${target}.json`, import.meta.url), 'utf8')
   return JSON.parse(raw) as ExtensionManifest
 }
 

--- a/apps/extension/src/extension/runtime-config.test.ts
+++ b/apps/extension/src/extension/runtime-config.test.ts
@@ -2,22 +2,78 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 import { readFile } from 'node:fs/promises'
 
-async function readManifest() {
-  const raw = await readFile(new URL('../../public/manifest.json', import.meta.url), 'utf8')
-  return JSON.parse(raw) as {
-    host_permissions?: string[]
+interface ExtensionManifest {
+  background?: {
+    service_worker?: string
+  }
+  content_scripts?: Array<{
+    matches?: string[]
+    js?: string[]
+  }>
+  host_permissions?: string[]
+  side_panel?: {
+    default_path?: string
   }
 }
 
-async function readEnvExample() {
+async function readManifest(target: 'dev' | 'production') {
+  const raw = await readFile(new URL(`../../../manifests/${target}.json`, import.meta.url), 'utf8')
+  return JSON.parse(raw) as ExtensionManifest
+}
+
+async function readDevEnvExample() {
   return readFile(new URL('../../.env.example', import.meta.url), 'utf8')
 }
 
-test('manifest allows requests to the default local API base url', async () => {
-  const manifest = await readManifest()
-  const envExample = await readEnvExample()
-  const apiUrl = envExample.match(/^VITE_TACHIGO_API_URL=(.+)$/m)?.[1]
+async function readProductionEnvExample() {
+  return readFile(new URL('../../.env.production.example', import.meta.url), 'utf8')
+}
+
+function readEnvValue(envExample: string, name: string) {
+  return envExample.match(new RegExp(`^${name}=(.+)$`, 'm'))?.[1]
+}
+
+function manifestUrls(manifest: ExtensionManifest) {
+  return [
+    ...(manifest.host_permissions ?? []),
+    ...(manifest.content_scripts ?? []).flatMap((script) => script.matches ?? []),
+  ]
+}
+
+function assertManifestEntrypoints(manifest: ExtensionManifest) {
+  assert.equal(manifest.background?.service_worker, 'assets/background.js')
+  assert.equal(manifest.side_panel?.default_path, 'sidepanel.html')
+  assert.ok(
+    manifest.content_scripts?.some((script) => script.js?.includes('assets/content.js')),
+    'manifest should include the content script bundle entry',
+  )
+}
+
+test('dev manifest allows requests to the default local API base url', async () => {
+  const manifest = await readManifest('dev')
+  const envExample = await readDevEnvExample()
+  const apiUrl = readEnvValue(envExample, 'VITE_TACHIGO_API_URL')
 
   assert.equal(apiUrl, 'http://localhost:8080')
   assert.ok(manifest.host_permissions?.includes('http://localhost:8080/*'))
+  assert.ok(manifest.content_scripts?.some((script) => script.matches?.includes('http://localhost:3000/*')))
+  assertManifestEntrypoints(manifest)
+})
+
+test('production manifest targets Twitch and tachigo API without localhost permissions', async () => {
+  const manifest = await readManifest('production')
+  const envExample = await readProductionEnvExample()
+  const apiUrl = readEnvValue(envExample, 'VITE_TACHIGO_API_URL')
+
+  assert.equal(apiUrl, 'https://api.tachigo.io')
+  assert.ok(manifest.host_permissions?.includes('https://api.tachigo.io/*'))
+  assert.ok(manifest.content_scripts?.some((script) => script.matches?.includes('https://www.twitch.tv/*')))
+  assertManifestEntrypoints(manifest)
+
+  const urls = manifestUrls(manifest)
+  assert.equal(
+    urls.some((url) => /localhost|127\.0\.0\.1|0\.0\.0\.0/.test(url)),
+    false,
+    `production manifest should not include local-only URLs: ${urls.join(', ')}`,
+  )
 })

--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -16,8 +16,11 @@ const processEnv =
 
 const BASE_URL =
   import.meta.env?.VITE_TACHIGO_API_URL ??
-  processEnv?.VITE_TACHIGO_API_URL ??
-  'http://localhost:8080'
+  processEnv?.VITE_TACHIGO_API_URL
+
+if (!BASE_URL) {
+  throw new Error('Missing VITE_TACHIGO_API_URL for Tachigo API client.')
+}
 
 const client = axios.create({
   baseURL: BASE_URL,

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -1,10 +1,50 @@
 import { defineConfig } from 'vite'
+import type { Plugin } from 'vite'
+import fs from 'node:fs'
 import path from 'path'
 import react from '@vitejs/plugin-react'
 
+const manifestTemplates = {
+  dev: path.resolve(__dirname, 'manifests/dev.json'),
+  production: path.resolve(__dirname, 'manifests/production.json'),
+} as const
+
+type ManifestTarget = keyof typeof manifestTemplates
+
+function getManifestTarget(): ManifestTarget {
+  const rawTarget = process.env.TACHIGO_EXTENSION_MANIFEST_TARGET ?? 'production'
+
+  if (rawTarget === 'dev' || rawTarget === 'production') {
+    return rawTarget
+  }
+
+  throw new Error(
+    `Unsupported TACHIGO_EXTENSION_MANIFEST_TARGET=${rawTarget}. Use "dev" or "production".`,
+  )
+}
+
+function extensionManifestPlugin(): Plugin {
+  const manifestTarget = getManifestTarget()
+  let outDir = path.resolve(__dirname, 'dist')
+
+  return {
+    name: 'tachigo-extension-manifest',
+    apply: 'build',
+    configResolved(config) {
+      outDir = path.isAbsolute(config.build.outDir)
+        ? config.build.outDir
+        : path.resolve(config.root, config.build.outDir)
+    },
+    closeBundle() {
+      fs.mkdirSync(outDir, { recursive: true })
+      fs.copyFileSync(manifestTemplates[manifestTarget], path.join(outDir, 'manifest.json'))
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), extensionManifestPlugin()],
   build: {
     chunkSizeWarningLimit: 350,
     rollupOptions: {

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'node',
+    env: {
+      VITE_TACHIGO_API_URL: 'http://localhost:8080',
+    },
     include: ['src/**/*.test.{ts,tsx}', 'scripts/*.test.{ts,tsx}'],
   },
 })


### PR DESCRIPTION
## 什麼改動
新增 extension manifest template split：dev 保留 localhost，production package 預設輸出 `https://www.twitch.tv/*` content script match 與 `https://api.tachigo.io/*` API host permission。補上 production package readback 腳本、package scripts、runtime config tests 與 Chrome Web Store / sideload checklist。

## 為什麼
closes #778。上線稽核發現 `apps/extension/public/manifest.json` 仍把 production package 綁在 localhost-only permissions，導致 sideload / Chrome Web Store review 前無法穩定驗證 production package。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#778
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 backend deployment / DNS / TLS 實際切換
  - 不做 Chrome Web Store submission
  - 不改 extension UI flow 或 auth behavior

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - n/a
- Actual worker profile(s)：
  - controller self-only
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller model=gpt-5.5 reasoning=medium controller_fallback=used fallback_reason=user_did_not_explicitly_request_subagents_single_surface_frontend_release_packaging
- Verification evidence：
  - `pnpm install --frozen-lockfile --ignore-scripts`
  - `./node_modules/.bin/tsc -b`
  - `pnpm lint`
  - `pnpm check:i18n`
  - manifest JSON parse check
  - `node --experimental-strip-types scripts/verify-production-package.ts` against a generated readback fixture
  - `git diff --check`
- Self-review / exception reason：
  - self-only exception: #778 is one frontend package/readback slice under 400 changed lines.
- Worker session closeout：
  - self-only controller session; no worker handles were opened, so no stale worker sessions remain.
- Workflow friction / follow-up split：
  - n/a

## Review conversation closeout
- Unresolved threads：
  - 0 at PR open.
- CodeRabbit：
  - status context success at initial head; no actionable comments at PR open.
- chatgpt-codex-connector：
  - no connector review requested yet; human review pending for R4.
- review_triage_ref：
  - initial self-triage in this PR body; no review findings existed at open.
- root_cause_gate_ref：
  - no repeated finding triggered; latest-head rationale is the #778 package/readback evidence in this PR body.
- finding_disposition_ref：
  - no findings to dispose at open; future findings will be recorded in PR comments.
- Final reviewer action：
  - initial PR open; no reviewer findings to resolve yet.

## Final merge gate
- Ready-to-merge decision：
  - blocked until CI confirms frontend test/build/readback; R4 draft requires human review.
- Latest head SHA：
  - a4d9181f0b10760133a4825458a84c6b62d5efba
- Required checks：
  - pending; local TypeScript/lint/i18n/static readback evidence collected.
- spec workflow-check evidence：
  - n/a; spec CLI unavailable in this environment.
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 extension production package 產出可審核、無 localhost 權限的 Manifest V3 bundle。
- Approx changed lines：~307
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #778 的 AC 同時要求 package behavior、reproducible readback、local dev documentation、Chrome Web Store / sideload checklist；這些是同一個 release-readiness slice。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Production package does not hardcode localhost content script matches or API host permissions.
- [x] Local dev behavior remains documented and testable.
- [x] Build/package verification is reproducible from repo commands.
- [x] Chrome Web Store / sideload permission review has a checklist and known owner.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm install --frozen-lockfile --ignore-scripts
PASS: installed from existing lockfile; no dependency changes

./node_modules/.bin/tsc -b
PASS

pnpm lint
PASS

pnpm check:i18n
PASS: 21 locale mappings, 69 keys

manifest JSON parse check
PASS: manifests/dev.json and manifests/production.json are valid JSON

node --experimental-strip-types scripts/verify-production-package.ts
PASS against generated readback fixture

pnpm test -- src/extension/runtime-config.test.ts
BLOCKED locally: Codex macOS process cannot load Vite/Rolldown native binding due code-signing Team ID mismatch.

pnpm package:production
BLOCKED locally at Vite build for the same Rolldown native binding issue. CI should verify on Linux.

git diff --check
PASS
```

## 備註
Production API origin is defined as `https://api.tachigo.io`; the release owner must confirm DNS, TLS, CORS allowlist, and backend availability before Chrome Web Store submission.

## Notes for Claude Code Review
- 請特別看 `manifests/production.json` 的 permission scope 是否符合 Chrome Web Store review 期待。
- 本 PR 沒有新增 dependency；package script 只使用 Node built-ins。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了开发和部署指南，包含完整的构建命令、清单配置说明及上线前检查项。

* **新功能**
  * 引入生产环境验证流程，确保扩展包的安全性和正确性。
  * 支持开发和生产环境的独立构建配置。

* **Chores**
  * 添加生产环境配置文件和环境变量。
  * 优化构建脚本，分离本地和生产部署流程。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->