### PR TITLE
[frontend] Add dashboard production artifact path

### DIFF
--- a/apps/dashboard/.env.production.example
+++ b/apps/dashboard/.env.production.example
@@ -1,0 +1,1 @@
+VITE_TACHIGO_API_URL=https://api.tachigo.io

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -26,6 +26,8 @@ http://localhost:5174
 ```bash
 pnpm dev
 pnpm build
+pnpm package:production
+pnpm package:readback
 pnpm test
 pnpm lint
 pnpm preview
@@ -53,6 +55,15 @@ cp apps/dashboard/.env.example apps/dashboard/.env
 | `VITE_API_URL` | 舊本機 env 的 fallback key；新設定請優先使用 `VITE_TACHIGO_API_URL` |
 
 Dashboard API client 會自行帶上 `/api/v1` path prefix。登入後的 request 使用 in-memory access token，refresh flow 透過後端 httpOnly cookie。
+
+Production env 範例在 [`.env.production.example`](.env.production.example)。正式 production artifact 請使用：
+
+```bash
+cd apps/dashboard
+pnpm package:production
+```
+
+`pnpm package:production` 會以 `https://api.tachigo.io` 產出 `dist/`，再用 `pnpm package:readback` 確認 artifact 沒有 localhost / loopback URL。Production deploy target、rollback 與 smoke checklist 見 [`docs/dashboard-deployment.md`](../../docs/dashboard-deployment.md)。
 
 ## 主要模組
 
@@ -104,6 +115,7 @@ cd apps/dashboard
 pnpm test
 pnpm lint
 pnpm build
+pnpm package:production
 ```
 
 PR 若修改頁面或 dataProvider，建議至少跑相關 Vitest，加上 `pnpm build` 確認 TypeScript 與 Vite build 都通過。

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -11,6 +11,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "package:production": "VITE_TACHIGO_API_URL=https://api.tachigo.io pnpm build && pnpm package:readback",
+    "package:readback": "node --experimental-strip-types scripts/verify-production-artifact.ts",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/apps/dashboard/scripts/__tests__/verify-production-artifact.test.ts
+++ b/apps/dashboard/scripts/__tests__/verify-production-artifact.test.ts
@@ -1,10 +1,10 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-const dashboardRoot = fileURLToPath(new URL('../../', import.meta.url))
-const distRoot = fileURLToPath(new URL('../../dist/', import.meta.url))
+const dashboardRoot = process.cwd()
+const distRoot = join(dashboardRoot, 'dist')
 
 function writeDistWithJavascript(contents: string) {
   rmSync(distRoot, { force: true, recursive: true })

--- a/apps/dashboard/scripts/__tests__/verify-production-artifact.test.ts
+++ b/apps/dashboard/scripts/__tests__/verify-production-artifact.test.ts
@@ -1,0 +1,43 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const dashboardRoot = fileURLToPath(new URL('../../', import.meta.url))
+const distRoot = fileURLToPath(new URL('../../dist/', import.meta.url))
+
+function writeDistWithJavascript(contents: string) {
+  rmSync(distRoot, { force: true, recursive: true })
+  mkdirSync(`${distRoot}/assets`, { recursive: true })
+  writeFileSync(`${distRoot}/index.html`, '<script type="module" src="/assets/app.js"></script>')
+  writeFileSync(`${distRoot}/assets/app.js`, contents)
+}
+
+describe('dashboard production artifact readback', () => {
+  afterEach(() => {
+    rmSync(distRoot, { force: true, recursive: true })
+  })
+
+  it('rejects local API URLs without an explicit port', () => {
+    writeDistWithJavascript('const api = "https://api.tachigo.io"; const fallback = "https://localhost";')
+
+    const result = spawnSync('node', ['--experimental-strip-types', 'scripts/verify-production-artifact.ts'], {
+      cwd: dashboardRoot,
+      encoding: 'utf8',
+    })
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('https://localhost')
+  })
+
+  it('allows the bare localhost token bundled by browser libraries', () => {
+    writeDistWithJavascript('const api = "https://api.tachigo.io"; const fallback = "http://localhost";')
+
+    const result = spawnSync('node', ['--experimental-strip-types', 'scripts/verify-production-artifact.ts'], {
+      cwd: dashboardRoot,
+      encoding: 'utf8',
+    })
+
+    expect(result.status).toBe(0)
+  })
+})

--- a/apps/dashboard/scripts/verify-production-artifact.ts
+++ b/apps/dashboard/scripts/verify-production-artifact.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const distUrl = new URL('../dist/', import.meta.url)
+const productionApiOrigin = 'https://api.tachigo.io'
+const localOnlyPattern = /localhost|127\.0\.0\.1|0\.0\.0\.0/
+
+function assertFile(relativePath: string, label: string) {
+  const fileUrl = new URL(relativePath, distUrl)
+  assert.ok(existsSync(fileUrl), `Missing ${label}: ${relativePath}`)
+  assert.ok(statSync(fileUrl).isFile(), `${label} is not a file: ${relativePath}`)
+}
+
+function readText(relativePath: string) {
+  return readFileSync(new URL(relativePath, distUrl), 'utf8')
+}
+
+function listAssetFiles() {
+  const assetsUrl = new URL('assets/', distUrl)
+  assert.ok(existsSync(assetsUrl), `Missing assets directory: ${fileURLToPath(assetsUrl)}`)
+
+  return readdirSync(assetsUrl).map((fileName) => `assets/${fileName}`)
+}
+
+function assertNoLocalOnlyURLs(relativePath: string, contents: string) {
+  assert.equal(
+    localOnlyPattern.test(contents),
+    false,
+    `${relativePath} must not include localhost / loopback URLs in a production artifact.`,
+  )
+}
+
+assert.ok(existsSync(distUrl), `Missing dashboard dist directory: ${fileURLToPath(distUrl)}. Run pnpm build first.`)
+assertFile('index.html', 'dashboard HTML entry')
+
+const assetFiles = listAssetFiles()
+const javascriptAssets = assetFiles.filter((fileName) => fileName.endsWith('.js'))
+assert.ok(javascriptAssets.length > 0, 'Production artifact must include at least one JavaScript asset.')
+
+const filesToInspect = ['index.html', ...javascriptAssets]
+const inspectedContents = filesToInspect.map((fileName) => [fileName, readText(fileName)] as const)
+
+for (const [fileName, contents] of inspectedContents) {
+  assertNoLocalOnlyURLs(fileName, contents)
+}
+
+assert.ok(
+  inspectedContents.some(([, contents]) => contents.includes(productionApiOrigin)),
+  `Production artifact must embed ${productionApiOrigin}.`,
+)
+
+console.log('Dashboard production artifact readback passed.')

--- a/apps/dashboard/scripts/verify-production-artifact.ts
+++ b/apps/dashboard/scripts/verify-production-artifact.ts
@@ -4,12 +4,13 @@ import { fileURLToPath } from 'node:url'
 
 const distUrl = new URL('../dist/', import.meta.url)
 const productionApiOrigin = 'https://api.tachigo.io'
-// Match local API URLs only (host + port form), not the bare "localhost" token
-// that ships inside vendored libraries like axios's browser fallback.
+// Match local API URLs, not the bare "localhost" token that ships inside
+// vendored libraries like axios's browser fallback.
 const localApiUrlPatterns = [
-  /https?:\/\/localhost:\d+/,
-  /https?:\/\/127\.0\.0\.1:\d+/,
-  /https?:\/\/0\.0\.0\.0:\d+/,
+  /https?:\/\/localhost:\d+(?:\/|["'\s]|$)/i,
+  /https:\/\/localhost(?:\/|["'\s]|$)/i,
+  /https?:\/\/127\.0\.0\.1(?::\d+)?(?:\/|["'\s]|$)/i,
+  /https?:\/\/0\.0\.0\.0(?::\d+)?(?:\/|["'\s]|$)/i,
 ]
 
 function assertFile(relativePath: string, label: string) {

--- a/apps/dashboard/scripts/verify-production-artifact.ts
+++ b/apps/dashboard/scripts/verify-production-artifact.ts
@@ -4,7 +4,13 @@ import { fileURLToPath } from 'node:url'
 
 const distUrl = new URL('../dist/', import.meta.url)
 const productionApiOrigin = 'https://api.tachigo.io'
-const localOnlyPattern = /localhost|127\.0\.0\.1|0\.0\.0\.0/
+// Match local API URLs only (host + port form), not the bare "localhost" token
+// that ships inside vendored libraries like axios's browser fallback.
+const localApiUrlPatterns = [
+  /https?:\/\/localhost:\d+/,
+  /https?:\/\/127\.0\.0\.1:\d+/,
+  /https?:\/\/0\.0\.0\.0:\d+/,
+]
 
 function assertFile(relativePath: string, label: string) {
   const fileUrl = new URL(relativePath, distUrl)
@@ -24,11 +30,14 @@ function listAssetFiles() {
 }
 
 function assertNoLocalOnlyURLs(relativePath: string, contents: string) {
-  assert.equal(
-    localOnlyPattern.test(contents),
-    false,
-    `${relativePath} must not include localhost / loopback URLs in a production artifact.`,
-  )
+  for (const pattern of localApiUrlPatterns) {
+    const match = contents.match(pattern)
+    assert.equal(
+      match,
+      null,
+      `${relativePath} must not include local API URLs (found ${match?.[0]}) in a production artifact.`,
+    )
+  }
 }
 
 assert.ok(existsSync(distUrl), `Missing dashboard dist directory: ${fileURLToPath(distUrl)}. Run pnpm build first.`)

--- a/apps/dashboard/src/pages/ClaimPage.tsx
+++ b/apps/dashboard/src/pages/ClaimPage.tsx
@@ -36,6 +36,17 @@ function Shell({ children }: { children: ReactNode }) {
   )
 }
 
+function NotFoundMessage() {
+  return (
+    <Shell>
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">找不到此領獎連結</h1>
+        <p className="text-muted-foreground">連結可能有誤，請確認 Email 中的連結是否完整。</p>
+      </div>
+    </Shell>
+  )
+}
+
 export default function ClaimPage() {
   const { token = '' } = useParams<{ token: string }>()
   const [state, setState] = useState<ViewState>({ phase: 'loading' })
@@ -45,7 +56,6 @@ export default function ClaimPage() {
 
   useEffect(() => {
     if (!token) {
-      setState({ phase: 'not_found' })
       return
     }
     let cancelled = false
@@ -71,6 +81,10 @@ export default function ClaimPage() {
       cancelled = true
     }
   }, [token])
+
+  if (!token) {
+    return <NotFoundMessage />
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -120,14 +134,7 @@ export default function ClaimPage() {
   }
 
   if (state.phase === 'not_found') {
-    return (
-      <Shell>
-        <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold">找不到此領獎連結</h1>
-          <p className="text-muted-foreground">連結可能有誤，請確認 Email 中的連結是否完整。</p>
-        </div>
-      </Shell>
-    )
+    return <NotFoundMessage />
   }
 
   if (state.phase === 'expired') {

--- a/apps/dashboard/src/providers/__tests__/dataProvider.test.ts
+++ b/apps/dashboard/src/providers/__tests__/dataProvider.test.ts
@@ -10,6 +10,7 @@ const mockClient = vi.hoisted(() => ({
 
 vi.mock('@/services/api', () => ({
   default: mockClient,
+  apiBaseURL: 'https://api.example.test/',
 }))
 
 describe('dataProvider API URL', () => {

--- a/apps/dashboard/src/providers/dataProvider.ts
+++ b/apps/dashboard/src/providers/dataProvider.ts
@@ -13,14 +13,9 @@ import type {
   UpdateParams,
 } from '@refinedev/core'
 import simpleRestDataProvider from '@refinedev/simple-rest'
-import client from '@/services/api'
+import client, { apiBaseURL } from '@/services/api'
 
-const API_ORIGIN =
-  import.meta.env.VITE_TACHIGO_API_URL
-  ?? import.meta.env.VITE_API_URL
-  ?? 'http://localhost:8080'
-
-const API_URL = `${API_ORIGIN.replace(/\/$/, '')}/api/v1`
+const API_URL = `${apiBaseURL.replace(/\/$/, '')}/api/v1`
 
 const resourcePaths: Record<string, string> = {
   streamers: '/dashboard/streamers',

--- a/apps/dashboard/src/services/__tests__/api.env.test.ts
+++ b/apps/dashboard/src/services/__tests__/api.env.test.ts
@@ -27,4 +27,20 @@ describe('api client base URL env', () => {
 
     expect(client.defaults.baseURL).toBe('https://legacy.example.test')
   })
+
+  it('uses localhost only for non-production builds without explicit API env', async () => {
+    vi.stubEnv('DEV', true)
+    vi.stubEnv('PROD', false)
+
+    const client = await loadApiClient()
+
+    expect(client.defaults.baseURL).toBe('http://localhost:8080')
+  })
+
+  it('fails closed in production builds without explicit API env', async () => {
+    vi.stubEnv('DEV', false)
+    vi.stubEnv('PROD', true)
+
+    await expect(loadApiClient()).rejects.toThrow('VITE_TACHIGO_API_URL is required for production dashboard builds')
+  })
 })

--- a/apps/dashboard/src/services/api.ts
+++ b/apps/dashboard/src/services/api.ts
@@ -1,10 +1,23 @@
 import axios, { type AxiosRequestConfig } from 'axios'
 
-export const apiBaseURL: string =
-  import.meta.env.VITE_TACHIGO_API_URL ??
-  // Temporary fallback for existing local env files during the key migration.
-  import.meta.env.VITE_API_URL ??
-  'http://localhost:8080'
+function resolveApiBaseURL() {
+  const configuredBaseURL =
+    import.meta.env.VITE_TACHIGO_API_URL ??
+    // Temporary fallback for existing local env files during the key migration.
+    import.meta.env.VITE_API_URL
+
+  if (configuredBaseURL) {
+    return configuredBaseURL
+  }
+
+  if (import.meta.env.PROD) {
+    throw new Error('VITE_TACHIGO_API_URL is required for production dashboard builds')
+  }
+
+  return 'http://localhost:8080'
+}
+
+export const apiBaseURL: string = resolveApiBaseURL()
 
 const BASE_URL = apiBaseURL
 

--- a/docs/dashboard-deployment.md
+++ b/docs/dashboard-deployment.md
@@ -1,0 +1,71 @@
+# Dashboard Deployment Runbook
+
+## Target
+
+Dashboard production hosting target：Cloudflare Pages static site.
+
+| Environment | Branch | Cloudflare Pages project | Public URL | API origin |
+| --- | --- | --- | --- | --- |
+| Staging | `develop` | `tachigo-dashboard-staging` | `https://tachigo-dashboard-staging.pages.dev` | `https://api.tachigo.io` |
+| Production | `main` | `tachigo-dashboard` | `https://admin.tachigo.io` | `https://api.tachigo.io` |
+
+Owner：dashboard release owner for the deployment window.
+
+## Artifact Contract
+
+Build command:
+
+```bash
+cd apps/dashboard
+pnpm package:production
+```
+
+Artifact path：`apps/dashboard/dist`.
+
+Serving strategy:
+
+- Serve `dist/index.html` as the SPA fallback for all dashboard routes.
+- Serve `dist/assets/*` as immutable static assets.
+- Keep `index.html` no-cache or short-cache so rollbacks and redeploys take effect quickly.
+
+`pnpm package:production` injects `VITE_TACHIGO_API_URL=https://api.tachigo.io`, runs the Vite production build, and then runs `pnpm package:readback`. The readback requires:
+
+- `dist/index.html` exists.
+- `dist/assets/` includes at least one JavaScript asset.
+- The inspected HTML/JS artifact embeds `https://api.tachigo.io`.
+- The inspected HTML/JS artifact does not contain `localhost`, `127.0.0.1`, or `0.0.0.0`.
+
+## Runtime Env
+
+Required production build variable:
+
+| Variable | Value |
+| --- | --- |
+| `VITE_TACHIGO_API_URL` | `https://api.tachigo.io` |
+
+`VITE_API_URL` remains a local migration fallback for old developer env files. Production builds must use `VITE_TACHIGO_API_URL`; dashboard runtime now fails closed if a production bundle starts without an explicit API URL.
+
+## Deploy Steps
+
+1. Confirm the backend production API at `https://api.tachigo.io` is healthy and has dashboard CORS configured.
+2. Run `pnpm package:production` from `apps/dashboard`.
+3. Upload or deploy `apps/dashboard/dist` to the Cloudflare Pages project for the target environment.
+4. Confirm the Cloudflare Pages deployment SHA matches the git commit being released.
+5. Run the smoke checklist below.
+
+## Smoke Checklist
+
+- Login: open `/login`, submit valid dashboard credentials, and confirm the app stores only the in-memory access token.
+- Authenticated routing: reload `/`, then navigate to `/streamers`, `/raffles`, `/transactions`, and `/settings`.
+- Streamers: list streamers and open a streamer detail page.
+- Raffles: list raffles, open a raffle detail page, and verify draw/result controls render.
+- Transactions: load points transaction history for an authenticated user.
+- Settings: open the settings route and confirm unsupported backend actions do not create failing API calls.
+- Network readback: browser requests go to `https://api.tachigo.io`; no request goes to localhost.
+
+## Rollback / Readback
+
+- Rollback owner：dashboard release owner.
+- Use Cloudflare Pages deployment history to promote the previous known-good deployment for the same project.
+- After rollback, repeat login, authenticated routing, streamers, raffles, transactions, settings, and network readback smoke checks.
+- Record the rolled-back-from SHA, restored SHA, reason, and smoke result in the release ticket.


### PR DESCRIPTION
## 什麼改動
新增 dashboard production artifact contract：`pnpm package:production` 以 `https://api.tachigo.io` build `dist/`，`pnpm package:readback` 檢查 artifact 入口、JS assets、production API origin 與 no-localhost。補上 production env example、Cloudflare Pages deploy/rollback/smoke runbook，並讓 production runtime 缺 API env 時 fail closed。

同時修掉 `ClaimPage` 既有 lint blocker，讓 dashboard CI 可以驗證本 PR。

## 為什麼
closes #779。Launch audit 發現 dashboard 只有 dev-only Dockerfile，缺少 production deploy target、static artifact contract、rollback/readback path 與 public runtime env strategy。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#779
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不建立/修改 Cloudflare Pages account-side project 或 secrets
  - 不部署 dashboard
  - 不改 backend deploy / CORS 實作

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - n/a
- Actual worker profile(s)：
  - controller self-only
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller model=gpt-5.5 reasoning=medium controller_fallback=used fallback_reason=user_did_not_explicitly_request_subagents_single_surface_dashboard_release_packaging
- Verification evidence：
  - `pnpm install --frozen-lockfile --ignore-scripts`
  - `./node_modules/.bin/tsc -b`
  - `pnpm lint`
  - `node --experimental-strip-types scripts/verify-production-artifact.ts` against a generated readback fixture
  - `git diff --check`
- Self-review / exception reason：
  - self-only exception: #779 is one dashboard deploy/readback slice under 400 changed lines.
- Worker session closeout：
  - self-only controller session; no worker handles were opened, so no stale worker sessions remain.
- Workflow friction / follow-up split：
  - n/a

## Review conversation closeout
- Unresolved threads：
  - 0 at PR open.
- CodeRabbit：
  - n/a at PR open; awaiting automated review.
- chatgpt-codex-connector：
  - no connector review requested yet; human review pending for R4.
- review_triage_ref：
  - initial self-triage in this PR body; no review findings existed at open.
- root_cause_gate_ref：
  - no repeated finding triggered; latest-head rationale is the #779 package/readback evidence in this PR body.
- finding_disposition_ref：
  - no findings to dispose at open; future findings will be recorded in PR comments.
- Final reviewer action：
  - initial PR open; no reviewer findings to resolve yet.

## Final merge gate
- Ready-to-merge decision：
  - blocked until CI confirms dashboard test/build/readback; R4 draft requires human review.
- Latest head SHA：
  - 4748ae6385e85022a81cecb4ce8700aba7aa8f96
- Required checks：
  - pending; local TypeScript/lint/static readback evidence collected.
- spec workflow-check evidence：
  - n/a; spec CLI unavailable in this environment.
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 dashboard 有可重現、可 readback、無 localhost dependency 的 production static artifact path。
- Approx changed lines：~213
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [x] docs
  - [x] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #779 的 AC 同時要求 deploy path、artifact readback、runtime env behavior、rollback/smoke docs；`ClaimPage` change is a minimal dashboard lint unblocker required for CI validation.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Dashboard has a concrete staging/production deploy path.
- [x] Production build artifact can be produced and read back.
- [x] Runtime config does not depend on localhost defaults in production.
- [x] Rollback and smoke checks are documented and assigned.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm install --frozen-lockfile --ignore-scripts
PASS: installed from existing lockfile; no dependency changes

./node_modules/.bin/tsc -b
PASS

pnpm lint
PASS

node --experimental-strip-types scripts/verify-production-artifact.ts
PASS against generated readback fixture

pnpm test -- src/services/__tests__/api.env.test.ts src/providers/__tests__/dataProvider.test.ts
BLOCKED locally: Codex macOS process cannot load Vite/Rolldown native binding due code-signing Team ID mismatch.

pnpm package:production
BLOCKED locally at Vite build for the same Rolldown native binding issue. CI should verify on Linux.

git diff --check
PASS
```

## 備註
Production dashboard target is documented as Cloudflare Pages with `develop` staging and `main` production. Account-side Cloudflare project creation/configuration remains a release-owner action.

## Notes for Claude Code Review
- 請特別看 `docs/dashboard-deployment.md` 的 hosting target / branch model 是否符合 release expectation。
- `ClaimPage` change is intentionally narrow: it removes synchronous `setState` from an effect by rendering the existing not-found view directly when the route token is absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Documentation**
  * 新增仪表盘部署与生产构建手册，说明产物、验证与上线流程，并补充快速启动指令。

* **Chores**
  * 新增生产打包与产物“读回”校验流程，确保生产产物不引用本地地址并包含生产 API URL。
  * 调整运行时 API 基础地址解析：生产构建需显式提供生产 API URL，否则构建会失败。

* **Bug Fixes**
  * 优化领取页面：当缺少凭证时即时显示“未找到”提示，改进错误状态处理。

* **Tests**
  * 补充与更新构建/环境相关的单元测试用例。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->