### PR TITLE
[frontend] Add ocean character domain module

### DIFF
--- a/apps/extension/src/app/features/characters/characters.test.ts
+++ b/apps/extension/src/app/features/characters/characters.test.ts
@@ -67,8 +67,8 @@ test('calculateCharacterBuff leaves whale and capybara at neutral phase 1 buffs'
   assert.equal(calculateCharacterBuff('capybara', {}), 1)
 })
 
-test('calculateCharacterBuff leaves future stages neutral until phase 2 hooks land', () => {
-  assert.equal(calculateCharacterBuff('crab', { effectiveClicksInWindow: 20, stage: 2 }), 1)
-  assert.equal(calculateCharacterBuff('dolphin', { chatCount: 5, stage: 3 }), 1)
-  assert.equal(calculateCharacterBuff('turtle', { continuousWatchSeconds: 90 * 60, stage: 2 }), 1)
+test('calculateCharacterBuff preserves S1 bonuses for evolved stages until phase 2 hooks land', () => {
+  assert.equal(calculateCharacterBuff('crab', { effectiveClicksInWindow: 20, stage: 2 }), 1.5)
+  assert.equal(calculateCharacterBuff('dolphin', { chatCount: 5, stage: 3 }), 1.8)
+  assert.equal(calculateCharacterBuff('turtle', { continuousWatchSeconds: 90 * 60, stage: 2 }), 1.35)
 })

--- a/apps/extension/src/app/features/characters/characters.test.ts
+++ b/apps/extension/src/app/features/characters/characters.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import {
+  CHARACTER_DEFINITIONS,
+  CHARACTER_IDS,
+  calculateCharacterBuff,
+  calculateFamiliarityMultiplier,
+} from './characters'
+
+test('exports the expected character ids in phase 1 order', () => {
+  assert.deepEqual(CHARACTER_IDS, ['crab', 'dolphin', 'turtle', 'whale', 'capybara'])
+})
+
+test('defines unlock costs, stage thresholds, and dev-only flags', () => {
+  assert.deepEqual(CHARACTER_DEFINITIONS.crab, {
+    id: 'crab',
+    displayName: 'Crab',
+    unlockCost: 0,
+    stages: [1, 2, 3],
+    evolutionXpThresholds: { stage2: 1000, stage3: 10000 },
+    devOnly: false,
+  })
+
+  assert.equal(CHARACTER_DEFINITIONS.dolphin.unlockCost, 50)
+  assert.equal(CHARACTER_DEFINITIONS.turtle.unlockCost, 1500)
+  assert.equal(CHARACTER_DEFINITIONS.whale.unlockCost, null)
+  assert.equal(CHARACTER_DEFINITIONS.capybara.devOnly, true)
+})
+
+test('calculateFamiliarityMultiplier follows the phase 1 curve without decay for 30 days', () => {
+  assert.equal(calculateFamiliarityMultiplier(0), 0.1)
+  assert.equal(calculateFamiliarityMultiplier(60 * 60), 0.5)
+  assert.equal(calculateFamiliarityMultiplier(3 * 60 * 60), 0.75)
+  assert.equal(calculateFamiliarityMultiplier(5 * 60 * 60), 1)
+  assert.equal(calculateFamiliarityMultiplier(5 * 60 * 60, 30), 1)
+})
+
+test('calculateFamiliarityMultiplier decays after 30 days and floors at 0.1', () => {
+  assert.equal(calculateFamiliarityMultiplier(5 * 60 * 60, 31), 0.99)
+  assert.equal(calculateFamiliarityMultiplier(0, 365), 0.1)
+})
+
+test('calculateCharacterBuff returns crab click bonus only after 10 effective clicks', () => {
+  assert.equal(calculateCharacterBuff('crab', { effectiveClicksInWindow: 9 }), 1)
+  assert.equal(calculateCharacterBuff('crab', { effectiveClicksInWindow: 10 }), 1.5)
+  assert.equal(calculateCharacterBuff('crab', { effectiveClicksInWindow: 17 }), 1.5)
+})
+
+test('calculateCharacterBuff returns capped dolphin chat bonus tiers', () => {
+  assert.equal(calculateCharacterBuff('dolphin', { chatCount: 0 }), 1)
+  assert.equal(calculateCharacterBuff('dolphin', { chatCount: 1 }), 1.4)
+  assert.equal(calculateCharacterBuff('dolphin', { chatCount: 2 }), 1.6)
+  assert.equal(calculateCharacterBuff('dolphin', { chatCount: 3 }), 1.8)
+  assert.equal(calculateCharacterBuff('dolphin', { chatCount: 999 }), 1.8)
+})
+
+test('calculateCharacterBuff returns turtle continuous watch bonus tiers', () => {
+  assert.equal(calculateCharacterBuff('turtle', { continuousWatchSeconds: 29 * 60 }), 1)
+  assert.equal(calculateCharacterBuff('turtle', { continuousWatchSeconds: 30 * 60 }), 1.1)
+  assert.equal(calculateCharacterBuff('turtle', { continuousWatchSeconds: 60 * 60 }), 1.2)
+  assert.equal(calculateCharacterBuff('turtle', { continuousWatchSeconds: 90 * 60 }), 1.35)
+})
+
+test('calculateCharacterBuff leaves whale and capybara at neutral phase 1 buffs', () => {
+  assert.equal(calculateCharacterBuff('whale', {}), 1)
+  assert.equal(calculateCharacterBuff('capybara', {}), 1)
+})

--- a/apps/extension/src/app/features/characters/characters.test.ts
+++ b/apps/extension/src/app/features/characters/characters.test.ts
@@ -66,3 +66,9 @@ test('calculateCharacterBuff leaves whale and capybara at neutral phase 1 buffs'
   assert.equal(calculateCharacterBuff('whale', {}), 1)
   assert.equal(calculateCharacterBuff('capybara', {}), 1)
 })
+
+test('calculateCharacterBuff leaves future stages neutral until phase 2 hooks land', () => {
+  assert.equal(calculateCharacterBuff('crab', { effectiveClicksInWindow: 20, stage: 2 }), 1)
+  assert.equal(calculateCharacterBuff('dolphin', { chatCount: 5, stage: 3 }), 1)
+  assert.equal(calculateCharacterBuff('turtle', { continuousWatchSeconds: 90 * 60, stage: 2 }), 1)
+})

--- a/apps/extension/src/app/features/characters/characters.ts
+++ b/apps/extension/src/app/features/characters/characters.ts
@@ -1,0 +1,136 @@
+export const CHARACTER_IDS = ['crab', 'dolphin', 'turtle', 'whale', 'capybara'] as const
+
+export type CharacterId = (typeof CHARACTER_IDS)[number]
+export type CharacterStage = 1 | 2 | 3
+
+export type CharacterDefinition = {
+  id: CharacterId
+  displayName: string
+  unlockCost: number | null
+  stages: CharacterStage[]
+  evolutionXpThresholds: {
+    stage2: number
+    stage3: number
+  }
+  devOnly: boolean
+}
+
+export type CharacterBuffContext = {
+  effectiveClicksInWindow?: number
+  chatCount?: number
+  continuousWatchSeconds?: number
+  stage?: CharacterStage
+}
+
+const DEFAULT_THRESHOLDS = {
+  stage2: 1000,
+  stage3: 10000,
+} as const
+
+export const CHARACTER_DEFINITIONS: Record<CharacterId, CharacterDefinition> = {
+  crab: {
+    id: 'crab',
+    displayName: 'Crab',
+    unlockCost: 0,
+    stages: [1, 2, 3],
+    evolutionXpThresholds: DEFAULT_THRESHOLDS,
+    devOnly: false,
+  },
+  dolphin: {
+    id: 'dolphin',
+    displayName: 'Dolphin',
+    unlockCost: 50,
+    stages: [1, 2, 3],
+    evolutionXpThresholds: DEFAULT_THRESHOLDS,
+    devOnly: false,
+  },
+  turtle: {
+    id: 'turtle',
+    displayName: 'Turtle',
+    unlockCost: 1500,
+    stages: [1, 2, 3],
+    evolutionXpThresholds: DEFAULT_THRESHOLDS,
+    devOnly: false,
+  },
+  whale: {
+    id: 'whale',
+    displayName: 'Whale',
+    unlockCost: null,
+    stages: [1, 2, 3],
+    evolutionXpThresholds: DEFAULT_THRESHOLDS,
+    devOnly: false,
+  },
+  capybara: {
+    id: 'capybara',
+    displayName: 'Capybara',
+    unlockCost: 0,
+    stages: [1, 2, 3],
+    evolutionXpThresholds: DEFAULT_THRESHOLDS,
+    devOnly: true,
+  },
+}
+
+export function calculateFamiliarityMultiplier(
+  cumulativeWatchSeconds: number,
+  daysSinceLastWatch = 0,
+): number {
+  const watchSeconds = Math.max(0, cumulativeWatchSeconds)
+  const watchHours = watchSeconds / 3600
+
+  const multiplier = (() => {
+    if (watchHours >= 5) {
+      return 1
+    }
+
+    if (watchHours >= 1) {
+      return 0.5 + ((watchHours - 1) / 4) * 0.5
+    }
+
+    return 0.1 + watchHours * 0.4
+  })()
+
+  const decayDays = Math.max(0, daysSinceLastWatch - 30)
+  const decayedMultiplier = multiplier - decayDays * 0.01
+
+  return roundToHundredths(clamp(decayedMultiplier, 0.1, 1))
+}
+
+export function calculateCharacterBuff(
+  characterId: CharacterId,
+  context: CharacterBuffContext,
+): number {
+  const stage = context.stage ?? 1
+  if (stage !== 1) {
+    return 1
+  }
+
+  switch (characterId) {
+    case 'crab':
+      return (context.effectiveClicksInWindow ?? 0) >= 10 ? 1.5 : 1
+    case 'dolphin': {
+      const chatCount = context.chatCount ?? 0
+      if (chatCount >= 3) return 1.8
+      if (chatCount === 2) return 1.6
+      if (chatCount === 1) return 1.4
+      return 1
+    }
+    case 'turtle': {
+      const continuousWatchSeconds = context.continuousWatchSeconds ?? 0
+      if (continuousWatchSeconds >= 90 * 60) return 1.35
+      if (continuousWatchSeconds >= 60 * 60) return 1.2
+      if (continuousWatchSeconds >= 30 * 60) return 1.1
+      return 1
+    }
+    case 'whale':
+    case 'capybara':
+      return 1
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function roundToHundredths(value: number): number {
+  return Math.round(value * 100) / 100
+}

--- a/apps/extension/src/app/features/characters/characters.ts
+++ b/apps/extension/src/app/features/characters/characters.ts
@@ -99,11 +99,6 @@ export function calculateCharacterBuff(
   characterId: CharacterId,
   context: CharacterBuffContext,
 ): number {
-  const stage = context.stage ?? 1
-  if (stage !== 1) {
-    return 1
-  }
-
   switch (characterId) {
     case 'crab':
       return (context.effectiveClicksInWindow ?? 0) >= 10 ? 1.5 : 1


### PR DESCRIPTION
## 什麼改動
新增海洋角色系統 Phase 1 的前端純 domain module，提供角色定義、解鎖成本、進化門檻、熟悉度曲線與 S1 buff 預覽函式，並補上 Vitest 單元測試。

## 為什麼
#756 需要先建立可被後續 UI 預覽共用的 `characters.ts` 純邏輯層；本 PR 不接 UI、不接 API，讓後續角色選單、buff list、熟悉度顯示能依同一組 domain constants 實作。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#756
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 UI 元件、API 串接、content script、backend、assets、i18n、package 或 lockfile 修改。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #756 issue comment: https://github.com/nurockplayer/tachigo/issues/756#issuecomment-4472105078
- routing_evidence_status: pass
- routing_evidence_ref: https://github.com/nurockplayer/tachigo/issues/756#issuecomment-4472105078
- ops_spark readback evidence: https://github.com/nurockplayer/tachigo/issues/756#issuecomment-4472105078
- worker_5_4 evidence: https://github.com/nurockplayer/tachigo/pull/799#issuecomment-4472374581
- Actual worker profile(s)：
  - ops_spark/readback explorer：open issues/PRs/branches duplicate scan and candidate routing。
  - implementation worker：frontend domain module and tests。
  - controller：scope decision, TDD verification, review finding disposition, root-cause correction, final PR gate。
- Model strength：
  - ops_spark = gpt-5.3-codex-spark / low
  - implementation worker = gpt-5.4 / medium
  - controller = gpt-5.5 / high
- controller_fallback: allowed
- controller_fallback_reason: controller_safety_review_fixed_single_lint_error_without_scope_expansion
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=low controller_fallback=denied fallback_reason=not_applicable_controller_fallback_denied task=metadata duplicate/candidate scan
  - profile=frontend_worker model=gpt-5.4 reasoning=medium controller_fallback=allowed fallback_reason=controller_safety_review_fixed_single_lint_error_without_scope_expansion controller_fallback_reason=controller_safety_review_fixed_single_lint_error_without_scope_expansion task=apps/extension/src/app/features/characters/* only
- Verification evidence：
  - `spec workflow-check --repo . --phase start --issue 756 --format text`：pass
  - `pnpm --dir apps/extension exec vitest run src/app/features/characters/characters.test.ts`：1 file / 9 tests pass
  - `pnpm --dir apps/extension test`：13 files / 51 tests pass
  - `pnpm --dir apps/extension build`：pass
  - `pnpm --dir apps/extension lint`：pass
  - `git diff --check`：pass
  - `spec workflow-check --repo . --phase commit --pr-body /tmp/tachigo-pr-756-body.md --format text`：manual fallback; clean staged repo-local state; routing mismatch none after explicit fallback reason
- Self-review / exception reason：
  - Controller reviewed worker output, fixed one lint finding in `calculateFamiliarityMultiplier`, rejected CodeRabbit stage-neutral nit after connector/root-cause review, and adopted the connector P2 by preserving evolved stages' S1 buffs; no scope expansion.
- Worker session closeout：
  - Worker returned changed files, RED/GREEN evidence, and risks. Controller read back results and did not need additional worker tasks.
- Workflow friction / follow-up split：
  - Friction: fresh worktree needed local-only `spec init` because `.spec-injector/` is intentionally untracked. `.spec-injector/` is not staged or committed. Threshold/dogfood comment will be added to #664 after merge.
- threshold_evidence_status: manual
- threshold_ledger_ref: https://github.com/nurockplayer/tachigo/issues/664

## Review conversation closeout
- Unresolved threads：
  - 0 unresolved threads observed. Connector P2 was fixed and resolved; CodeRabbit stage-neutral nit was rejected with technical rationale.
- CodeRabbit：
  - reviewed latest head; status success. Stage-neutral nit not adopted after root-cause review because it conflicts with additive buff model; docstring coverage warning not adopted because repo does not gate pure domain helper docstrings.
- chatgpt-codex-connector：
  - reviewed prior head and raised one P2; adopted in latest head, thread resolved.
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/799#issuecomment-4472374581
- root_cause_gate_ref：
  - https://github.com/nurockplayer/tachigo/pull/799#issuecomment-4472374581
- finding_disposition_status: pass
- finding_disposition_ref: https://github.com/nurockplayer/tachigo/pull/799#issuecomment-4472374581
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/799#issuecomment-4472374581
- Final reviewer action：
  - All observed automated findings are fixed/resolved or rejected with technical rationale. Human approval still required by repo review policy.

## Final merge gate
- Ready-to-merge decision：
  - blocked by required human review; CI, Scope Police, CodeRabbit, and local validation are green at latest head.
- ready_to_merge: blocked by required human review
- Latest head SHA：
  - f06dc04a2e22adfb98f9487e4271150c3f4908b7
- Required checks：
  - PR Scope Police: pass
  - CI Scope gate / workflow regression / PR metadata / commit messages / frontend build / Backend CI gate: pass
  - CodeRabbit: success
  - Notify Discord on failure: skipped, non-blocking notification job
  - Human review: required, pending
- spec workflow-check evidence：
  - spec workflow-check status: manual
  - workflow-check evidence: https://github.com/nurockplayer/tachigo/pull/799#issuecomment-4472374581
  - start gate: pass; commit gate: manual with clean staged repo-local state and explicit controller fallback reason; merge/readback gate local check before PR body update.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/799#issuecomment-4472374581

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增海洋角色系統前端純 domain module，供後續 UI 預覽使用。
- Approx changed lines：~210
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a；production code 與對應單元測試同 PR。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 新增 `apps/extension/src/app/features/characters/characters.ts`
- [x] 角色定義、解鎖價格、進化門檻常數
- [x] buff / 熟悉度曲線純函式（與計劃中的後端 B2/B5 值對齊，用於 UI 預覽）
- [x] vitest 單元測試
- [x] 曲線函式測試與計劃值一致；`pnpm test` 通過

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
pnpm --dir apps/extension exec vitest run src/app/features/characters/characters.test.ts
Test Files  1 passed (1)
Tests       9 passed (9)

pnpm --dir apps/extension test
Test Files  13 passed (13)
Tests       51 passed (51)

pnpm --dir apps/extension build
pass

pnpm --dir apps/extension lint
pass

git diff --check
pass
```

## 備註
螃蟹 S1 依計劃實作為「每 60s tick 10 次有效點擊上限，達 10 次後 1.5x，超過不再增加」。若後續設計改成線性爬升，應另開 issue 調整 domain test 與後端 B5 對齊。

## Notes for Claude Code Review
- 請特別看 `calculateFamiliarityMultiplier` 的 0→60min、60→300min、30 天後每日 -1% 衰減是否符合目前 #710/#756 決策。
- `displayName` 目前是 internal English label，未導入 i18n；本 PR 不處理 UI 顯示文案。
