### PR TITLE
[infra] Add backend metrics and alerting baseline

### DIFF
--- a/docs/backend-observability.md
+++ b/docs/backend-observability.md
@@ -23,8 +23,8 @@ HTTP metrics:
 
 Raffle scheduler metrics:
 
-- `tachigo_raffle_scheduler_runs_total{result}`: scheduled snapshot run count.
-- `tachigo_raffle_scheduler_failures_total{result="failure"}`: failed scheduled snapshot run count.
+- `tachigo_raffle_scheduler_runs_total{result}`: scheduled snapshot run count. `result` is `success`, `partial_failure`, or `failure`.
+- `tachigo_raffle_scheduler_failures_total{result="failure"}`: failed scheduled snapshot batch count. Per-raffle tolerated errors use `result="partial_failure"` and do not increment this counter.
 - `tachigo_raffle_scheduler_duration_seconds{result}`: scheduled snapshot duration histogram.
 
 ## Tracing baseline
@@ -122,13 +122,13 @@ Staging thresholds:
 
 - Request 5xx rate: warn if `sum(rate(tachigo_http_request_errors_total[5m])) / sum(rate(tachigo_http_requests_total[5m])) > 0.02` for 10 minutes.
 - Request latency: warn if the 95th percentile from `tachigo_http_request_duration_seconds` exceeds 1 second for 10 minutes.
-- Raffle scheduler failure: warn on any increase in `tachigo_raffle_scheduler_failures_total` over 30 minutes.
+- Raffle scheduler failure: warn on any increase in `tachigo_raffle_scheduler_failures_total` over 30 minutes; track `result="partial_failure"` separately for noisy upstream/data issues.
 
 Production thresholds:
 
 - Request 5xx rate: page if the 5xx ratio exceeds 1% for 10 minutes, warn above 0.5% for 15 minutes.
 - Request latency: page if the 95th percentile exceeds 2 seconds for 10 minutes, warn above 1 second for 15 minutes.
-- Raffle scheduler failure: page on any production scheduler failure, because the scheduled snapshot window is daily and user-visible.
+- Raffle scheduler failure: page on any production scheduler batch failure, because the scheduled snapshot window is daily and user-visible. Treat `result="partial_failure"` as an investigation signal, not a paging signal.
 
 Dashboard readback ownership:
 

--- a/docs/backend-observability.md
+++ b/docs/backend-observability.md
@@ -2,12 +2,30 @@
 
 ## Current baseline
 
-The first production baseline is vendor-neutral structured logging:
+The first production baseline includes vendor-neutral structured logging and
+Prometheus-compatible text metrics:
 
 - HTTP requests get an `X-Request-ID` response header. Incoming safe request IDs are preserved; otherwise the API generates one.
 - Request logs emit `event=http_request`, `request_id`, `method`, matched `route`, sanitized `path`, `status`, `duration_ms`, `client_ip`, and Gin error count.
 - Request logs intentionally do not include query strings, request bodies, `Authorization`, cookies, OAuth tokens, signer keys, vouchers, or receipt payloads.
 - Raffle scheduled snapshot jobs emit start, per-raffle error, query-error, and completion events with `job=raffle_scheduled_snapshots`, counts, IDs, source, and redacted error text.
+- When `ENABLE_METRICS=true`, the backend exposes `/metrics` in Prometheus text format.
+- Production deployments with metrics enabled must set `METRICS_BEARER_TOKEN`; scrapers send `Authorization: Bearer <token>`.
+- Metrics labels are intentionally limited to Gin route pattern plus `status_family`, or scheduler `result`. They must not include query strings, bodies, `Authorization`, cookies, tokens, user IDs, vouchers, or receipts.
+
+## Metrics inventory
+
+HTTP metrics:
+
+- `tachigo_http_requests_total{route,status_family}`: request count.
+- `tachigo_http_request_errors_total{route,status_family}`: 5xx response count.
+- `tachigo_http_request_duration_seconds{route,status_family}`: request latency histogram.
+
+Raffle scheduler metrics:
+
+- `tachigo_raffle_scheduler_runs_total{result}`: scheduled snapshot run count.
+- `tachigo_raffle_scheduler_failures_total{result="failure"}`: failed scheduled snapshot run count.
+- `tachigo_raffle_scheduler_duration_seconds{result}`: scheduled snapshot duration histogram.
 
 ## Tracing baseline
 
@@ -36,7 +54,20 @@ Sentry remains a future error-reporting adapter candidate only. The current back
 3. Confirm the response contains `X-Request-ID: local-readback-1`.
 4. Confirm the API log contains `event=http_request request_id=local-readback-1`.
 5. Confirm the same log line does not contain `access_token`, `Authorization`, `Bearer`, cookies, or request body content.
-6. Optional: run a local OTLP collector, set `TRACING_ENABLED=true`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to the collector traces endpoint, and confirm the span contains `request_id=local-readback-1` without query/body/header secrets.
+6. Enable metrics locally:
+
+   ```bash
+   ENABLE_METRICS=true METRICS_BEARER_TOKEN=local-metrics-token make run
+   ```
+
+7. Scrape metrics after a synthetic request:
+
+   ```bash
+   curl -s -H 'Authorization: Bearer local-metrics-token' http://localhost:8080/metrics
+   ```
+
+8. Confirm the output includes `tachigo_http_requests_total` and does not include query strings, request bodies, `Authorization`, cookies, bearer tokens, vouchers, receipts, or user IDs.
+9. Optional: run a local OTLP collector, set `TRACING_ENABLED=true`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to the collector traces endpoint, and confirm the span contains `request_id=local-readback-1` without query/body/header secrets.
 
 ## Staging readback
 
@@ -46,9 +77,12 @@ Sentry remains a future error-reporting adapter candidate only. The current back
 4. Trigger or simulate a raffle scheduled snapshot window in staging.
 5. Verify scheduler logs include `event=raffle_scheduled_snapshots_start` and `event=raffle_scheduled_snapshots_complete`.
 6. If a staging raffle snapshot fails, verify `event=raffle_scheduled_snapshot_error` includes `raffle_id`, `user_id`, and `source`, but does not include OAuth tokens.
-7. Enable tracing only after the staging OTLP collector endpoint is known. Startup must fail fast if `TRACING_ENABLED=true` but `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is empty or `OTEL_TRACES_SAMPLE_RATIO` is outside `0..1`.
-8. Send a request with a known `X-Request-ID` and verify the trace span contains the same `request_id`, matched route, method, and status code.
-9. Inspect the span attributes and confirm there is no query string, request body, `Authorization`, cookie, OAuth token, signing key, wallet address, or raw handler error text.
+7. Set `ENABLE_METRICS=true` and `METRICS_BEARER_TOKEN` in staging.
+8. Scrape `/metrics` with the bearer token after synthetic requests and a scheduler exercise.
+9. Confirm `tachigo_http_requests_total`, `tachigo_http_request_duration_seconds`, and `tachigo_raffle_scheduler_runs_total` advance.
+10. Enable tracing only after the staging OTLP collector endpoint is known. Startup must fail fast if `TRACING_ENABLED=true` but `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is empty or `OTEL_TRACES_SAMPLE_RATIO` is outside `0..1`.
+11. Send a request with a known `X-Request-ID` and verify the trace span contains the same `request_id`, matched route, method, and status code.
+12. Inspect the span attributes and confirm there is no query string, request body, `Authorization`, cookie, OAuth token, signing key, wallet address, or raw handler error text.
 
 ## Sampling, retention, and PII
 
@@ -82,6 +116,26 @@ Escalation: if tracing causes startup failure, elevated latency, exporter backpr
 
 OTel is the baseline because it keeps instrumentation vendor-neutral and works with any OTLP-compatible collector. Sentry is useful for grouped application errors and release health, but adopting it would introduce vendor-specific SDK behavior and DSN ownership. The next Sentry step should be a separate adapter issue that maps sanitized server errors to Sentry events using `request_id` and OTel trace IDs, with PII redaction tests before rollout.
 
+## Alerting baseline
+
+Staging thresholds:
+
+- Request 5xx rate: warn if `sum(rate(tachigo_http_request_errors_total[5m])) / sum(rate(tachigo_http_requests_total[5m])) > 0.02` for 10 minutes.
+- Request latency: warn if the 95th percentile from `tachigo_http_request_duration_seconds` exceeds 1 second for 10 minutes.
+- Raffle scheduler failure: warn on any increase in `tachigo_raffle_scheduler_failures_total` over 30 minutes.
+
+Production thresholds:
+
+- Request 5xx rate: page if the 5xx ratio exceeds 1% for 10 minutes, warn above 0.5% for 15 minutes.
+- Request latency: page if the 95th percentile exceeds 2 seconds for 10 minutes, warn above 1 second for 15 minutes.
+- Raffle scheduler failure: page on any production scheduler failure, because the scheduled snapshot window is daily and user-visible.
+
+Dashboard readback ownership:
+
+- Backend/on-call release owner owns the `/metrics` scrape readback during deployment.
+- Production on-call owns alert acknowledgement and threshold tuning after launch.
+- Dashboard panels should group HTTP metrics by `route` and `status_family`, and scheduler metrics by `result` only.
+
 ## Owner
 
 Backend production owner: backend/on-call release owner for the deployment window.
@@ -89,10 +143,9 @@ Backend production owner: backend/on-call release owner for the deployment windo
 Review cadence:
 
 - During staging deploy: verify request logs and scheduler logs before promoting.
-- During production launch: keep the log stream open for first request traffic and first scheduled job window.
-- After launch: keep OTel tracing sampling and retention under review, and handle Sentry/error-reporting as a separate adapter decision.
+- During production launch: keep the log stream, metrics dashboard, and trace readback open for first request traffic and first scheduled job window.
+- After launch: keep OTel tracing sampling, retention, and metrics thresholds under review, and handle Sentry/error-reporting as a separate adapter decision.
 
 ## Deferred follow-ups
 
-- #792: backend metrics and alerting baseline.
 - Future Sentry adapter: sanitized error grouping on top of the OTel/request-id baseline.

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -397,6 +397,9 @@ export interface ApiOperations {
       data?: HandlersAuthResponse;
     };
   };
+  "GET /metrics": {
+    response: string;
+  };
   "POST /spend/redeem": {
     requestBody: HandlersRedeemRequest;
     response: HandlersResponse & {

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -32,6 +32,13 @@ OTEL_EXPORTER_OTLP_TRACES_INSECURE=false
 # Optional comma-separated OTLP headers, for example: x-api-key=replace-me
 OTEL_EXPORTER_OTLP_HEADERS=
 
+# Enable Prometheus-compatible /metrics endpoint (default: false)
+ENABLE_METRICS=false
+
+# Required in production when ENABLE_METRICS=true. Scrapers send:
+# Authorization: Bearer <METRICS_BEARER_TOKEN>
+METRICS_BEARER_TOKEN=
+
 # Comma-separated trusted reverse proxy IPs (empty = trust all)
 TRUSTED_PROXIES=
 

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -83,6 +83,8 @@ cp services/api/.env.example services/api/.env
 | `TWITCH_EXTENSION_SECRET` | Twitch Extension dashboard 內的 base64 extension secret |
 | `TACHIYA_INTERNAL_SHARED_SECRET` | tachiya -> tachigo server-to-server request shared secret |
 | `TACHIYA_BASE_URL` | tachiya internal API base URL |
+| `ENABLE_METRICS` | 啟用 Prometheus-compatible `/metrics` endpoint，預設 `false` |
+| `METRICS_BEARER_TOKEN` | `/metrics` bearer token；production 啟用 metrics 時必填 |
 | `GOOGLE_CLIENT_ID` | Google OAuth client id |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
 | `GOOGLE_REDIRECT_URL` | Google OAuth callback URL |

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1629,6 +1629,44 @@ const docTemplate = `{
                 }
             }
         },
+        "/metrics": {
+            "get": {
+                "description": "Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer \u003cMETRICS_BEARER_TOKEN\u003e.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "summary": "Scrape backend metrics",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer metrics token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Prometheus text metrics",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/spend/redeem": {
             "post": {
                 "security": [

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1631,7 +1631,7 @@ const docTemplate = `{
         },
         "/metrics": {
             "get": {
-                "description": "Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer \u003cMETRICS_BEARER_TOKEN\u003e.",
+                "description": "Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer \u003cMETRICS_BEARER_TOKEN\u003e when METRICS_BEARER_TOKEN is set.",
                 "produces": [
                     "text/plain"
                 ],
@@ -1642,10 +1642,9 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Bearer metrics token",
+                        "description": "Bearer metrics token when METRICS_BEARER_TOKEN is set",
                         "name": "Authorization",
-                        "in": "header",
-                        "required": true
+                        "in": "header"
                     }
                 ],
                 "responses": {

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1623,6 +1623,44 @@
                 }
             }
         },
+        "/metrics": {
+            "get": {
+                "description": "Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer \u003cMETRICS_BEARER_TOKEN\u003e.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "observability"
+                ],
+                "summary": "Scrape backend metrics",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer metrics token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Prometheus text metrics",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/spend/redeem": {
             "post": {
                 "security": [

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1625,7 +1625,7 @@
         },
         "/metrics": {
             "get": {
-                "description": "Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer \u003cMETRICS_BEARER_TOKEN\u003e.",
+                "description": "Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer \u003cMETRICS_BEARER_TOKEN\u003e when METRICS_BEARER_TOKEN is set.",
                 "produces": [
                     "text/plain"
                 ],
@@ -1636,10 +1636,9 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Bearer metrics token",
+                        "description": "Bearer metrics token when METRICS_BEARER_TOKEN is set",
                         "name": "Authorization",
-                        "in": "header",
-                        "required": true
+                        "in": "header"
                     }
                 ],
                 "responses": {

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -1329,6 +1329,32 @@ paths:
       summary: Complete a T-point transaction
       tags:
       - extension
+  /metrics:
+    get:
+      description: 'Operational endpoint exposed at root /metrics when ENABLE_METRICS=true.
+        Requires Authorization: Bearer <METRICS_BEARER_TOKEN>.'
+      parameters:
+      - description: Bearer metrics token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: Prometheus text metrics
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Scrape backend metrics
+      tags:
+      - observability
   /spend/redeem:
     post:
       consumes:

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -1332,12 +1332,12 @@ paths:
   /metrics:
     get:
       description: 'Operational endpoint exposed at root /metrics when ENABLE_METRICS=true.
-        Requires Authorization: Bearer <METRICS_BEARER_TOKEN>.'
+        Requires Authorization: Bearer <METRICS_BEARER_TOKEN> when METRICS_BEARER_TOKEN
+        is set.'
       parameters:
-      - description: Bearer metrics token
+      - description: Bearer metrics token when METRICS_BEARER_TOKEN is set
         in: header
         name: Authorization
-        required: true
         type: string
       produces:
       - text/plain

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Contract ContractConfig
 	Internal InternalConfig
 	Tracing  TracingConfig
+	Metrics  MetricsConfig
 }
 
 type ContractConfig struct {
@@ -48,6 +49,11 @@ type TracingConfig struct {
 	OTLPTracesEndpoint string
 	OTLPInsecure       bool
 	OTLPHeaders        map[string]string
+}
+
+type MetricsConfig struct {
+	EnableMetrics bool
+	BearerToken   string // METRICS_BEARER_TOKEN — never log or expose
 }
 
 type SMTPConfig struct {
@@ -190,6 +196,10 @@ func Load() *Config {
 			OTLPInsecure:       getBoolEnv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", false),
 			OTLPHeaders:        getMapEnv("OTEL_EXPORTER_OTLP_HEADERS"),
 		},
+		Metrics: MetricsConfig{
+			EnableMetrics: getBoolEnv("ENABLE_METRICS", false),
+			BearerToken:   strings.TrimSpace(getEnv("METRICS_BEARER_TOKEN", "")),
+		},
 	}
 }
 
@@ -259,6 +269,9 @@ func ValidateProductionSecrets(cfg *Config) error {
 	}
 	if err := ValidateTracing(cfg.Tracing); err != nil {
 		return err
+	}
+	if cfg.Metrics.EnableMetrics && strings.TrimSpace(cfg.Metrics.BearerToken) == "" {
+		return fmt.Errorf("METRICS_BEARER_TOKEN must be configured when ENABLE_METRICS is true in production")
 	}
 
 	// These launch flows are mounted unconditionally in production, so fail fast

--- a/services/api/internal/config/config_test.go
+++ b/services/api/internal/config/config_test.go
@@ -158,6 +158,21 @@ func TestValidateProductionSecrets(t *testing.T) {
 			}),
 			wantErr: "OAUTH_TOKEN_ENCRYPTION_KEY",
 		},
+		{
+			name: "rejects enabled production metrics without bearer token",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.Metrics.EnableMetrics = true
+			}),
+			wantErr: "METRICS_BEARER_TOKEN",
+		},
+		{
+			name: "rejects enabled production metrics with blank bearer token",
+			cfg: withConfig(func(cfg *Config) {
+				cfg.Metrics.EnableMetrics = true
+				cfg.Metrics.BearerToken = "   "
+			}),
+			wantErr: "METRICS_BEARER_TOKEN",
+		},
 	}
 
 	for _, tc := range tests {
@@ -177,6 +192,20 @@ func TestValidateProductionSecrets(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
 			}
 		})
+	}
+}
+
+func TestLoad_MetricsConfig(t *testing.T) {
+	t.Setenv("ENABLE_METRICS", "true")
+	t.Setenv("METRICS_BEARER_TOKEN", " local-metrics-token ")
+
+	cfg := Load()
+
+	if !cfg.Metrics.EnableMetrics {
+		t.Fatal("expected EnableMetrics=true")
+	}
+	if cfg.Metrics.BearerToken != "local-metrics-token" {
+		t.Fatalf("expected bearer token to load, got %q", cfg.Metrics.BearerToken)
 	}
 }
 

--- a/services/api/internal/metrics/collector.go
+++ b/services/api/internal/metrics/collector.go
@@ -1,0 +1,224 @@
+package metrics
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	httpDurationBuckets      = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+	schedulerDurationBuckets = []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300}
+)
+
+type Collector struct {
+	mu sync.Mutex
+
+	httpRequests map[httpKey]*histogram
+	scheduler    map[string]*histogram
+}
+
+type httpKey struct {
+	route        string
+	statusFamily string
+}
+
+type histogram struct {
+	count   uint64
+	sum     float64
+	buckets []uint64
+}
+
+func NewCollector() *Collector {
+	return &Collector{
+		httpRequests: make(map[httpKey]*histogram),
+		scheduler:    make(map[string]*histogram),
+	}
+}
+
+func (c *Collector) ObserveHTTPRequest(route string, status int, duration time.Duration) {
+	if c == nil {
+		return
+	}
+	key := httpKey{
+		route:        safeRoute(route),
+		statusFamily: statusFamily(status),
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	h := c.httpRequests[key]
+	if h == nil {
+		h = newHistogram(len(httpDurationBuckets))
+		c.httpRequests[key] = h
+	}
+	h.observe(duration.Seconds(), httpDurationBuckets)
+}
+
+func (c *Collector) ObserveRaffleSchedulerRun(result string, duration time.Duration) {
+	if c == nil {
+		return
+	}
+	result = safeResult(result)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	h := c.scheduler[result]
+	if h == nil {
+		h = newHistogram(len(schedulerDurationBuckets))
+		c.scheduler[result] = h
+	}
+	h.observe(duration.Seconds(), schedulerDurationBuckets)
+}
+
+func (c *Collector) RenderPrometheus() string {
+	if c == nil {
+		return ""
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var b strings.Builder
+	writeHTTPMetrics(&b, c.httpRequests)
+	writeSchedulerMetrics(&b, c.scheduler)
+	return b.String()
+}
+
+func newHistogram(bucketCount int) *histogram {
+	return &histogram{buckets: make([]uint64, bucketCount)}
+}
+
+func (h *histogram) observe(value float64, buckets []float64) {
+	if value < 0 {
+		value = 0
+	}
+	h.count++
+	h.sum += value
+	for i, bucket := range buckets {
+		if value <= bucket {
+			h.buckets[i]++
+		}
+	}
+}
+
+func writeHTTPMetrics(b *strings.Builder, metrics map[httpKey]*histogram) {
+	keys := make([]httpKey, 0, len(metrics))
+	for key := range metrics {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].route == keys[j].route {
+			return keys[i].statusFamily < keys[j].statusFamily
+		}
+		return keys[i].route < keys[j].route
+	})
+
+	b.WriteString("# HELP tachigo_http_requests_total HTTP requests by route pattern and status family.\n")
+	b.WriteString("# TYPE tachigo_http_requests_total counter\n")
+	for _, key := range keys {
+		h := metrics[key]
+		fmt.Fprintf(b, "tachigo_http_requests_total{route=%q,status_family=%q} %d\n", escapeLabelValue(key.route), key.statusFamily, h.count)
+	}
+
+	b.WriteString("# HELP tachigo_http_request_errors_total HTTP 5xx responses by route pattern and status family.\n")
+	b.WriteString("# TYPE tachigo_http_request_errors_total counter\n")
+	for _, key := range keys {
+		if key.statusFamily != "5xx" {
+			continue
+		}
+		h := metrics[key]
+		fmt.Fprintf(b, "tachigo_http_request_errors_total{route=%q,status_family=%q} %d\n", escapeLabelValue(key.route), key.statusFamily, h.count)
+	}
+
+	writeHTTPHistogram(b, keys, metrics)
+}
+
+func writeHTTPHistogram(b *strings.Builder, keys []httpKey, metrics map[httpKey]*histogram) {
+	b.WriteString("# HELP tachigo_http_request_duration_seconds HTTP request duration by route pattern and status family.\n")
+	b.WriteString("# TYPE tachigo_http_request_duration_seconds histogram\n")
+	for _, key := range keys {
+		h := metrics[key]
+		for i, bucket := range httpDurationBuckets {
+			fmt.Fprintf(b, "tachigo_http_request_duration_seconds_bucket{route=%q,status_family=%q,le=%q} %d\n", escapeLabelValue(key.route), key.statusFamily, formatBucket(bucket), h.buckets[i])
+		}
+		fmt.Fprintf(b, "tachigo_http_request_duration_seconds_bucket{route=%q,status_family=%q,le=\"+Inf\"} %d\n", escapeLabelValue(key.route), key.statusFamily, h.count)
+		fmt.Fprintf(b, "tachigo_http_request_duration_seconds_sum{route=%q,status_family=%q} %g\n", escapeLabelValue(key.route), key.statusFamily, h.sum)
+		fmt.Fprintf(b, "tachigo_http_request_duration_seconds_count{route=%q,status_family=%q} %d\n", escapeLabelValue(key.route), key.statusFamily, h.count)
+	}
+}
+
+func writeSchedulerMetrics(b *strings.Builder, metrics map[string]*histogram) {
+	results := make([]string, 0, len(metrics))
+	for result := range metrics {
+		results = append(results, result)
+	}
+	sort.Strings(results)
+
+	b.WriteString("# HELP tachigo_raffle_scheduler_runs_total Raffle scheduler runs by result.\n")
+	b.WriteString("# TYPE tachigo_raffle_scheduler_runs_total counter\n")
+	for _, result := range results {
+		h := metrics[result]
+		fmt.Fprintf(b, "tachigo_raffle_scheduler_runs_total{result=%q} %d\n", result, h.count)
+	}
+
+	b.WriteString("# HELP tachigo_raffle_scheduler_failures_total Raffle scheduler failed runs.\n")
+	b.WriteString("# TYPE tachigo_raffle_scheduler_failures_total counter\n")
+	for _, result := range results {
+		if result != "failure" {
+			continue
+		}
+		h := metrics[result]
+		fmt.Fprintf(b, "tachigo_raffle_scheduler_failures_total{result=%q} %d\n", result, h.count)
+	}
+
+	b.WriteString("# HELP tachigo_raffle_scheduler_duration_seconds Raffle scheduler run duration by result.\n")
+	b.WriteString("# TYPE tachigo_raffle_scheduler_duration_seconds histogram\n")
+	for _, result := range results {
+		h := metrics[result]
+		for i, bucket := range schedulerDurationBuckets {
+			fmt.Fprintf(b, "tachigo_raffle_scheduler_duration_seconds_bucket{result=%q,le=%q} %d\n", result, formatBucket(bucket), h.buckets[i])
+		}
+		fmt.Fprintf(b, "tachigo_raffle_scheduler_duration_seconds_bucket{result=%q,le=\"+Inf\"} %d\n", result, h.count)
+		fmt.Fprintf(b, "tachigo_raffle_scheduler_duration_seconds_sum{result=%q} %g\n", result, h.sum)
+		fmt.Fprintf(b, "tachigo_raffle_scheduler_duration_seconds_count{result=%q} %d\n", result, h.count)
+	}
+}
+
+func statusFamily(status int) string {
+	if status < 100 || status > 599 {
+		return "unknown"
+	}
+	return fmt.Sprintf("%dxx", status/100)
+}
+
+func safeRoute(route string) string {
+	route = strings.TrimSpace(route)
+	if route == "" {
+		return "__unmatched__"
+	}
+	return route
+}
+
+func safeResult(result string) string {
+	switch result {
+	case "success", "failure":
+		return result
+	default:
+		return "unknown"
+	}
+}
+
+func escapeLabelValue(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "\n", `\n`)
+	return strings.ReplaceAll(value, `"`, `\"`)
+}
+
+func formatBucket(bucket float64) string {
+	return fmt.Sprintf("%g", bucket)
+}

--- a/services/api/internal/metrics/collector.go
+++ b/services/api/internal/metrics/collector.go
@@ -206,7 +206,7 @@ func safeRoute(route string) string {
 
 func safeResult(result string) string {
 	switch result {
-	case "success", "failure":
+	case "success", "partial_failure", "failure":
 		return result
 	default:
 		return "unknown"

--- a/services/api/internal/metrics/collector_test.go
+++ b/services/api/internal/metrics/collector_test.go
@@ -1,0 +1,52 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCollectorRendersHTTPMetricsWithoutRequestSecrets(t *testing.T) {
+	collector := NewCollector()
+
+	collector.ObserveHTTPRequest("/api/v1/claim/:token", 200, 12*time.Millisecond)
+	collector.ObserveHTTPRequest("/api/v1/claim/:token", 503, 30*time.Millisecond)
+
+	text := collector.RenderPrometheus()
+
+	for _, want := range []string{
+		`tachigo_http_requests_total{route="/api/v1/claim/:token",status_family="2xx"} 1`,
+		`tachigo_http_requests_total{route="/api/v1/claim/:token",status_family="5xx"} 1`,
+		`tachigo_http_request_errors_total{route="/api/v1/claim/:token",status_family="5xx"} 1`,
+		`tachigo_http_request_duration_seconds_count{route="/api/v1/claim/:token",status_family="2xx"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected rendered metrics to contain %q, got:\n%s", want, text)
+		}
+	}
+	for _, forbidden := range []string{"access_token", "Authorization", "Bearer", "cookie", "voucher", "receipt", "user_id"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("metrics text leaked forbidden value %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestCollectorRendersRaffleSchedulerMetricsByResult(t *testing.T) {
+	collector := NewCollector()
+
+	collector.ObserveRaffleSchedulerRun("success", 1400*time.Millisecond)
+	collector.ObserveRaffleSchedulerRun("failure", 2*time.Second)
+
+	text := collector.RenderPrometheus()
+
+	for _, want := range []string{
+		`tachigo_raffle_scheduler_runs_total{result="success"} 1`,
+		`tachigo_raffle_scheduler_runs_total{result="failure"} 1`,
+		`tachigo_raffle_scheduler_failures_total{result="failure"} 1`,
+		`tachigo_raffle_scheduler_duration_seconds_count{result="success"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected rendered metrics to contain %q, got:\n%s", want, text)
+		}
+	}
+}

--- a/services/api/internal/metrics/collector_test.go
+++ b/services/api/internal/metrics/collector_test.go
@@ -35,12 +35,14 @@ func TestCollectorRendersRaffleSchedulerMetricsByResult(t *testing.T) {
 	collector := NewCollector()
 
 	collector.ObserveRaffleSchedulerRun("success", 1400*time.Millisecond)
+	collector.ObserveRaffleSchedulerRun("partial_failure", 1500*time.Millisecond)
 	collector.ObserveRaffleSchedulerRun("failure", 2*time.Second)
 
 	text := collector.RenderPrometheus()
 
 	for _, want := range []string{
 		`tachigo_raffle_scheduler_runs_total{result="success"} 1`,
+		`tachigo_raffle_scheduler_runs_total{result="partial_failure"} 1`,
 		`tachigo_raffle_scheduler_runs_total{result="failure"} 1`,
 		`tachigo_raffle_scheduler_failures_total{result="failure"} 1`,
 		`tachigo_raffle_scheduler_duration_seconds_count{result="success"} 1`,

--- a/services/api/internal/metrics/collector_test.go
+++ b/services/api/internal/metrics/collector_test.go
@@ -51,4 +51,7 @@ func TestCollectorRendersRaffleSchedulerMetricsByResult(t *testing.T) {
 			t.Fatalf("expected rendered metrics to contain %q, got:\n%s", want, text)
 		}
 	}
+	if strings.Contains(text, `tachigo_raffle_scheduler_failures_total{result="partial_failure"}`) {
+		t.Fatalf("partial_failure must not increment raffle scheduler failure counter, got:\n%s", text)
+	}
 }

--- a/services/api/internal/middleware/http_metrics.go
+++ b/services/api/internal/middleware/http_metrics.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tachigo/tachigo/internal/metrics"
+)
+
+func HTTPMetrics(collector *metrics.Collector) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if collector == nil {
+			c.Next()
+			return
+		}
+
+		start := time.Now()
+		c.Next()
+
+		route := c.FullPath()
+		collector.ObserveHTTPRequest(route, c.Writer.Status(), time.Since(start))
+	}
+}
+
+func MetricsBearerGuard(token string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if token == "" {
+			c.Next()
+			return
+		}
+
+		header := c.GetHeader("Authorization")
+		got, ok := strings.CutPrefix(header, "Bearer ")
+		if !ok || subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/services/api/internal/middleware/http_metrics_test.go
+++ b/services/api/internal/middleware/http_metrics_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tachigo/tachigo/internal/metrics"
+)
+
+func TestHTTPMetricsRecordsRoutePatternAndStatusFamily(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	collector := metrics.NewCollector()
+	engine := gin.New()
+	engine.Use(HTTPMetrics(collector))
+	engine.GET("/claim/:token", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/claim/secret-token?access_token=should-not-appear", nil)
+	req.Header.Set("Authorization", "Bearer should-not-appear")
+	req.Header.Set("Cookie", "session=should-not-appear")
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	text := collector.RenderPrometheus()
+	if !strings.Contains(text, `tachigo_http_requests_total{route="/claim/:token",status_family="2xx"} 1`) {
+		t.Fatalf("expected route-pattern request metric, got:\n%s", text)
+	}
+	for _, forbidden := range []string{"secret-token", "access_token", "should-not-appear", "Authorization", "Cookie"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("metrics leaked forbidden request detail %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestHTTPMetricsRecordsUnmatchedRouteWithoutRawPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	collector := metrics.NewCollector()
+	engine := gin.New()
+	engine.Use(HTTPMetrics(collector))
+
+	req := httptest.NewRequest(http.MethodGet, "/missing/private-user-123?access_token=should-not-appear", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	text := collector.RenderPrometheus()
+	if !strings.Contains(text, `tachigo_http_requests_total{route="__unmatched__",status_family="4xx"} 1`) {
+		t.Fatalf("expected unmatched route bucket, got:\n%s", text)
+	}
+	for _, forbidden := range []string{"private-user-123", "access_token", "should-not-appear"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("metrics leaked unmatched request detail %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestMetricsBearerGuard(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/metrics", MetricsBearerGuard("expected-token"), func(c *gin.Context) {
+		c.String(http.StatusOK, "metrics")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected missing token to return 401, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer expected-token")
+	rec = httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected valid token to return 200, got %d", rec.Code)
+	}
+}

--- a/services/api/internal/middleware/http_metrics_test.go
+++ b/services/api/internal/middleware/http_metrics_test.go
@@ -73,6 +73,14 @@ func TestMetricsBearerGuard(t *testing.T) {
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rec = httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected wrong token to return 401, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	req.Header.Set("Authorization", "Bearer expected-token")
 	rec = httptest.NewRecorder()
 	engine.ServeHTTP(rec, req)

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -64,10 +64,6 @@ func New(
 		r.Use(middleware.Tracing(otel.Tracer("github.com/tachigo/tachigo/services/api")))
 	}
 	r.Use(middleware.StructuredRequestLogger(log.Default()), gin.Recovery())
-	if cfg != nil {
-		r.Use(middleware.RequestTimeout(cfg.Server.RequestTimeout))
-	}
-	r.Use(middleware.CORS(allowedOrigins))
 	var metricsCollector *metrics.Collector
 	if cfg != nil && cfg.Metrics.EnableMetrics {
 		metricsCollector = metrics.NewCollector()
@@ -76,6 +72,10 @@ func New(
 			raffleSvc.SetMetricsCollector(metricsCollector)
 		}
 	}
+	if cfg != nil {
+		r.Use(middleware.RequestTimeout(cfg.Server.RequestTimeout))
+	}
+	r.Use(middleware.CORS(allowedOrigins))
 
 	if cfg != nil && len(cfg.Server.TrustedProxies) > 0 {
 		if err := r.SetTrustedProxies(cfg.Server.TrustedProxies); err != nil {

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/tachigo/tachigo/internal/config"
 	"github.com/tachigo/tachigo/internal/handlers"
+	"github.com/tachigo/tachigo/internal/metrics"
 	"github.com/tachigo/tachigo/internal/middleware"
 	"github.com/tachigo/tachigo/internal/models"
 	"github.com/tachigo/tachigo/internal/services"
@@ -67,6 +68,14 @@ func New(
 		r.Use(middleware.RequestTimeout(cfg.Server.RequestTimeout))
 	}
 	r.Use(middleware.CORS(allowedOrigins))
+	var metricsCollector *metrics.Collector
+	if cfg != nil && cfg.Metrics.EnableMetrics {
+		metricsCollector = metrics.NewCollector()
+		r.Use(middleware.HTTPMetrics(metricsCollector))
+		if raffleSvc != nil {
+			raffleSvc.SetMetricsCollector(metricsCollector)
+		}
+	}
 
 	if cfg != nil && len(cfg.Server.TrustedProxies) > 0 {
 		if err := r.SetTrustedProxies(cfg.Server.TrustedProxies); err != nil {
@@ -99,6 +108,9 @@ func New(
 
 	r.GET("/health", healthHandler(db))
 	r.GET("/readyz", readinessHandler(db))
+	if metricsCollector != nil {
+		r.GET("/metrics", middleware.MetricsBearerGuard(cfg.Metrics.BearerToken), metricsHandler(metricsCollector))
+	}
 	if config.ShouldEnableSwagger(cfg) {
 		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	}
@@ -355,6 +367,12 @@ func readinessHandler(db *gorm.DB) gin.HandlerFunc {
 			"status": "ready",
 			"db":     "ok",
 		})
+	}
+}
+
+func metricsHandler(collector *metrics.Collector) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Data(http.StatusOK, "text/plain; version=0.0.4; charset=utf-8", []byte(collector.RenderPrometheus()))
 	}
 }
 

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -373,10 +373,10 @@ func readinessHandler(db *gorm.DB) gin.HandlerFunc {
 // metricsHandler returns Prometheus-compatible backend metrics.
 //
 // @Summary      Scrape backend metrics
-// @Description  Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer <METRICS_BEARER_TOKEN>.
+// @Description  Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer <METRICS_BEARER_TOKEN> when METRICS_BEARER_TOKEN is set.
 // @Tags         observability
 // @Produce      plain
-// @Param        Authorization  header  string  true  "Bearer metrics token"
+// @Param        Authorization  header  string  false  "Bearer metrics token when METRICS_BEARER_TOKEN is set"
 // @Success      200  {string}  string  "Prometheus text metrics"
 // @Failure      401  {object}  map[string]string
 // @Router       /metrics [get]

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -370,6 +370,16 @@ func readinessHandler(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
+// metricsHandler returns Prometheus-compatible backend metrics.
+//
+// @Summary      Scrape backend metrics
+// @Description  Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer <METRICS_BEARER_TOKEN>.
+// @Tags         observability
+// @Produce      plain
+// @Param        Authorization  header  string  true  "Bearer metrics token"
+// @Success      200  {string}  string  "Prometheus text metrics"
+// @Failure      401  {object}  map[string]string
+// @Router       /metrics [get]
 func metricsHandler(collector *metrics.Collector) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Data(http.StatusOK, "text/plain; version=0.0.4; charset=utf-8", []byte(collector.RenderPrometheus()))

--- a/services/api/internal/router/router_test.go
+++ b/services/api/internal/router/router_test.go
@@ -207,6 +207,39 @@ func TestMetricsRoute_GatedByConfigAndBearerToken(t *testing.T) {
 	}
 }
 
+func TestMetricsRoute_RecordsTimeoutStatusAfterRequestTimeout(t *testing.T) {
+	cfg := routerTestConfig("development", false, false)
+	cfg.Server.RequestTimeout = time.Millisecond
+	cfg.Metrics.EnableMetrics = true
+	cfg.Metrics.BearerToken = "metrics-token"
+	env := newRouterTestEnv(t, cfg)
+	env.router.GET("/test-metrics-timeout", func(c *gin.Context) {
+		<-c.Request.Context().Done()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test-metrics-timeout", nil)
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected timeout request to return 504, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer metrics-token")
+	rec = httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected metrics endpoint to return 200, got %d", rec.Code)
+	}
+	text := rec.Body.String()
+	if !strings.Contains(text, `tachigo_http_requests_total{route="/test-metrics-timeout",status_family="5xx"} 1`) {
+		t.Fatalf("expected timeout request to be recorded as 5xx, got:\n%s", text)
+	}
+	if !strings.Contains(text, `tachigo_http_request_errors_total{route="/test-metrics-timeout",status_family="5xx"} 1`) {
+		t.Fatalf("expected timeout request to be recorded as error, got:\n%s", text)
+	}
+}
+
 func routerTestConfig(serverEnv string, enableSwagger, enableSwaggerSet bool) *config.Config {
 	return &config.Config{
 		Server: config.ServerConfig{

--- a/services/api/internal/router/router_test.go
+++ b/services/api/internal/router/router_test.go
@@ -167,6 +167,46 @@ func TestRouter_AppliesRequestTimeoutMiddleware(t *testing.T) {
 	}
 }
 
+func TestMetricsRoute_GatedByConfigAndBearerToken(t *testing.T) {
+	disabled := newRouterTestEnv(t, routerTestConfig("development", false, false))
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	disabled.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected disabled metrics endpoint to return 404, got %d", rec.Code)
+	}
+
+	cfg := routerTestConfig("development", false, false)
+	cfg.Metrics.EnableMetrics = true
+	cfg.Metrics.BearerToken = "metrics-token"
+	enabled := newRouterTestEnv(t, cfg)
+
+	req = httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec = httptest.NewRecorder()
+	enabled.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("health request: want 200, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec = httptest.NewRecorder()
+	enabled.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected missing metrics bearer token to return 401, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer metrics-token")
+	rec = httptest.NewRecorder()
+	enabled.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected metrics endpoint to return 200, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `tachigo_http_requests_total{route="/health",status_family="2xx"} 1`) {
+		t.Fatalf("expected /health request metric, got:\n%s", rec.Body.String())
+	}
+}
+
 func routerTestConfig(serverEnv string, enableSwagger, enableSwaggerSet bool) *config.Config {
 	return &config.Config{
 		Server: config.ServerConfig{

--- a/services/api/internal/services/raffle_scheduler_metrics_test.go
+++ b/services/api/internal/services/raffle_scheduler_metrics_test.go
@@ -1,0 +1,60 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tachigo/tachigo/internal/metrics"
+)
+
+func TestRunScheduledSnapshotsRecordsSchedulerMetrics(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "", "", nil)
+	collector := metrics.NewCollector()
+	svc.SetMetricsCollector(collector)
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("RunScheduledSnapshots: %v", err)
+	}
+
+	text := collector.RenderPrometheus()
+	for _, want := range []string{
+		`tachigo_raffle_scheduler_runs_total{result="success"} 1`,
+		`tachigo_raffle_scheduler_duration_seconds_count{result="success"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected scheduler metric %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestRunScheduledSnapshotsRecordsFailureMetrics(t *testing.T) {
+	db := newTestDB(t)
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db handle: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	svc := NewRaffleService(db, "", "", nil)
+	collector := metrics.NewCollector()
+	svc.SetMetricsCollector(collector)
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err == nil {
+		t.Fatal("expected RunScheduledSnapshots to fail after closing db")
+	}
+
+	text := collector.RenderPrometheus()
+	for _, want := range []string{
+		`tachigo_raffle_scheduler_runs_total{result="failure"} 1`,
+		`tachigo_raffle_scheduler_failures_total{result="failure"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected scheduler failure metric %q, got:\n%s", want, text)
+		}
+	}
+}

--- a/services/api/internal/services/raffle_scheduler_metrics_test.go
+++ b/services/api/internal/services/raffle_scheduler_metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/tachigo/tachigo/internal/metrics"
+	"github.com/tachigo/tachigo/internal/models"
 )
 
 func TestRunScheduledSnapshotsRecordsSchedulerMetrics(t *testing.T) {
@@ -56,5 +57,32 @@ func TestRunScheduledSnapshotsRecordsFailureMetrics(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected scheduler failure metric %q, got:\n%s", want, text)
 		}
+	}
+}
+
+func TestRunScheduledSnapshotsRecordsPartialFailureWithoutFailureCounter(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "test-client-id", "", nil)
+	collector := metrics.NewCollector()
+	svc.SetMetricsCollector(collector)
+
+	user := insertRaffleTestUser(t, db)
+	insertScheduledRaffle(t, db, user.ID, time.Now().UTC().Add(5*time.Minute), models.RaffleSourceTwitchAPI)
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected batch error: %v", err)
+	}
+
+	text := collector.RenderPrometheus()
+	for _, want := range []string{
+		`tachigo_raffle_scheduler_runs_total{result="partial_failure"} 1`,
+		`tachigo_raffle_scheduler_duration_seconds_count{result="partial_failure"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected scheduler partial failure metric %q, got:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, `tachigo_raffle_scheduler_failures_total{result="failure"}`) {
+		t.Fatalf("partial per-raffle errors must not increment batch failure counter, got:\n%s", text)
 	}
 }

--- a/services/api/internal/services/raffle_scheduler_metrics_test.go
+++ b/services/api/internal/services/raffle_scheduler_metrics_test.go
@@ -2,12 +2,14 @@ package services
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/tachigo/tachigo/internal/metrics"
 	"github.com/tachigo/tachigo/internal/models"
+	"github.com/tachigo/tachigo/internal/testutil"
 )
 
 func TestRunScheduledSnapshotsRecordsSchedulerMetrics(t *testing.T) {
@@ -63,11 +65,22 @@ func TestRunScheduledSnapshotsRecordsFailureMetrics(t *testing.T) {
 func TestRunScheduledSnapshotsRecordsPartialFailureWithoutFailureCounter(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewRaffleService(db, "test-client-id", "", nil)
+	svc.SetTwitchBaseURL("https://twitch.test")
+	svc.httpClient = testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			return testutil.NewStringResponse(http.StatusOK, `{"data":[],"pagination":{}}`), nil
+		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
+	})
 	collector := metrics.NewCollector()
 	svc.SetMetricsCollector(collector)
 
-	user := insertRaffleTestUser(t, db)
-	insertScheduledRaffle(t, db, user.ID, time.Now().UTC().Add(5*time.Minute), models.RaffleSourceTwitchAPI)
+	successUser := insertRaffleTestUser(t, db)
+	insertRaffleTwitchProvider(t, db, successUser.ID, "broadcaster123", "streamer_token")
+	insertScheduledRaffle(t, db, successUser.ID, time.Now().UTC().Add(5*time.Minute), models.RaffleSourceTwitchAPI)
+
+	failingUser := insertRaffleTestUser(t, db)
+	insertScheduledRaffle(t, db, failingUser.ID, time.Now().UTC().Add(5*time.Minute), models.RaffleSourceTwitchAPI)
 
 	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
 		t.Fatalf("unexpected batch error: %v", err)
@@ -84,5 +97,30 @@ func TestRunScheduledSnapshotsRecordsPartialFailureWithoutFailureCounter(t *test
 	}
 	if strings.Contains(text, `tachigo_raffle_scheduler_failures_total{result="failure"}`) {
 		t.Fatalf("partial per-raffle errors must not increment batch failure counter, got:\n%s", text)
+	}
+}
+
+func TestRunScheduledSnapshotsRecordsAllPerRaffleFailuresAsFailure(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "test-client-id", "", nil)
+	collector := metrics.NewCollector()
+	svc.SetMetricsCollector(collector)
+
+	user := insertRaffleTestUser(t, db)
+	insertScheduledRaffle(t, db, user.ID, time.Now().UTC().Add(5*time.Minute), models.RaffleSourceTwitchAPI)
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected batch error: %v", err)
+	}
+
+	text := collector.RenderPrometheus()
+	for _, want := range []string{
+		`tachigo_raffle_scheduler_runs_total{result="failure"} 1`,
+		`tachigo_raffle_scheduler_failures_total{result="failure"} 1`,
+		`tachigo_raffle_scheduler_duration_seconds_count{result="failure"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected scheduler all-failed metric %q, got:\n%s", want, text)
+		}
 	}
 }

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -770,7 +770,12 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 			)
 		}
 	}
-	if failed > 0 {
+	switch {
+	case failed == 0:
+		result = "success"
+	case failed == len(raffles):
+		result = "failure"
+	default:
 		result = "partial_failure"
 	}
 	log.Printf(

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -738,7 +738,7 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 
 	window := now.Add(10 * time.Minute)
 	var raffles []models.Raffle
-	if err := s.db.Where(
+	if err := s.db.WithContext(ctx).Where(
 		"status = ? AND source != ? AND scheduled_at IS NOT NULL AND scheduled_at >= ? AND scheduled_at <= ?",
 		models.RaffleStatusDraft, models.RaffleSourceCSV, now, window,
 	).Find(&raffles).Error; err != nil {
@@ -829,7 +829,7 @@ func (s *RaffleService) snapshotOne(ctx context.Context, r models.Raffle) error 
 		return fmt.Errorf("unsupported snapshot source: %s", r.Source)
 	}
 	// Guard against concurrent status changes: only promote if still draft.
-	return s.db.Model(&models.Raffle{}).
+	return s.db.WithContext(ctx).Model(&models.Raffle{}).
 		Where("id = ? AND status = ?", r.ID, models.RaffleStatusDraft).
 		Update("status", models.RaffleStatusActive).Error
 }

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -771,7 +771,7 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 		}
 	}
 	if failed > 0 {
-		result = "failure"
+		result = "partial_failure"
 	}
 	log.Printf(
 		"event=raffle_scheduled_snapshots_complete job=raffle_scheduled_snapshots run_at=%s window_end=%s candidate_count=%d processed=%d failed=%d",

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -20,6 +20,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
+	"github.com/tachigo/tachigo/internal/metrics"
 	"github.com/tachigo/tachigo/internal/models"
 )
 
@@ -56,6 +57,7 @@ type RaffleService struct {
 	mailer         Mailer
 	frontendURL    string
 	tokenCipher    *oauthTokenCipher
+	metrics        *metrics.Collector
 }
 
 func NewRaffleService(db *gorm.DB, twitchClientID, frontendURL string, mailer Mailer, tokenEncryptionSecret ...string) *RaffleService {
@@ -80,6 +82,13 @@ func (s *RaffleService) SetHTTPClient(c *http.Client) {
 		return
 	}
 	s.httpClient = c
+}
+
+func (s *RaffleService) SetMetricsCollector(collector *metrics.Collector) {
+	if s == nil {
+		return
+	}
+	s.metrics = collector
 }
 
 // Create creates a new raffle owned by the given user.
@@ -719,6 +728,14 @@ func (s *RaffleService) clearProviderTokens(providerID uuid.UUID) {
 // and triggers their snapshot. Per-raffle errors are logged and do not abort the batch.
 // CSV raffles are excluded: they are uploaded manually and have no remote source to sync from.
 func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time) error {
+	start := time.Now()
+	result := "success"
+	defer func() {
+		if s != nil && s.metrics != nil {
+			s.metrics.ObserveRaffleSchedulerRun(result, time.Since(start))
+		}
+	}()
+
 	window := now.Add(10 * time.Minute)
 	var raffles []models.Raffle
 	if err := s.db.Where(
@@ -731,6 +748,7 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 			window.Format(time.RFC3339),
 			err,
 		)
+		result = "failure"
 		return err
 	}
 	log.Printf(
@@ -751,6 +769,9 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 				safeScheduledJobError(err),
 			)
 		}
+	}
+	if failed > 0 {
+		result = "failure"
 	}
 	log.Printf(
 		"event=raffle_scheduled_snapshots_complete job=raffle_scheduled_snapshots run_at=%s window_end=%s candidate_count=%d processed=%d failed=%d",


### PR DESCRIPTION
## 什麼改動
新增 backend metrics and alerting baseline：
- Prometheus-compatible in-memory metrics collector。
- `ENABLE_METRICS=true` 時啟用 HTTP request metrics middleware 與 root `/metrics` endpoint。
- production 啟用 metrics 時必須設定 `METRICS_BEARER_TOKEN`。
- request count / 5xx error count / latency histogram 只以 route pattern 與 status family 標籤輸出。
- raffle scheduler run / failure / duration metrics；per-raffle tolerated error 以 `result="partial_failure"` 記錄，不進 batch failure paging counter。
- 更新 observability docs、env example、API README、Swagger artifacts，補 staging/production readback 與 alert thresholds。

## 為什麼
#792 是 #784 logging baseline 的後續。#784 已建立 vendor-neutral structured logging，但 production readiness 還需要 request/job metrics、staging readback、alert threshold 與 dashboard ownership。

closes #792
refs #784

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#792
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不接 hosted metrics vendor。
  - 不接 OpenTelemetry tracing / error reporting；#793 owns that.
  - 不新增 frontend / dashboard UI。
  - 不輸出 query strings、request bodies、Authorization、cookies、tokens、user IDs、vouchers、receipts 或其他高基數/敏感 labels。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #792 claim/routing evidence: https://github.com/nurockplayer/tachigo/issues/792#issuecomment-4472788751
- Actual worker profile(s)：
  - ops_spark: GitHub metadata / duplicate branch / PR queue readback
  - backend_worker: backend metrics collector / middleware / router / service / docs / tests
  - controller: scope decision, metrics surface decision, review, final PR gate
- Model strength：
  - ops_spark = low
  - backend_worker = GPT-5.4 medium
  - controller = GPT-5.5 medium
- Spawn directive(s)：
  - profile=ops_spark model=inherited reasoning=low controller_fallback=allowed fallback_reason=controller_select_next_issue_while_metadata_worker_runs
  - profile=backend_worker model=inherited/GPT-5.4-class reasoning=medium controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `spec workflow-check --repo . --phase start --issue 792 --format text` passed.
  - `spec plan 792 --repo . --dry-run --format prompt --verbose` produced bounded backend/infra/api context.
  - `spec workflow-check --repo . --phase commit --issue 792 --pr-body <current-pr-body> --format text` passed after rebase/review follow-up.
  - `swag init -g cmd/server/main.go -o docs` ran and generated `services/api/docs/` updates.
  - `pnpm api:types:generate` ran and generated `packages/shared-types/src/index.ts` for `GET /metrics`.
  - `gofmt` ran on changed Go files.
  - Initial validation: `go test ./internal/metrics ./internal/middleware ./internal/services ./internal/config ./internal/router` passed.
  - Initial validation: `go test ./...` passed.
  - Review follow-up validation: `go test ./internal/middleware ./internal/router ./internal/services` passed.
  - Latest validation: `go test ./internal/metrics ./internal/middleware ./internal/router ./internal/services ./docs` passed.
  - Latest validation: `go test ./...` passed.
  - Latest contract validation: `pnpm api:types:check`, `pnpm api:client:test`, and `pnpm smoke:contracts` passed.
  - `git diff --check` passed.
- Self-review / exception reason：
  - Controller kept metrics surface vendor-neutral and rejected hosted/OTel integration for this PR. Controller added review hardening tests for blank/wrong metrics token, unmatched-route label safety, timeout final-status metrics, and scheduler partial-failure metrics.
  - Review follow-up used controller-direct fallback because #800 was already blocked by a rebase conflict plus two targeted review findings; `controller_fallback_reason=review_followup_rebase_conflict_and_two_targeted_findings_small_scope`.
- Worker session closeout：
  - backend_worker completed and reported changed files/tests; controller reviewed the diff and no active worker session remains.
- Workflow friction / follow-up split：
  - `spec` warned that dirty/untracked local files can limit evidence inspection; only repo/PR artifacts listed in this body are committed. Threshold/dogfood record will be added to #664 after merge.

## Review conversation closeout
- Latest review finding disposition：
  - YUAN-117 `/metrics` Swagger artifact finding：valid/adopted. Added operational endpoint annotation and committed `services/api/docs/docs.go`, `services/api/docs/swagger.json`, `services/api/docs/swagger.yaml` from `swag init`.
  - YUAN-117 scheduler `result="failure"` finding：valid/adopted. Per-raffle tolerated errors now emit `result="partial_failure"`; only batch-returning failures increment `tachigo_raffle_scheduler_failures_total`.
- Previous review finding disposition：
  - adopted: timeout final-status metrics, wrong bearer token regression test, scheduler DB `WithContext(ctx)`.
- review_triage_ref：
  - review-followup-2: adopted all valid YUAN-117 findings on latest review; no finding rejected.
- root_cause_gate_ref：
  - root cause: generated Swagger path for new `/metrics` route was missing, and per-raffle tolerated scheduler errors shared the same `failure` label as batch-returning failures.
- finding_disposition_ref：
  - adopted: Swagger artifacts plus shared generated API type for `GET /metrics`; scheduler partial errors now use `partial_failure` and do not increment `tachigo_raffle_scheduler_failures_total`.
- Final reviewer action：
  - blocked with reason: awaiting human review approval and fresh GitHub checks on latest head.

## Final merge gate
- Ready-to-merge decision：
  - blocked with reason: `reviewDecision=REVIEW_REQUIRED`; GitHub required checks are passing.
- Latest head SHA：
  - 2a4e89bb6051d3b8a43ec1a647ae33b390fdced3
- Required checks：
  - GitHub checks readback after latest push: required backend/contract/scope checks pass; local focused/full backend and API contract drift commands passed.
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:commit:issue-792
  - start gate passed; commit gate passed after latest rebase/review follow-up; merge gate live readback: checks pass; still pending human approval.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/792#issuecomment-4472788751

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 backend metrics and alerting baseline，延伸 #784 logging baseline 到 request/job metrics 與 alert readback。
- Approx changed lines：~842 (+/-)
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [x] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #792 的驗收面同時要求 backend emits metrics、staging readback、production alert ownership；collector/middleware/router/service metrics、tests 與 docs 必須同 PR 才能完整驗證。Scope Police 已提示 diff 超過 soft limit，但拆開會讓 metrics endpoint 與 its correctness/readback 無法在單一 PR 驗證。
- 若已拆分，相關 PR：
  - #793 remains follow-up for tracing/error reporting.

## Acceptance Criteria
- [x] Backend emits request and job metrics without logging or exporting secrets.
- [x] Staging readback verifies metrics after synthetic requests and scheduler exercise.
- [x] Production alert owners and thresholds are documented.

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
spec workflow-check --repo . --phase start --issue 792 --format text
PASS

spec plan 792 --repo . --dry-run --format prompt --verbose
PASS: bounded context generated

spec workflow-check --repo . --phase commit --issue 792 --pr-body <current-pr-body> --format text
PASS

swag init -g cmd/server/main.go -o docs
PASS: generated docs.go / swagger.json / swagger.yaml

pnpm api:types:generate
PASS: generated packages/shared-types/src/index.ts

pnpm api:types:check
PASS

pnpm api:client:test
PASS: 8 tests

pnpm smoke:contracts
PASS: 9 checks

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/metrics ./internal/middleware ./internal/router ./internal/services ./docs
PASS: 5 packages

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
PASS: all backend packages

git diff --check
PASS
```

## 備註
`/metrics` uses a simple bearer token guard and emits Prometheus text format from an in-memory collector. This intentionally avoids new dependencies and leaves hosted metrics / OTel integration to a future PR.

## Notes for Claude Code Review
- 請特別看 `/metrics` exposure model 是否符合 maintainer expectation：預設 disabled，production enabled 時需要 `METRICS_BEARER_TOKEN`。
- Metrics labels intentionally stay low-cardinality: `route`, `status_family`, scheduler `result` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增可选的 /metrics 端点（Prometheus 文本格式），通过 ENABLE_METRICS 开启并以 Bearer token 保护；采集 HTTP 请求、错误、延迟及抽奖调度器运行/失败/耗时指标。

* **文档**
  * 更新环境变量示例与服务 README，补充可观测性基线、指标清单、本地/预发抓取与校验步骤、告警/仪表盘对齐要点及启动后待办项。

* **测试**
  * 新增端到端与单元测试，覆盖指标采集、渲染、不泄露敏感信息与鉴权行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


