### PR TITLE
[infra] Restore rebase notification permissions

### DIFF
--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2690,6 +2690,9 @@ test('develop merge issue closer only runs after merged PRs close into develop',
 test('notify rebase workflow uses read-only pull request permission', async () => {
   const parsedWorkflow = parseYaml(notifyRebaseNeededWorkflowPath)
 
+  assert.deepEqual(parsedWorkflow.on.pull_request_target.types, ['closed'])
+  assert.deepEqual(parsedWorkflow.on.pull_request_target.branches, ['develop'])
+  assert.equal(parsedWorkflow.on.pull_request, undefined)
   assert.equal(parsedWorkflow.permissions.issues, 'write')
   assert.equal(parsedWorkflow.permissions['pull-requests'], 'read')
 })

--- a/.github/workflows/notify-rebase-needed.yml
+++ b/.github/workflows/notify-rebase-needed.yml
@@ -1,7 +1,7 @@
 name: Notify PRs needing rebase
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [develop]
 


### PR DESCRIPTION
## 什麼改動
將 `Notify PRs needing rebase` workflow 從 `pull_request` 改成 `pull_request_target`，讓 merge 後偵測到衝突 PR 時可以用 base repo token 留下 rebase 通知；同步補上 workflow regression test。

## 為什麼
refs #208

PR #788/#791/#795/#796/#797/#798 merge 後，`Notify PRs needing rebase` 嘗試對衝突中的 #800 建立 comment，但 `POST /issues/800/comments` 回 `403 Resource not accessible by integration`。此 workflow 不 checkout PR head，只讀 PR metadata 並留言通知，因此適合用 `pull_request_target` 取得 base repo comment 權限。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#208
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 #800 merge conflict，不變更 auto-ready / merge policy，不改產品程式碼。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #208 CI / workflow quality gate initiative；本次為 current-sprint merge 後通知 workflow 的窄範圍修補。
- Actual worker profile(s)：
  - controller + ops_spark sidecar readback
- Model strength：
  - controller = gpt-5.5 xhigh；ops_spark sidecar = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `rtk node --test .github/workflows/ci.test.mjs` -> 93 pass / 0 fail
  - `rtk git --no-optional-locks diff --check` -> pass
- Self-review / exception reason：
  - Self-review completed against failing workflow log; root cause was 403 while creating issue comment from `pull_request` event.
- Worker session closeout：
  - 已讀回 sidecar PR/issue 狀態盤點；不需追加 sidecar 任務。
- Workflow friction / follow-up split：
  - 此 PR 只修 rebase notification workflow permission mismatch；#800 conflict resolution and review remain separate.

## Review conversation closeout
- Unresolved threads：
  - 0；new PR
- CodeRabbit：
  - pending new PR review
- chatgpt-codex-connector：
  - pending new PR review
- review_triage_ref：
  - pending with reason: new PR has no review findings yet
- root_cause_gate_ref：
  - local evidence: workflow run `26016327731` / `26016326223` failed with `403 Resource not accessible by integration` on `issues.createComment`
- finding_disposition_ref：
  - pending with reason: new PR has no review findings yet
- Final reviewer action：
  - pending human review; R4 workflow PR does not use auto-ready

## Final merge gate
- Ready-to-merge decision：
  - blocked pending CI and human review
- Latest head SHA：
  - f6a5adc0
- Required checks：
  - pending after PR creation
- spec workflow-check evidence：
  - tool_gap: `spec` unavailable; manual AWP checklist used
- Evidence URL：
  - n/a before PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Restore rebase notification comments for conflicting PRs after develop merges.
- Approx changed lines：5
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Workflow token permission behavior is aligned with the comment-writing job.
- [x] Regression test covers the trigger type and permissions.
- [x] No product code or unrelated governance policy changes are included.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk node --test .github/workflows/ci.test.mjs
tests 93
pass 93
fail 0

rtk git --no-optional-locks diff --check
pass
```

## 備註
此 PR 修改 workflow event，依 repo policy 標為 R4，不使用 `AUTO_READY=1`。

## Notes for Claude Code Review
- 請特別看 `pull_request_target` 是否可接受；此 workflow 不 checkout or execute PR head code，只透過 `github-script` 讀 PR metadata 並建立 issue comment。
