### PR TITLE
[backend] extension JWT 登入自動建帳號

### DIFF
--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -106,15 +106,9 @@ func (s *ExtensionService) VerifyReceiptJWT(receiptStr string) (*ReceiptClaims, 
 	return claims, nil
 }
 
-// LoginWithExtension looks up an existing tachigo account by Twitch user ID and
-// issues a tachigo token pair. The viewer must have already signed up on tachigo
-// and linked their Twitch account — this endpoint does not create new accounts.
-//
-// Returns ErrInvalidExtJWT if the JWT is invalid or the viewer has not authorized
-// the Extension (UserID is empty). Returns ErrUserNotFound if no tachigo account
-// is linked to the Twitch identity.
-// lookupExtensionUser resolves a Twitch identity to a tachigo User.
+// lookupExtensionUser resolves a Twitch identity to an existing tachigo User.
 // It does not issue tokens; call issueTokenPair separately.
+// Returns ErrInvalidExtJWT if UserID is empty, ErrUserNotFound if no account is linked.
 func (s *ExtensionService) lookupExtensionUser(claims *ExtensionClaims) (*models.User, error) {
 	if claims.UserID == "" {
 		return nil, ErrInvalidExtJWT
@@ -135,12 +129,77 @@ func (s *ExtensionService) lookupExtensionUser(claims *ExtensionClaims) (*models
 	return &user, nil
 }
 
+// findOrCreateExtensionUser finds or creates a tachigo account for the Twitch identity in claims.
+// New users receive username "twitch_<twitchUserID>" and role viewer.
+// On concurrent unique-constraint violation the winner's record is returned (conflict recovery).
+func (s *ExtensionService) findOrCreateExtensionUser(claims *ExtensionClaims) (*models.User, error) {
+	if claims.UserID == "" {
+		return nil, ErrInvalidExtJWT
+	}
+
+	user, err := s.findOrCreateExtensionUserTx(claims)
+	if err == nil {
+		return user, nil
+	}
+	if !isDuplicatedKeyError(err) {
+		return nil, err
+	}
+	// conflict recovery: concurrent goroutine won the INSERT race; look up the winning record
+	return s.lookupExtensionUser(claims)
+}
+
+func (s *ExtensionService) findOrCreateExtensionUserTx(claims *ExtensionClaims) (*models.User, error) {
+	var result *models.User
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var ap models.AuthProvider
+		if err := tx.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, claims.UserID).
+			First(&ap).Error; err == nil {
+			var u models.User
+			if err := tx.First(&u, ap.UserID).Error; err != nil {
+				return err
+			}
+			result = &u
+			return nil
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		username := "twitch_" + claims.UserID
+		newUser := models.User{
+			Username: &username,
+			Role:     models.RoleViewer,
+		}
+		if err := tx.Create(&newUser).Error; err != nil {
+			return err
+		}
+
+		newAP := models.AuthProvider{
+			UserID:     newUser.ID,
+			Provider:   models.ProviderTwitch,
+			ProviderID: claims.UserID,
+		}
+		if err := tx.Create(&newAP).Error; err != nil {
+			return err
+		}
+
+		result = &newUser
+		return nil
+	})
+	return result, err
+}
+
+// LoginWithExtension verifies the Extension JWT and issues a tachigo token pair.
+// If no tachigo account is linked to the Twitch identity yet, one is created automatically
+// (username: "twitch_<twitchUserID>"). Concurrent first-logins are safe: at most one account
+// is created and all callers receive a token pair for the same account.
+//
+// Returns ErrInvalidExtJWT if the JWT is invalid or the viewer has not shared their identity.
 func (s *ExtensionService) LoginWithExtension(extJWT string) (*models.User, *TokenPair, error) {
 	claims, err := s.VerifyExtJWT(extJWT)
 	if err != nil {
 		return nil, nil, err
 	}
-	user, err := s.lookupExtensionUser(claims)
+	user, err := s.findOrCreateExtensionUser(claims)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/api/internal/services/extension_service_pg_test.go
+++ b/services/api/internal/services/extension_service_pg_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package services
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/tachigo/tachigo/internal/models"
+)
+
+func TestLoginWithExtension_ConcurrentLogin_NoDuplicateUser(t *testing.T) {
+	db := newPGTestDB(t)
+	cfg := extTestConfig()
+	authSvc := NewAuthService(db, cfg)
+	watchSvc := NewWatchService(db)
+	pointsSvc := NewPointsService(db, watchSvc)
+	svc := NewExtensionService(db, cfg, authSvc, pointsSvc)
+
+	twitchID := fmt.Sprintf("twitch-conc-%s", uuid.New().String()[:8])
+
+	const goroutines = 10
+	type result struct {
+		user *models.User
+		err  error
+	}
+	results := make([]result, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			extJWT := makeExtJWT(t, twitchID, "channel-concurrent")
+			u, _, err := svc.LoginWithExtension(extJWT)
+			results[i] = result{u, err}
+		}()
+	}
+	wg.Wait()
+
+	var successUserID uuid.UUID
+	for _, r := range results {
+		if r.err != nil {
+			t.Errorf("concurrent login error: %v", r.err)
+			continue
+		}
+		if successUserID == uuid.Nil {
+			successUserID = r.user.ID
+		} else if r.user.ID != successUserID {
+			t.Errorf("concurrent logins created different users: %s vs %s", successUserID, r.user.ID)
+		}
+	}
+
+	var count int64
+	db.Model(&models.User{}).
+		Joins("JOIN auth_providers ON auth_providers.user_id = users.id").
+		Where("auth_providers.provider = ? AND auth_providers.provider_id = ?", models.ProviderTwitch, twitchID).
+		Count(&count)
+	if count != 1 {
+		t.Errorf("want exactly 1 user after concurrent login, got %d", count)
+	}
+}

--- a/services/api/internal/services/extension_service_pg_test.go
+++ b/services/api/internal/services/extension_service_pg_test.go
@@ -30,11 +30,11 @@ func TestLoginWithExtension_ConcurrentLogin_NoDuplicateUser(t *testing.T) {
 	results := make([]result, goroutines)
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
+	extJWT := makeExtJWT(t, twitchID, "channel-concurrent")
 	for i := 0; i < goroutines; i++ {
 		i := i
 		go func() {
 			defer wg.Done()
-			extJWT := makeExtJWT(t, twitchID, "channel-concurrent")
 			u, _, err := svc.LoginWithExtension(extJWT)
 			results[i] = result{u, err}
 		}()

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -309,6 +309,100 @@ func TestCompleteTPointTransaction_PointsWriteFailure_NoOrphanRefreshToken(t *te
 	}
 }
 
+// --- LoginWithExtension find-or-create tests ---
+
+func TestLoginWithExtension_NewUser_CreatesAccountAndReturnsTokens(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	twitchID := "twitch-new-user-001"
+	extJWT := makeExtJWT(t, twitchID, "channel-1")
+
+	user, tokens, err := svc.LoginWithExtension(extJWT)
+	if err != nil {
+		t.Fatalf("want nil error for new user, got %v", err)
+	}
+	if user == nil {
+		t.Fatal("want user, got nil")
+	}
+	if tokens == nil {
+		t.Fatal("want tokens, got nil")
+	}
+
+	// auth_provider must exist now
+	var ap models.AuthProvider
+	if err := svc.db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, twitchID).First(&ap).Error; err != nil {
+		t.Errorf("auth_provider not created: %v", err)
+	}
+	if ap.UserID != user.ID {
+		t.Errorf("auth_provider.user_id mismatch: want %s, got %s", user.ID, ap.UserID)
+	}
+}
+
+func TestLoginWithExtension_NewUser_UsernameIsDeterministic(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	twitchID := "twitch-det-user-002"
+	extJWT := makeExtJWT(t, twitchID, "channel-1")
+
+	user, _, err := svc.LoginWithExtension(extJWT)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "twitch_" + twitchID
+	if user.Username == nil || *user.Username != want {
+		t.Errorf("want username=%q, got %v", want, user.Username)
+	}
+}
+
+func TestLoginWithExtension_ExistingUser_DoesNotDuplicate(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	twitchID := "twitch-exist-003"
+	extJWT := makeExtJWT(t, twitchID, "channel-1")
+
+	// first login creates user
+	user1, _, err := svc.LoginWithExtension(extJWT)
+	if err != nil {
+		t.Fatalf("first login: %v", err)
+	}
+
+	// second login must return the same user
+	user2, tokens2, err := svc.LoginWithExtension(extJWT)
+	if err != nil {
+		t.Fatalf("second login: %v", err)
+	}
+	if user1.ID != user2.ID {
+		t.Errorf("second login created new user: got %s, want %s", user2.ID, user1.ID)
+	}
+	if tokens2 == nil {
+		t.Error("second login returned nil tokens")
+	}
+
+	var count int64
+	svc.db.Model(&models.AuthProvider{}).
+		Where("provider = ? AND provider_id = ?", models.ProviderTwitch, twitchID).
+		Count(&count)
+	if count != 1 {
+		t.Errorf("want exactly 1 auth_provider, got %d", count)
+	}
+}
+
+func TestLoginWithExtension_EmptyUserID_ReturnsErrInvalidExtJWT(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	// JWT with empty user_id (identity not shared)
+	claims := ExtensionClaims{
+		UserID:                "",
+		ExtensionScopedUserID: "U-opaque-only",
+		ChannelID:             "channel-1",
+		Role:                  "viewer",
+		RegisteredClaims:      jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour))},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, _ := token.SignedString([]byte(testExtSecretRaw))
+
+	_, _, err := svc.LoginWithExtension(signed)
+	if !errors.Is(err, ErrInvalidExtJWT) {
+		t.Errorf("want ErrInvalidExtJWT for empty user_id, got %v", err)
+	}
+}
+
 func TestCompleteTPointTransaction_ReceiptUserMismatch_DoesNotCreditPoints(t *testing.T) {
 	svc, pointsSvc := newExtSvc(t)
 	userID, twitchID := seedTwitchUser(t, svc.db)


### PR DESCRIPTION
## 什麼改動

`LoginWithExtension` 從「lookup-only」改為「find-or-create」：查無 `AuthProvider{Twitch, userID}` 時，在單一 transaction 內建立 `User`（username: `twitch_<twitchUserID>`）+ `AuthProvider`，再發 token pair。unique constraint 衝突（並發 race）後 fallback 查已存在的 record。

## 為什麼

closes #734

MVP 要讓使用者用 Twitch 登入後自動建立 tachigo 帳號，但現有 `LoginWithExtension` 查無 Twitch 連結就回 `ErrUserNotFound`，不建帳號。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Test-Driven / Debug Loop

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#734
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 DB-only claim/redeem（B2/B3）
  - 不做前端
  - 不做 on-chain 行為

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Self-review / exception reason: trivial/self-only — non-autonomous human PR; auto-ready label used as CI gate only
- Worker session closeout: non-autonomous PR; no worker session to close

## Review conversation closeout
- Unresolved threads：0（goroutine test fix applied per nurockplayer review）
- CodeRabbit：fix applied — moved makeExtJWT outside goroutine loop
- chatgpt-codex-connector：n/a
- review_triage_ref：https://github.com/nurockplayer/tachigo/pull/805#pullrequestreview-4309566322
- root_cause_gate_ref：n/a — feature PR, no root cause investigation
- finding_disposition_ref：https://github.com/nurockplayer/tachigo/pull/805#pullrequestreview-4311342205
- Final reviewer action：CHANGES_REQUESTED by nurockplayer; fix applied in c7fa266

## Final merge gate
- Ready-to-merge decision：pending CI
- Latest head SHA：c7fa266
- Required checks：pending
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 Extension JWT 登入自動 find-or-create tachigo 帳號
- Approx changed lines：~237
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service 與對應測試不可分離，合併在同一 PR 才能驗證行為
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] 新使用者首次 Twitch 登入成功建帳號並取得 token pair
- [x] 並發登入不產生重複 user/provider（integration test in `extension_service_pg_test.go`）
- [x] `docker compose run --no-deps --rm app go test ./...` 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
=== RUN   TestLoginWithExtension_NewUser_CreatesAccountAndReturnsTokens
--- PASS
=== RUN   TestLoginWithExtension_NewUser_UsernameIsDeterministic
--- PASS
=== RUN   TestLoginWithExtension_ExistingUser_DoesNotDuplicate
--- PASS
=== RUN   TestLoginWithExtension_EmptyUserID_ReturnsErrInvalidExtJWT
--- PASS
ok  github.com/tachigo/tachigo/internal/services  0.020s
```

## 備註
並發衝突 recovery 測試（`TestLoginWithExtension_ConcurrentLogin_NoDuplicateUser`）放在 `extension_service_pg_test.go`，需要 `//go:build integration` + PostgreSQL，與現有 `auth_service_pg_test.go` 模式一致。

## Notes for Claude Code Review
- `findOrCreateExtensionUserTx` 的 conflict recovery 仰賴 `isDuplicatedKeyError`（與 `auth_service.go` 共用），SQLite 測試環境中 unique index 衝突的錯誤格式需確認是否被正確捕捉
- `lookupExtensionUser` 保留不改，因為 `CompleteTPointTransaction` 仍依賴它（需要 lookup-only 語意，不應在此 create）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * Extension 登录现在会自动为新用户创建账户，而不是返回错误。

* **测试**
  * 新增并发登录测试，确保不会创建重复用户。
  * 新增用户创建、用户名生成、既有用户处理和 JWT 验证的单元测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->