### PR TITLE
[backend] Propagate points request context

### DIFF
--- a/services/api/internal/handlers/points_handler.go
+++ b/services/api/internal/handlers/points_handler.go
@@ -42,7 +42,7 @@ func (h *PointsHandler) GetBalance(c *gin.Context) {
 		return
 	}
 
-	balance, err := h.pointsSvc.GetBalance(userID, channelID)
+	balance, err := h.pointsSvc.GetBalanceContext(c.Request.Context(), userID, channelID)
 	if err != nil {
 		internal(c)
 		return
@@ -77,7 +77,7 @@ func (h *PointsHandler) GetHistory(c *gin.Context) {
 		return
 	}
 
-	txs, err := h.pointsSvc.ListTransactions(userID, channelID)
+	txs, err := h.pointsSvc.ListTransactionsContext(c.Request.Context(), userID, channelID)
 	if err != nil {
 		internal(c)
 		return

--- a/services/api/internal/handlers/points_handler_test.go
+++ b/services/api/internal/handlers/points_handler_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"context"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/middleware"
@@ -48,6 +50,32 @@ func (e *pointsEnv) registerViewer(t *testing.T, suffix string) (uuid.UUID, stri
 	return user.ID, tokens.AccessToken
 }
 
+type pointsHandlerContextKey struct{}
+
+func installPointsHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:points_handler_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name + ":query")
+	})
+
+	return func() int {
+		return seen
+	}
+}
+
 func TestPointsHandler_GetBalance_ReturnsWrappedBalances(t *testing.T) {
 	e := newPointsEnv(t)
 	userID, token := e.registerViewer(t, "balance")
@@ -75,6 +103,26 @@ func TestPointsHandler_GetBalance_ReturnsWrappedBalances(t *testing.T) {
 	}
 	if data["cumulative_total"] != float64(100) {
 		t.Fatalf("cumulative_total: want 100, got %v", data["cumulative_total"])
+	}
+}
+
+func TestPointsHandler_GetBalance_UsesRequestContext(t *testing.T) {
+	e := newPointsEnv(t)
+	_, token := e.registerViewer(t, "balance_context")
+	key := pointsHandlerContextKey{}
+	seen := installPointsHandlerDBContextProbe(t, e.db, key, "points-balance")
+	ctx := context.WithValue(context.Background(), key, "points-balance")
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/users/me/points?channel_id=ch_abc", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetBalance handler to pass request context to GORM")
 	}
 }
 
@@ -156,6 +204,26 @@ func TestPointsHandler_GetBalance_RequiresChannelID(t *testing.T) {
 	}
 	if resp["error"] != "channel_id is required" {
 		t.Fatalf("error: want channel_id is required, got %v", resp["error"])
+	}
+}
+
+func TestPointsHandler_GetHistory_UsesRequestContext(t *testing.T) {
+	e := newPointsEnv(t)
+	_, token := e.registerViewer(t, "history_context")
+	key := pointsHandlerContextKey{}
+	seen := installPointsHandlerDBContextProbe(t, e.db, key, "points-history")
+	ctx := context.WithValue(context.Background(), key, "points-history")
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/users/me/points/history?channel_id=ch_abc", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetHistory handler to pass request context to GORM")
 	}
 }
 

--- a/services/api/internal/services/points_service.go
+++ b/services/api/internal/services/points_service.go
@@ -67,7 +67,11 @@ func (s *PointsService) dbWithContext(ctx context.Context) *gorm.DB {
 // GetBalance wraps WatchService.GetBalance and returns a PointsBalance struct.
 // Returns zeroed balance if no ledger exists yet.
 func (s *PointsService) GetBalance(userID uuid.UUID, channelID string) (*PointsBalance, error) {
-	spendable, cumulative, err := s.watchSvc.GetBalance(userID, channelID)
+	return s.GetBalanceContext(context.Background(), userID, channelID)
+}
+
+func (s *PointsService) GetBalanceContext(ctx context.Context, userID uuid.UUID, channelID string) (*PointsBalance, error) {
+	spendable, cumulative, err := s.watchSvc.GetBalanceContext(ctx, userID, channelID)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +83,13 @@ func (s *PointsService) GetBalance(userID uuid.UUID, channelID string) (*PointsB
 
 // ListTransactions returns the most recent 50 transactions for a viewer in a channel.
 func (s *PointsService) ListTransactions(userID uuid.UUID, channelID string) ([]models.PointsTransaction, error) {
+	return s.ListTransactionsContext(context.Background(), userID, channelID)
+}
+
+func (s *PointsService) ListTransactionsContext(ctx context.Context, userID uuid.UUID, channelID string) ([]models.PointsTransaction, error) {
+	db := s.dbWithContext(ctx)
 	var ledger models.PointsLedger
-	if err := s.db.Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
+	if err := db.Where("user_id = ? AND channel_id = ?", userID, channelID).First(&ledger).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return []models.PointsTransaction{}, nil
 		}
@@ -88,7 +97,7 @@ func (s *PointsService) ListTransactions(userID uuid.UUID, channelID string) ([]
 	}
 
 	var txs []models.PointsTransaction
-	err := s.db.Where("ledger_id = ?", ledger.ID).
+	err := db.Where("ledger_id = ?", ledger.ID).
 		Order("created_at DESC, id DESC").
 		Limit(50).
 		Find(&txs).Error

--- a/services/api/internal/services/points_service_test.go
+++ b/services/api/internal/services/points_service_test.go
@@ -94,6 +94,21 @@ func TestPointsService_GetBalance_AfterEarning(t *testing.T) {
 	}
 }
 
+func TestPointsService_GetBalanceContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+	key := pointsContextKey("points-balance-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-balance")
+
+	_, err := svc.GetBalanceContext(context.WithValue(context.Background(), key, "points-balance"), userID, "ch_context")
+	if err != nil {
+		t.Fatalf("get balance with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetBalanceContext DB operations to carry request context")
+	}
+}
+
 // ─── DeductPoints ────────────────────────────────────────────────────────────
 
 func TestPointsService_DeductPoints_InsufficientBalance(t *testing.T) {
@@ -315,6 +330,20 @@ func TestPointsService_ListTransactions_EmptyWhenNoLedger(t *testing.T) {
 	}
 	if len(txs) != 0 {
 		t.Errorf("want 0 transactions, got %d", len(txs))
+	}
+}
+
+func TestPointsService_ListTransactionsContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+	key := pointsContextKey("points-history-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-history")
+
+	if _, err := svc.ListTransactionsContext(context.WithValue(context.Background(), key, "points-history"), userID, "ch_context"); err != nil {
+		t.Fatalf("list transactions with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected ListTransactionsContext DB operations to carry request context")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
讓 viewer points read endpoints 把 HTTP request context 傳進 service / GORM query：
- `GET /api/v1/users/me/points`
- `GET /api/v1/users/me/points/history`
- 新增 `PointsService.GetBalanceContext` 與 `ListTransactionsContext`，保留既有 wrapper 作為 background context 相容路徑。

## 為什麼
refs #645

#645 要求 DB query / transaction path 傳遞 request context。本 PR 只處理 points read endpoints 這個 bounded slice，不關閉整張 #645。

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: workflow-check:commit:645-points-read-context

## AWP routing evidence
- routing evidence status: pass
- routing evidence ref: workflow-check:start:645:7f1c973642074214bb5f543416d760c544789959
- controller_fallback: allowed
- controller_fallback_reason: explorer did not return before implementation closeout; controller proceeded with the already identified low-risk points read endpoint slice.

## Finding disposition evidence
- finding disposition status: pass
- finding disposition ref: workflow-check:finding-disposition:645-initial-self-review

## Threshold calibration evidence
- threshold evidence status: pass
- threshold ledger ref: workflow-check:threshold:645-points-read

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 claim / spend / extension JWT / airdrop / coupon shop / schema / migration / frontend。
  - 不關閉 #645；剩餘 DB context gap 留給後續 slice。
  - 不修改別人的 open PR branch。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 DB request context propagation；本 PR 採 bounded slice：points read endpoints。
- Actual worker profile(s)：
  - controller：scope selection、TDD implementation、validation、PR publication。
  - explorer：read-only remaining-gap scan；因超過主線等待時間，實作 closeout 前已關閉。
- Model strength：
  - controller = high；explorer = medium。
- Spawn directive(s)：
  - `profile=explorer model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=explorer_timeout_before_implementation_closeout`
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestPointsService_(GetBalanceContext|ListTransactionsContext)_UsesRequestContext|TestPointsHandler_(GetBalance|GetHistory)_UsesRequestContext'`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers ./internal/router`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：
  - 已完成 self-review；diff 僅限 points handler/service 與對應 context propagation tests。
- Worker session closeout：
  - explorer session 已 close；未採用其輸出。
- Workflow friction / follow-up split：
  - 約 40% infra / 60% workflow friction：主要摩擦是 #645 範圍大，需要切成 points read endpoints 小 PR；threshold calibration 於 merge 後補 #664 ledger comment。

## Review conversation closeout
- Unresolved threads：
  - 0 before initial PR open。
- CodeRabbit：
  - n/a before PR open。
- chatgpt-codex-connector：
  - n/a before PR open。
- review_triage_ref：
  - `/tmp/tachigo-645-finding-disposition.json`
- root_cause_gate_ref：
  - `/tmp/tachigo-645-finding-disposition.json`
- finding_disposition_ref：
  - `/tmp/tachigo-645-finding-disposition.json`
- Final reviewer action：
  - n/a before PR open。

## Final merge gate
- Ready-to-merge decision：
  - n/a before initial PR open。
- Latest head SHA：
  - n/a before initial PR open。
- Required checks：
  - local backend tests pass；GitHub checks pending after PR open。
- spec workflow-check evidence：
  - start gate: pass, `head_sha=7f1c973642074214bb5f543416d760c544789959`
  - commit gate: pass with `/tmp/tachigo-645-pr-body.md`, `/tmp/tachigo-645-routing-evidence.json`, `/tmp/tachigo-645-finding-disposition.json`, `/tmp/tachigo-645-threshold-evidence.json`
- Evidence URL：
  - #645 claim comment: https://github.com/nurockplayer/tachigo/issues/645#issuecomment-4476904711

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through points read endpoints and their GORM queries.
- Approx changed lines：~116
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler 必須把 request context 傳入 service，service 才能把 context 傳到 GORM；測試覆蓋同一條 request-context 行為。
- 若已拆分，相關 PR：
  - Prior merged #645 slices: #666, #691, #686, #685, #690, #718；本 PR 是新的 points read endpoints slice。

## Acceptance Criteria
- [x] Points balance read path has context-aware service method and handler wiring.
- [x] Points history read path has context-aware service method and handler wiring.
- [x] Regression tests verify request context reaches GORM callbacks.
- [x] This PR does not close #645 and does not modify unrelated DB context paths.

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestPointsService_(GetBalanceContext|ListTransactionsContext)_UsesRequestContext|TestPointsHandler_(GetBalance|GetHistory)_UsesRequestContext'
ok  	github.com/tachigo/tachigo/internal/services
ok  	github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers ./internal/router
ok  	github.com/tachigo/tachigo/internal/services
ok  	github.com/tachigo/tachigo/internal/handlers
ok  	github.com/tachigo/tachigo/internal/router

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/cmd/loader
ok  	github.com/tachigo/tachigo/cmd/server
ok  	github.com/tachigo/tachigo/docs
ok  	github.com/tachigo/tachigo/internal/config
ok  	github.com/tachigo/tachigo/internal/contract
ok  	github.com/tachigo/tachigo/internal/handlers
ok  	github.com/tachigo/tachigo/internal/middleware
ok  	github.com/tachigo/tachigo/internal/models
ok  	github.com/tachigo/tachigo/internal/router
ok  	github.com/tachigo/tachigo/internal/services
```

## 備註
Merge 後會依使用者要求在 #664 補一則 spec-injector dogfood / threshold calibration ledger comment。

## Notes for Claude Code Review
- 請特別確認本 PR 是否足夠 bounded：只處理 points read endpoints 的 request context propagation。
- `DeductPoints` / `AddPointsWithMeta` / claim / spend / extension receipt paths 仍可能有 context gap，但刻意留給後續 slice，避免 #645 再次變成大包。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **可靠性改进**
  * 优化了点数余额和交易历史查询功能，确保请求取消和超时设置能够正确传播至数据库操作，提升应用的稳定性和响应效率。

* **测试**
  * 新增测试用例验证请求上下文的正确传播。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->