### PR TITLE
[frontend] Add mining onboarding tour

### DIFF
--- a/apps/extension/src/app/App.tsx
+++ b/apps/extension/src/app/App.tsx
@@ -18,6 +18,8 @@ import { MarioHUD } from './components/MarioHUD';
 import { ClaimPanel } from './components/ClaimPanel';
 import { CouponShopPanel } from './components/CouponShopPanel';
 import { RaffleResultPanel } from './components/RaffleResultPanel';
+import { OnboardingOverlay } from './components/OnboardingOverlay';
+import { markOnboardingComplete, shouldShowOnboarding } from './onboarding';
 import { useTwitch } from '../hooks/useTwitch';
 import { executeCouponRedeem, type CouponRedeemOutcome } from './couponRedeem';
 
@@ -148,6 +150,11 @@ export default function App() {
     })
   }
 
+  const completeOnboarding = () => {
+    setFlags(markOnboardingComplete)
+  }
+  const showOnboarding = shouldShowOnboarding(screen, flags)
+
   if (!isHydrated) {
     return (
       <div
@@ -241,6 +248,9 @@ export default function App() {
         ) : (
           <MarioHUD state={hudState} onStateChange={setHudState} onNavigate={(s) => setScreen(s)} />
         )}
+        {showOnboarding ? (
+          <OnboardingOverlay onComplete={completeOnboarding} />
+        ) : null}
       </div>
 
       {/* Demo controls */}

--- a/apps/extension/src/app/components/OnboardingOverlay.tsx
+++ b/apps/extension/src/app/components/OnboardingOverlay.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+const onboardingSteps = [
+  {
+    key: 'points',
+    marker: 'CPC',
+    accent: '#ffd866',
+  },
+  {
+    key: 'rewards',
+    marker: 'TCG',
+    accent: '#6fffd2',
+  },
+] as const
+
+interface OnboardingOverlayProps {
+  onComplete: () => void
+}
+
+export function OnboardingOverlay({ onComplete }: OnboardingOverlayProps) {
+  const { t } = useTranslation()
+  const [stepIndex, setStepIndex] = useState(0)
+  const step = onboardingSteps[stepIndex]
+  const isFinalStep = stepIndex === onboardingSteps.length - 1
+
+  const handlePrimaryAction = () => {
+    if (isFinalStep) {
+      onComplete()
+      return
+    }
+
+    setStepIndex((current) => current + 1)
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tachigo-onboarding-title"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 30,
+        display: 'flex',
+        alignItems: 'flex-end',
+        justifyContent: 'center',
+        padding: 14,
+        boxSizing: 'border-box',
+        background:
+          'linear-gradient(180deg, rgba(4,6,20,0.18) 0%, rgba(4,6,20,0.72) 46%, rgba(4,6,20,0.94) 100%)',
+        backdropFilter: 'blur(2px)',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          borderRadius: 8,
+          border: '1px solid rgba(255,255,255,0.14)',
+          background:
+            'linear-gradient(180deg, rgba(19,24,50,0.96) 0%, rgba(10,12,28,0.98) 100%)',
+          boxShadow: `0 0 0 1px rgba(0,0,0,0.88), 0 -10px 28px rgba(0,0,0,0.38), 0 0 24px ${step.accent}22`,
+          padding: '13px 13px 12px',
+          boxSizing: 'border-box',
+          color: '#fff7d6',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 10,
+            marginBottom: 9,
+          }}
+        >
+          <div
+            id="tachigo-onboarding-title"
+            style={{
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 9,
+              letterSpacing: '0.08em',
+              color: '#fff7d6',
+              textTransform: 'uppercase',
+              lineHeight: 1.5,
+            }}
+          >
+            {t('onboarding.title')}
+          </div>
+          <div
+            style={{
+              flex: '0 0 auto',
+              borderRadius: 4,
+              border: `1px solid ${step.accent}88`,
+              color: step.accent,
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 8,
+              lineHeight: 1,
+              padding: '5px 6px',
+              background: `${step.accent}14`,
+            }}
+          >
+            {step.marker}
+          </div>
+        </div>
+
+        <div
+          style={{
+            fontFamily: 'var(--pixel-font-family)',
+            fontSize: 11,
+            lineHeight: 1.55,
+            color: step.accent,
+            marginBottom: 7,
+          }}
+        >
+          {t(`onboarding.steps.${step.key}.title`)}
+        </div>
+        <p
+          style={{
+            margin: 0,
+            color: 'rgba(255,255,255,0.78)',
+            fontSize: 12,
+            lineHeight: 1.55,
+          }}
+        >
+          {t(`onboarding.steps.${step.key}.body`)}
+        </p>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 10,
+            marginTop: 13,
+          }}
+        >
+          <div
+            style={{
+              color: 'rgba(255,255,255,0.45)',
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 8,
+              letterSpacing: '0.06em',
+            }}
+          >
+            {t('onboarding.progress', {
+              current: stepIndex + 1,
+              total: onboardingSteps.length,
+            })}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+            <button
+              type="button"
+              onClick={onComplete}
+              style={{
+                border: '1px solid rgba(255,255,255,0.12)',
+                borderRadius: 4,
+                background: 'rgba(255,255,255,0.04)',
+                color: 'rgba(255,255,255,0.62)',
+                fontFamily: 'var(--pixel-font-family)',
+                fontSize: 8,
+                lineHeight: 1,
+                padding: '8px 9px',
+                cursor: 'pointer',
+              }}
+            >
+              {t('onboarding.skip')}
+            </button>
+            <button
+              type="button"
+              onClick={handlePrimaryAction}
+              style={{
+                border: `1px solid ${step.accent}`,
+                borderRadius: 4,
+                background: step.accent,
+                color: '#111423',
+                fontFamily: 'var(--pixel-font-family)',
+                fontSize: 8,
+                lineHeight: 1,
+                padding: '8px 10px',
+                boxShadow: `0 0 14px ${step.accent}55`,
+                cursor: 'pointer',
+              }}
+            >
+              {isFinalStep ? t('onboarding.finish') : t('onboarding.next')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/extension/src/app/onboarding.test.ts
+++ b/apps/extension/src/app/onboarding.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import { markOnboardingComplete, shouldShowOnboarding } from './onboarding'
+import type { NavigationFlags } from './navigation/types'
+
+const freshFlags: NavigationFlags = {
+  hasCompletedLogin: true,
+  onboardingVersion: 0,
+  selectedCharacterOnce: false,
+}
+
+test('shouldShowOnboarding only opens the tour for first-time mining viewers', () => {
+  assert.equal(shouldShowOnboarding('hud', freshFlags), true)
+  assert.equal(shouldShowOnboarding('login', freshFlags), false)
+  assert.equal(shouldShowOnboarding('claim', freshFlags), false)
+  assert.equal(
+    shouldShowOnboarding('hud', {
+      ...freshFlags,
+      onboardingVersion: 1,
+    }),
+    false,
+  )
+})
+
+test('markOnboardingComplete stores the current onboarding version without lowering newer versions', () => {
+  assert.deepEqual(markOnboardingComplete(freshFlags), {
+    ...freshFlags,
+    onboardingVersion: 1,
+  })
+  assert.deepEqual(
+    markOnboardingComplete({
+      ...freshFlags,
+      onboardingVersion: 3,
+    }),
+    {
+      ...freshFlags,
+      onboardingVersion: 3,
+    },
+  )
+})

--- a/apps/extension/src/app/onboarding.ts
+++ b/apps/extension/src/app/onboarding.ts
@@ -1,0 +1,15 @@
+import type { NavigationFlags } from './navigation/types'
+import type { DemoScreen } from '../extension/types'
+
+export const ONBOARDING_VERSION = 1
+
+export function shouldShowOnboarding(screen: DemoScreen, flags: NavigationFlags): boolean {
+  return screen === 'hud' && flags.onboardingVersion < ONBOARDING_VERSION
+}
+
+export function markOnboardingComplete(flags: NavigationFlags): NavigationFlags {
+  return {
+    ...flags,
+    onboardingVersion: Math.max(flags.onboardingVersion, ONBOARDING_VERSION),
+  }
+}

--- a/apps/extension/src/i18n/locales/en/common.json
+++ b/apps/extension/src/i18n/locales/en/common.json
@@ -91,6 +91,23 @@
       }
     }
   },
+  "onboarding": {
+    "title": "Mining guide",
+    "progress": "{{current}} / {{total}}",
+    "next": "NEXT",
+    "finish": "START",
+    "skip": "SKIP",
+    "steps": {
+      "points": {
+        "title": "Mine points while you watch",
+        "body": "Stay on stream to earn CPC, then tap the miner for short click boosts."
+      },
+      "rewards": {
+        "title": "Claim coins and shop rewards",
+        "body": "Convert CPC into TCG, spend it in the coupon shop, and swap characters as the world grows."
+      }
+    }
+  },
   "raffle_result": {
     "title": "RAFFLE RESULTS",
     "loading": "LOADING...",

--- a/apps/extension/src/i18n/locales/zh-CN/common.json
+++ b/apps/extension/src/i18n/locales/zh-CN/common.json
@@ -91,6 +91,23 @@
       }
     }
   },
+  "onboarding": {
+    "title": "挖矿导览",
+    "progress": "{{current}} / {{total}}",
+    "next": "下一步",
+    "finish": "开始挖矿",
+    "skip": "略过",
+    "steps": {
+      "points": {
+        "title": "观看时累积点数",
+        "body": "停留在直播间可累积 CPC，也能点击矿工取得短时间加速。"
+      },
+      "rewards": {
+        "title": "提领平台币并兑换奖励",
+        "body": "把 CPC 转成 TCG，前往 Coupon 商城兑换福利，之后还能切换角色。"
+      }
+    }
+  },
   "raffle_result": {
     "title": "抽奖结果",
     "loading": "加载中...",

--- a/apps/extension/src/i18n/locales/zh-TW/common.json
+++ b/apps/extension/src/i18n/locales/zh-TW/common.json
@@ -91,6 +91,23 @@
       }
     }
   },
+  "onboarding": {
+    "title": "挖礦導覽",
+    "progress": "{{current}} / {{total}}",
+    "next": "下一步",
+    "finish": "開始挖礦",
+    "skip": "略過",
+    "steps": {
+      "points": {
+        "title": "觀看時累積點數",
+        "body": "停留在直播間可累積 CPC，也能點擊礦工取得短時間加速。"
+      },
+      "rewards": {
+        "title": "提領平台幣並兌換獎勵",
+        "body": "把 CPC 轉成 TCG，前往 Coupon 商城兌換福利，之後還能切換角色。"
+      }
+    }
+  },
   "raffle_result": {
     "title": "抽獎結果",
     "loading": "載入中...",


### PR DESCRIPTION
## 什麼改動
新增 extension mining/HUD 首次進入的新手導覽 overlay：兩步 coach mark、可略過/完成、完成後以 `flags.onboardingVersion` 持久化，不再自動顯示。

## 為什麼
refs #744

首次進入挖礦主頁時，需要簡短說明 CPC 點數、提領成 TCG、Coupon 商城與後續角色切換方向。既有 demo state 已有 `flags.onboardingVersion` 欄位，本 PR 將它接上實際 onboarding overlay。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#744
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 settings/account/menu overlay、不新增 backend API、不改角色系統、不改 manifest/content script。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #744；本輪 automation audit-first 後選定此低風險 frontend onboarding 切片。
- Actual worker profile(s)：
  - controller + ops_spark sidecar readback
- Model strength：
  - controller = gpt-5.5 xhigh；ops_spark sidecar = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `pnpm --dir apps/extension exec eslint src/app/App.tsx src/app/components/OnboardingOverlay.tsx src/app/onboarding.ts src/app/onboarding.test.ts` -> pass
  - `pnpm --dir apps/extension exec tsc -p tsconfig.app.json --noEmit` -> pass
  - `node --experimental-strip-types apps/extension/scripts/check-i18n.ts` -> pass
  - `rtk git --no-optional-locks diff --check` -> pass
  - `pnpm --dir apps/extension test -- src/app/onboarding.test.ts` -> blocked locally by existing `rolldown` native binding code-signature error before tests start
- Self-review / exception reason：
  - Controller implemented the narrow frontend slice after ops_spark readback; no high-risk backend/schema/auth/payment/wallet changes.
- Worker session closeout：
  - 已讀回 worker 結果；controller live GitHub readback 與 worker network readback 有差異，最終以 controller live GraphQL/gh readback 為準，worker 不需追加任務。
- Workflow friction / follow-up split：
  - 本 PR 僅完成 #744 onboarding overlay；review capacity 與 current-sprint PR closeout 另由 sprint ledger 追蹤。No threshold change.

## Review conversation closeout
- Unresolved threads：
  - 0；new PR
- CodeRabbit：
  - pending new PR review
- chatgpt-codex-connector：
  - pending new PR review
- review_triage_ref：
  - pending with reason: new PR has no review findings yet
- root_cause_gate_ref：
  - local evidence: first-run behavior derives from `screen === 'hud'` and `flags.onboardingVersion < 1`; close action updates stored flags
- finding_disposition_ref：
  - pending with reason: new PR has no review findings yet
- Final reviewer action：
  - pending CI / automated review / human review

## Final merge gate
- Ready-to-merge decision：
  - blocked pending CI and review
- Latest head SHA：
  - 00e59b9c
- Required checks：
  - pending after PR creation
- spec workflow-check evidence：
  - tool_gap: `spec` unavailable; manual AWP checklist used
- Evidence URL：
  - n/a before PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 mining 首次進入的新手導覽 overlay 並持久化完成版本。
- Approx changed lines：+309 / -0
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接覆蓋本 PR 的 onboarding 首次顯示與完成持久化行為。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `onboarding` overlay 實作（2 頁 coach mark）。
- [x] 首次進 `mining`/HUD 且 `onboardingVersion` 低於目前版本時自動顯示。
- [x] 可關閉、不強制；完成後保存 `onboardingVersion`，不再自動顯示。
- [x] i18n 文案已新增。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm --dir apps/extension exec eslint src/app/App.tsx src/app/components/OnboardingOverlay.tsx src/app/onboarding.ts src/app/onboarding.test.ts
pass

pnpm --dir apps/extension exec tsc -p tsconfig.app.json --noEmit
pass

node --experimental-strip-types apps/extension/scripts/check-i18n.ts
i18n check passed: 21 locale mappings, 78 keys

rtk git --no-optional-locks diff --check
pass

pnpm --dir apps/extension test -- src/app/onboarding.test.ts
blocked before tests start: rolldown native binding code-signature / optional binding error
```

## 備註
本機 Vitest 與 Vite dev server 皆被既有 `rolldown` native binding code-signature 問題擋住；本 PR 已補 onboarding state helper 測試，但需要 CI 或修復本機 binding 後執行。

## Notes for Claude Code Review
- 請特別確認 `flags.onboardingVersion` 的完成語義是否符合 #744；目前略過與完成都視為已看過版本 1，避免非強制導覽反覆跳出。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了入门指引流程，在用户首次访问时展示教程覆盖层，包含多步骤教学内容和进度显示。
  * 支持多语言（英文、简体中文、繁体中文），用户可选择跳过或完成指引。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->