### PR TITLE
[frontend] Add onboarding overlay interaction tests

### DIFF
--- a/apps/extension/src/app/components/OnboardingOverlay.test.ts
+++ b/apps/extension/src/app/components/OnboardingOverlay.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import assert from 'node:assert/strict'
+import React from 'react'
+import { afterEach, describe, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { OnboardingOverlay } from './OnboardingOverlay'
+
+const translations: Record<string, string> = {
+  'onboarding.title': 'Mining tour',
+  'onboarding.progress': '{{current}} / {{total}}',
+  'onboarding.next': 'Next',
+  'onboarding.finish': 'Start mining',
+  'onboarding.skip': 'Skip',
+  'onboarding.steps.points.title': 'Earn points while watching',
+  'onboarding.steps.points.body': 'Stay in the stream to earn CPC.',
+  'onboarding.steps.rewards.title': 'Claim rewards',
+  'onboarding.steps.rewards.body': 'Turn CPC into TCG and spend it.',
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, number>) => {
+      const template = translations[key] ?? key
+
+      if (!values) {
+        return template
+      }
+
+      return Object.entries(values).reduce(
+        (text, [name, value]) => text.replace(`{{${name}}}`, String(value)),
+        template,
+      )
+    },
+  }),
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('OnboardingOverlay', () => {
+  test('renders the first onboarding step as a modal dialog', () => {
+    render(React.createElement(OnboardingOverlay, { onComplete: () => undefined }))
+
+    const dialog = screen.getByRole('dialog', { name: 'Mining tour' })
+
+    assert.equal(dialog.getAttribute('aria-modal'), 'true')
+    screen.getByText('CPC')
+    screen.getByText('Earn points while watching')
+    screen.getByText('Stay in the stream to earn CPC.')
+    screen.getByText('1 / 2')
+    screen.getByRole('button', { name: 'Next' })
+    screen.getByRole('button', { name: 'Skip' })
+  })
+
+  test('advances to the final rewards step before completing', () => {
+    const onComplete = vi.fn()
+    render(React.createElement(OnboardingOverlay, { onComplete }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    screen.getByText('TCG')
+    screen.getByText('Claim rewards')
+    screen.getByText('Turn CPC into TCG and spend it.')
+    screen.getByText('2 / 2')
+    assert.equal(onComplete.mock.calls.length, 0)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start mining' }))
+
+    assert.equal(onComplete.mock.calls.length, 1)
+  })
+
+  test('skip completes onboarding from the first step', () => {
+    const onComplete = vi.fn()
+    render(React.createElement(OnboardingOverlay, { onComplete }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+
+    assert.equal(onComplete.mock.calls.length, 1)
+  })
+})


### PR DESCRIPTION
## 什麼改動
新增 `OnboardingOverlay` 的 jsdom 元件互動測試，覆蓋初始導覽步驟、下一步切換、完成與略過回呼。

## 為什麼
#809 已合併 onboarding overlay；CodeRabbit 後續指出 overlay 元件本身缺少互動測試。本 PR 是 #744 的窄範圍 follow-up，只補測試覆蓋，不改 runtime behavior。

refs #744

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#744 / #809 CodeRabbit follow-up
- Depends on PR：#809
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 onboarding runtime 行為、文案、樣式、storage、backend、manifest 或導航結構。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #744 original feature issue; this is a narrow test follow-up after #809 merged.
- Actual worker profile(s)：
  - controller + ops_spark readback worker
- Model strength：
  - controller = GPT-5.5 xhigh; ops_spark = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `pnpm --dir apps/extension exec eslint src/app/components/OnboardingOverlay.tsx src/app/components/OnboardingOverlay.test.ts` -> pass
  - `pnpm --dir apps/extension exec tsc -p tsconfig.app.json --noEmit` -> pass
  - `node --experimental-strip-types apps/extension/scripts/check-i18n.ts` -> pass
  - `rtk git --no-optional-locks diff --check` -> pass
- Self-review / exception reason：
  - Self-review completed; patch only adds a component interaction test and keeps app behavior unchanged.
- Worker session closeout：
  - Read back worker PR/issue capacity report; no worker-authored code was adopted.
- Workflow friction / follow-up split：
  - #745 was rejected this cycle because its issue assumes menu overlay prerequisites that are not present on current `develop`; this PR is a narrow current-sprint follow-up instead.

## Review conversation closeout
- Unresolved threads：
  - 0 on #809 at readback time; CodeRabbit summary had a non-blocking test coverage suggestion.
- CodeRabbit：
  - #809 latest review had no actionable inline threads; this follow-up adopts the component-test suggestion.
- chatgpt-codex-connector：
  - n/a for this PR at creation time.
- review_triage_ref：
  - #809 CodeRabbit summary comment, latest head `00e59b9c`.
- root_cause_gate_ref：
  - Component behavior was previously covered only by helper tests; overlay click flow lacked direct component coverage.
- finding_disposition_ref：
  - Adopted: added jsdom tests for modal rendering, step advance, final complete, and skip complete.
- Final reviewer action：
  - pending reviewer / bot review.

## Final merge gate
- Ready-to-merge decision：
  - pending CI / review
- Latest head SHA：
  - 88d8ffaa30d9292544bb5a63e540978379945bc2
- Required checks：
  - pending after PR creation
- spec workflow-check evidence：
  - unavailable locally (`spec: command not found`); manual checklist used.
- Evidence URL：
  - n/a at PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 補上 onboarding overlay 的元件互動測試。
- Approx changed lines：+82 / -0
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #809

## Acceptance Criteria
- [x] 初始 onboarding modal render 行為有測試覆蓋。
- [x] Next 到最後一步、Finish 呼叫 `onComplete` 有測試覆蓋。
- [x] Skip 立即呼叫 `onComplete` 有測試覆蓋。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm --dir apps/extension exec eslint src/app/components/OnboardingOverlay.tsx src/app/components/OnboardingOverlay.test.ts
pass

pnpm --dir apps/extension exec tsc -p tsconfig.app.json --noEmit
pass

node --experimental-strip-types apps/extension/scripts/check-i18n.ts
i18n check passed: 21 locale mappings, 78 keys

rtk git --no-optional-locks diff --check
pass

pnpm --dir apps/extension test -- src/app/components/OnboardingOverlay.test.ts
blocked locally by existing rolldown native binding code-signature failure before test execution.
```

## 備註
為了在乾淨 worktree 做靜態驗證，曾用本機既有 `node_modules` symlink 做臨時工具解析；symlink 已移除，未納入 git。

## Notes for Claude Code Review
- 請確認 follow-up test scope 是否足以回應 #809 的 overlay component coverage gap。
