### PR TITLE
[chore] Route root Dependabot npm updates to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,16 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - chore
+    allow:
+      - dependency-type: production
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
+      - dependency-type: development
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
+          - version-update:semver-major
 
   # Dependabot uses the "npm" ecosystem name for npm, yarn, and pnpm projects.
   - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,19 @@ updates:
 
   # Dependabot uses the "npm" ecosystem name for npm, yarn, and pnpm projects.
   - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      day: monday
+      time: "09:15"
+      timezone: Asia/Taipei
+    target-branch: develop
+    open-pull-requests-limit: 2
+    labels:
+      - chore
+
+  # Dependabot uses the "npm" ecosystem name for npm, yarn, and pnpm projects.
+  - package-ecosystem: npm
     directory: /apps/dashboard
     schedule:
       interval: monthly

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2289,6 +2289,7 @@ test('Dependabot pnpm version updates skip routine production patch releases', (
   const rootUpdate = pnpmUpdates.find((update) => update.directory === '/')
   const workspaceUpdates = pnpmUpdates.filter((update) => update.directory !== '/')
 
+  assert.ok(rootUpdate, 'expected Dependabot npm config to include root directory "/" update')
   assert.equal(rootUpdate['target-branch'], 'develop')
   assert.equal(workspaceUpdates.length, 2)
   for (const update of workspaceUpdates) {

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2286,9 +2286,12 @@ test('dependency review policy documents Dependabot split and waiver handling', 
 test('Dependabot pnpm version updates skip routine production patch releases', () => {
   const config = parseYaml(dependabotConfigPath)
   const pnpmUpdates = config.updates.filter((update) => update['package-ecosystem'] === 'npm')
+  const rootUpdate = pnpmUpdates.find((update) => update.directory === '/')
+  const workspaceUpdates = pnpmUpdates.filter((update) => update.directory !== '/')
 
-  assert.equal(pnpmUpdates.length, 2)
-  for (const update of pnpmUpdates) {
+  assert.equal(rootUpdate['target-branch'], 'develop')
+  assert.equal(workspaceUpdates.length, 2)
+  for (const update of workspaceUpdates) {
     assert.deepEqual(update.allow, [
       {
         'dependency-type': 'production',

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2287,29 +2287,29 @@ test('Dependabot pnpm version updates skip routine production patch releases', (
   const config = parseYaml(dependabotConfigPath)
   const pnpmUpdates = config.updates.filter((update) => update['package-ecosystem'] === 'npm')
   const rootUpdate = pnpmUpdates.find((update) => update.directory === '/')
-  const workspaceUpdates = pnpmUpdates.filter((update) => update.directory !== '/')
+  const expectedAllow = [
+    {
+      'dependency-type': 'production',
+      'update-types': [
+        'version-update:semver-minor',
+        'version-update:semver-major',
+      ],
+    },
+    {
+      'dependency-type': 'development',
+      'update-types': [
+        'version-update:semver-patch',
+        'version-update:semver-minor',
+        'version-update:semver-major',
+      ],
+    },
+  ]
 
   assert.ok(rootUpdate, 'expected Dependabot npm config to include root directory "/" update')
   assert.equal(rootUpdate['target-branch'], 'develop')
-  assert.equal(workspaceUpdates.length, 2)
-  for (const update of workspaceUpdates) {
-    assert.deepEqual(update.allow, [
-      {
-        'dependency-type': 'production',
-        'update-types': [
-          'version-update:semver-minor',
-          'version-update:semver-major',
-        ],
-      },
-      {
-        'dependency-type': 'development',
-        'update-types': [
-          'version-update:semver-patch',
-          'version-update:semver-minor',
-          'version-update:semver-major',
-        ],
-      },
-    ])
+  assert.equal(pnpmUpdates.length, 3)
+  for (const update of pnpmUpdates) {
+    assert.deepEqual(update.allow, expectedAllow)
   }
 })
 


### PR DESCRIPTION
## 什麼改動
新增根目錄 `/` 的 npm Dependabot entry，讓 root `pnpm-lock.yaml` 相關更新也明確以 `develop` 為目標分支。

## 為什麼
Root-level pnpm lockfile 更新沒有命中既有 `/apps/dashboard` 或 `/apps/extension` 的 npm entry 時，Dependabot 會回退到 repo default branch。這導致 #808 開到 `main`，而不是專案日常 PR 目標分支 `develop`。

refs #817

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#817
- Depends on PR：`none`
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不更新任何 dependency 版本。
  - 不修改 workspace package 設定。
  - 不直接處理或重開 #808。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #817 has no worker delegation plan; this remains a narrow Dependabot config and workflow-test fix.
- Actual worker profile(s)：
  - controller / ops_spark readback during closeout
- Model strength：
  - controller = medium; ops_spark = high readback
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `rtk git --no-optional-locks diff --cached --check` before initial commit
  - `rtk node --test .github/workflows/ci.test.mjs`
  - `rtk gh pr checks 818 --repo nurockplayer/tachigo --watch=false`
- Self-review / exception reason：
  - Initial implementation was a trivial/self-only single-surface tooling fix. Later closeout used ops_spark readback for GitHub/CI/review state.
- Worker session closeout：
  - ops_spark readback was consumed by controller; no additional worker action is needed for #818.
- Workflow friction / follow-up split：
  - CodeRabbit quota/rate-limit was observed on the latest comment, but required CI and the CodeRabbit status context are green. No follow-up split is needed.

## Review conversation closeout
- Unresolved threads：
  - 0 actionable review threads observed for latest head `d95879b082e15056c6f32e0e1f0aee828ff07fb2`.
- CodeRabbit：
  - Nit from prior head was adopted by adding an explicit `rootUpdate` existence assertion in `.github/workflows/ci.test.mjs`; latest CodeRabbit status context is SUCCESS. The latest summary also reported free-tier rate limiting, so no extra review was requested.
- chatgpt-codex-connector：
  - n/a; no actionable connector finding observed on this PR.
- review_triage_ref：
  - CodeRabbit nit adopted in commit `d95879b082e15056c6f32e0e1f0aee828ff07fb2`; see CodeRabbit review and latest PR checks on #818.
- root_cause_gate_ref：
  - latest-head rationale: single assertion clarity nit, no repeated parser/state-model finding.
- finding_disposition_ref：
  - adopted: `rootUpdate` existence assertion added; verification `node --test .github/workflows/ci.test.mjs` passed 93/93.
- Final reviewer action：
  - all automated findings addressed or non-actionable; human approval by Erick52106 is present on latest head.

## Final merge gate
- Ready-to-merge decision：
  - ready after normal maintainer merge policy; automation will not self-merge.
- Latest head SHA：
  - d95879b082e15056c6f32e0e1f0aee828ff07fb2
- Required checks：
  - GitHub readback: PR Scope Police, workflow regression tests, supply-chain guardrails, commit/metadata checks, Backend CI gate, Auto-ready, Cloudflare Pages, and CodeRabbit status are SUCCESS; product-heavy checks are expected skipped for this tooling-only PR.
- spec workflow-check evidence：
  - n/a; manual autonomous checklist fallback.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/818

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 root npm/pnpm Dependabot 更新固定開到 `develop`。
- Approx changed lines：~21
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Dependabot config change and its workflow regression assertion are one CI/tooling behavior change.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Root npm/pnpm Dependabot updates target `develop`.
- [x] Existing `/apps/dashboard`, `/apps/extension`, and `/services/api` entries continue to target `develop`.
- [x] No dependency versions or lockfiles are changed.
- [x] Workflow regression test expectation covers the new root npm entry.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk node --test .github/workflows/ci.test.mjs
# tests 93
# pass 93
# fail 0

rtk gh pr checks 818 --repo nurockplayer/tachigo --watch=false
# Required/meaningful checks pass; product-heavy checks are expected skipped for tooling-only PR.
```

## 備註
Ruby 檢查會因本機 PATH 內 `/Users/tachikoma/.local` 權限吐 warning，但 YAML 檢查本身 exit code 為 0。

## Notes for Claude Code Review
- 請確認新增 root `/` npm entry 的 schedule 時間 `09:15` 不會與 dashboard `09:30`、extension `10:00` 互相踩到。
- 本 PR 不處理已開到 `main` 的 #808，只修正後續 Dependabot routing。
