### PR TITLE
[backend] Propagate TACHI balance request context

### DIFF
--- a/services/api/internal/handlers/claim_handler.go
+++ b/services/api/internal/handlers/claim_handler.go
@@ -100,7 +100,7 @@ func (h *ClaimHandler) GetTachiBalance(c *gin.Context) {
 		return
 	}
 
-	balance, err := h.claimSvc.GetTachiBalance(userID)
+	balance, err := h.claimSvc.GetTachiBalanceContext(c.Request.Context(), userID)
 	if err != nil {
 		internal(c)
 		return

--- a/services/api/internal/handlers/claim_handler_test.go
+++ b/services/api/internal/handlers/claim_handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/config"
 	"github.com/tachigo/tachigo/internal/handlers"
@@ -68,6 +69,36 @@ func seedLedgerForHandler(t *testing.T, env *testEnv, userID uuid.UUID, channelI
 	}
 }
 
+type claimHandlerContextKey struct{}
+
+func installClaimHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:claim_handler_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", probe); err != nil {
+		t.Fatalf("register raw context probe: %v", err)
+	}
+	if err := db.Callback().Row().Before("gorm:row").Register(name+":row", probe); err != nil {
+		t.Fatalf("register row context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Raw().Remove(name + ":raw")
+		_ = db.Callback().Row().Remove(name + ":row")
+	})
+
+	return func() int {
+		return seen
+	}
+}
+
 // resolveUserID resolves a userID from email, failing the test if not found or unparseable.
 func resolveUserID(t *testing.T, env *testEnv, email string) uuid.UUID {
 	t.Helper()
@@ -83,6 +114,26 @@ func resolveUserID(t *testing.T, env *testEnv, email string) uuid.UUID {
 		t.Fatalf("resolveUserID: parse error: %v", err)
 	}
 	return userID
+}
+
+func TestClaimHandler_GetTachiBalance_UsesRequestContext(t *testing.T) {
+	env, r := newClaimTestEnv(t)
+	token, _ := env.registerUser(t, "user_context", "user_context@example.com", "password123")
+	key := claimHandlerContextKey{}
+	seen := installClaimHandlerDBContextProbe(t, env.db, key, "tachi-balance")
+	ctx := context.WithValue(context.Background(), key, "tachi-balance")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/users/me/tachi/balance", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetTachiBalance handler to pass request context to GORM")
+	}
 }
 
 func TestClaimHandler_GetTachiBalance_Empty(t *testing.T) {

--- a/services/api/internal/services/claim_service.go
+++ b/services/api/internal/services/claim_service.go
@@ -118,7 +118,13 @@ func (s *ClaimService) SetMintCallerForTest(mc MintCaller) { s.mintCaller = mc }
 // GetTachiBalance returns the user's current $TACHI balance.
 // Returns 0 if no balance record exists yet.
 func (s *ClaimService) GetTachiBalance(userID uuid.UUID) (int64, error) {
-	balance, err := loadTachiBalanceValue(s.db, userID)
+	return s.GetTachiBalanceContext(context.Background(), userID)
+}
+
+// GetTachiBalanceContext returns the user's current $TACHI balance using ctx
+// for request cancellation.
+func (s *ClaimService) GetTachiBalanceContext(ctx context.Context, userID uuid.UUID) (int64, error) {
+	balance, err := loadTachiBalanceValue(ctx, s.db, userID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return 0, nil
@@ -555,7 +561,7 @@ func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, 
 		}
 
 		if existing.Status == models.ClaimStatusConfirmed {
-			balance, err := loadTachiBalanceValue(tx, reservation.userID)
+			balance, err := loadTachiBalanceValue(gormStatementContext(tx), tx, reservation.userID)
 			if err != nil {
 				return 0, fmt.Errorf("finalizeClaim: confirmed claim missing tachi balance: %w", err)
 			}
@@ -581,7 +587,7 @@ func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, 
 		return 0, err
 	}
 
-	balance, err := loadTachiBalanceValue(tx, reservation.userID)
+	balance, err := loadTachiBalanceValue(gormStatementContext(tx), tx, reservation.userID)
 	if err != nil {
 		return 0, err
 	}
@@ -589,9 +595,12 @@ func (s *ClaimService) finalizeClaim(tx *gorm.DB, reservation claimReservation, 
 	return balance, nil
 }
 
-func loadTachiBalanceValue(db *gorm.DB, userID uuid.UUID) (int64, error) {
+func loadTachiBalanceValue(ctx context.Context, db *gorm.DB, userID uuid.UUID) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var balance int64
-	err := db.Raw(
+	err := db.WithContext(ctx).Raw(
 		// Claim and spend flows currently store whole-token int64 balances.
 		"SELECT CAST(balance AS BIGINT) FROM tachi_balances WHERE user_id = ?",
 		userID,
@@ -603,6 +612,13 @@ func loadTachiBalanceValue(db *gorm.DB, userID uuid.UUID) (int64, error) {
 		return 0, err
 	}
 	return balance, nil
+}
+
+func gormStatementContext(db *gorm.DB) context.Context {
+	if db != nil && db.Statement != nil && db.Statement.Context != nil {
+		return db.Statement.Context
+	}
+	return context.Background()
 }
 
 func (s *ClaimService) resolveWalletAddress(db *gorm.DB, userID uuid.UUID) (string, error) {

--- a/services/api/internal/services/claim_service_test.go
+++ b/services/api/internal/services/claim_service_test.go
@@ -36,6 +36,8 @@ type mintCall struct {
 	amount int64
 }
 
+type claimContextKey string
+
 func (m *mockMintCaller) MintBroadcastOnChain(_ context.Context, toAddr string, amount int64) (string, error) {
 	m.broadcastCalls = append(m.broadcastCalls, mintCall{toAddr: toAddr, amount: amount})
 	if m.broadcastErr != nil {
@@ -171,6 +173,22 @@ func TestGetTachiBalance_Zero(t *testing.T) {
 	}
 	if bal != 0 {
 		t.Fatalf("expected 0, got %d", bal)
+	}
+}
+
+func TestGetTachiBalanceContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := &ClaimService{db: db}
+	userID := userIDForClaim(t, db)
+	key := claimContextKey("tachi-balance-context")
+	seen := installDBContextProbe(t, db, key, "tachi-balance")
+
+	_, err := svc.GetTachiBalanceContext(context.WithValue(context.Background(), key, "tachi-balance"), userID)
+	if err != nil {
+		t.Fatalf("get tachi balance with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetTachiBalanceContext DB operations to carry request context")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
讓 `GET /api/v1/users/me/tachi/balance` 的 request context 傳到 `ClaimService` 與底層 GORM raw/row query。

## 為什麼
#645 追蹤 request timeout cancellation 後，service / repository 層 DB work 仍需接上 request context。這張 PR 只處理 TACHI balance read endpoint 的 bounded slice，使用 `refs #645`，不關閉 #645。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做完整 #645 DB audit
  - 不做 claim transaction path 的 context propagation
  - 不做 spend / raffle / Extension JWT / router / swagger / schema / migration 變更

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 bounded slice from request-timeout DB context propagation audit.
- Actual worker profile(s)：
  - repo_scout/explorer for read-only surface scan; controller for TDD implementation and final gate.
- Model strength：
  - repo_scout = medium; controller = high.
- Spawn directive(s)：
  - profile=repo_scout model=inherited-explorer reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=controller model=gpt-5.5 reasoning=high controller_fallback=allowed fallback_reason=small bounded backend read-path patch after repo_scout; controller kept TDD implementation to avoid cross-worker write coordination; evidence=workflow-check:start:issue-645
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-645
- controller_fallback: allowed
- controller_fallback_reason: small bounded backend read-path patch after repo_scout; controller kept TDD implementation to avoid cross-worker write coordination; evidence=workflow-check:start:issue-645
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - RED: focused tests failed before implementation with missing `GetTachiBalanceContext` and handler context probe failure.
  - GREEN: focused tests passed after implementation.
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers ./internal/router`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
  - `git diff --check`
- Self-review / exception reason：
  - Self-review completed; kept existing `GetTachiBalance(userID)` wrapper for compatibility and only added context-aware request path.
- Worker session closeout：
  - Explorer result read back; worker session closed after no additional task was needed.
- Workflow friction / follow-up split：
  - Full #645 audit remains split across bounded PRs. #664 threshold ledger entry will be added only after this PR is merged.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: initial PR creation, no review threads yet.
- CodeRabbit：
  - pending with reason: initial PR creation.
- chatgpt-codex-connector：
  - pending with reason: initial PR creation.
- review_triage_ref：
  - pending with reason: no review findings yet.
- root_cause_gate_ref：
  - pending with reason: no repeated finding or root-cause escalation yet.
- finding_disposition_ref：
  - workflow-check:start:issue-645
- Final reviewer action：
  - pending with reason: initial PR creation.

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: waiting for GitHub checks and human review.
- Latest head SHA：
  - b2c0f09
- Required checks：
  - pending with reason: GitHub checks start after PR creation.
- spec workflow-check evidence：
  - spec_evidence_status: pass
  - workflow-check_ref: workflow-check:start:issue-645
  - commit gate pass at local head b2c0f09
- threshold_evidence_status: pass
- threshold_ledger_ref: https://github.com/nurockplayer/tachigo/issues/664
- finding_disposition_status: pass
- Evidence URL：
  - n/a before PR creation.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context for the TACHI balance read endpoint.
- Approx changed lines：~97
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler must pass `c.Request.Context()` to the service, and the service must apply it to the DB query for the same endpoint-level behavior.
- 若已拆分，相關 PR：
  - #806 covered points read endpoints; this PR covers only TACHI balance read endpoint.

## Acceptance Criteria
- [x] Bounded slice audit: `GET /api/v1/users/me/tachi/balance` no longer drops request context.
- [x] Service-layer DB read uses `WithContext(ctx)` for the TACHI balance raw/row query.
- [x] Regression tests cover service and handler context propagation.
- [ ] Full #645 audit remains open for other DB query / transaction paths.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestGetTachiBalanceContext_UsesRequestContext|TestClaimHandler_GetTachiBalance_UsesRequestContext'
# github.com/tachigo/tachigo/internal/services [github.com/tachigo/tachigo/internal/services.test]
internal/services/claim_service_test.go:186:16: svc.GetTachiBalanceContext undefined
--- FAIL: TestClaimHandler_GetTachiBalance_UsesRequestContext
    expected GetTachiBalance handler to pass request context to GORM

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestGetTachiBalanceContext_UsesRequestContext|TestClaimHandler_GetTachiBalance_UsesRequestContext'
ok  	github.com/tachigo/tachigo/internal/services	0.348s
ok  	github.com/tachigo/tachigo/internal/handlers	0.507s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers ./internal/router
ok  	github.com/tachigo/tachigo/internal/services	2.704s
ok  	github.com/tachigo/tachigo/internal/handlers	16.363s
ok  	github.com/tachigo/tachigo/internal/router	0.760s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/cmd/loader	1.119s
ok  	github.com/tachigo/tachigo/cmd/server	0.369s
ok  	github.com/tachigo/tachigo/docs	1.360s
ok  	github.com/tachigo/tachigo/internal/config	0.801s
ok  	github.com/tachigo/tachigo/internal/contract	1.820s
ok  	github.com/tachigo/tachigo/internal/handlers	(cached)
ok  	github.com/tachigo/tachigo/internal/middleware	1.585s
ok  	github.com/tachigo/tachigo/internal/models	0.577s
ok  	github.com/tachigo/tachigo/internal/router	(cached)
ok  	github.com/tachigo/tachigo/internal/services	(cached)

git diff --check
pass
```

## 備註
No swagger docs were regenerated because this PR does not change route registration or swagger annotations.

## Notes for Claude Code Review
- Please verify this stays a narrow #645 slice: TACHI balance read endpoint only, with no claim transaction-path or broader DB audit changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 改进了余额查询的内部请求上下文处理，以增强请求生命周期管理。

* **Tests**
  * 新增测试用例验证上下文在余额查询流程中的正确传递。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->