### PR TITLE
[backend] Propagate internal points request context

### DIFF
--- a/services/api/internal/handlers/internal_points_handler.go
+++ b/services/api/internal/handlers/internal_points_handler.go
@@ -25,8 +25,10 @@ func (h *InternalPointsHandler) GetUserPointsBalance(c *gin.Context) {
 		return
 	}
 
+	db := h.db.WithContext(c.Request.Context())
+
 	var user models.User
-	if err := h.db.Where("LOWER(email) = ?", email).First(&user).Error; err != nil {
+	if err := db.Where("LOWER(email) = ?", email).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			notFound(c, "user not found")
 			return
@@ -39,7 +41,7 @@ func (h *InternalPointsHandler) GetUserPointsBalance(c *gin.Context) {
 		SpendableBalance int64 `gorm:"column:spendable_balance"`
 		CumulativeTotal  int64 `gorm:"column:cumulative_total"`
 	}
-	if err := h.db.Raw(`
+	if err := db.Raw(`
 		SELECT
 			COALESCE(SUM(spendable_balance), 0) AS spendable_balance,
 			COALESCE(SUM(cumulative_total), 0) AS cumulative_total

--- a/services/api/internal/handlers/internal_points_handler_test.go
+++ b/services/api/internal/handlers/internal_points_handler_test.go
@@ -1,15 +1,48 @@
 package handlers_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/handlers"
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+type internalPointsContextKey struct{}
+
+func installInternalPointsDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:internal_points_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", probe); err != nil {
+		t.Fatalf("register raw context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name + ":query")
+		_ = db.Callback().Raw().Remove(name + ":raw")
+	})
+
+	return func() int {
+		return seen
+	}
+}
 
 func TestInternalPointsHandler_NormalizesEmailQueryAndReturnsCanonicalEmail(t *testing.T) {
 	env := newTestEnv(t)
@@ -62,6 +95,41 @@ func TestInternalPointsHandler_NormalizesEmailQueryAndReturnsCanonicalEmail(t *t
 	}
 	if data["cumulative_total"] != float64(120) {
 		t.Fatalf("want cumulative_total 120, got %v", data["cumulative_total"])
+	}
+}
+
+func TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	key := internalPointsContextKey{}
+	seen := installInternalPointsDBContextProbe(t, env.db, key, "internal-points")
+	ctx := context.WithValue(context.Background(), key, "internal-points")
+
+	canonicalEmail := "context@example.com"
+	user := &models.User{
+		Username: stringPtr("context_viewer"),
+		Email:    &canonicalEmail,
+	}
+	if err := env.db.Create(user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	r := gin.New()
+	r.GET("/api/v1/internal/tachiya/users/points/balance", handlers.NewInternalPointsHandler(env.db).GetUserPointsBalance)
+
+	req := httptest.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"/api/v1/internal/tachiya/users/points/balance?email=context@example.com",
+		nil,
+	)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected internal points handler DB operations to carry request context")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
讓 internal Tachiya points balance endpoint 的 user lookup 與 points ledger aggregate query 使用 request context。

## 為什麼
#645 追蹤 request timeout cancellation 後，service / repository 層 DB work 仍需接上 request context。這張 PR 只處理 internal points balance read endpoint 的 bounded slice，使用 `refs #645`，不關閉 #645。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做完整 #645 DB audit
  - 不做 user profile/provider context propagation
  - 不做 Extension JWT / raffle / router / swagger / schema / migration 變更

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 bounded slice from request-timeout DB context propagation audit.
- Actual worker profile(s)：
  - repo_scout/explorer for read-only candidate comparison; controller for tiny TDD implementation and final gate.
- Model strength：
  - repo_scout = medium; controller = high.
- Spawn directive(s)：
  - profile=repo_scout model=inherited-explorer reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=controller model=gpt-5.5 reasoning=high controller_fallback=allowed fallback_reason=tiny single-handler backend read-path patch after repo_scout; controller kept TDD implementation to avoid cross-worker write coordination; evidence=workflow-check:start:issue-645
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-645
- controller_fallback: allowed
- controller_fallback_reason: tiny single-handler backend read-path patch after repo_scout; controller kept TDD implementation to avoid cross-worker write coordination; evidence=workflow-check:start:issue-645
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - RED: focused handler context propagation test failed before implementation.
  - GREEN: focused handler test passed after implementation.
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/router`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
  - `git diff --check`
- Self-review / exception reason：
  - Self-review completed; change is limited to one handler DB handle and a regression probe test.
- Worker session closeout：
  - Explorer result read back; worker session closed after no additional task was needed.
- Workflow friction / follow-up split：
  - Full #645 audit remains split across bounded PRs. #664 threshold ledger entry will be added only after this PR is merged.

## Review conversation closeout
- Unresolved threads：
  - pending with reason: initial PR creation, no review threads yet.
- CodeRabbit：
  - pending with reason: initial PR creation.
- chatgpt-codex-connector：
  - pending with reason: initial PR creation.
- review_triage_ref：
  - pending with reason: no review findings yet.
- root_cause_gate_ref：
  - pending with reason: no repeated finding or root-cause escalation yet.
- finding_disposition_ref：
  - workflow-check:start:issue-645
- Final reviewer action：
  - pending with reason: initial PR creation.

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: waiting for GitHub checks and human review.
- Latest head SHA：
  - 3bdc2c5
- Required checks：
  - pending with reason: GitHub checks start after PR creation.
- spec workflow-check evidence：
  - spec_evidence_status: pass
  - workflow-check_ref: workflow-check:start:issue-645
  - commit gate pass at local head 3bdc2c5
- threshold_evidence_status: pass
- threshold_ledger_ref: https://github.com/nurockplayer/tachigo/issues/664
- finding_disposition_status: pass
- Evidence URL：
  - n/a before PR creation.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context for the internal Tachiya points balance read endpoint.
- Approx changed lines：~74
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The handler owns the direct DB reads, so the regression test and `WithContext` patch must live together.
- 若已拆分，相關 PR：
  - #806 covered points read endpoints; #821 covered TACHI balance read endpoint; this PR covers only internal Tachiya points balance.

## Acceptance Criteria
- [x] Bounded slice audit: internal Tachiya points balance endpoint no longer drops request context.
- [x] GORM user lookup and points ledger aggregate use `WithContext(ctx)`.
- [x] Regression test covers handler request context propagation.
- [ ] Full #645 audit remains open for other DB query / transaction paths.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext'
--- FAIL: TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext
    expected internal points handler DB operations to carry request context

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext|TestInternalPointsHandler_NormalizesEmailQueryAndReturnsCanonicalEmail'
ok  	github.com/tachigo/tachigo/internal/handlers	0.296s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/router
ok  	github.com/tachigo/tachigo/internal/handlers	18.797s
ok  	github.com/tachigo/tachigo/internal/router	1.146s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/cmd/loader	0.576s
ok  	github.com/tachigo/tachigo/cmd/server	2.164s
ok  	github.com/tachigo/tachigo/docs	1.850s
ok  	github.com/tachigo/tachigo/internal/config	0.249s
ok  	github.com/tachigo/tachigo/internal/contract	1.192s
ok  	github.com/tachigo/tachigo/internal/handlers	(cached)
ok  	github.com/tachigo/tachigo/internal/middleware	2.384s
ok  	github.com/tachigo/tachigo/internal/models	1.587s
ok  	github.com/tachigo/tachigo/internal/router	(cached)
ok  	github.com/tachigo/tachigo/internal/services	5.084s

git diff --check
pass
```

## 備註
No swagger docs were regenerated because this PR does not change route registration or swagger annotations.

## Notes for Claude Code Review
- Please verify this stays a narrow #645 slice: internal Tachiya points balance endpoint only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * 新增测试用例，确保数据库操作正确传播请求上下文信息，提升系统可靠性和可追踪性。

* **Refactor**
  * 优化了用户积分查询的内部处理流程，增强请求上下文集成。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->