### PR TITLE
[backend] Propagate airdrop request context

### DIFF
--- a/services/api/internal/handlers/airdrop_handler.go
+++ b/services/api/internal/handlers/airdrop_handler.go
@@ -58,7 +58,7 @@ func (h *AirdropHandler) Airdrop(c *gin.Context) {
 		return
 	}
 
-	result, err := h.airdropSvc.Execute(services.AirdropRequest{
+	result, err := h.airdropSvc.ExecuteContext(c.Request.Context(), services.AirdropRequest{
 		ChannelID: channelID,
 		Amount:    body.Amount,
 		Note:      body.Note,

--- a/services/api/internal/services/airdrop_service.go
+++ b/services/api/internal/services/airdrop_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"sort"
@@ -75,6 +76,13 @@ func (s *AirdropService) TodayTotal(channelID string) (int64, error) {
 }
 
 func (s *AirdropService) Execute(req AirdropRequest) (*AirdropResult, error) {
+	return s.ExecuteContext(context.Background(), req)
+}
+
+func (s *AirdropService) ExecuteContext(ctx context.Context, req AirdropRequest) (*AirdropResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if req.Amount <= 0 {
 		return nil, ErrInvalidPointsAmount
 	}
@@ -94,7 +102,7 @@ func (s *AirdropService) Execute(req AirdropRequest) (*AirdropResult, error) {
 		airdropAt := time.Now().UTC()
 		var result *AirdropResult
 
-		lastErr = s.db.Transaction(func(tx *gorm.DB) error {
+		lastErr = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			// Snapshot viewers inside the transaction so each retry reflects
 			// the current session state at commit time.
 			viewers, err := s.activeViewersInTx(tx, req.ChannelID)

--- a/services/api/internal/services/airdrop_service_test.go
+++ b/services/api/internal/services/airdrop_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"math"
 	"sync"
@@ -38,6 +39,67 @@ func seedAirdropViewer(t *testing.T, db *gorm.DB, channelID string, accumulatedS
 	}
 
 	return userID
+}
+
+func installAirdropDBContextProbe(t *testing.T, db *gorm.DB, key, expected any) func() int {
+	t.Helper()
+
+	var mu sync.Mutex
+	seen := 0
+	record := func(tx *gorm.DB) {
+		if tx.Statement.Context.Value(key) != expected {
+			return
+		}
+		mu.Lock()
+		seen++
+		mu.Unlock()
+	}
+
+	queryName := "test:airdrop_context_probe_query"
+	rawName := "test:airdrop_context_probe_raw"
+	if err := db.Callback().Query().Before("gorm:query").Register(queryName, record); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+	if err := db.Callback().Raw().Before("gorm:raw").Register(rawName, record); err != nil {
+		t.Fatalf("register raw context probe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(queryName)
+		_ = db.Callback().Raw().Remove(rawName)
+	})
+
+	return func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return seen
+	}
+}
+
+func TestAirdrop_ExecuteContextUsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	watchSvc := NewWatchService(db)
+	pointsSvc := NewPointsService(db, watchSvc)
+	configSvc := NewChannelConfigService(db)
+	svc := NewAirdropService(db, pointsSvc, configSvc)
+
+	channelID := "ch_context"
+	seedAirdropViewer(t, db, channelID, 60)
+
+	type contextKey string
+	key := contextKey("airdrop-context-probe")
+	ctx := context.WithValue(context.Background(), key, "request-context")
+	seen := installAirdropDBContextProbe(t, db, key, "request-context")
+
+	_, err := svc.ExecuteContext(ctx, AirdropRequest{
+		ChannelID: channelID,
+		Amount:    100,
+	})
+	if err != nil {
+		t.Fatalf("execute context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected airdrop DB operations to use request context")
+	}
 }
 
 func TestAirdrop_NoActiveSessions(t *testing.T) {


### PR DESCRIPTION
## 什麼改動

讓 dashboard airdrop request 的實際 DB transaction 使用 request context：

- `AirdropHandler.Airdrop` 改呼叫 `ExecuteContext(c.Request.Context(), ...)`
- `AirdropService` 新增 `ExecuteContext(ctx, req)`，既有 `Execute(req)` 保留為 `context.Background()` wrapper
- 新增 regression test，用 GORM callback 驗證 airdrop DB query/raw callback 能看到 request context marker

## 為什麼

refs #645

#645 要逐步 audit `services/api` 的 DB query / transaction context propagation。這片只處理 dashboard airdrop execution path：authorization 早已使用 request context，但授權通過後的 `s.db.Transaction(...)` 仍未接 request context。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不 audit 全部 `services/api`
  - 不修改 timeout policy values
  - 不新增 queue / worker / background job framework
  - 不改 schema / migration / auth permission policy
  - 不處理 #823 的 internal points handler path

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：
  - #645
- Actual worker profile(s)：
  - AWP scout / repo_scout for next-slice selection; controller direct implementation fallback
- Model strength：
  - controller = medium; scout = medium
- Spawn directive(s)：
  - profile=repo_scout model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=AWP scout selected a single low-risk airdrop transaction path and the controller implemented the small TDD patch directly with focused verification.
  - controller_fallback: allowed
  - controller_fallback_reason: AWP scout selected a single low-risk airdrop transaction path and the controller implemented the small TDD patch directly with focused verification.
- Verification evidence：
  - spec workflow-check status: pass
  - spec gate evidence ref: workflow-check:start:issue-645
  - routing_evidence_status: pass
  - routing_evidence_ref: workflow-check:start:issue-645
  - finding_disposition_status: pass
  - threshold_evidence_status: pass
  - threshold_ledger_ref: workflow-check:start:issue-645
  - `/tmp/tachigo-645-airdrop-routing.json`
  - `/tmp/tachigo-645-airdrop-threshold.json`
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
- Self-review / exception reason：
  - Self-reviewed small diff; no self-authored PR review/approval will be submitted
- Worker session closeout：
  - Scout result read; no further worker task needed for this tiny slice
- Workflow friction / follow-up split：
  - #664 dogfood datapoint will be posted only after this PR is merged

## Review conversation closeout

- Unresolved threads：
  - 0 before PR creation
- CodeRabbit：
  - pending GitHub review on PR
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - `/tmp/tachigo-645-airdrop-routing.json`
- root_cause_gate_ref：
  - #645
- finding_disposition_ref：
  - finding_disposition_ref: workflow-check:start:issue-645
- Final reviewer action：
  - pending reviewer

## Final merge gate

- Ready-to-merge decision：
  - pending GitHub checks and reviewer
- Latest head SHA：
  - 72b0f31c8412e1dd2c3f88d7f425ab80ec5162de
- Required checks：
  - pending GitHub checks
- spec workflow-check evidence：
  - start gate passed; commit gate passed (`workflow-check:start:issue-645`)
- Evidence URL：
  - n/a before PR creation

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - Propagate request context into the airdrop execution DB transaction.
- Approx changed lines：~74
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler must pass the request context into the service method, and the service test proves the DB transaction observes that context.
- 若已拆分，相關 PR：
  - #821, #823 are separate #645 slices

## Acceptance Criteria

- [ ] Audit all DB queries and transactions under `services/api`
- [x] All service-layer DB access paths propagate request context — covered for airdrop execution path only
- [x] All GORM / sql queries use `WithContext(ctx)` or equivalent — covered for airdrop execution transaction only
- [x] Transaction helpers preserve context — covered for airdrop `ExecuteContext`
- [x] Add regression tests for canceled request context — regression probe verifies request context reaches DB operations
- [ ] Add at least one integration test proving timeout cancels DB work
- [ ] Document any intentionally detached async job paths

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**

```text
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestAirdrop_ExecuteContextUsesRequestContext
FAIL: svc.ExecuteContext undefined

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestAirdrop_ExecuteContextUsesRequestContext|TestAirdrop_ProportionalDistribution|TestAirdrop_DailyLimitExceeded'
ok github.com/tachigo/tachigo/internal/services 0.677s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers
ok github.com/tachigo/tachigo/internal/services 2.445s
ok github.com/tachigo/tachigo/internal/handlers 15.929s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok ./...
```

## 備註

#645 remains open for the remaining audit/integration-test work.

## Notes for Claude Code Review

- Please check that `Execute(req)` remaining as a background-context wrapper is acceptable for non-request callers.
- The request-bound dashboard path now uses `ExecuteContext(c.Request.Context(), ...)`.
