### PR TITLE
[backend] Tighten internal points context probe

### DIFF
--- a/services/api/internal/handlers/internal_points_handler_test.go
+++ b/services/api/internal/handlers/internal_points_handler_test.go
@@ -16,21 +16,27 @@ import (
 
 type internalPointsContextKey struct{}
 
-func installInternalPointsDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+func installInternalPointsDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() (int, int) {
 	t.Helper()
 
-	var seen int
+	var querySeen int
+	var rawSeen int
 	name := "test:internal_points_db_context:" + uuid.NewString()
-	probe := func(tx *gorm.DB) {
+	queryProbe := func(tx *gorm.DB) {
 		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
-			seen++
+			querySeen++
+		}
+	}
+	rawProbe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			rawSeen++
 		}
 	}
 
-	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", queryProbe); err != nil {
 		t.Fatalf("register query context probe: %v", err)
 	}
-	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", probe); err != nil {
+	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", rawProbe); err != nil {
 		t.Fatalf("register raw context probe: %v", err)
 	}
 
@@ -39,8 +45,8 @@ func installInternalPointsDBContextProbe(t *testing.T, db *gorm.DB, key, want an
 		_ = db.Callback().Raw().Remove(name + ":raw")
 	})
 
-	return func() int {
-		return seen
+	return func() (int, int) {
+		return querySeen, rawSeen
 	}
 }
 
@@ -128,8 +134,9 @@ func TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext(t *testin
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if seen() == 0 {
-		t.Fatal("expected internal points handler DB operations to carry request context")
+	querySeen, rawSeen := seen()
+	if querySeen == 0 || rawSeen == 0 {
+		t.Fatalf("expected internal points handler query and raw DB operations to carry request context, got query=%d raw=%d", querySeen, rawSeen)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
收緊 #823 後續的 internal points request context regression test：GORM probe 現在分別統計 `Query` 與 `Raw` callback 命中次數，測試會同時要求 user lookup 與 ledger aggregate query 都帶到 request context。

## 為什麼
closes none；refs #645。

#823 已在 CodeRabbit nit 處理前 merge。本 PR 是 #823 的 narrow follow-up，只處理該 bot finding 的測試顆粒度，不改 runtime behavior。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645；follow-up to #823 CodeRabbit nit
- Depends on PR：#823
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 handler runtime behavior
  - 不做完整 #645 DB audit
  - 不碰 router / swagger / schema / auth / wallet / payments

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 bounded context propagation audit；#823 merged before bot nit follow-up was applied.
- Actual worker profile(s)：
  - ops_spark sidecar for PR/review capacity readback; controller for final review-comment disposition and tiny test-only patch.
- Model strength：
  - ops_spark = gpt-5.3-codex-spark high；controller = gpt-5.5 xhigh.
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a
  - profile=controller model=gpt-5.5 reasoning=xhigh controller_fallback=allowed fallback_reason=review_or_merge_decision: #823 merged before follow-up patch landed; impact=narrow follow-up PR decision; evidence=#823 mergedAt 2026-05-20T07:03:27Z
- Verification evidence：
  - `git diff --check origin/develop..HEAD` pass
  - focused Go test attempted but blocked by sandbox DNS/module download (`proxy.golang.org: no such host`)
- Self-review / exception reason：
  - Self-review completed; patch is a single test helper/assertion refinement matching the CodeRabbit finding.
- Worker session closeout：
  - ops_spark result read back in thread; no additional sidecar action needed.
- Workflow friction / follow-up split：
  - Follow-up split used because #823 merged before the nit fix could be included. No new feature work is included.

## Review conversation closeout
- Unresolved threads：
  - #823 CodeRabbit nit addressed by this follow-up because the original PR is already merged; no human review thread resolved.
- CodeRabbit：
  - #823 finding adopted in this follow-up PR.
- chatgpt-codex-connector：
  - n/a for this follow-up before review.
- review_triage_ref：
  - #823 CodeRabbit review comment on `internal_points_handler_test.go`
- root_cause_gate_ref：
  - n/a; first occurrence, test-only granularity issue.
- finding_disposition_ref：
  - adopted: split query/raw context probe counts in `internal_points_handler_test.go`
- Final reviewer action：
  - pending with reason: waiting for GitHub checks and review.

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: waiting for GitHub checks and review.
- Latest head SHA：
  - a9677c30
- Required checks：
  - pending with reason: GitHub checks start after PR creation.
- spec workflow-check evidence：
  - manual checklist fallback; spec CLI unavailable in this cycle.
- Evidence URL：
  - n/a before PR creation.

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Tighten the #823 internal points context regression test to assert both query and raw DB paths carry request context.
- Approx changed lines：~27
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #823

## Acceptance Criteria
- [x] `installInternalPointsDBContextProbe` separately tracks GORM query and raw callbacks.
- [x] context propagation test fails if either user lookup or ledger aggregate query drops request context.
- [x] Runtime handler behavior remains unchanged.

## 超出範圍內容
無

## 測試方式
- [ ] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
git diff --check origin/develop..HEAD
pass

GOTOOLCHAIN=local GOCACHE=/private/tmp/tachigo-go-build-cache GOMODCACHE=/private/tmp/tachigo-gomod-cache /Users/tachikoma/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.darwin-arm64/bin/go test ./internal/handlers -run TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext -count=1
blocked: sandbox cannot resolve proxy.golang.org to download missing Go modules (`no such host`)
```

## 備註
No swagger docs were regenerated because this PR only changes tests.

## Notes for Claude Code Review
- Please verify this stays test-only and does not expand #645 beyond #823 follow-up scope.
