### PR TITLE
[backend] Fix internal points context probe

### DIFF
--- a/services/api/internal/handlers/internal_points_handler_test.go
+++ b/services/api/internal/handlers/internal_points_handler_test.go
@@ -20,33 +20,33 @@ func installInternalPointsDBContextProbe(t *testing.T, db *gorm.DB, key, want an
 	t.Helper()
 
 	var querySeen int
-	var rawSeen int
+	var rowSeen int
 	name := "test:internal_points_db_context:" + uuid.NewString()
 	queryProbe := func(tx *gorm.DB) {
 		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
 			querySeen++
 		}
 	}
-	rawProbe := func(tx *gorm.DB) {
+	rowProbe := func(tx *gorm.DB) {
 		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
-			rawSeen++
+			rowSeen++
 		}
 	}
 
 	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", queryProbe); err != nil {
 		t.Fatalf("register query context probe: %v", err)
 	}
-	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", rawProbe); err != nil {
-		t.Fatalf("register raw context probe: %v", err)
+	if err := db.Callback().Row().Before("gorm:row").Register(name+":row", rowProbe); err != nil {
+		t.Fatalf("register row context probe: %v", err)
 	}
 
 	t.Cleanup(func() {
 		_ = db.Callback().Query().Remove(name + ":query")
-		_ = db.Callback().Raw().Remove(name + ":raw")
+		_ = db.Callback().Row().Remove(name + ":row")
 	})
 
 	return func() (int, int) {
-		return querySeen, rawSeen
+		return querySeen, rowSeen
 	}
 }
 
@@ -134,9 +134,9 @@ func TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext(t *testin
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	querySeen, rawSeen := seen()
-	if querySeen == 0 || rawSeen == 0 {
-		t.Fatalf("expected internal points handler query and raw DB operations to carry request context, got query=%d raw=%d", querySeen, rawSeen)
+	querySeen, rowSeen := seen()
+	if querySeen == 0 || rowSeen == 0 {
+		t.Fatalf("expected internal points handler query and row DB operations to carry request context, got query=%d row=%d", querySeen, rowSeen)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- 將 internal points request-context regression test 的 GORM probe 從 `Raw` callback 改為 `Row` callback。
- 保留 handler 行為不變，只修正 `db.Raw(...).Scan(...)` 的實際 callback 觀測點，讓 #645 的 context propagation 測試能正確驗證 SQL row query context。

## 為什麼
- closes #645 的 follow-up slice
- PR #826 合併後，`develop` 上的 `TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext` 會失敗，原因是 GORM `Raw(...).Scan(...)` 實際執行路徑不會觸發 `Raw` callback；這會阻擋後續所有 backend PR 的 CI。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 handler 行為
  - 不新增 DB schema / migration
  - 不擴大 #645 其他未完成 audit slice

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 issue-first backend context propagation audit
- Actual worker profile(s)：
  - controller + AWP repo_scout
- Model strength：
  - controller = high；repo_scout = medium
- Spawn directive(s)：
  - profile=repo_scout model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=AWP scout identified #645 as the active suitable backend context audit issue; controller handled this one-file test probe follow-up to unblock the merged develop baseline.
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：
  - local diff and tests checked by controller; no public self-review will be posted.
- Worker session closeout：
  - AWP scout result read back; no additional worker task needed for this one-file follow-up.
- Workflow friction / follow-up split：
  - #826 dogfood datapoint posted to #664; this PR is the narrow follow-up to correct the observed GORM callback probe mismatch.
- spec_gate_status: pass
- spec evidence status: pass
- spec gate evidence ref: workflow-check:start:issue-645
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-645
- finding_disposition_status: pass
- finding_disposition_ref: workflow-check:start:issue-645
- threshold_evidence_status: pass
- threshold_ledger_ref: workflow-check:start:issue-645
- controller_fallback: allowed
- controller_fallback_reason: AWP scout identified #645 as the active suitable backend context audit issue; controller handled this one-file test probe follow-up to unblock the merged develop baseline.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pending GitHub review on PR
- chatgpt-codex-connector：
  - n/a; self-authored PR will not be self-reviewed
- review_triage_ref：
  - workflow-check:start:issue-645
- root_cause_gate_ref：
  - baseline reproduction on `d75e05a4f5e4bd36c5949482b5e36e7e4806bcd8`
- finding_disposition_ref：
  - workflow-check:start:issue-645
- Final reviewer action：
  - pending external review

## Final merge gate
- Ready-to-merge decision：
  - pending GitHub checks and external reviewer
- Latest head SHA：
  - bb552ec41b2355ea9b46d04066a18e3875433291
- Required checks：
  - pending GitHub checks
- spec workflow-check evidence：
  - start status: pass; commit status: pass; ref: workflow-check:start:issue-645
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Correct the internal points context regression probe to observe GORM row query execution for `Raw(...).Scan(...)`.
- Approx changed lines：~20
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #826 introduced the failing probe; this PR is the narrow follow-up.

## Acceptance Criteria
- [x] Keep #645 scope limited to backend DB request context audit/test coverage.
- [x] Preserve existing internal points response behavior.
- [x] Regression test passes locally and validates request context on both lookup and SQL aggregate execution paths.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.456s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services
ok  	github.com/tachigo/tachigo/internal/handlers	17.151s
ok  	github.com/tachigo/tachigo/internal/services	3.057s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/internal/handlers	18.122s
ok  	github.com/tachigo/tachigo/internal/services	3.363s
```

## 備註
- `spec plan` 仍提示 `docs/claude-codex-workflow.md` missing；這是既有 always_read 警告，未在本 PR 擴 scope 處理。

## Notes for Claude Code Review
- 請特別看這個測試是否應以 GORM `Row` callback 代表 `Raw(...).Scan(...)` 的 SQL aggregate execution path；handler production code 未變更。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* 更新了内部数据库上下文探针的测试基础设施，改进了相关测试用例的上下文验证逻辑。

---

**注：** 本次变更仅涉及测试代码，对用户端功能无影响。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->