### PR TITLE
[backend] fix: register Row callback in internal points context probe

### DIFF
--- a/services/api/internal/handlers/internal_points_handler_test.go
+++ b/services/api/internal/handlers/internal_points_handler_test.go
@@ -39,10 +39,14 @@ func installInternalPointsDBContextProbe(t *testing.T, db *gorm.DB, key, want an
 	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", rawProbe); err != nil {
 		t.Fatalf("register raw context probe: %v", err)
 	}
+	if err := db.Callback().Row().Before("gorm:row").Register(name+":row", rawProbe); err != nil {
+		t.Fatalf("register row context probe: %v", err)
+	}
 
 	t.Cleanup(func() {
 		_ = db.Callback().Query().Remove(name + ":query")
 		_ = db.Callback().Raw().Remove(name + ":raw")
+		_ = db.Callback().Row().Remove(name + ":row")
 	})
 
 	return func() (int, int) {


### PR DESCRIPTION
## 什麼改動
- 在 `installInternalPointsDBContextProbe` 中額外註冊 `Row` callback，與現有 `Raw` callback 並行，使 `Raw().Scan(...)` 執行路徑的 context 也能被 probe 捕捉。

## 為什麼
- refs #645 — GORM `Raw().Scan(...)` 的實際執行路徑不觸發 `Raw` callback，需要額外掛 `Row` callback 才能正確觀測 context propagation。

> **關閉說明（依 nurockplayer review 建議）**
> PR #828 已於 2026-05-20 merge 進 develop（commit `55d4411`），以「替換」策略修正同一問題：移除 `Raw` callback、改掛 `Row` callback。本 PR 採「並存」策略（Raw + Row 同時存在），rebase 後反而會把 #828 故意移除的 `Raw` callback 重新加回，造成 regression，故以 #828 為最終修正，關閉本 PR。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 handler 行為
  - 不新增 DB schema / migration
  - 不擴大 #645 其他未完成 audit slice

## Delegation Execution Log（非 Codex autonomous PR 可略過）
n/a

## Review conversation closeout
- Unresolved threads：0（以關閉 PR 收斂）
- CodeRabbit：n/a
- chatgpt-codex-connector：n/a
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：n/a
- Final reviewer action：依 nurockplayer review 關閉，以 #828 為最終修正

## Final merge gate
- Ready-to-merge decision：closed — superseded by #828
- Latest head SHA：5ab6729ecdc2dcfcc392ec840d183faae12b0d9f
- Required checks：n/a（不 merge）
- spec workflow-check evidence：n/a
- Evidence URL：#828

## PR 拆分檢查
- 這個 PR 的單一句子目的：在 internal points context probe 中額外掛 Row callback
- Approx changed lines：~4
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [x] tests
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #828（已 merge，採替換策略，為最終修正）

## Acceptance Criteria
- [x] 保留 #645 scope 在 backend DB request context audit/test coverage
- [x] 不改 handler 行為（已由 #828 確認）

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過（#828 已驗證）
- [x] 有寫 / 更新測試

**驗證結果**
```
# 由 #828 提供驗證（develop 上 Row callback 已通過 CI）
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestInternalPointsHandler_GetUserPointsBalance_UsesRequestContext -count=1
ok  github.com/tachigo/tachigo/internal/handlers  0.456s
```

## 備註
- 本 PR 被 #828 supersede，關閉以避免 Raw callback regression。

## Notes for Claude Code Review
- 依 reviewer 建議關閉，不需要額外 review。