### PR TITLE
[backend] Propagate user providers request context

### DIFF
--- a/services/api/internal/handlers/user_handler.go
+++ b/services/api/internal/handlers/user_handler.go
@@ -127,7 +127,7 @@ func (h *UserHandler) ListProviders(c *gin.Context) {
 	claims := middleware.MustClaims(c)
 	userID, _ := uuid.Parse(claims.UserID)
 
-	providers, err := h.user.ListProviders(userID)
+	providers, err := h.user.ListProvidersContext(c.Request.Context(), userID)
 	if err != nil {
 		internal(c)
 		return

--- a/services/api/internal/handlers/user_handler_test.go
+++ b/services/api/internal/handlers/user_handler_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
@@ -13,9 +14,37 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+type userHandlerContextKey struct{}
+
+func installUserHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:user_handler_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name + ":query")
+	})
+
+	return func() int {
+		return seen
+	}
+}
 
 func TestMeHandler_Success(t *testing.T) {
 	env := newTestEnv(t)
@@ -110,6 +139,27 @@ func TestListProvidersHandler_Success(t *testing.T) {
 	// Register creates an email provider record
 	if len(providers) == 0 {
 		t.Error("expected at least one provider after registration")
+	}
+}
+
+func TestListProvidersHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "provctx", "provctx@example.com", "password123")
+
+	key := userHandlerContextKey{}
+	seen := installUserHandlerDBContextProbe(t, env.db, key, "list-providers")
+	ctx := context.WithValue(context.Background(), key, "list-providers")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/providers", nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected ListProviders DB query to use request context")
 	}
 }
 

--- a/services/api/internal/services/user_service.go
+++ b/services/api/internal/services/user_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"time"
@@ -70,8 +71,16 @@ func (s *UserService) UpdateProfile(id uuid.UUID, input UpdateProfileInput) (*mo
 }
 
 func (s *UserService) ListProviders(userID uuid.UUID) ([]models.AuthProvider, error) {
+	return s.ListProvidersContext(context.Background(), userID)
+}
+
+func (s *UserService) ListProvidersContext(ctx context.Context, userID uuid.UUID) ([]models.AuthProvider, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var providers []models.AuthProvider
-	if err := s.db.Where("user_id = ?", userID).Find(&providers).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).Find(&providers).Error; err != nil {
 		return nil, err
 	}
 	return providers, nil


### PR DESCRIPTION
## 什麼改動
- 讓 `GET /users/me/providers` 的 DB 查詢使用 request context。
- 新增 `UserService.ListProvidersContext(ctx, userID)`，並保留原本 `ListProviders(userID)` 相容 wrapper。
- 新增 handler regression test，驗證 list providers 查詢會攜帶 request context。

## 為什麼
- refs #645
- #645 要求 audit backend DB query context propagation；這個 PR 是 user providers read path 的小切片，避免把整個 audit scope 塞進同一張 PR。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 API response shape
  - 不改 auth/session/token 行為
  - 不新增 DB schema / migration
  - 不處理 #645 其他 DB query paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 backend DB request context propagation audit
- Actual worker profile(s)：
  - controller + AWP repo_scout
- Model strength：
  - controller = high；repo_scout = medium
- Spawn directive(s)：
  - profile=repo_scout model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=AWP scout selected the user providers read path as a single low-risk #645 backend context propagation slice; controller implemented the small TDD patch directly after readback.
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestListProvidersHandler|TestListProviders_' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：
  - local diff and tests checked by controller; no public self-review will be posted.
- Worker session closeout：
  - AWP scout result read back; implementation was below worker threshold and stayed controller-direct.
- Workflow friction / follow-up split：
  - #828 merged first to repair develop baseline; this PR resumes the next #645 slice without stacking.
- spec_gate_status: pass
- spec evidence status: pass
- spec gate evidence ref: workflow-check:start:issue-645
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-645
- finding_disposition_status: pass
- finding_disposition_ref: workflow-check:start:issue-645
- threshold_evidence_status: pass
- threshold_ledger_ref: workflow-check:start:issue-645
- controller_fallback: allowed
- controller_fallback_reason: AWP scout selected the user providers read path as a single low-risk #645 backend context propagation slice; controller implemented the small TDD patch directly after readback.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pending GitHub review on PR
- chatgpt-codex-connector：
  - n/a; self-authored PR will not be self-reviewed
- review_triage_ref：
  - workflow-check:start:issue-645
- root_cause_gate_ref：
  - workflow-check:start:issue-645
- finding_disposition_ref：
  - workflow-check:start:issue-645
- Final reviewer action：
  - pending external review

## Final merge gate
- Ready-to-merge decision：
  - pending GitHub checks and external reviewer
- Latest head SHA：
  - ee208b10aadc90327d3050538fe824925a6ed5e0
- Required checks：
  - pending GitHub checks
- spec workflow-check evidence：
  - start status: pass; commit status: pass; ref: workflow-check:start:issue-645
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through the user providers DB read path.
- Approx changed lines：~63
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The handler must pass `c.Request.Context()` into the service, and the service must expose a context-aware method; the test verifies the same request path end-to-end.
- 若已拆分，相關 PR：
  - #828 repaired the internal points probe baseline before this slice.

## Acceptance Criteria
- [x] User providers DB read path accepts request context.
- [x] Existing `ListProviders(userID)` callers remain compatible.
- [x] Regression test verifies request context propagation.
- [x] Backend focused and full test suites pass locally.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestListProvidersHandler|TestListProviders_' -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.843s
ok  	github.com/tachigo/tachigo/internal/services	0.381s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services
ok  	github.com/tachigo/tachigo/internal/handlers	16.584s
ok  	github.com/tachigo/tachigo/internal/services	(cached)

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/internal/handlers	17.542s
ok  	github.com/tachigo/tachigo/internal/middleware	2.015s
ok  	github.com/tachigo/tachigo/internal/router	1.463s
```

## 備註
- `spec plan` 仍提示 `docs/claude-codex-workflow.md` missing；這是既有 always_read 警告，未在本 PR 擴 scope 處理。

## Notes for Claude Code Review
- 請特別看 `ListProvidersContext` 的相容 wrapper 是否符合 repo 服務層慣例；production behavior 只改成讓 DB 查詢跟隨 request cancellation/deadline。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **稳定性改进**
  * 优化了用户 OAuth 提供商列表检索功能的请求处理机制，确保请求上下文正确传递至数据库操作，增强系统可靠性和运行稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->