### PR TITLE
[backend] Propagate current user request context

### DIFF
--- a/services/api/internal/handlers/user_handler.go
+++ b/services/api/internal/handlers/user_handler.go
@@ -28,7 +28,7 @@ func (h *UserHandler) Me(c *gin.Context) {
 	claims := middleware.MustClaims(c)
 	userID, _ := uuid.Parse(claims.UserID)
 
-	user, err := h.user.GetByID(userID)
+	user, err := h.user.GetByIDContext(c.Request.Context(), userID)
 	if err != nil {
 		notFound(c, "user not found")
 		return

--- a/services/api/internal/handlers/user_handler_test.go
+++ b/services/api/internal/handlers/user_handler_test.go
@@ -66,6 +66,27 @@ func TestMeHandler_Success(t *testing.T) {
 	}
 }
 
+func TestMeHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "mectx", "mectx@example.com", "password123")
+
+	key := userHandlerContextKey{}
+	seen := installUserHandlerDBContextProbe(t, env.db, key, "me")
+	ctx := context.WithValue(context.Background(), key, "me")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me", nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected Me DB query to use request context")
+	}
+}
+
 func TestUpdateMeHandler_Username(t *testing.T) {
 	env := newTestEnv(t)
 	accessToken, _ := env.registerUser(t, "oldname", "update@example.com", "password123")

--- a/services/api/internal/services/user_service.go
+++ b/services/api/internal/services/user_service.go
@@ -35,8 +35,16 @@ type LinkWalletInput struct {
 }
 
 func (s *UserService) GetByID(id uuid.UUID) (*models.User, error) {
+	return s.GetByIDContext(context.Background(), id)
+}
+
+func (s *UserService) GetByIDContext(ctx context.Context, id uuid.UUID) (*models.User, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var user models.User
-	if err := s.db.First(&user, "id = ?", id).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&user, "id = ?", id).Error; err != nil {
 		return nil, ErrUserNotFound
 	}
 	return &user, nil

--- a/services/api/internal/services/user_service.go
+++ b/services/api/internal/services/user_service.go
@@ -45,7 +45,10 @@ func (s *UserService) GetByIDContext(ctx context.Context, id uuid.UUID) (*models
 
 	var user models.User
 	if err := s.db.WithContext(ctx).First(&user, "id = ?", id).Error; err != nil {
-		return nil, ErrUserNotFound
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrUserNotFound
+		}
+		return nil, err
 	}
 	return &user, nil
 }

--- a/services/api/internal/services/user_service_test.go
+++ b/services/api/internal/services/user_service_test.go
@@ -1,8 +1,10 @@
 package services
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -38,6 +40,17 @@ func TestGetByID_NotFound(t *testing.T) {
 	_, err := svc.GetByID(uuid.New())
 	if err != ErrUserNotFound {
 		t.Errorf("want ErrUserNotFound, got %v", err)
+	}
+}
+
+func TestGetByIDContext_CanceledContextReturnsCanceled(t *testing.T) {
+	svc := NewUserService(newTestDB(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.GetByIDContext(ctx, uuid.New())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- 讓 `GET /users/me` 的使用者查詢使用 request context。
- 新增 `UserService.GetByIDContext(ctx, id)`，並保留原本 `GetByID(id)` 相容 wrapper。
- 新增 handler regression test，驗證 current-user 查詢會攜帶 request context。

## 為什麼
- refs #645
- #645 要求 audit backend DB query context propagation；這個 PR 是 current-user read path 的小切片，避免把整個 audit scope 塞進同一張 PR。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 API response shape
  - 不改 auth/session/token 行為
  - 不新增 DB schema / migration
  - 不處理 #645 其他 DB query paths
  - 不處理 `UpdateMe` / wallet mutation paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 backend DB request context propagation audit
- Actual worker profile(s)：
  - controller + AWP repo_scout
- Model strength：
  - controller = high；repo_scout = medium
- Spawn directive(s)：
  - profile=repo_scout model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=AWP scout showed agency paths were already covered on develop; controller selected the current-user read path as a single low-risk #645 backend context propagation slice and implemented the tiny TDD patch directly after spec dry-run and code readback.
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestMeHandler_UsesRequestContext -count=1` failed before implementation with `expected Me DB query to use request context`
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestMeHandler_UsesRequestContext -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestMeHandler|TestGetByID|TestListProviders' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：
  - local diff and tests checked by controller; no public self-review will be posted.
- Worker session closeout：
  - AWP scout result read back; implementation was below worker threshold and stayed controller-direct.
- Workflow friction / follow-up split：
  - #830 merged first; this PR resumes the next independent #645 read-path slice from updated `develop`.
- spec_gate_status: pass
- spec evidence status: pass
- spec gate evidence ref: workflow-check:start:issue-645
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-645
- finding_disposition_status: pass
- finding_disposition_ref: workflow-check:start:issue-645
- threshold_evidence_status: pass
- threshold_ledger_ref: workflow-check:start:issue-645
- controller_fallback: allowed
- controller_fallback_reason: AWP scout showed agency paths were already covered on develop; controller selected the current-user read path as a single low-risk #645 backend context propagation slice and implemented the tiny TDD patch directly after spec dry-run and code readback.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pending GitHub review on PR
- chatgpt-codex-connector：
  - n/a; self-authored PR will not be self-reviewed
- review_triage_ref：
  - workflow-check:start:issue-645
- root_cause_gate_ref：
  - workflow-check:start:issue-645
- finding_disposition_ref：
  - workflow-check:start:issue-645
- Final reviewer action：
  - pending external review

## Final merge gate
- Ready-to-merge decision：
  - pending GitHub checks and external reviewer
- Latest head SHA：
  - e566fe971547c237bd15347fa89aa17d4f76f490
- Required checks：
  - pending GitHub checks
- spec workflow-check evidence：
  - start status: pass; commit status: pass; ref: workflow-check:start:issue-645
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through the current-user DB read path.
- Approx changed lines：~33
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The handler must pass `c.Request.Context()` into the service, and the service must expose a context-aware method; the test verifies the same request path end-to-end.
- 若已拆分，相關 PR：
  - #830 covered the user providers read path first and is already merged.

## Acceptance Criteria
- [x] Current-user DB read path accepts request context.
- [x] Existing `GetByID(id)` callers remain compatible.
- [x] Regression test verifies request context propagation.
- [x] Backend full test suite passes locally.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestMeHandler_UsesRequestContext -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.335s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestMeHandler|TestGetByID|TestListProviders' -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.467s
ok  	github.com/tachigo/tachigo/internal/services	0.470s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/internal/handlers	17.985s
ok  	github.com/tachigo/tachigo/internal/services	5.408s
```

## 備註
- `spec plan` / `spec workflow-check` 仍提示 `docs/claude-codex-workflow.md` missing；這是既有 always_read 警告，未在本 PR 擴 scope 處理。

## Notes for Claude Code Review
- 請特別看 `GetByIDContext` 的相容 wrapper 是否符合 repo 服務層慣例；production behavior 只改成讓 current-user DB 查詢跟隨 request cancellation/deadline。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 用户信息查询现在更可靠地尊重请求上下文（例如取消或超时），减少挂起或延迟的响应风险。
* **测试**
  * 增加了覆盖请求上下文和取消场景的自动化测试，提升在真实请求中行为的可观测性与稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->