### PR TITLE
[backend] Propagate raffle list request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -78,7 +78,7 @@ func (h *RaffleHandler) List(c *gin.Context) {
 		return
 	}
 
-	raffles, err := h.raffleSvc.ListByStreamer(userID)
+	raffles, err := h.raffleSvc.ListByStreamerContext(c.Request.Context(), userID)
 	if err != nil {
 		log.Printf("raffle list: %v", err)
 		internal(c)

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -26,6 +27,32 @@ import (
 	"github.com/tachigo/tachigo/internal/services"
 	"github.com/tachigo/tachigo/internal/testutil"
 )
+
+type raffleHandlerContextKey struct{}
+
+func installRaffleHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:raffle_handler_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name + ":query")
+	})
+
+	return func() int {
+		return seen
+	}
+}
 
 // raffleTestEnv wires only the raffle-related handlers.
 type raffleTestEnv struct {
@@ -225,6 +252,37 @@ func TestRaffle_List(t *testing.T) {
 	raffles := data["raffles"].([]interface{})
 	if len(raffles) != 2 {
 		t.Errorf("want 2 raffles, got %d", len(raffles))
+	}
+}
+
+func TestRaffle_List_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "streamerctx", "streamerctx@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Context Raffle"})
+	createReq, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", bearer(token))
+	createW := httptest.NewRecorder()
+	env.router.ServeHTTP(createW, createReq)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create raffle: want 201, got %d: %s", createW.Code, createW.Body.String())
+	}
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbe(t, env.db, key, "raffle-list")
+	ctx := context.WithValue(context.Background(), key, "raffle-list")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/dashboard/raffles", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected raffle list DB query to use request context")
 	}
 }
 

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -113,8 +113,16 @@ func (s *RaffleService) GetByID(id, userID uuid.UUID) (*models.Raffle, error) {
 
 // ListByStreamer returns all raffles owned by the user.
 func (s *RaffleService) ListByStreamer(userID uuid.UUID) ([]models.Raffle, error) {
+	return s.ListByStreamerContext(context.Background(), userID)
+}
+
+func (s *RaffleService) ListByStreamerContext(ctx context.Context, userID uuid.UUID) ([]models.Raffle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var raffles []models.Raffle
-	if err := s.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&raffles).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).Order("created_at DESC").Find(&raffles).Error; err != nil {
 		return nil, err
 	}
 	if raffles == nil {


### PR DESCRIPTION
## 什麼改動
- 讓 `GET /dashboard/raffles` 的 raffle list 查詢使用 request context。
- 新增 `RaffleService.ListByStreamerContext(ctx, userID)`，並保留原本 `ListByStreamer(userID)` 相容 wrapper。
- 新增 handler regression test，驗證 raffle list DB 查詢會攜帶 request context。

## 為什麼
- refs #645
- #645 要求 audit backend DB query context propagation；這個 PR 是 raffle dashboard list read path 的小切片，避免把 raffle draw/import/create mutation paths 混進同一張 PR。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 API response shape
  - 不改 auth/session/token 行為
  - 不新增 DB schema / migration
  - 不處理 #645 其他 DB query paths
  - 不處理 raffle create/get/import/draw/result paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 backend DB request context propagation audit
- Actual worker profile(s)：
  - controller + AWP repo_scout
- Model strength：
  - controller = high；repo_scout = medium
- Spawn directive(s)：
  - profile=repo_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=AWP repo_scout was dispatched and reported raffle read paths as the next suitable #645 slice; controller had already isolated the tiny dashboard raffle list read path and finished the TDD patch directly to avoid overlapping with open self-authored PR #831.
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRaffle_List_UsesRequestContext -count=1` failed before implementation with `expected raffle list DB query to use request context`
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRaffle_List_UsesRequestContext -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_List|TestRaffle_Get' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestRaffle|TestListByStreamer' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：
  - local diff and tests checked by controller; no public self-review will be posted.
- Worker session closeout：
  - AWP scout result read back; implementation was below worker threshold and stayed controller-direct.
- Workflow friction / follow-up split：
  - AWP scout recommended raffle draws/result as next clean slice; this PR intentionally limits itself to dashboard list because that TDD slice was already isolated and does not touch #831 files.
- spec_gate_status: pass
- spec evidence status: pass
- spec gate evidence ref: workflow-check:start:issue-645
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-645
- finding_disposition_status: pass
- finding_disposition_ref: workflow-check:start:issue-645
- threshold_evidence_status: pass
- threshold_ledger_ref: workflow-check:threshold:issue-645-raffle-list
- controller_fallback: allowed
- controller_fallback_reason: AWP repo_scout was dispatched and reported raffle read paths as the next suitable #645 slice; controller had already isolated the tiny dashboard raffle list read path and finished the TDD patch directly to avoid overlapping with open self-authored PR #831.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pending GitHub review on PR
- chatgpt-codex-connector：
  - n/a; self-authored PR will not be self-reviewed
- review_triage_ref：
  - workflow-check:start:issue-645
- root_cause_gate_ref：
  - workflow-check:start:issue-645
- finding_disposition_ref：
  - workflow-check:start:issue-645
- Final reviewer action：
  - pending external review

## Final merge gate
- Ready-to-merge decision：
  - pending GitHub checks and external reviewer
- Latest head SHA：
  - 80c525efa95aa1f28b09bc7ccabd2816dd086533
- Required checks：
  - pending GitHub checks
- spec workflow-check evidence：
  - start status: pass; commit status: pass; ref: workflow-check:start:issue-645
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through the dashboard raffle list DB read path.
- Approx changed lines：~70
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The handler must pass `c.Request.Context()` into the service, and the service must expose a context-aware method; the test verifies the same request path end-to-end.
- 若已拆分，相關 PR：
  - #831 covers the current-user read path and is still awaiting external review.

## Acceptance Criteria
- [x] Dashboard raffle list DB read path accepts request context.
- [x] Existing `ListByStreamer(userID)` callers remain compatible.
- [x] Regression test verifies request context propagation.
- [x] Backend full test suite passes locally.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRaffle_List_UsesRequestContext -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.887s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_List|TestRaffle_Get' -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	0.842s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestRaffle|TestListByStreamer' -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	3.641s
ok  	github.com/tachigo/tachigo/internal/services	0.447s [no tests to run]

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/internal/handlers	18.273s
ok  	github.com/tachigo/tachigo/internal/services	3.431s
```

## 備註
- `spec plan` / `spec workflow-check` 仍提示 `docs/claude-codex-workflow.md` missing；這是既有 always_read 警告，未在本 PR 擴 scope 處理。
- 下一個 raffle #645 候選可拆到 `ListDraws` / public result read paths，避免塞進這張 PR。

## Notes for Claude Code Review
- 請特別看 `ListByStreamerContext` 的相容 wrapper 是否符合 repo 服務層慣例；production behavior 只改成讓 dashboard raffle list DB 查詢跟隨 request cancellation/deadline。
