### PR TITLE
[backend] Propagate raffle draw request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -270,7 +270,7 @@ func (h *RaffleHandler) ListDraws(c *gin.Context) {
 		return
 	}
 
-	draws, err := h.raffleSvc.ListDraws(raffleID, userID)
+	draws, err := h.raffleSvc.ListDrawsContext(c.Request.Context(), raffleID, userID)
 	if err != nil {
 		if errors.Is(err, services.ErrRaffleNotFound) {
 			notFound(c, "raffle not found")
@@ -597,7 +597,7 @@ func (h *RaffleHandler) GetResult(c *gin.Context) {
 		return
 	}
 
-	draws, err := h.raffleSvc.GetDrawsByRafflePublic(raffleID)
+	draws, err := h.raffleSvc.GetDrawsByRafflePublicContext(c.Request.Context(), raffleID)
 	if err != nil {
 		internal(c)
 		return

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -310,7 +310,7 @@ func TestRaffle_ListDraws_UsesRequestContext(t *testing.T) {
 	raffleID := env.createRaffle(t, token, "Draw Context Raffle")
 
 	key := raffleHandlerContextKey{}
-	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-draw-list", "raffle_draws")
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-draw-list", "raffles", "raffle_draws")
 	ctx := context.WithValue(context.Background(), key, "raffle-draw-list")
 
 	w := httptest.NewRecorder()
@@ -321,8 +321,8 @@ func TestRaffle_ListDraws_UsesRequestContext(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
-	if seen() == 0 {
-		t.Fatal("expected raffle draw list DB query to use request context")
+	if seen() < 2 {
+		t.Fatal("expected raffle ownership and draw list DB queries to use request context")
 	}
 }
 

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -33,9 +33,27 @@ type raffleHandlerContextKey struct{}
 func installRaffleHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
 	t.Helper()
 
+	return installRaffleHandlerDBContextProbeForTables(t, db, key, want)
+}
+
+func installRaffleHandlerDBContextProbeForTables(t *testing.T, db *gorm.DB, key, want any, tables ...string) func() int {
+	t.Helper()
+
 	var seen int
 	name := "test:raffle_handler_db_context:" + uuid.NewString()
+	wantedTables := map[string]struct{}{}
+	for _, table := range tables {
+		wantedTables[table] = struct{}{}
+	}
 	probe := func(tx *gorm.DB) {
+		if len(wantedTables) > 0 {
+			if tx.Statement == nil {
+				return
+			}
+			if _, ok := wantedTables[tx.Statement.Table]; !ok {
+				return
+			}
+		}
 		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
 			seen++
 		}
@@ -283,6 +301,28 @@ func TestRaffle_List_UsesRequestContext(t *testing.T) {
 	}
 	if seen() == 0 {
 		t.Fatal("expected raffle list DB query to use request context")
+	}
+}
+
+func TestRaffle_ListDraws_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "drawctx", "drawctx@test.com", "pass1234")
+	raffleID := env.createRaffle(t, token, "Draw Context Raffle")
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-draw-list", "raffle_draws")
+	ctx := context.WithValue(context.Background(), key, "raffle-draw-list")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/dashboard/raffles/"+raffleID+"/draws", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected raffle draw list DB query to use request context")
 	}
 }
 
@@ -753,6 +793,26 @@ func TestRaffle_GetResult_Extension(t *testing.T) {
 	draws := extResp["data"].(map[string]interface{})["draws"].([]interface{})
 	if len(draws) != 1 {
 		t.Errorf("want 1 draw, got %d", len(draws))
+	}
+}
+
+func TestRaffle_GetResult_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	raffleID := uuid.NewString()
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-result", "raffle_draws")
+	ctx := context.WithValue(context.Background(), key, "raffle-result")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/extension/raffles/"+raffleID+"/result", nil)
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected raffle result DB query to use request context")
 	}
 }
 

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -98,8 +98,16 @@ func (s *RaffleService) Create(userID uuid.UUID, title string) (*models.Raffle, 
 
 // GetByID returns a raffle, verifying ownership.
 func (s *RaffleService) GetByID(id, userID uuid.UUID) (*models.Raffle, error) {
+	return s.getByIDContext(context.Background(), id, userID)
+}
+
+func (s *RaffleService) getByIDContext(ctx context.Context, id, userID uuid.UUID) (*models.Raffle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var raffle models.Raffle
-	if err := s.db.Where("id = ?", id).First(&raffle).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&raffle).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrRaffleNotFound
 		}
@@ -375,12 +383,20 @@ func (s *RaffleService) sendDiscordNotification(ctx context.Context, draw *model
 
 // ListDraws returns all draws for a raffle (with entry preloaded).
 func (s *RaffleService) ListDraws(raffleID, userID uuid.UUID) ([]models.RaffleDraw, error) {
-	if _, err := s.GetByID(raffleID, userID); err != nil {
+	return s.ListDrawsContext(context.Background(), raffleID, userID)
+}
+
+func (s *RaffleService) ListDrawsContext(ctx context.Context, raffleID, userID uuid.UUID) ([]models.RaffleDraw, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if _, err := s.getByIDContext(ctx, raffleID, userID); err != nil {
 		return nil, err
 	}
 
 	var draws []models.RaffleDraw
-	if err := s.db.
+	if err := s.db.WithContext(ctx).
 		Preload("Entry").
 		Where("raffle_id = ?", raffleID).
 		Order("drawn_at DESC").
@@ -498,8 +514,16 @@ func (s *RaffleService) SubmitClaim(token string, userID uuid.UUID, input ClaimI
 
 // GetDrawsByRafflePublic returns drawn entries for Extension display (no auth check).
 func (s *RaffleService) GetDrawsByRafflePublic(raffleID uuid.UUID) ([]models.RaffleDraw, error) {
+	return s.GetDrawsByRafflePublicContext(context.Background(), raffleID)
+}
+
+func (s *RaffleService) GetDrawsByRafflePublicContext(ctx context.Context, raffleID uuid.UUID) ([]models.RaffleDraw, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var draws []models.RaffleDraw
-	if err := s.db.
+	if err := s.db.WithContext(ctx).
 		Preload("Entry").
 		Where("raffle_id = ?", raffleID).
 		Order("drawn_at DESC").

--- a/services/api/internal/services/raffle_service_hardening_test.go
+++ b/services/api/internal/services/raffle_service_hardening_test.go
@@ -36,8 +36,8 @@ func TestRaffleService_ListDrawsContext_UsesRequestContext(t *testing.T) {
 	if len(draws) != 1 {
 		t.Fatalf("want 1 draw, got %d", len(draws))
 	}
-	if seen() == 0 {
-		t.Fatal("expected ListDrawsContext DB operations to use request context")
+	if seen() < 2 {
+		t.Fatal("expected at least 2 ListDrawsContext DB operations to use request context")
 	}
 }
 

--- a/services/api/internal/services/raffle_service_hardening_test.go
+++ b/services/api/internal/services/raffle_service_hardening_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/tachigo/tachigo/internal/models"
 )
 
+type raffleServiceContextKey struct{}
+
 func TestRaffleService_ListDrawsContext_UsesRequestContext(t *testing.T) {
 	db := newTestDB(t)
 	ownerID := seedUserWithEmail(t, db, "list_draws_ctx@example.com")
@@ -22,7 +24,7 @@ func TestRaffleService_ListDrawsContext_UsesRequestContext(t *testing.T) {
 	entryID := seedEntry(t, db, raffleID, nil, "draw_ctx_player")
 	seedDraw(t, db, raffleID, entryID, "draw-context-token")
 
-	key := struct{}{}
+	key := raffleServiceContextKey{}
 	seen := installDBContextProbe(t, db, key, "raffle-list-draws")
 	ctx := context.WithValue(context.Background(), key, "raffle-list-draws")
 
@@ -46,7 +48,7 @@ func TestRaffleService_GetDrawsByRafflePublicContext_UsesRequestContext(t *testi
 	entryID := seedEntry(t, db, raffleID, nil, "public_draw_ctx_player")
 	seedDraw(t, db, raffleID, entryID, "public-draw-context-token")
 
-	key := struct{}{}
+	key := raffleServiceContextKey{}
 	seen := installDBContextProbe(t, db, key, "raffle-public-draws")
 	ctx := context.WithValue(context.Background(), key, "raffle-public-draws")
 

--- a/services/api/internal/services/raffle_service_hardening_test.go
+++ b/services/api/internal/services/raffle_service_hardening_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -13,6 +14,54 @@ import (
 
 	"github.com/tachigo/tachigo/internal/models"
 )
+
+func TestRaffleService_ListDrawsContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "list_draws_ctx@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	entryID := seedEntry(t, db, raffleID, nil, "draw_ctx_player")
+	seedDraw(t, db, raffleID, entryID, "draw-context-token")
+
+	key := struct{}{}
+	seen := installDBContextProbe(t, db, key, "raffle-list-draws")
+	ctx := context.WithValue(context.Background(), key, "raffle-list-draws")
+
+	svc := &RaffleService{db: db}
+	draws, err := svc.ListDrawsContext(ctx, raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("ListDrawsContext: %v", err)
+	}
+	if len(draws) != 1 {
+		t.Fatalf("want 1 draw, got %d", len(draws))
+	}
+	if seen() == 0 {
+		t.Fatal("expected ListDrawsContext DB operations to use request context")
+	}
+}
+
+func TestRaffleService_GetDrawsByRafflePublicContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "public_draws_ctx@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	entryID := seedEntry(t, db, raffleID, nil, "public_draw_ctx_player")
+	seedDraw(t, db, raffleID, entryID, "public-draw-context-token")
+
+	key := struct{}{}
+	seen := installDBContextProbe(t, db, key, "raffle-public-draws")
+	ctx := context.WithValue(context.Background(), key, "raffle-public-draws")
+
+	svc := &RaffleService{db: db}
+	draws, err := svc.GetDrawsByRafflePublicContext(ctx, raffleID)
+	if err != nil {
+		t.Fatalf("GetDrawsByRafflePublicContext: %v", err)
+	}
+	if len(draws) != 1 {
+		t.Fatalf("want 1 draw, got %d", len(draws))
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetDrawsByRafflePublicContext DB operations to use request context")
+	}
+}
 
 // TestDrawNext_SkipsAlreadyDrawnEntry verifies that if one entry is already
 // drawn (seeded directly into DB), DrawNext picks the remaining entry rather


### PR DESCRIPTION
## 什麼改動
將 raffle draw/result 兩個讀取路徑接上 request context：
- dashboard `ListDraws` 改呼叫 `ListDrawsContext(c.Request.Context(), ...)`
- extension `GetResult` 改呼叫 `GetDrawsByRafflePublicContext(c.Request.Context(), ...)`
- 保留既有 service wrapper，新增 Context 版本並使用 `WithContext(ctx)`
- 新增 handler/service request-context regression tests

## 為什麼
refs #645

#645 要求 backend DB query/transaction 逐步接上 request context，避免 request timeout 後 DB work 繼續執行。本 PR 是 raffle draw/result read path 的小切片，不關閉 #645。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 `DrawNext`
  - 不處理 claim token read paths
  - 不做 schema / migration / timeout policy 變更
  - 不關閉 #645

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- spec gate status: pass
- spec evidence ref: workflow-check:start:issue-645
- Source issue delegation plan：
  - #645；heartbeat 授權的 Hybrid AWP + spec-injector loop，使用 `spec plan 645 --repo . --dry-run --format prompt --verbose` 產生 bounded context。
- Actual worker profile(s)：
  - controller + repo_scout
- Model strength：
  - controller = current Codex controller；repo_scout = explorer, medium reasoning
- Spawn directive(s)：
  - profile=repo_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=backend_worker_not_spawned_after_repo_scout because implementation was a tiny four-file TDD slice with no schema/auth/wallet/payment change
- routing evidence status: pass
- routing evidence ref: workflow-check:start:issue-645
- controller_fallback: allowed
- controller_fallback_reason: backend_worker_not_spawned_after_repo_scout because implementation was a tiny four-file TDD slice with no schema/auth/wallet/payment change; repo_scout completed the required surface scan
- Verification evidence：
  - RED handler test failed before implementation: `TestRaffle_ListDraws_UsesRequestContext`, `TestRaffle_GetResult_UsesRequestContext`
  - RED service test failed before implementation: missing `ListDrawsContext` / `GetDrawsByRafflePublicContext`
  - GREEN focused handler/service tests passed
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestRaffle' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
  - `spec workflow-check --repo . --phase start --issue 645`
- Self-review / exception reason：
  - repo_scout validated the slice and warned not to expand into `DrawNext`, claim token paths, or full `GetByID` refactor. Controller implemented the tiny TDD patch directly after RED tests.
- Worker session closeout：
  - repo_scout result read back and agent session closed.
- Workflow friction / follow-up split：
  - #664 ledger ref pending until merge. Follow-on raffle write/claim paths should be separate #645 slices to avoid scope growth.

## Review conversation closeout
- Unresolved threads：
  - 0 before PR creation
- CodeRabbit：
  - reviewed previous head and posted 2 test-hardening findings; both adopted in latest head
- chatgpt-codex-connector：
  - pending with reason: PR not created yet
- review_triage_ref：
  - local-only `/tmp/tachigo-645-raffle-draws-finding-disposition.json`
- root_cause_gate_ref：
  - local-only TDD RED evidence; root-cause was missing `WithContext(ctx)` on raffle draw/result read queries
- finding_disposition_ref：
  - local-only `/tmp/tachigo-645-raffle-draws-finding-disposition.json`
- finding disposition status: pass
- finding disposition ref: workflow-check:start:issue-645
- Final reviewer action：
  - pending with reason: awaiting PR review

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review
- Latest head SHA：
  - 91c85ad5fe3f94f033930266fb828a65395c02c9
- Required checks：
  - pass: Backend CI gate / Scope police / CodeRabbit / Cloudflare completed successfully on latest head
- spec workflow-check evidence：
  - start: pass (`spec workflow-check --repo . --phase start --issue 645`)
  - commit: pass (`spec workflow-check --repo . --phase commit --pr-body /tmp/tachigo-pr-645-raffle-draws-body.md --routing-evidence /tmp/tachigo-645-raffle-draws-routing.json --finding-disposition /tmp/tachigo-645-raffle-draws-finding-disposition.json --threshold-evidence /tmp/tachigo-645-raffle-draws-threshold.json`)
  - context warning: `docs/claude-codex-workflow.md` is listed as always-read but not present in this checkout; not fixed here to avoid scope pollution
- threshold evidence status: pass
- threshold ledger ref: https://github.com/nurockplayer/tachigo/issues/664
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/833

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through raffle draw list/result DB read paths.
- Approx changed lines：~145
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 單一行為變更需要 service Context API、handler 傳入 request context，以及 regression tests 同步驗證。
- 若已拆分，相關 PR：
  - #832 raffle list context slice；本 PR 是後續 draw/result read path slice

## Acceptance Criteria
- [x] All service-layer DB access paths in this raffle draw/result slice propagate request context
- [x] GORM queries in this slice use `WithContext(ctx)`
- [x] Add regression tests for request context propagation
- [ ] Full #645 audit remains open for later slices

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_(ListDraws|GetResult)_UsesRequestContext' -count=1
=> failed as expected: expected raffle draw list/result DB query to use request context

RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestRaffleService_(ListDrawsContext|GetDrawsByRafflePublicContext)_UsesRequestContext' -count=1
=> failed as expected: ListDrawsContext / GetDrawsByRafflePublicContext undefined

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_(ListDraws|GetResult)_UsesRequestContext' -count=1
=> ok github.com/tachigo/tachigo/internal/handlers

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestRaffleService_(ListDrawsContext|GetDrawsByRafflePublicContext)_UsesRequestContext' -count=1
=> ok github.com/tachigo/tachigo/internal/services

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestRaffle' -count=1
=> ok github.com/tachigo/tachigo/internal/handlers; ok github.com/tachigo/tachigo/internal/services

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
=> ok all packages

GOCACHE=/tmp/tachigo-go-build-cache go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...
=> pass

CodeRabbit follow-up:
- adopted ListDraws handler probe tightening for both `raffles` and `raffle_draws`
- adopted service-level `ListDrawsContext` threshold `seen() >= 2`
- reran focused raffle tests, full `go test ./...`, and staticcheck successfully
```

## 備註
`spec plan` / start gate reported missing always-read file `docs/claude-codex-workflow.md`; this PR records the context risk but does not add or move docs.

## Notes for Claude Code Review
- 請特別看 `ListDrawsContext` ownership check 與 draw query 是否都套用同一個 request context。
- `getByIDContext` 是 unexported helper，用來避免擴大 public service API；既有 `GetByID` wrapper 行為保留。
