### PR TITLE
[backend] Propagate raffle detail request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -111,7 +111,7 @@ func (h *RaffleHandler) Get(c *gin.Context) {
 		return
 	}
 
-	raffle, err := h.raffleSvc.GetByID(raffleID, userID)
+	raffle, err := h.raffleSvc.GetByIDContext(c.Request.Context(), raffleID, userID)
 	if err != nil {
 		if errors.Is(err, services.ErrRaffleNotFound) {
 			notFound(c, "raffle not found")

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -326,6 +326,28 @@ func TestRaffle_ListDraws_UsesRequestContext(t *testing.T) {
 	}
 }
 
+func TestRaffle_Get_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "getctx", "getctx@test.com", "pass1234")
+	raffleID := env.createRaffle(t, token, "Get Context Raffle")
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-get", "raffles")
+	ctx := context.WithValue(context.Background(), key, "raffle-get")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/dashboard/raffles/"+raffleID, nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected raffle detail DB query to use request context")
+	}
+}
+
 func TestRaffle_Get_Forbidden(t *testing.T) {
 	env := newRaffleTestEnv(t)
 	ownerToken := env.registerStreamer(t, "owner", "owner@test.com", "pass1234")

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -98,10 +98,10 @@ func (s *RaffleService) Create(userID uuid.UUID, title string) (*models.Raffle, 
 
 // GetByID returns a raffle, verifying ownership.
 func (s *RaffleService) GetByID(id, userID uuid.UUID) (*models.Raffle, error) {
-	return s.getByIDContext(context.Background(), id, userID)
+	return s.GetByIDContext(context.Background(), id, userID)
 }
 
-func (s *RaffleService) getByIDContext(ctx context.Context, id, userID uuid.UUID) (*models.Raffle, error) {
+func (s *RaffleService) GetByIDContext(ctx context.Context, id, userID uuid.UUID) (*models.Raffle, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -391,7 +391,7 @@ func (s *RaffleService) ListDrawsContext(ctx context.Context, raffleID, userID u
 		ctx = context.Background()
 	}
 
-	if _, err := s.getByIDContext(ctx, raffleID, userID); err != nil {
+	if _, err := s.GetByIDContext(ctx, raffleID, userID); err != nil {
 		return nil, err
 	}
 

--- a/services/api/internal/services/raffle_service_hardening_test.go
+++ b/services/api/internal/services/raffle_service_hardening_test.go
@@ -17,6 +17,28 @@ import (
 
 type raffleServiceContextKey struct{}
 
+func TestRaffleService_GetByIDContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "raffle_get_ctx@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+
+	key := raffleServiceContextKey{}
+	seen := installDBContextProbe(t, db, key, "raffle-get")
+	ctx := context.WithValue(context.Background(), key, "raffle-get")
+
+	svc := &RaffleService{db: db}
+	raffle, err := svc.GetByIDContext(ctx, raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("GetByIDContext: %v", err)
+	}
+	if raffle.ID != raffleID {
+		t.Fatalf("want raffle ID %s, got %s", raffleID, raffle.ID)
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetByIDContext DB query to use request context")
+	}
+}
+
 func TestRaffleService_ListDrawsContext_UsesRequestContext(t *testing.T) {
 	db := newTestDB(t)
 	ownerID := seedUserWithEmail(t, db, "list_draws_ctx@example.com")


### PR DESCRIPTION
## 什麼改動
Propagate `GET /api/v1/dashboard/raffles/:id` request context into `RaffleService.GetByIDContext`, while keeping `GetByID` as the background-context compatibility wrapper.

## 為什麼
#645 要求 service-layer DB access path 傳遞 request context，避免 request timeout 後 DB query 繼續執行。本 PR 是 #645 的 raffle detail bounded slice，不關閉整張 #645。

refs #645

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 timeout policy values
  - 不重設 raffle API response shape 或 auth policy
  - 不處理 raffle list / draw / mutation flows
  - 不做 schema、migration、frontend、queue / worker architecture redesign
  - 不關閉 #645，因為其他 DB query / transaction path 仍需後續 slice

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645；本 PR是 raffle detail request-context propagation bounded slice。
- Actual worker profile(s)：
  - repo_scout sidecar：辨識 raffle detail 為小型 backend-only slice；controller：TDD patch、PR body 修補與 final readback。
- Model strength：
  - repo_scout = gpt-5.3-codex-spark high；controller = gpt-5.5 xhigh。
- Spawn directive(s)：profile=repo_scout model=gpt-5.3-codex-spark reasoning=high controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - RED focused test failed before implementation because `GetByIDContext` was missing and handler used background context.
  - GREEN focused context-propagation command passed after implementation.
  - Regression `go test ./internal/handlers ./internal/services -run TestRaffle -count=1` passed.
  - Full backend `go test ./...` passed.
- Self-review / exception reason：
  - Focused self-review completed for context propagation, compatibility wrapper, and regression probes.
- Worker session closeout：
  - Worker result read back; no further worker task needed for this bounded metadata/code slice.
- Workflow friction / follow-up split：
  - #645 remains split by endpoint/service path. This PR stays at 4 backend files / ~52 lines and does not expand into unrelated DB paths.

## Review conversation closeout
- Unresolved threads：
  - 0 review threads in latest readback.
- CodeRabbit：
  - Rate limit comment observed at PR creation; no actionable code finding was produced.
- chatgpt-codex-connector：
  - pending first review / n/a in latest readback.
- review_triage_ref：https://github.com/nurockplayer/tachigo/pull/834#issuecomment-4500723560
- root_cause_gate_ref：https://github.com/nurockplayer/tachigo/pull/834#issuecomment-4500723560
- finding_disposition_ref：https://github.com/nurockplayer/tachigo/pull/834#issuecomment-4500723560
- Final reviewer action：
  - pending review.

## Final merge gate
- Ready-to-merge decision：
  - blocked by PR Scope Police until this template repair lands, then pending CI/review.
- Latest head SHA：
  - 49bfac42464de6ae0b4cb30f189295a189d19fe3
- Required checks：
  - PR Scope Police failed before metadata repair; backend CI gate passed.
- spec workflow-check evidence：
  - PR creation evidence reported `workflow-check:start:issue-645`; current controller shell has `spec` unavailable, so closeout uses manual checklist fallback.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/834

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Make raffle detail DB lookup observe the incoming request context.
- Approx changed lines：~52
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler must pass `c.Request.Context()` and service must expose `GetByIDContext`; tests prove the request context reaches the DB lookup.
- 若已拆分，相關 PR：
  - #645 has prior and future bounded context-propagation slices; this PR only covers raffle detail.

## Acceptance Criteria
- [x] Raffle detail handler propagates request context to the service layer.
- [x] Service DB lookup uses caller-provided context.
- [x] Compatibility wrapper remains available for background-context callers.
- [x] Regression tests cover handler and service context propagation.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
Focused context-propagation tests: PASS after implementation
Raffle regression suite: PASS
Full backend go test ./...: PASS
```

## 備註
本次 metadata repair 只補專案 PR template 欄位，沒有修改 latest head code。

## Notes for Claude Code Review
- 請確認這個 #645 slice 是否維持在 raffle detail read path，沒有把其他 raffle flows 混入同一 PR。
