### PR TITLE
[backend] Propagate raffle create request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -54,7 +54,7 @@ func (h *RaffleHandler) Create(c *gin.Context) {
 		return
 	}
 
-	raffle, err := h.raffleSvc.Create(userID, body.Title)
+	raffle, err := h.raffleSvc.CreateContext(c.Request.Context(), userID, body.Title)
 	if err != nil {
 		log.Printf("raffle create: %v", err)
 		internal(c)

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -62,9 +62,13 @@ func installRaffleHandlerDBContextProbeForTables(t *testing.T, db *gorm.DB, key,
 	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
 		t.Fatalf("register query context probe: %v", err)
 	}
+	if err := db.Callback().Create().Before("gorm:create").Register(name+":create", probe); err != nil {
+		t.Fatalf("register create context probe: %v", err)
+	}
 
 	t.Cleanup(func() {
 		_ = db.Callback().Query().Remove(name + ":query")
+		_ = db.Callback().Create().Remove(name + ":create")
 	})
 
 	return func() int {
@@ -225,6 +229,29 @@ func TestRaffle_Create(t *testing.T) {
 	}
 	if raffle["status"] != "draft" {
 		t.Errorf("expected draft status, got %v", raffle["status"])
+	}
+}
+
+func TestRaffle_Create_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "createctx", "createctx@test.com", "pass1234")
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-create", "raffles")
+	ctx := context.WithValue(context.Background(), key, "raffle-create")
+
+	body, _ := json.Marshal(map[string]string{"title": "Context Create Raffle"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected raffle create DB operation to use request context")
 	}
 }
 

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -84,13 +84,21 @@ func (s *RaffleService) SetHTTPClient(c *http.Client) {
 
 // Create creates a new raffle owned by the given user.
 func (s *RaffleService) Create(userID uuid.UUID, title string) (*models.Raffle, error) {
+	return s.CreateContext(context.Background(), userID, title)
+}
+
+func (s *RaffleService) CreateContext(ctx context.Context, userID uuid.UUID, title string) (*models.Raffle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	raffle := &models.Raffle{
 		UserID: userID,
 		Title:  title,
 		Status: models.RaffleStatusDraft,
 		Source: models.RaffleSourceCSV,
 	}
-	if err := s.db.Create(raffle).Error; err != nil {
+	if err := s.db.WithContext(ctx).Create(raffle).Error; err != nil {
 		return nil, err
 	}
 	return raffle, nil

--- a/services/api/internal/services/raffle_service_hardening_test.go
+++ b/services/api/internal/services/raffle_service_hardening_test.go
@@ -17,6 +17,27 @@ import (
 
 type raffleServiceContextKey struct{}
 
+func TestRaffleService_CreateContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "raffle_create_ctx@example.com")
+
+	key := raffleServiceContextKey{}
+	seen := installDBContextProbe(t, db, key, "raffle-create")
+	ctx := context.WithValue(context.Background(), key, "raffle-create")
+
+	svc := &RaffleService{db: db}
+	raffle, err := svc.CreateContext(ctx, ownerID, "Context Create Raffle")
+	if err != nil {
+		t.Fatalf("CreateContext: %v", err)
+	}
+	if raffle.UserID != ownerID {
+		t.Fatalf("want user ID %s, got %s", ownerID, raffle.UserID)
+	}
+	if seen() == 0 {
+		t.Fatal("expected CreateContext DB operation to use request context")
+	}
+}
+
 func TestRaffleService_GetByIDContext_UsesRequestContext(t *testing.T) {
 	db := newTestDB(t)
 	ownerID := seedUserWithEmail(t, db, "raffle_get_ctx@example.com")


### PR DESCRIPTION
## 什麼改動

- Propagate `POST /api/v1/dashboard/raffles` request context into `RaffleService.CreateContext`.
- Keep `Create` as the background-context compatibility wrapper.
- Add handler and service regression probes proving the raffle create DB operation sees the request context.

## 為什麼

refs #645

#645 tracks request timeout cancellation coverage. The raffle create path still called the background-context service wrapper and used `s.db.Create(...)` directly.

## Release Context

- Release type：`n/a`

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 schema / migration
  - 不改 response shape 或 auth/role policy
  - 不處理 raffle import / draw / claim-token / snapshot paths
  - 不處理 AuthService / SpendService / ClaimService
  - 不改 frontend

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：#645 request context propagation audit
- Actual worker profile(s)：repo_scout + controller
- Model strength：controller = current Codex session; repo_scout = explorer
- Spawn directive(s)：profile=repo_scout model=current-explorer reasoning=medium controller_fallback=allowed fallback_reason=small_backend_tdd_slice_after_scout_selected_raffle_create
- Verification evidence：RED/GREEN focused tests; `go test ./internal/handlers ./internal/services -run 'TestRaffle_Create_UsesRequestContext|TestRaffleService_CreateContext_UsesRequestContext' -count=1`; `go test ./internal/handlers ./internal/services -run 'TestRaffle' -count=1`; `go test ./...`; `spec workflow-check --phase start --issue 645 --repo .`
- Self-review / exception reason：self-review done; diff is four files and limited to raffle create request-context propagation
- Worker session closeout：repo_scout result read back; no pending worker task
- Workflow friction / follow-up split：threshold ledger deferred to #664 after merge; no new follow-up needed for this slice

## Review conversation closeout

- Unresolved threads：n/a, initial PR
- CodeRabbit：pending GitHub review/check signal
- chatgpt-codex-connector：n/a
- review_triage_ref：workflow-check:start:issue-645
- root_cause_gate_ref：workflow-check:start:issue-645
- finding_disposition_ref：workflow-check:start:issue-645
- Final reviewer action：n/a

## Final merge gate

- Ready-to-merge decision：pending checks/review
- Latest head SHA：4a674c7945aec26ec314e8d0f740943b059995bc
- Required checks：pending GitHub checks
- spec workflow-check evidence：pass; workflow-check:start:issue-645 and commit gate via local PR body
- Evidence URL：n/a until final closeout

## PR 拆分檢查

- 這個 PR 的單一句子目的：Propagate request context for the dashboard raffle create path.
- Approx changed lines：~60
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler must pass `c.Request.Context()` into the service, and the service must expose the matching context-aware create method; tests cover both boundaries.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria

- [x] Service-layer DB access path in this slice propagates request context
- [x] GORM create query uses `WithContext(ctx)`
- [x] Regression tests cover request context propagation signal for handler and service boundary

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestRaffle_Create_UsesRequestContext|TestRaffleService_CreateContext_UsesRequestContext' -count=1
  failed as expected: CreateContext missing; handler create query used background context

GREEN: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestRaffle_Create_UsesRequestContext|TestRaffleService_CreateContext_UsesRequestContext' -count=1
  ok github.com/tachigo/tachigo/internal/handlers
  ok github.com/tachigo/tachigo/internal/services

Regression: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestRaffle' -count=1
  ok github.com/tachigo/tachigo/internal/handlers
  ok github.com/tachigo/tachigo/internal/services

Full backend: GOCACHE=/tmp/tachigo-go-build-cache go test ./...
  all packages passed
```

## 備註

Scope is intentionally limited to raffle creation. Broader raffle import/draw/claim side effects remain out of scope.

## Notes for Claude Code Review

- 請確認 this remains a #645 bounded slice and does not imply closure of the full audit issue.
