### PR TITLE
[backend] Propagate profile update request context

### DIFF
--- a/services/api/internal/handlers/user_handler.go
+++ b/services/api/internal/handlers/user_handler.go
@@ -58,7 +58,7 @@ func (h *UserHandler) UpdateMe(c *gin.Context) {
 		return
 	}
 
-	user, err := h.user.UpdateProfile(userID, input)
+	user, err := h.user.UpdateProfileContext(c.Request.Context(), userID, input)
 	if err != nil {
 		switch err {
 		case services.ErrUsernameExists:

--- a/services/api/internal/handlers/user_handler_test.go
+++ b/services/api/internal/handlers/user_handler_test.go
@@ -109,6 +109,29 @@ func TestUpdateMeHandler_Username(t *testing.T) {
 	}
 }
 
+func TestUpdateMeHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "updatectx", "updatectx@example.com", "password123")
+
+	key := userHandlerContextKey{}
+	seen := installUserHandlerDBContextProbe(t, env.db, key, "update-me")
+	ctx := context.WithValue(context.Background(), key, "update-me")
+
+	body := `{"username":"contextupdate"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/users/me", bytes.NewBufferString(body)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected UpdateMe DB query to use request context")
+	}
+}
+
 func TestUpdateMeHandler_DuplicateUsername(t *testing.T) {
 	env := newTestEnv(t)
 	env.registerUser(t, "taken", "taken@example.com", "password123")

--- a/services/api/internal/services/user_service.go
+++ b/services/api/internal/services/user_service.go
@@ -54,17 +54,32 @@ func (s *UserService) GetByIDContext(ctx context.Context, id uuid.UUID) (*models
 }
 
 func (s *UserService) UpdateProfile(id uuid.UUID, input UpdateProfileInput) (*models.User, error) {
+	return s.UpdateProfileContext(context.Background(), id, input)
+}
+
+func (s *UserService) UpdateProfileContext(ctx context.Context, id uuid.UUID, input UpdateProfileInput) (*models.User, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	db := s.db.WithContext(ctx)
+
 	var user models.User
-	if err := s.db.First(&user, "id = ?", id).Error; err != nil {
-		return nil, ErrUserNotFound
+	if err := db.First(&user, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrUserNotFound
+		}
+		return nil, err
 	}
 
 	if input.Username != nil {
 		// Uniqueness check
 		var count int64
-		s.db.Model(&models.User{}).
+		if err := db.Model(&models.User{}).
 			Where("username = ? AND id != ?", *input.Username, id).
-			Count(&count)
+			Count(&count).Error; err != nil {
+			return nil, err
+		}
 		if count > 0 {
 			return nil, ErrUsernameExists
 		}
@@ -75,7 +90,7 @@ func (s *UserService) UpdateProfile(id uuid.UUID, input UpdateProfileInput) (*mo
 		user.AvatarURL = input.AvatarURL
 	}
 
-	if err := s.db.Save(&user).Error; err != nil {
+	if err := db.Save(&user).Error; err != nil {
 		return nil, err
 	}
 	return &user, nil

--- a/services/api/internal/services/user_service_test.go
+++ b/services/api/internal/services/user_service_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/tachigo/tachigo/internal/models"
 )
 
+type userServiceContextKey struct{}
+
 func TestGetByID_Found(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewUserService(db)
@@ -68,6 +70,47 @@ func TestUpdateProfile_Username(t *testing.T) {
 	}
 	if *user.Username != newName {
 		t.Errorf("username: want %s, got %s", newName, *user.Username)
+	}
+}
+
+func TestUpdateProfileContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key := userServiceContextKey{}
+	seen := installDBContextProbe(t, db, key, "profile-update")
+	ctx := context.WithValue(context.Background(), key, "profile-update")
+
+	newName := "contextname"
+	user, err := svc.UpdateProfileContext(ctx, userID, UpdateProfileInput{Username: &newName})
+	if err != nil {
+		t.Fatalf("UpdateProfileContext: %v", err)
+	}
+	if *user.Username != newName {
+		t.Errorf("username: want %s, got %s", newName, *user.Username)
+	}
+	if seen() == 0 {
+		t.Fatal("expected UpdateProfileContext DB operations to use request context")
+	}
+}
+
+func TestUpdateProfileContext_CanceledContextReturnsCanceled(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	newName := "canceledname"
+	_, err := svc.UpdateProfileContext(ctx, userID, UpdateProfileInput{Username: &newName})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
讓 `PUT /api/v1/users/me` profile update 路徑把 request context 傳到 `UserService` 的 GORM 查詢與儲存流程。

## 為什麼
refs #645

issue #645 要求 backend DB operations 接上 request-scoped context。本 PR 補齊 user profile update 這條低風險 backend-only 路徑。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 schema / migration
  - 不做 auth、OAuth、wallet、SIWE、provider linking
  - 不做 frontend / dashboard / extension
  - 不做 response shape 或 API contract 變更
  - 不做 raffle paths；已由 #832/#833/#834/#835 覆蓋

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 context propagation backlog；本切片限定 `PUT /api/v1/users/me`
- Actual worker profile(s)：
  - repo_scout / controller
- Model strength：
  - controller = high；repo_scout = current explorer medium
- Spawn directive(s)：
  - profile=repo_scout model=current-explorer reasoning=medium controller_fallback=allowed fallback_reason=worker_timeout_then_controller_direct_small_backend_tdd_slice
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --phase start --issue 645 --repo .`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestUpdateMeHandler_UsesRequestContext|TestUpdateProfileContext_UsesRequestContext|TestUpdateProfileContext_CanceledContextReturnsCanceled' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestUpdateMe|TestUpdateProfile' -count=1`
  - `git diff --check`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：
  - controller reviewed latest local diff after RED/GREEN; no scope expansion found
- Worker session closeout：
  - repo_scout result was read back; worker session closed after recommending this exact slice
- Workflow friction / follow-up split：
  - AWP scout completed after controller had already proceeded from timeout fallback; recorded here as worker_timeout_then_controller_direct_small_backend_tdd_slice. Threshold calibration stays in #664 ledger after merge.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - status success; review skipped on this head
- chatgpt-codex-connector：
  - pending with reason: no self-review action will be requested or posted by Codex
- review_triage_ref：
  - pending with reason: no external review findings yet; local self-review evidence is workflow-check:start:issue-645
- root_cause_gate_ref：
  - pending with reason: no repeated same-concept finding on this head; local root-cause rationale is issue #645 request-context gap
- finding_disposition_ref：
  - pending with reason: no external review findings yet; disposition is not applicable at PR creation
- Final reviewer action：
  - pending with reason: human/automated review not complete yet

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review; all observed GitHub checks passed or skipped
- Latest head SHA：
  - 69425936df2bc497bcc46c452a52a5ac0e2e8bb2
- Required checks：
  - Backend CI (gate) pass; Scope police pass; CodeRabbit success/skipped; Cloudflare Pages pass
- spec workflow-check evidence：
  - spec workflow-check status: pass
  - workflow-check evidence ref: workflow-check:commit:issue-645
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/836

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through the authenticated user profile update path.
- Approx changed lines：~93
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 這是同一條 endpoint call chain 的 context propagation；service、handler、tests 必須一起變更才能獨立驗證。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `UserService.UpdateProfile` 保留既有 API 並委派到 context-aware method
- [x] `UserHandler.UpdateMe` 使用 `c.Request.Context()`
- [x] 新增 handler/service regression tests 覆蓋 request context propagation
- [x] context cancellation 不會被誤轉成 `ErrUserNotFound`

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestUpdateMeHandler_UsesRequestContext|TestUpdateProfileContext_UsesRequestContext|TestUpdateProfileContext_CanceledContextReturnsCanceled' -count=1
=> services build failed: UpdateProfileContext undefined
=> handlers failed: expected UpdateMe DB query to use request context

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestUpdateMeHandler_UsesRequestContext|TestUpdateProfileContext_UsesRequestContext|TestUpdateProfileContext_CanceledContextReturnsCanceled' -count=1
=> ok github.com/tachigo/tachigo/internal/handlers
=> ok github.com/tachigo/tachigo/internal/services

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestUpdateMe|TestUpdateProfile' -count=1
=> ok github.com/tachigo/tachigo/internal/handlers
=> ok github.com/tachigo/tachigo/internal/services

git diff --check
=> pass

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
=> pass
```

## 備註
無

## Notes for Claude Code Review
- 這張 PR 刻意不碰 `LinkWallet`；wallet/SIWE/provider linking 屬於 R4 風險，應獨立 issue/PR。
