### PR TITLE
[backend] Propagate extension T-point request context

### DIFF
--- a/services/api/internal/handlers/extension_handler.go
+++ b/services/api/internal/handlers/extension_handler.go
@@ -74,7 +74,7 @@ func (h *ExtensionHandler) TPointComplete(c *gin.Context) {
 		return
 	}
 
-	user, tokens, err := h.ext.CompleteTPointTransaction(body.ExtensionJWT, body.TransactionReceipt, body.SKU)
+	user, tokens, err := h.ext.CompleteTPointTransactionContext(c.Request.Context(), body.ExtensionJWT, body.TransactionReceipt, body.SKU)
 	if err != nil {
 		switch err {
 		case services.ErrInvalidExtJWT:

--- a/services/api/internal/handlers/extension_handler_test.go
+++ b/services/api/internal/handlers/extension_handler_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -23,6 +24,31 @@ import (
 )
 
 const extHandlerSecretRaw = "test-extension-secret-32chars!!!"
+
+type extensionHandlerContextKey struct{}
+
+func installExtensionHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:extension_handler_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name + ":query")
+	})
+
+	return func() int {
+		return seen
+	}
+}
 
 func newExtHandlerEnv(t *testing.T) (*gin.Engine, *gorm.DB) {
 	t.Helper()
@@ -150,6 +176,30 @@ func tpointBody(t *testing.T, extJWT, receipt, sku string) *bytes.Buffer {
 		"sku":                 sku,
 	})
 	return bytes.NewBuffer(b)
+}
+
+func TestTPointComplete_UsesRequestContextForUserLookup(t *testing.T) {
+	r, db := newExtHandlerEnv(t)
+	twitchID := seedTwitchUserForHandler(t, db)
+	extJWT := signExtJWTForHandler(t, twitchID, "ch-context")
+	receipt := signReceiptJWTForHandler(t, "tx-handler-context", twitchID, "TPOINT100", 100, "bits")
+
+	key := extensionHandlerContextKey{}
+	seen := installExtensionHandlerDBContextProbe(t, db, key, "extension-tpoint")
+	ctx := context.WithValue(context.Background(), key, "extension-tpoint")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/extension/t-point/complete",
+		tpointBody(t, extJWT, receipt, "TPOINT100")).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected TPointComplete DB lookup to use request context")
+	}
 }
 
 func TestTPointComplete_DuplicateTransactionID_Returns409(t *testing.T) {

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -412,6 +412,13 @@ func (s *AuthService) issueTokenPair(user *models.User) (*TokenPair, error) {
 	return s.issueTokenPairTx(s.db, user)
 }
 
+func (s *AuthService) issueTokenPairContext(ctx context.Context, user *models.User) (*TokenPair, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.issueTokenPairTx(s.db.WithContext(ctx), user)
+}
+
 // ─── OAuth upsert helper ─────────────────────────────────────────────────────
 
 type googleUserInfo struct {

--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -116,11 +117,20 @@ func (s *ExtensionService) VerifyReceiptJWT(receiptStr string) (*ReceiptClaims, 
 // lookupExtensionUser resolves a Twitch identity to a tachigo User.
 // It does not issue tokens; call issueTokenPair separately.
 func (s *ExtensionService) lookupExtensionUser(claims *ExtensionClaims) (*models.User, error) {
+	return s.lookupExtensionUserContext(context.Background(), claims)
+}
+
+func (s *ExtensionService) lookupExtensionUserContext(ctx context.Context, claims *ExtensionClaims) (*models.User, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if claims.UserID == "" {
 		return nil, ErrInvalidExtJWT
 	}
+	db := s.db.WithContext(ctx)
+
 	var provider models.AuthProvider
-	err := s.db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, claims.UserID).
+	err := db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, claims.UserID).
 		First(&provider).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, ErrUserNotFound
@@ -129,7 +139,7 @@ func (s *ExtensionService) lookupExtensionUser(claims *ExtensionClaims) (*models
 		return nil, err
 	}
 	var user models.User
-	if err := s.db.First(&user, provider.UserID).Error; err != nil {
+	if err := db.First(&user, provider.UserID).Error; err != nil {
 		return nil, err
 	}
 	return &user, nil
@@ -155,6 +165,14 @@ func (s *ExtensionService) LoginWithExtension(extJWT string) (*models.User, *Tok
 // CompleteTPointTransaction verifies the Extension JWT + receipt, then issues a
 // tachigo token pair for the already-linked viewer.
 func (s *ExtensionService) CompleteTPointTransaction(extJWT, receipt, sku string) (*models.User, *TokenPair, error) {
+	return s.CompleteTPointTransactionContext(context.Background(), extJWT, receipt, sku)
+}
+
+func (s *ExtensionService) CompleteTPointTransactionContext(ctx context.Context, extJWT, receipt, sku string) (*models.User, *TokenPair, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	extClaims, err := s.VerifyExtJWT(extJWT)
 	if err != nil {
 		return nil, nil, err
@@ -185,7 +203,7 @@ func (s *ExtensionService) CompleteTPointTransaction(extJWT, receipt, sku string
 	}
 
 	// Resolve user before touching any write path.
-	user, err := s.lookupExtensionUser(extClaims)
+	user, err := s.lookupExtensionUserContext(ctx, extClaims)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -211,7 +211,8 @@ func (s *ExtensionService) CompleteTPointTransactionContext(ctx context.Context,
 	// Write points first; tokens are issued only on success to avoid orphan
 	// refresh token records when the points write fails.
 	txID := receiptClaims.Data.TransactionID
-	err = s.pointsSvc.AddPointsWithMeta(
+	err = s.pointsSvc.AddPointsWithMetaContext(
+		ctx,
 		user.ID,
 		extClaims.ChannelID,
 		models.TxSourceTPoint,
@@ -234,7 +235,7 @@ func (s *ExtensionService) CompleteTPointTransactionContext(ctx context.Context,
 	// Points are now committed. If issueTokenPair fails here, points remain credited
 	// and the client will receive an error. On retry, AddPointsWithMeta returns
 	// ErrDuplicateTransaction — the client should call LoginWithExtension to get tokens.
-	tokens, err := s.authSvc.issueTokenPair(user)
+	tokens, err := s.authSvc.issueTokenPairContext(ctx, user)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"testing"
@@ -17,6 +18,8 @@ import (
 const testExtSecretRaw = "test-extension-secret-32chars!!!"
 
 var testExtSecretB64 = base64.StdEncoding.EncodeToString([]byte(testExtSecretRaw))
+
+type extensionServiceContextKey struct{}
 
 func extTestConfig() *config.Config {
 	cfg := testConfig()
@@ -139,6 +142,26 @@ func TestCompleteTPointTransaction_Success(t *testing.T) {
 	var tx models.PointsTransaction
 	if err := svc.db.Where("external_transaction_id = ?", "tx-success-001").First(&tx).Error; err != nil {
 		t.Errorf("points_transaction not found by external_transaction_id: %v", err)
+	}
+}
+
+func TestCompleteTPointTransactionContext_UsesRequestContextForUserLookup(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	_, twitchID := seedTwitchUser(t, svc.db)
+	channelID := "channel-context"
+
+	extJWT := makeExtJWT(t, twitchID, channelID)
+	receipt := makeReceiptJWT(t, "tx-context-001", twitchID, "TPOINT100", 100, "bits")
+
+	key := extensionServiceContextKey{}
+	seen := installDBContextProbe(t, svc.db, key, "extension-tpoint")
+	ctx := context.WithValue(context.Background(), key, "extension-tpoint")
+
+	if _, _, err := svc.CompleteTPointTransactionContext(ctx, extJWT, receipt, "TPOINT100"); err != nil {
+		t.Fatalf("CompleteTPointTransactionContext: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected CompleteTPointTransactionContext user lookup to carry request context")
 	}
 }
 

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -162,6 +163,58 @@ func TestCompleteTPointTransactionContext_UsesRequestContextForUserLookup(t *tes
 	}
 	if seen() == 0 {
 		t.Fatal("expected CompleteTPointTransactionContext user lookup to carry request context")
+	}
+}
+
+func TestCompleteTPointTransactionContext_UsesRequestContextForPointsWriteAndTokenIssue(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	_, twitchID := seedTwitchUser(t, svc.db)
+	channelID := "channel-context-write"
+
+	extJWT := makeExtJWT(t, twitchID, channelID)
+	receipt := makeReceiptJWT(t, "tx-context-write-001", twitchID, "TPOINT100", 100, "bits")
+
+	key := extensionServiceContextKey{}
+	ctx := context.WithValue(context.Background(), key, "extension-tpoint-write")
+	var seenPointsWrite bool
+	var seenRefreshTokenWrite bool
+
+	callbackName := "test:extension_tpoint_write_context"
+	probe := func(tx *gorm.DB) {
+		if tx.Statement == nil || tx.Statement.Schema == nil {
+			return
+		}
+		if tx.Statement.Schema.Table != "points_transactions" && tx.Statement.Schema.Table != "refresh_tokens" {
+			return
+		}
+		if tx.Statement.Context.Value(key) != "extension-tpoint-write" {
+			tx.AddError(fmt.Errorf("missing request context for %s", tx.Statement.Schema.Table))
+			return
+		}
+		switch tx.Statement.Schema.Table {
+		case "points_transactions":
+			seenPointsWrite = true
+		case "refresh_tokens":
+			seenRefreshTokenWrite = true
+		}
+	}
+	if err := svc.db.Callback().Create().Before("gorm:create").Register(callbackName, probe); err != nil {
+		t.Fatalf("register context probe: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := svc.db.Callback().Create().Remove(callbackName); err != nil {
+			t.Fatalf("remove context probe: %v", err)
+		}
+	})
+
+	if _, _, err := svc.CompleteTPointTransactionContext(ctx, extJWT, receipt, "TPOINT100"); err != nil {
+		t.Fatalf("CompleteTPointTransactionContext: %v", err)
+	}
+	if !seenPointsWrite {
+		t.Fatal("expected points transaction write to carry request context")
+	}
+	if !seenRefreshTokenWrite {
+		t.Fatal("expected refresh token write to carry request context")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
讓 `/api/v1/extension/t-point/complete` 的 Extension T-point completion 路徑把 request context 傳到 Extension user lookup 的 GORM 查詢。

## 為什麼
refs #645

issue #645 要求 backend DB operations 接上 request-scoped context。本 PR 補齊 Extension T-point completion 中查找 linked Twitch user 的低範圍缺口。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 AuthService token issuance / login / refresh / OAuth / Web3 wallet
  - 不改 PointsService credit semantics or transaction idempotency
  - 不改 receipt validation, SKU rules, response shape, or API contract
  - 不做 schema / migration / frontend
  - 不碰 raffle / claim / spend paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 context propagation backlog；本切片限定 Extension T-point completion user lookup
- Actual worker profile(s)：
  - repo_scout / controller
- Model strength：
  - controller = high；repo_scout = current explorer medium
- Spawn directive(s)：
  - profile=repo_scout model=current-explorer reasoning=medium controller_fallback=allowed fallback_reason=worker_selected_extension_tpoint_slice_controller_direct_small_backend_tdd_patch
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --phase start --issue 645 --repo .`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestCompleteTPointTransactionContext_UsesRequestContextForUserLookup|TestTPointComplete_UsesRequestContextForUserLookup' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestCompleteTPointTransaction|TestTPointComplete' -count=1`
  - `git diff --check`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：
  - controller reviewed latest local diff after RED/GREEN; no AuthService or PointsService behavior changes included
- Worker session closeout：
  - repo_scout result was read back and closed; implementation followed its Extension T-point recommendation
- Workflow friction / follow-up split：
  - Raffle activate local spike was discarded before public state because repo_scout identified raffle surface as already saturated by recent #645 slices. Threshold calibration stays in #664 ledger after merge.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - status success; review skipped on head `64f88f655aafea49a16c7db18442f7451e84124c`
- chatgpt-codex-connector：
  - pending with reason: no self-review action will be requested or posted by Codex
- review_triage_ref：
  - pending with reason: no external review findings yet; local self-review evidence is workflow-check:start:issue-645
- root_cause_gate_ref：
  - pending with reason: no repeated same-concept finding on this head; local root-cause rationale is issue #645 request-context gap
- finding_disposition_ref：
  - pending with reason: no external review findings yet; disposition is not applicable at PR creation
- Final reviewer action：
  - pending with reason: human review required; Codex will not self-review this PR

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review; all observed GitHub checks passed or skipped
- Latest head SHA：
  - 64f88f655aafea49a16c7db18442f7451e84124c
- Required checks：
  - Backend CI (gate): pass
  - Backend security scanners: pass
  - Backend tests: pass
  - Backend integration tests: pass
  - Scope police: pass
  - Scope gate: pass
  - PR metadata regression tests: pass
  - PR commit messages: pass
  - Workflow regression tests: pass
  - Supply-chain guardrails: pass
  - Cloudflare Pages: pass
  - CodeRabbit: pass / Review skipped
- spec workflow-check evidence：
  - spec workflow-check status: pass
  - workflow-check evidence ref: workflow-check:commit:issue-645
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/837

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through Extension T-point completion user lookup.
- Approx changed lines：~97
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 這是同一條 endpoint call chain 的 request-context propagation；service、handler、tests 必須一起變更才能獨立驗證。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `CompleteTPointTransaction` 保留既有 API 並委派到 context-aware method
- [x] `TPointComplete` 使用 `c.Request.Context()`
- [x] Extension user lookup DB queries use `WithContext(ctx)`
- [x] 新增 handler/service regression tests 覆蓋 request context propagation

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestCompleteTPointTransactionContext_UsesRequestContextForUserLookup|TestTPointComplete_UsesRequestContextForUserLookup' -count=1
=> services build failed: CompleteTPointTransactionContext undefined
=> handlers failed: expected TPointComplete DB lookup to use request context

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestCompleteTPointTransactionContext_UsesRequestContextForUserLookup|TestTPointComplete_UsesRequestContextForUserLookup' -count=1
=> ok github.com/tachigo/tachigo/internal/services
=> ok github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestCompleteTPointTransaction|TestTPointComplete' -count=1
=> ok github.com/tachigo/tachigo/internal/services
=> ok github.com/tachigo/tachigo/internal/handlers

git diff --check
=> pass

GOCACHE=/tmp/tachigo-go-build-cache go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...
=> pass

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
=> pass
```

## 備註
無

## Notes for Claude Code Review
- R4 是保守分類：這條 endpoint 涉及 Extension T-point receipt completion 與 token response，但本 PR 沒改 receipt validation、token issuance 或 points credit 行為。
