### PR TITLE
[chore] Route root npm Dependabot updates to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,28 @@ updates:
 
   # Dependabot uses the "npm" ecosystem name for npm, yarn, and pnpm projects.
   - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      day: monday
+      time: "09:15"
+      timezone: Asia/Taipei
+    target-branch: develop
+    open-pull-requests-limit: 2
+    labels:
+      - chore
+    allow:
+      - dependency-type: production
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
+      - dependency-type: development
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
+          - version-update:semver-major
+
+  - package-ecosystem: npm
     directory: /apps/dashboard
     schedule:
       interval: monthly

--- a/.github/workflows/ci.test.mjs
+++ b/.github/workflows/ci.test.mjs
@@ -2287,7 +2287,11 @@ test('Dependabot pnpm version updates skip routine production patch releases', (
   const config = parseYaml(dependabotConfigPath)
   const pnpmUpdates = config.updates.filter((update) => update['package-ecosystem'] === 'npm')
 
-  assert.equal(pnpmUpdates.length, 2)
+  assert.equal(pnpmUpdates.length, 3)
+  assert.deepEqual(
+    pnpmUpdates.map((update) => update.directory).sort(),
+    ['/', '/apps/dashboard', '/apps/extension'],
+  )
   for (const update of pnpmUpdates) {
     assert.deepEqual(update.allow, [
       {


### PR DESCRIPTION
## 什麼改動
新增 root `/` 的 npm Dependabot entry，讓 root `package.json` / `pnpm-lock.yaml` 更新 PR 目標分支固定為 `develop`。

## 為什麼
closes #817

root-level pnpm lockfile 更新目前沒有對應的 root npm Dependabot entry，Dependabot 可能退回 repo default branch，導致 dependency PR 開到 `main`。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: workflow-check:start:issue-817

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#817
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 dependency versions
  - 不改 `pnpm-lock.yaml`
  - 不改 workspace package settings
  - 不改 auto-merge / CI / scope-police workflow behavior
  - 不修正 Dependabot policy docs 裡既有 wording 差異

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #817 root npm Dependabot entry；本切片限定 `.github/dependabot.yml`
- Actual worker profile(s)：
  - repo_scout / controller
- Model strength：
  - controller = high；repo_scout = current explorer medium
- Spawn directive(s)：
  - profile=repo_scout model=current-explorer reasoning=medium controller_fallback=allowed fallback_reason=single_file_metadata_patch_after_scout_confirmation
- Verification evidence：
  - `spec plan 817 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --phase start --issue 817 --repo .`
  - `ruby -ryaml -e 'c=YAML.safe_load(File.read(".github/dependabot.yml"), aliases: false); u=c.fetch("updates"); expected=%w[/ /apps/dashboard /apps/extension]; npm=u.select { |e| e["package-ecosystem"]=="npm" }; abort("unexpected npm dirs") unless npm.map { |e| e["directory"] }.sort == expected.sort; npm.each { |e| abort("#{e["directory"]} missing develop target") unless e["target-branch"]=="develop"; abort("#{e["directory"]} missing allow policy") unless e["allow"].is_a?(Array) && e["allow"].length==2 }; puts "dependabot npm targets OK"'`
  - `node --test .github/workflows/ci.test.mjs`
  - `git diff --check`
- Self-review / exception reason：
  - controller reviewed the Dependabot config and matching workflow regression test diff; no dependency or workflow behavior changed
- Worker session closeout：
  - repo_scout confirmed the minimal file, entry shape, validation, and scope exclusions
- Workflow friction / follow-up split：
  - `spec workflow-check --phase start` reported existing missing `docs/claude-codex-workflow.md`; no scope expansion was made because #817 only requires Dependabot config.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - status success; review skipped on head `4d5c46880ca32eb74751cd6f2c598f1482d97c12`
- chatgpt-codex-connector：
  - pending with reason: no self-review action will be requested or posted by Codex
- review_triage_ref：
  - pending with reason: no external review findings yet; local self-review evidence is workflow-check:start:issue-817
- root_cause_gate_ref：
  - pending with reason: root cause is missing root `/` npm Dependabot entry
- finding_disposition_ref：
  - pending with reason: no external review findings yet; disposition is not applicable at PR creation
- Final reviewer action：
  - pending with reason: human review required; Codex will not self-review this PR

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review; all observed GitHub checks passed or skipped
- Latest head SHA：
  - 4d5c46880ca32eb74751cd6f2c598f1482d97c12
- Required checks：
  - `.github/dependabot.yml`: pass
  - Workflow regression tests: pass
  - PR metadata check regression tests: pass
  - Scope police: pass
  - Scope gate: pass
  - Backend CI (gate): pass
  - Backend tests: pass
  - Backend security scanners: pass
  - Backend integration tests: pass
  - Frontend build: pass
  - Dashboard build: pass
  - Cloudflare Pages: pass
  - CodeRabbit: pass / Review skipped
- spec workflow-check evidence：
  - spec workflow-check status: pass
  - workflow-check evidence ref: workflow-check:commit:issue-817
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/838

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Route root npm/pnpm Dependabot updates to `develop`.
- Approx changed lines：~30
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Root npm/pnpm Dependabot updates target `develop`
- [x] Existing `/apps/dashboard` npm entry continues to target `develop`
- [x] Existing `/apps/extension` npm entry continues to target `develop`
- [x] Dependency versions and workspace package settings unchanged
- [x] Workflow regression test covers root/dashboard/extension npm entries and shared allow policy

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
ruby -ryaml -e 'c=YAML.safe_load(File.read(".github/dependabot.yml"), aliases: false); u=c.fetch("updates"); expected=%w[/ /apps/dashboard /apps/extension]; npm=u.select { |e| e["package-ecosystem"]=="npm" }; abort("unexpected npm dirs") unless npm.map { |e| e["directory"] }.sort == expected.sort; npm.each { |e| abort("#{e["directory"]} missing develop target") unless e["target-branch"]=="develop"; abort("#{e["directory"]} missing allow policy") unless e["allow"].is_a?(Array) && e["allow"].length==2 }; puts "dependabot npm targets OK"'
=> dependabot npm targets OK

node --test .github/workflows/ci.test.mjs
=> 93 pass, 0 fail

git diff --check
=> pass
```

## 備註
無
