### PR TITLE
[backend] Propagate wallet linking request context

### DIFF
--- a/services/api/internal/handlers/user_handler.go
+++ b/services/api/internal/handlers/user_handler.go
@@ -96,7 +96,7 @@ func (h *UserHandler) LinkWallet(c *gin.Context) {
 		return
 	}
 
-	addr, err := h.user.LinkWallet(userID, input)
+	addr, err := h.user.LinkWalletContext(c.Request.Context(), userID, input)
 	if err != nil {
 		switch err {
 		case services.ErrInvalidWalletAddress:

--- a/services/api/internal/handlers/user_handler_test.go
+++ b/services/api/internal/handlers/user_handler_test.go
@@ -357,6 +357,35 @@ func TestLinkWalletHandler_Success(t *testing.T) {
 	}
 }
 
+func TestLinkWalletHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "walletctx", "walletctx@example.com", "password123")
+
+	key, addr := newHandlerTestWallet(t)
+	nonce := "handler-context-nonce"
+	nr := seedHandlerWalletNonce(t, env, addr, nonce)
+	msg := handlerSIWEMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	sig := handlerSignSIWE(t, msg, key)
+
+	ctxKey := userHandlerContextKey{}
+	seen := installUserHandlerDBContextProbe(t, env.db, ctxKey, "link-wallet")
+	ctx := context.WithValue(context.Background(), ctxKey, "link-wallet")
+
+	body := fmt.Sprintf(`{"address":%q,"nonce":%q,"signature":%q}`, addr, nonce, sig)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/wallet", bytes.NewBufferString(body)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected LinkWallet DB query to use request context")
+	}
+}
+
 func TestLinkWalletHandler_WalletAlreadyLinked(t *testing.T) {
 	env := newTestEnv(t)
 	key, addr := newHandlerTestWallet(t)

--- a/services/api/internal/services/user_service.go
+++ b/services/api/internal/services/user_service.go
@@ -113,15 +113,24 @@ func (s *UserService) ListProvidersContext(ctx context.Context, userID uuid.UUID
 }
 
 func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (string, error) {
+	return s.LinkWalletContext(context.Background(), userID, input)
+}
+
+func (s *UserService) LinkWalletContext(ctx context.Context, userID uuid.UUID, input LinkWalletInput) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	if !common.IsHexAddress(input.Address) {
 		return "", ErrInvalidWalletAddress
 	}
 
+	db := s.db.WithContext(ctx)
 	checksumAddr := common.HexToAddress(input.Address).Hex()
 	lookupAddr := strings.ToLower(checksumAddr)
 
 	var nonceRecord models.Web3Nonce
-	if err := s.db.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
+	if err := db.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
 		First(&nonceRecord).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return "", ErrInvalidNonce
@@ -138,7 +147,7 @@ func (s *UserService) LinkWallet(userID uuid.UUID, input LinkWalletInput) (strin
 		return "", ErrInvalidSignature
 	}
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := db.Transaction(func(tx *gorm.DB) error {
 		result := tx.Where("nonce = ? AND address = ?", input.Nonce, lookupAddr).
 			Delete(&models.Web3Nonce{})
 		if result.Error != nil {

--- a/services/api/internal/services/user_service_test.go
+++ b/services/api/internal/services/user_service_test.go
@@ -277,6 +277,58 @@ func TestLinkWallet_Success(t *testing.T) {
 	}
 }
 
+func TestLinkWalletContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	key, addr := newTestWallet(t)
+	nonce := "link-wallet-context"
+	nr := seedWalletNonce(t, db, addr, nonce)
+	msg := siweMessage(addr, nonce, nr.CreatedAt.UTC().Format(time.RFC3339))
+	sig := signSIWE(t, msg, key)
+
+	ctxKey := userServiceContextKey{}
+	seen := installDBContextProbe(t, db, ctxKey, "link-wallet")
+	ctx := context.WithValue(context.Background(), ctxKey, "link-wallet")
+
+	got, err := svc.LinkWalletContext(ctx, userID, LinkWalletInput{
+		Address:   addr,
+		Nonce:     nonce,
+		Signature: sig,
+	})
+	if err != nil {
+		t.Fatalf("LinkWalletContext: %v", err)
+	}
+	if got != addr {
+		t.Errorf("address: want %s, got %s", addr, got)
+	}
+	if seen() == 0 {
+		t.Fatal("expected LinkWalletContext DB operations to use request context")
+	}
+}
+
+func TestLinkWalletContext_CanceledContextReturnsCanceled(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewUserService(db)
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Role: models.RoleViewer})
+
+	_, addr := newTestWallet(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.LinkWalletContext(ctx, userID, LinkWalletInput{
+		Address:   addr,
+		Nonce:     "canceled-link-wallet",
+		Signature: "0x" + strings.Repeat("ab", 65),
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}
+
 func TestLinkWallet_AddressAlreadyLinkedToOtherUser(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewUserService(db)


### PR DESCRIPTION
## 什麼改動
讓 `/api/v1/users/me/wallet` 的 wallet linking 路徑把 request context 傳到 `UserService.LinkWallet` 的 GORM nonce lookup 與 transaction。

## 為什麼
refs #645

issue #645 要求 backend DB operations 接上 request-scoped context。本 PR 補齊 user wallet linking 中仍使用 bare `s.db` 的低範圍缺口。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: workflow-check:start:issue-645

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 wallet signature / SIWE verification logic
  - 不改 nonce consumption, provider uniqueness, or soft-delete restore behavior
  - 不改 AuthService login / refresh / OAuth paths
  - 不改 schema / migration / frontend
  - 不碰 extension / raffle / spend paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 context propagation backlog；本切片限定 `POST /api/v1/users/me/wallet`
- Actual worker profile(s)：
  - repo_scout / controller
- Model strength：
  - controller = high；repo_scout = current explorer medium
- Spawn directive(s)：
  - profile=repo_scout model=current-explorer reasoning=medium controller_fallback=allowed fallback_reason=worker_selected_link_wallet_slice_controller_direct_small_backend_tdd_patch
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --phase start --issue 645 --repo .`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestLinkWalletContext|TestLinkWalletHandler_UsesRequestContext' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'Test(LinkWallet|GetByIDContext|UpdateProfileContext|ListProviders|MeHandler|UpdateMeHandler|ListProvidersHandler)' -count=1`
  - `git diff --check`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
  - `GOCACHE=/tmp/tachigo-go-build-cache go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...`
- Self-review / exception reason：
  - controller reviewed latest local diff after RED/GREEN; no wallet signature, nonce semantics, provider uniqueness, or schema behavior changed
- Worker session closeout：
  - repo_scout result was read back and closed; implementation followed its LinkWallet recommendation
- Workflow friction / follow-up split：
  - A local SpendService spike was discarded before public state after repo_scout flagged burn-after-cancel compensation semantics as higher risk. This PR keeps the #645 slice on the lower-risk wallet linking path.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - status success; review completed on head `054680263ca53693b5539e2ab112a0ec48f4aea0`
- chatgpt-codex-connector：
  - pending with reason: no self-review action will be requested or posted by Codex
- review_triage_ref：
  - pending with reason: no external review findings yet; local self-review evidence is workflow-check:start:issue-645
- root_cause_gate_ref：
  - pending with reason: no repeated same-concept finding on this head; local root-cause rationale is issue #645 request-context gap
- finding_disposition_ref：
  - pending with reason: no external review findings yet; disposition is not applicable at PR creation
- Final reviewer action：
  - pending with reason: human review required; Codex will not self-review this PR

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review; all observed GitHub checks passed or skipped
- Latest head SHA：
  - 054680263ca53693b5539e2ab112a0ec48f4aea0
- Required checks：
  - Backend CI (gate): pass
  - Backend security scanners: pass
  - Backend tests: pass
  - Backend integration tests: pass
  - Scope police: pass
  - Scope gate: pass
  - PR metadata regression tests: pass
  - PR commit messages: pass
  - Workflow regression tests: pass
  - Supply-chain guardrails: pass
  - Cloudflare Pages: pass
  - CodeRabbit: pass / Review completed
- spec workflow-check evidence：
  - spec workflow-check status: pass
  - workflow-check evidence ref: workflow-check:commit:issue-645
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/839

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through wallet linking DB operations.
- Approx changed lines：~95
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 這是同一條 endpoint call chain 的 request-context propagation；service、handler、tests 必須一起變更才能獨立驗證。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `LinkWallet` 保留既有 API 並委派到 context-aware method
- [x] `LinkWallet` handler 使用 `c.Request.Context()`
- [x] wallet nonce lookup 與 provider transaction 使用 `WithContext(ctx)`
- [x] 新增 service/handler regression tests 覆蓋 request context propagation
- [x] 取消 context 時 service 回傳 `context.Canceled`

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestLinkWalletContext|TestLinkWalletHandler_UsesRequestContext' -count=1
=> services build failed: LinkWalletContext undefined
=> handlers failed: expected LinkWallet DB query to use request context

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestLinkWalletContext|TestLinkWalletHandler_UsesRequestContext' -count=1
=> ok github.com/tachigo/tachigo/internal/services
=> ok github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'Test(LinkWallet|GetByIDContext|UpdateProfileContext|ListProviders|MeHandler|UpdateMeHandler|ListProvidersHandler)' -count=1
=> ok github.com/tachigo/tachigo/internal/services
=> ok github.com/tachigo/tachigo/internal/handlers

git diff --check
=> pass

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
=> pass

GOCACHE=/tmp/tachigo-go-build-cache go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...
=> pass
```

## 備註
無
