### PR TITLE
[backend] Propagate auth unlink request context

### DIFF
--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -359,7 +359,7 @@ func (h *AuthHandler) UnlinkProvider(c *gin.Context) {
 	userID, _ := uuid.Parse(claims.UserID)
 	provider := models.ProviderType(c.Param("provider"))
 
-	if err := h.auth.UnlinkProvider(userID, provider); err != nil {
+	if err := h.auth.UnlinkProviderContext(c.Request.Context(), userID, provider); err != nil {
 		switch err {
 		case services.ErrLastProvider:
 			badRequest(c, "cannot unlink the only login method")

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -13,9 +13,37 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/tachigo/tachigo/internal/models"
 	"golang.org/x/oauth2"
+	"gorm.io/gorm"
 )
+
+type authHandlerContextKey struct{}
+
+func installAuthHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int {
+	t.Helper()
+
+	var seen int
+	name := "test:auth_handler_db_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Context != nil && tx.Statement.Context.Value(key) == want {
+			seen++
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
+		t.Fatalf("register query context probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name + ":query")
+	})
+
+	return func() int {
+		return seen
+	}
+}
 
 // ─── Register ────────────────────────────────────────────────────────────────
 
@@ -966,6 +994,29 @@ func TestWeb3VerifyHandler_InvalidSignatureReturns401AndKeepsNonce(t *testing.T)
 	env.db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount)
 	if nonceCount != 1 {
 		t.Fatalf("invalid signature should keep nonce for retry, got %d rows", nonceCount)
+	}
+}
+
+// ─── UnlinkProvider ──────────────────────────────────────────────────────────
+
+func TestUnlinkProviderHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	accessToken, _ := env.registerUser(t, "unlinkctx", "unlinkctx@example.com", "password123")
+
+	key := authHandlerContextKey{}
+	seen := installAuthHandlerDBContextProbe(t, env.db, key, "unlink-provider")
+	ctx := context.WithValue(context.Background(), key, "unlink-provider")
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/auth/providers/email", nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected UnlinkProvider DB query to use request context")
 	}
 }
 

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -338,19 +338,28 @@ func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPai
 }
 
 func (s *AuthService) UnlinkProvider(userID uuid.UUID, provider models.ProviderType) error {
+	return s.UnlinkProviderContext(context.Background(), userID, provider)
+}
+
+func (s *AuthService) UnlinkProviderContext(ctx context.Context, userID uuid.UUID, provider models.ProviderType) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db := s.db.WithContext(ctx)
+
 	// Ensure the user still has at least one other way to log in
 	var count int64
-	s.db.Model(&models.AuthProvider{}).Where("user_id = ?", userID).Count(&count)
+	db.Model(&models.AuthProvider{}).Where("user_id = ?", userID).Count(&count)
 
 	var user models.User
-	s.db.First(&user, "id = ?", userID)
+	db.First(&user, "id = ?", userID)
 	hasPassword := user.PasswordHash != nil
 
 	if count <= 1 && !hasPassword {
 		return ErrLastProvider
 	}
 
-	return s.db.Where("user_id = ? AND provider = ?", userID, provider).Delete(&models.AuthProvider{}).Error
+	return db.Where("user_id = ? AND provider = ?", userID, provider).Delete(&models.AuthProvider{}).Error
 }
 
 // ─── JWT helpers ─────────────────────────────────────────────────────────────

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -349,10 +349,14 @@ func (s *AuthService) UnlinkProviderContext(ctx context.Context, userID uuid.UUI
 
 	// Ensure the user still has at least one other way to log in
 	var count int64
-	db.Model(&models.AuthProvider{}).Where("user_id = ?", userID).Count(&count)
+	if err := db.Model(&models.AuthProvider{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+		return err
+	}
 
 	var user models.User
-	db.First(&user, "id = ?", userID)
+	if err := db.First(&user, "id = ?", userID).Error; err != nil {
+		return err
+	}
 	hasPassword := user.PasswordHash != nil
 
 	if count <= 1 && !hasPassword {

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -1039,6 +1039,73 @@ func TestUnlinkProviderContext_UsesRequestContext(t *testing.T) {
 	}
 }
 
+func installUnlinkProviderQueryError(t *testing.T, db *gorm.DB, err error, failOnQuery int) {
+	t.Helper()
+
+	queryCount := 0
+	name := "test:unlink_provider_query_error:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		queryCount++
+		if queryCount == failOnQuery {
+			tx.AddError(err)
+		}
+	}
+
+	if err := db.Callback().Query().Before("gorm:query").Register(name, probe); err != nil {
+		t.Fatalf("register unlink provider query error probe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(name)
+	})
+}
+
+func TestUnlinkProviderContext_ReturnsCountError(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	userID := uuid.New()
+	if err := db.Create(&models.User{ID: userID, Role: models.RoleViewer}).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := db.Create(&models.AuthProvider{UserID: userID, Provider: models.ProviderTwitch, ProviderID: "twitch-count-err"}).Error; err != nil {
+		t.Fatalf("create twitch provider: %v", err)
+	}
+	if err := db.Create(&models.AuthProvider{UserID: userID, Provider: models.ProviderGoogle, ProviderID: "google-count-err"}).Error; err != nil {
+		t.Fatalf("create google provider: %v", err)
+	}
+
+	installUnlinkProviderQueryError(t, db, context.Canceled, 1)
+
+	err := svc.UnlinkProviderContext(context.Background(), userID, models.ProviderTwitch)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled from count query, got %v", err)
+	}
+}
+
+func TestUnlinkProviderContext_ReturnsUserLookupError(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	userID := uuid.New()
+	if err := db.Create(&models.User{ID: userID, Role: models.RoleViewer}).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := db.Create(&models.AuthProvider{UserID: userID, Provider: models.ProviderTwitch, ProviderID: "twitch-first-err"}).Error; err != nil {
+		t.Fatalf("create twitch provider: %v", err)
+	}
+	if err := db.Create(&models.AuthProvider{UserID: userID, Provider: models.ProviderGoogle, ProviderID: "google-first-err"}).Error; err != nil {
+		t.Fatalf("create google provider: %v", err)
+	}
+
+	installUnlinkProviderQueryError(t, db, context.DeadlineExceeded, 2)
+
+	err := svc.UnlinkProviderContext(context.Background(), userID, models.ProviderTwitch)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded from user lookup, got %v", err)
+	}
+}
+
 // ─── crypto helpers ───────────────────────────────────────────────────────────
 
 func TestHashToken_Deterministic(t *testing.T) {

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -1011,6 +1011,34 @@ func TestUnlinkProvider_MultipleProviders(t *testing.T) {
 	}
 }
 
+func TestUnlinkProviderContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	userID := uuid.New()
+	if err := db.Create(&models.User{ID: userID, Role: models.RoleViewer}).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := db.Create(&models.AuthProvider{UserID: userID, Provider: models.ProviderTwitch, ProviderID: "twitch-ctx"}).Error; err != nil {
+		t.Fatalf("create twitch provider: %v", err)
+	}
+	if err := db.Create(&models.AuthProvider{UserID: userID, Provider: models.ProviderGoogle, ProviderID: "google-ctx"}).Error; err != nil {
+		t.Fatalf("create google provider: %v", err)
+	}
+
+	type unlinkProviderContextKey struct{}
+	key := unlinkProviderContextKey{}
+	seen := installDBContextProbe(t, db, key, "unlink-provider")
+	ctx := context.WithValue(context.Background(), key, "unlink-provider")
+
+	if err := svc.UnlinkProviderContext(ctx, userID, models.ProviderTwitch); err != nil {
+		t.Fatalf("unlink provider: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected UnlinkProvider DB query to use request context")
+	}
+}
+
 // ─── crypto helpers ───────────────────────────────────────────────────────────
 
 func TestHashToken_Deterministic(t *testing.T) {


### PR DESCRIPTION
## 什麼改動
- 將 `DELETE /auth/providers/:provider` 的 request context 傳入 `AuthService.UnlinkProviderContext`。
- 保留既有 `UnlinkProvider` wrapper 給非 request caller 使用。
- 新增 handler-level 與 service-level DB context probe，覆蓋 unlink provider 路徑。

## 為什麼
#645 要求稽核並補齊 backend DB query context propagation，避免 request timeout / cancel 後 DB work 繼續執行。這個 PR 只處理 auth provider unlink 的小切片。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 schema / migration
  - 不做 OAuth callback / token issuance 行為變更
  - 不做 frontend / dashboard / extension 變更
  - 不關閉 #645，因為這是 audit issue 的一個 bounded slice

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645 context propagation audit slice
- Actual worker profile(s)：repo_scout read-only validation, backend_fix_worker reviewer-comment fix, controller implementation/review
- Model strength：controller = high；repo_scout = medium；backend_fix_worker = high
- Spawn directive(s)：profile=repo_scout model=gpt-5.3-codex-spark reasoning=medium controller_fallback=not_needed fallback_reason=worker_validated_slice; profile=backend_fix_worker model=gpt-5.4 reasoning=high write_scope=services/api/internal/services/auth_service.go,services/api/internal/services/auth_service_test.go
- Verification evidence：spec plan dry-run; RED/GREEN handler probe; focused auth tests; package handlers/services tests; git diff --check; GitHub Backend CI pass at latest head
- Self-review / exception reason：self-authored PR; no self-review/approval will be performed
- Worker session closeout：repo_scout completed read-only and confirmed no overlap with open PRs #800/#803/#837/#839
- Workflow friction / follow-up split：threshold calibration留 #664 ledger；本 PR 未 merge 前不新增 #664 datapoint

## Review conversation closeout
- Unresolved threads：0 after bot-thread closeout
- CodeRabbit：latest-head review reports no actionable comments; old inline thread replied/resolved
- chatgpt-codex-connector：old inline thread replied/resolved; self-authored PR will not be self-reviewed
- review_triage_ref：https://github.com/nurockplayer/tachigo/pull/840#discussion_r3277531084 and https://github.com/nurockplayer/tachigo/pull/840#discussion_r3277531413
- root_cause_gate_ref：review finding was valid; Count / First DB errors were previously masked by business logic; fixed at latest head
- finding_disposition_ref：https://github.com/nurockplayer/tachigo/pull/840#issuecomment-4503039477
- Final reviewer action：pending with reason: R4 auth/security PR requires human review

## Final merge gate
- Ready-to-merge decision：blocked by human review; R4 auth/security PR must not be self-approved
- Latest head SHA：a906af625908beb1cb249666ee2d1f92177f5e07
- Required checks：GitHub Scope Police, Backend tests, Backend security scanners, Backend integration tests, Backend CI (gate), and CodeRabbit all passed at latest head
- spec workflow-check evidence：local dry-run context only: `spec plan 645 --repo . --dry-run --format prompt --verbose`
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/840

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 auth provider unlink 的 DB queries 使用 request context。
- Approx changed lines：~167
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - handler 只負責傳入 request context；service 只負責使用 `WithContext(ctx)`；測試驗證同一條 request-bound DB path。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Service-layer DB access path propagates request context for auth provider unlink.
- [x] GORM queries in this path use `WithContext(ctx)`.
- [x] Count / user lookup DB errors are returned instead of being masked as business errors.
- [x] Added regression tests proving request context reaches DB queries.
- [x] Schema, frontend, and unrelated auth behavior unchanged.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
PR creation RED: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestUnlinkProviderHandler_UsesRequestContext -count=1
FAIL: expected UnlinkProvider DB query to use request context

PR creation GREEN: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestUnlinkProviderHandler_UsesRequestContext -count=1
ok github.com/tachigo/tachigo/internal/handlers 0.420s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'TestUnlinkProvider|TestUnlinkProviderHandler' -count=1
ok github.com/tachigo/tachigo/internal/handlers 0.505s
ok github.com/tachigo/tachigo/internal/services 0.800s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -run 'Auth|Register|Login|Refresh|Logout|Web3|OAuth|UnlinkProvider' -count=1
ok github.com/tachigo/tachigo/internal/handlers 1.542s
ok github.com/tachigo/tachigo/internal/services 1.790s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers ./internal/services -count=1
ok github.com/tachigo/tachigo/internal/handlers 17.983s
ok github.com/tachigo/tachigo/internal/services 3.056s

git diff --check
pass

Latest head local verification:
git diff --check
pass

Latest head focused local go test:
blocked: sandbox cannot resolve proxy.golang.org while downloading go1.26.3 toolchain

Latest head docker go test:
blocked: sandbox cannot access /Users/tachikoma/.orbstack/run/docker.sock

Latest head GitHub verification:
pass: Scope Police, Backend tests, Backend security scanners, Backend integration tests, Backend CI (gate), CodeRabbit
```

## 備註
- `spec plan` reported `docs/claude-codex-workflow.md` as configured always-read but missing; this PR did not change spec-injector config.
- This is intentionally not marked `closes #645`; #645 remains a broader audit.

## Notes for Claude Code Review
- Please focus review on whether `UnlinkProviderContext` preserves auth unlink semantics while making the DB query/delete path request-context-aware.
