### PR TITLE
[backend] Add points credit context variant

### DIFF
--- a/services/api/internal/services/points_service.go
+++ b/services/api/internal/services/points_service.go
@@ -163,6 +163,17 @@ func (s *PointsService) AddPointsWithMeta(
 	amount int64,
 	meta PointsCreditMeta,
 ) error {
+	return s.AddPointsWithMetaContext(context.Background(), userID, channelID, source, amount, meta)
+}
+
+func (s *PointsService) AddPointsWithMetaContext(
+	ctx context.Context,
+	userID uuid.UUID,
+	channelID string,
+	source models.TxSource,
+	amount int64,
+	meta PointsCreditMeta,
+) error {
 	if err := validatePositivePointsAmount(amount); err != nil {
 		return err
 	}
@@ -172,7 +183,7 @@ func (s *PointsService) AddPointsWithMeta(
 	if meta.ExternalTransactionID != nil && utf8.RuneCountInString(*meta.ExternalTransactionID) > 255 {
 		return ErrInvalidExternalTransactionID
 	}
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	return s.dbWithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		return s.addPointsWithMeta(tx, userID, channelID, source, amount, meta)
 	})
 }

--- a/services/api/internal/services/points_service_test.go
+++ b/services/api/internal/services/points_service_test.go
@@ -285,6 +285,29 @@ func TestAddPointsWithMeta_ExternalTransactionID_Persisted(t *testing.T) {
 	}
 }
 
+func TestPointsService_AddPointsWithMetaContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+	key := pointsContextKey("points-add-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-add")
+	sku := "bits_100"
+
+	err := svc.AddPointsWithMetaContext(
+		context.WithValue(context.Background(), key, "points-add"),
+		userID,
+		"ch_context",
+		models.TxSourceTPoint,
+		100,
+		PointsCreditMeta{SKU: &sku},
+	)
+	if err != nil {
+		t.Fatalf("add points with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected AddPointsWithMetaContext DB operations to carry request context")
+	}
+}
+
 func TestAddPointsWithMeta_DuplicateExternalTransactionID_Fails(t *testing.T) {
 	svc, _ := newPointsSvc(t)
 	userID := seedViewer(t, svc)


### PR DESCRIPTION
## 什麼改動
新增 `PointsService.AddPointsWithMetaContext(ctx, ...)`，讓 points credit transaction 可透過 `db.WithContext(ctx)` 繼承 request cancellation context。既有 `AddPointsWithMeta(...)` 保持相容，改為包一層 `context.Background()`。

## 為什麼
補 #645 的 service-layer DB context propagation 缺口。這張 PR 先處理 `points_service.go` 內的 context-aware service variant；不碰 #837 正在修改的 extension caller，避免踩到其他 open PR 的檔案範圍。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 extension handler/service caller；#837 仍由原作者處理。
  - 不修改 schema、migration、auth、wallet、raffle、spend flow。
  - 不宣稱完成 #645 全部 audit。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645
- Actual worker profile(s)：controller + explorer scout
- Model strength：controller = high；explorer scout = inherited
- Spawn directive(s)：profile=explorer model=inherited reasoning=inherited controller_fallback=denied fallback_reason=n/a；task=read-only scout for next non-overlapping #645 slice
- Verification evidence：`spec plan 645 --repo . --dry-run --format prompt --verbose`；`go test ./internal/services -run 'TestPointsService_AddPointsWithMetaContext_UsesRequestContext|TestPointsService_AddPoints|TestPointsService_ListTransactions|TestPointsService_GetBalance' -count=1`；`go test ./internal/services -count=1`；`git diff --check`
- Self-review / exception reason：TDD red/green completed; scope limited to `points_service.go` and `points_service_test.go`.
- Worker session closeout：worker result read back; recommended `points_service.go` service-level slice and warned not to touch #837 caller files.
- Workflow friction / follow-up split：#837 owns extension caller files, so this PR intentionally leaves caller adoption for after #837 merge or for that PR author; #664 ledger comment only after merge.

## Review conversation closeout
- Unresolved threads：0 at PR creation
- CodeRabbit：pending initial review
- chatgpt-codex-connector：n/a; self-authored PR, no self-review requested
- review_triage_ref：pending with reason: initial PR creation, no review threads yet
- root_cause_gate_ref：pending with reason: initial PR creation, no repeated finding yet
- finding_disposition_ref：pending with reason: initial PR creation, no findings yet
- Final reviewer action：pending human/automated review

## Final merge gate
- Ready-to-merge decision：blocked until GitHub checks and reviewer signals complete
- Latest head SHA：cd348e5
- Required checks：pending after PR creation
- spec workflow-check evidence：local-only spec-injector dry-run completed for #645; missing always-read noted: `docs/claude-codex-workflow.md` not found
- Evidence URL：n/a at PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：新增 points credit 的 context-aware service method，讓 request context 可進入 credit transaction。
- Approx changed lines：~35
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？service behavior 與 regression test 必須同 PR 驗證。
- 若已拆分，相關 PR：#837 owns extension caller files; this PR does not depend on it.

## Acceptance Criteria
- [x] Add regression test that proves a points credit DB operation carries request context.
- [x] Ensure the points credit transaction uses `WithContext(ctx)` through the service DB handle.
- [x] Preserve existing `AddPointsWithMeta(...)` callers and behavior.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
RED: go test ./internal/services -run 'TestPointsService_AddPointsWithMetaContext_UsesRequestContext|TestPointsService_AddPoints|TestPointsService_ListTransactions|TestPointsService_GetBalance' -count=1
FAIL: svc.AddPointsWithMetaContext undefined

GREEN: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestPointsService_AddPointsWithMetaContext_UsesRequestContext|TestPointsService_AddPoints|TestPointsService_ListTransactions|TestPointsService_GetBalance' -count=1
ok  github.com/tachigo/tachigo/internal/services  0.706s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -count=1
ok  github.com/tachigo/tachigo/internal/services  2.605s

git diff --check
pass
```

## 備註
`spec plan` dry-run reported missing always-read file `docs/claude-codex-workflow.md`; implementation stayed within existing local repo context and #645 scope.

## Notes for Claude Code Review
- 請特別確認這個 preparatory service-level slice 是否符合 #645 的拆分策略。
- 這張 PR 不更新 extension caller 是刻意的，因為 #837 正在處理同一組 caller 檔案。
