### PR TITLE
[backend] Propagate spend reservation request context

### DIFF
--- a/services/api/internal/services/spend_service.go
+++ b/services/api/internal/services/spend_service.go
@@ -76,7 +76,7 @@ func (s *SpendService) Redeem(ctx context.Context, userID uuid.UUID, couponID st
 	}
 
 	var reservation spendReservation
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var err error
 		reservation, err = s.reserveSpend(tx, userID, amount)
 		return err

--- a/services/api/internal/services/spend_service_test.go
+++ b/services/api/internal/services/spend_service_test.go
@@ -131,6 +131,33 @@ func TestRedeem_Success(t *testing.T) {
 	}
 }
 
+func TestRedeem_CanceledRequestContextStopsReservationBeforeBurn(t *testing.T) {
+	db := newTestDB(t)
+	burnCaller := &mockBurnCaller{txHash: "0xburn123"}
+	svc := &SpendService{db: db, burnCaller: burnCaller}
+
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedTachiBalance(t, db, userID, 500)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := svc.Redeem(ctx, userID, "coupon-123", 100)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if len(burnCaller.calls) != 0 {
+		t.Fatalf("burn should not run after canceled reservation context, got %d calls", len(burnCaller.calls))
+	}
+
+	var dbBal int64
+	db.Raw("SELECT balance FROM tachi_balances WHERE user_id = ?", userID).Scan(&dbBal)
+	if dbBal != 500 {
+		t.Fatalf("expected balance unchanged at 500, got %d", dbBal)
+	}
+}
+
 func TestRedeem_TachiyaIssuedVoucherButPersistFailureReturnsErrorAndLeavesPending(t *testing.T) {
 	db := newTestDB(t)
 	updateErr := errors.New("forced redeemed voucher update failure")


### PR DESCRIPTION
## 什麼改動
- 將 `SpendService.Redeem` 的 spend reservation transaction 改為 `s.db.WithContext(ctx).Transaction(...)`。
- 新增取消 request context 的 regression test，確認 reservation 階段會停止、burn 不會被呼叫、餘額不會被扣。

## 為什麼
#645 要求 service-layer DB access path 傳遞 request context。`SpendHandler.Redeem` 已傳入 `c.Request.Context()`，但 spend reservation transaction 先前沒有把 ctx 接到 GORM transaction，取消的 request 仍可能完成 DB reservation 並進入 burn。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 timeout policy values
  - 不改 queue / worker architecture
  - 不改 burn 後的 coupon redemption / compensation persistence context policy
  - 不關閉 #645，這只是 audit ticket 的小切片

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645
- Actual worker profile(s)：AWP read-only scout + controller implementation
- Model strength：controller = medium；AWP scout = medium
- Spawn directive(s)：profile=explorer model=inherited reasoning=medium read_only=true target=#645 spend reservation context candidate controller_fallback=allowed fallback_reason=small 2-file TDD implementation after scout identified non-overlapping candidate
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - RED test-only patch on `origin/develop` failed with `expected context.Canceled, got <nil>`
  - `git diff --check refs/remotes/origin/develop...HEAD`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestRedeem_CanceledRequestContextStopsReservationBeforeBurn -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestRedeem_' -count=1`
- Self-review / exception reason：self-authored PR; no self-review requested or performed
- Worker session closeout：AWP scout returned one safe candidate; controller verified overlap and implemented only the bounded spend reservation slice
- Workflow friction / follow-up split：Dogfood signal for #664 after merge; burn-after-reservation persistence context policy intentionally deferred because it affects reconciliation semantics

## Review conversation closeout
- Unresolved threads：n/a at PR open
- CodeRabbit：pending at PR open
- chatgpt-codex-connector：n/a; self-authored PR is not self-reviewed
- review_triage_ref：PR #842 body records self-authored PR policy: no self-review requested or performed
- root_cause_gate_ref：PR #842 body Notes for Claude Code Review: burn-after-reservation persistence context policy intentionally deferred
- finding_disposition_ref：PR #842 has no human/automated blocking findings at body update time; future findings will be handled by PR author
- Final reviewer action：n/a

## Final merge gate
- Ready-to-merge decision：pending checks and human review
- Latest head SHA：75254d719d8c9c97fad0f8d32f667833bad9c609
- Required checks：pending GitHub checks at PR open
- spec workflow-check evidence：local-only spec-injector dry-run context generated with `spec plan 645 --repo . --dry-run --format prompt --verbose`
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/842

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 spend reservation DB transaction 使用 request context，避免 canceled request 仍進入 burn 前 reservation。
- Approx changed lines：~29
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - backend service change needs the paired regression test proving canceled request context stops before burn
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] All service-layer DB access paths propagate request context: spend reservation slice only
- [x] GORM transaction uses `WithContext(ctx)` for the spend reservation path
- [x] Add regression test for canceled request context
- [ ] Full #645 audit remains open for additional service paths
- [ ] Integration timeout cancellation test remains out of this small slice

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED: test-only patch on origin/develop failed with: expected context.Canceled, got <nil>
ok github.com/tachigo/tachigo/internal/services 0.442s  # TestRedeem_CanceledRequestContextStopsReservationBeforeBurn
ok github.com/tachigo/tachigo/internal/services 0.286s  # TestRedeem_
git diff --check refs/remotes/origin/develop...HEAD  # pass
```

## 備註
此 PR 不改 burn 已發生後的 Tachiya / coupon redemption persistence context，避免改變 reconciliation 語意。

## Notes for Claude Code Review
- 請特別看 canceled request 是否應該只停在 burn 前 reservation；burn 後 persistence context policy 已明確留給後續決策。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了数据库操作对请求取消信号的处理，确保取消请求能够及时停止相关操作。

* **Tests**
  * 添加了新的测试用例，验证请求取消时的行为正确性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

