### PR TITLE
[backend] Propagate claim reservation request context

### DIFF
--- a/services/api/internal/services/claim_service.go
+++ b/services/api/internal/services/claim_service.go
@@ -144,7 +144,7 @@ func (s *ClaimService) Claim(ctx context.Context, userID uuid.UUID, amount int64
 	}
 
 	var reservation claimReservation
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var err error
 		reservation, err = s.reserveClaim(tx, userID, amount)
 		return err

--- a/services/api/internal/services/claim_service_test.go
+++ b/services/api/internal/services/claim_service_test.go
@@ -267,6 +267,42 @@ func TestClaim_ReservesSpendableBeforeMint(t *testing.T) {
 	}
 }
 
+func TestClaim_CanceledRequestContextStopsReservationBeforeMint(t *testing.T) {
+	db := newTestDB(t)
+	mintCaller := &mockMintCaller{broadcastHash: "0xabc"}
+	svc := &ClaimService{db: db, mintCaller: mintCaller}
+	userID := userIDForClaim(t, db)
+	seedWeb3Provider(t, db, userID, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+	seedLedger(t, db, userID, "ch1", 80)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.Claim(ctx, userID, 50)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if len(mintCaller.broadcastCalls) != 0 {
+		t.Fatalf("mint should not run after canceled reservation context, got %d calls", len(mintCaller.broadcastCalls))
+	}
+
+	var remaining int64
+	if err := db.Raw("SELECT spendable_balance FROM points_ledgers WHERE user_id = ? AND channel_id = 'ch1'", userID).Scan(&remaining).Error; err != nil {
+		t.Fatalf("query remaining: %v", err)
+	}
+	if remaining != 80 {
+		t.Fatalf("expected spendable balance unchanged at 80, got %d", remaining)
+	}
+
+	var claimCount int64
+	if err := db.Model(&models.Claim{}).Where("user_id = ?", userID).Count(&claimCount).Error; err != nil {
+		t.Fatalf("count claims: %v", err)
+	}
+	if claimCount != 0 {
+		t.Fatalf("expected no claim rows after canceled reservation context, got %d", claimCount)
+	}
+}
+
 func TestClaim_InsufficientBalance(t *testing.T) {
 	db := newTestDB(t)
 	svc := &ClaimService{db: db}


### PR DESCRIPTION
## 什麼改動
- 將 `ClaimService.Claim` 的 mint 前 reservation transaction 改為 `s.db.WithContext(ctx).Transaction(...)`。
- 新增取消 request context 的 regression test，確認取消時不建立 claim、不扣 ledger spendable、不呼叫 mint。

## 為什麼
#645 要求 service-layer DB access path 傳遞 request context。`ClaimHandler.Claim` 已傳入 `c.Request.Context()`，但 `ClaimService.Claim` 的初始 reservation transaction 先前沒有把 ctx 接到 GORM transaction，取消的 request 仍可能完成 DB reservation 並進入鏈上 mint。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 timeout policy values
  - 不改 queue / worker architecture
  - 不改 mint broadcast / receipt / finalize / compensation 之後的 transaction context policy
  - 不關閉 #645，這只是 audit ticket 的小切片

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645
- Actual worker profile(s)：AWP read-only scout + controller implementation
- Model strength：controller = medium；AWP scout = medium
- Spawn directive(s)：profile=explorer model=inherited reasoning=medium read_only=true target=#645 claim reservation context candidate controller_fallback=allowed fallback_reason=small 2-file TDD implementation after scout identified non-overlapping candidate
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestClaim_CanceledRequestContextStopsReservationBeforeMint -count=1` failed with `expected context.Canceled, got <nil>`
  - `git diff --check refs/remotes/origin/develop...HEAD`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestClaim_CanceledRequestContextStopsReservationBeforeMint -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestClaim|TestGetTachiBalance' -count=1`
- Self-review / exception reason：self-authored PR; no self-review requested or performed
- Worker session closeout：AWP scout returned one safe candidate; controller verified overlap and implemented only the bounded claim reservation slice
- Workflow friction / follow-up split：Dogfood signal for #664 after merge; mint-after-reservation persistence context policy intentionally deferred because it affects reconciliation semantics

## Review conversation closeout
- Unresolved threads：n/a at PR open
- CodeRabbit：pending at PR open
- chatgpt-codex-connector：n/a; self-authored PR is not self-reviewed
- review_triage_ref：PR body records self-authored PR policy: no self-review requested or performed
- root_cause_gate_ref：PR body Notes for Claude Code Review: mint-after-reservation transaction context policy intentionally deferred
- finding_disposition_ref：No human/automated blocking findings at PR open; future findings will be handled by PR author
- Final reviewer action：n/a

## Final merge gate
- Ready-to-merge decision：pending checks and human review
- Latest head SHA：4d2668948af306e54d0d2d22beddd618ec46dc9c
- Required checks：pending GitHub checks at PR open
- spec workflow-check evidence：local-only spec-injector dry-run context generated with `spec plan 645 --repo . --dry-run --format prompt --verbose`
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/new/fix/claim-context-gap-645

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 claim mint 前 reservation DB transaction 使用 request context，避免 canceled request 仍建立 claim 並進入 mint。
- Approx changed lines：~38
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - backend service change needs the paired regression test proving canceled request context stops before mint
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] All service-layer DB access paths propagate request context: claim mint-before-reservation slice only
- [x] GORM transaction uses `WithContext(ctx)` for the claim reservation path
- [x] Add regression test for canceled request context
- [ ] Full #645 audit remains open for additional service paths
- [ ] Integration timeout cancellation test remains out of this small slice

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED: TestClaim_CanceledRequestContextStopsReservationBeforeMint failed with: expected context.Canceled, got <nil>
ok github.com/tachigo/tachigo/internal/services 0.194s  # TestClaim_CanceledRequestContextStopsReservationBeforeMint
ok github.com/tachigo/tachigo/internal/services 0.404s  # TestClaim|TestGetTachiBalance
git diff --check refs/remotes/origin/develop...HEAD  # pass
```

## 備註
此 PR 不改 mint broadcast 後的 receipt / finalize / compensation transactions，避免改變鏈上 side effect 後的 reconciliation 語意。

## Notes for Claude Code Review
- 請特別看 canceled request 是否應該只停在 mint 前 reservation；mint 後 persistence context policy 已明確留給後續決策。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 改进了声明服务的事务处理机制，使其正确响应请求的超时和取消信号，确保数据库操作在请求被中止时及时中断。

## Tests
- 新增测试用例验证请求取消时的行为，确保相关操作正确停止。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->