### PR TITLE
[infra] enforce TypeScript-only source policy

### DIFF
--- a/.github/workflows/auto-ready-pr.yml
+++ b/.github/workflows/auto-ready-pr.yml
@@ -47,6 +47,7 @@ jobs:
               develop: [
                 { context: 'Scope gate', appId: 15368 },
                 { context: 'Supply-chain guardrails', appId: 15368 },
+                { context: 'TypeScript-only guardrail', appId: 15368 },
                 { context: 'Dependency Review', appId: 15368 },
                 { context: 'API contract drift', appId: 15368 },
                 { context: 'Frontend build', appId: 15368 },

--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -42,6 +42,7 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 const developRequiredCheckRuns = [
   'Scope gate',
   'Supply-chain guardrails',
+  'TypeScript-only guardrail',
   'Dependency Review',
   'API contract drift',
   'Frontend build',
@@ -55,7 +56,7 @@ const developRequiredCheckRuns = [
   status: 'completed',
   conclusion: 'success',
   app: { id: 15368 },
-  completed_at: `2026-05-02T00:00:0${index}Z`,
+  completed_at: `2026-05-02T00:00:${String(index).padStart(2, '0')}Z`,
 }))
 
 function successfulDevelopRequiredCheckRuns(...overrides) {
@@ -268,6 +269,7 @@ async function runCiAutoReadyAfterCiWorkflow({
     env: {
       SCOPE_GATE_RESULT: 'success',
       SUPPLY_CHAIN_GUARDRAILS_RESULT: 'success',
+      TYPESCRIPT_ONLY_GUARDRAIL_RESULT: 'success',
       BACKEND_CI_RESULT: 'success',
       DEPENDENCY_REVIEW_RESULT: 'success',
       API_CONTRACTS_RESULT: 'success',
@@ -795,6 +797,8 @@ test('CI workflow uses infra script entrypoints', async () => {
 
   assert.match(workflow, /run: bash infra\/scripts\/check-backend-ci-cache\.sh/)
   assert.match(workflow, /run: bash infra\/scripts\/check-supply-chain-guardrails\.test\.sh/)
+  assert.match(workflow, /run: bash infra\/scripts\/check-typescript-only\.test\.sh/)
+  assert.match(workflow, /run: bash infra\/scripts\/check-typescript-only\.sh/)
   assert.match(workflow, /run: bash infra\/scripts\/check-developer-persistence\.test\.sh/)
   assert.match(workflow, /run: bash infra\/scripts\/commit-message-check\.test\.sh/)
   assert.match(workflow, /run: bash infra\/scripts\/pr-open\.test\.sh/)
@@ -824,6 +828,21 @@ test('supply-chain guardrail CI job runs the repository guardrail script', async
   assert.match(
     jobBlock,
     /run: node --experimental-strip-types --no-warnings infra\/scripts\/check-supply-chain-guardrails\.ts/,
+  )
+})
+
+test('TypeScript-only guardrail CI job runs the repository guardrail script', async () => {
+  const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
+  const job = parsedWorkflow.jobs['typescript-only-guardrail']
+  const jobBlock = workflowJobBlock(workflow, 'typescript-only-guardrail')
+
+  assert.equal(job.name, 'TypeScript-only guardrail')
+  assert.equal(job['timeout-minutes'], 5)
+  assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.equal(
+    workflowJobStep(parsedWorkflow, 'typescript-only-guardrail', 'Reject tracked JavaScript source files').run,
+    'bash infra/scripts/check-typescript-only.sh',
   )
 })
 
@@ -2815,6 +2834,8 @@ test('auto-ready workflow checks required contexts and excludes its own run', as
   assert.match(workflow, /const requiredCheckSnapshots = \{/)
   assert.match(workflow, /develop: \[/)
   assert.match(workflow, /\{ context: 'Scope gate', appId: 15368 \}/)
+  assert.match(workflow, /\{ context: 'Supply-chain guardrails', appId: 15368 \}/)
+  assert.match(workflow, /\{ context: 'TypeScript-only guardrail', appId: 15368 \}/)
   assert.match(workflow, /\{ context: 'Dependency Review', appId: 15368 \}/)
   assert.match(workflow, /\{ context: 'API contract drift', appId: 15368 \}/)
   assert.match(workflow, /\{ context: 'Frontend build', appId: 15368 \}/)
@@ -2872,7 +2893,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
 
   assert.equal(job.name, 'Auto-ready draft PR after CI')
   assert.equal(job.if, "always() && github.event_name == 'pull_request'")
-  assert.deepEqual(job.needs, ['scope-gate', 'supply-chain-guardrails', 'backend-ci', 'dependency-review', 'api-contracts', 'frontend', 'dashboard', 'contracts', 'contracts-slither', 'contracts-gas-snapshot'])
+  assert.deepEqual(job.needs, ['scope-gate', 'supply-chain-guardrails', 'typescript-only-guardrail', 'backend-ci', 'dependency-review', 'api-contracts', 'frontend', 'dashboard', 'contracts', 'contracts-slither', 'contracts-gas-snapshot'])
   assert.equal(job.permissions['pull-requests'], 'write')
   assert.equal(job.permissions.contents, 'write')
   assert.equal(job.permissions.issues, 'write')
@@ -2886,6 +2907,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /const successConclusions = new Set\(\['success', 'neutral', 'skipped'\]\)/)
   assert.match(jobBlock, /SCOPE_GATE_RESULT/)
   assert.match(jobBlock, /SUPPLY_CHAIN_GUARDRAILS_RESULT/)
+  assert.match(jobBlock, /TYPESCRIPT_ONLY_GUARDRAIL_RESULT/)
   assert.match(jobBlock, /BACKEND_CI_RESULT/)
   assert.match(jobBlock, /DEPENDENCY_REVIEW_RESULT/)
   assert.match(jobBlock, /API_CONTRACTS_RESULT/)
@@ -2909,6 +2931,7 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /const requiredCheckSnapshots = \{/)
   assert.match(jobBlock, /\{ context: 'Scope gate', appId: 15368 \}/)
   assert.match(jobBlock, /\{ context: 'Supply-chain guardrails', appId: 15368 \}/)
+  assert.match(jobBlock, /\{ context: 'TypeScript-only guardrail', appId: 15368 \}/)
   assert.match(jobBlock, /\{ context: 'Dependency Review', appId: 15368 \}/)
   assert.match(jobBlock, /\{ context: 'API contract drift', appId: 15368 \}/)
   assert.match(jobBlock, /\{ context: 'Frontend build', appId: 15368 \}/)
@@ -2989,9 +3012,34 @@ test('standalone auto-ready workflow waits when dependency review check fails', 
   assert.deepEqual(result.labelsAdded, [])
 })
 
+test('standalone auto-ready workflow waits when TypeScript-only guardrail check fails', async () => {
+  const result = await runAutoReadyWorkflow({
+    checkRuns: successfulDevelopRequiredCheckRuns({
+      name: 'TypeScript-only guardrail',
+      status: 'completed',
+      conclusion: 'failure',
+      app: { id: 15368 },
+      completed_at: '2026-05-03T00:01:00Z',
+    }),
+  })
+
+  assert.deepEqual(result.graphqlCalls, [])
+  assert.deepEqual(result.labelsAdded, [])
+})
+
 test('CI auto-ready job waits when supply-chain guardrails fail', async () => {
   const result = await runCiAutoReadyAfterCiWorkflow({
     env: { SUPPLY_CHAIN_GUARDRAILS_RESULT: 'failure' },
+    checkRuns: successfulDevelopRequiredCheckRuns(),
+  })
+
+  assert.deepEqual(result.graphqlCalls, [])
+  assert.deepEqual(result.labelsAdded, [])
+})
+
+test('CI auto-ready job waits when TypeScript-only guardrail fails', async () => {
+  const result = await runCiAutoReadyAfterCiWorkflow({
+    env: { TYPESCRIPT_ONLY_GUARDRAIL_RESULT: 'failure' },
     checkRuns: successfulDevelopRequiredCheckRuns(),
   })
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,9 @@ jobs:
       - name: Verify supply-chain guardrail assertions
         run: bash infra/scripts/check-supply-chain-guardrails.test.sh
 
+      - name: Verify TypeScript-only guardrail assertions
+        run: bash infra/scripts/check-typescript-only.test.sh
+
       - name: Verify developer persistence guardrail assertions
         run: bash infra/scripts/check-developer-persistence.test.sh
 
@@ -371,6 +374,16 @@ jobs:
 
       - name: Verify dependency install guardrails
         run: node --experimental-strip-types --no-warnings infra/scripts/check-supply-chain-guardrails.ts
+
+  typescript-only-guardrail:
+    timeout-minutes: 5
+    name: TypeScript-only guardrail
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Reject tracked JavaScript source files
+        run: bash infra/scripts/check-typescript-only.sh
 
   commit-message-regression:
     timeout-minutes: 5
@@ -834,7 +847,7 @@ jobs:
   auto-ready-after-ci:
     timeout-minutes: 5
     name: Auto-ready draft PR after CI
-    needs: [scope-gate, supply-chain-guardrails, backend-ci, dependency-review, api-contracts, frontend, dashboard, contracts, contracts-slither, contracts-gas-snapshot]
+    needs: [scope-gate, supply-chain-guardrails, typescript-only-guardrail, backend-ci, dependency-review, api-contracts, frontend, dashboard, contracts, contracts-slither, contracts-gas-snapshot]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -849,6 +862,7 @@ jobs:
         env:
           SCOPE_GATE_RESULT: ${{ needs.scope-gate.result }}
           SUPPLY_CHAIN_GUARDRAILS_RESULT: ${{ needs.supply-chain-guardrails.result }}
+          TYPESCRIPT_ONLY_GUARDRAIL_RESULT: ${{ needs.typescript-only-guardrail.result }}
           BACKEND_CI_RESULT: ${{ needs.backend-ci.result }}
           DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
           API_CONTRACTS_RESULT: ${{ needs.api-contracts.result }}
@@ -874,6 +888,7 @@ jobs:
               develop: [
                 { context: 'Scope gate', appId: 15368 },
                 { context: 'Supply-chain guardrails', appId: 15368 },
+                { context: 'TypeScript-only guardrail', appId: 15368 },
                 { context: 'Dependency Review', appId: 15368 },
                 { context: 'API contract drift', appId: 15368 },
                 { context: 'Frontend build', appId: 15368 },
@@ -890,6 +905,7 @@ jobs:
             const requiredJobResults = [
               ['scope-gate', process.env.SCOPE_GATE_RESULT],
               ['supply-chain-guardrails', process.env.SUPPLY_CHAIN_GUARDRAILS_RESULT],
+              ['typescript-only-guardrail', process.env.TYPESCRIPT_ONLY_GUARDRAIL_RESULT],
               ['backend-ci', process.env.BACKEND_CI_RESULT],
               ['dependency-review', process.env.DEPENDENCY_REVIEW_RESULT],
               ['api-contracts', process.env.API_CONTRACTS_RESULT],
@@ -1213,7 +1229,7 @@ jobs:
   notify-discord:
     timeout-minutes: 5
     name: Notify Discord on failure
-    needs: [workflow-regression, supply-chain-guardrails, commit-message-regression, pr-metadata-regression, check-cache-wiring, atlas-migration-tooling, backend-ci, dependency-review, frontend, dashboard, contracts, contracts-slither, contracts-gas-snapshot]
+    needs: [workflow-regression, supply-chain-guardrails, typescript-only-guardrail, commit-message-regression, pr-metadata-regression, check-cache-wiring, atlas-migration-tooling, backend-ci, dependency-review, frontend, dashboard, contracts, contracts-slither, contracts-gas-snapshot]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Reject tracked JavaScript source files
         run: bash infra/scripts/check-typescript-only.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,8 @@ PR Diff 大小規則詳見 [CLAUDE.md](CLAUDE.md)（conventions.md 的 PR Diff �
 - 不得把 docs / research draft 直接當成 implementation source of truth
 - 不得未經驗證就宣稱「已完成」；至少回報實際執行過的測試、未驗證部分、已知風險
 - 供應鏈安全規則見 [docs/ai/supply-chain-security.md](docs/ai/supply-chain-security.md)：AI agent 不得自行新增依賴，不得執行 `npx` / `pnpm dlx` / `npm exec` / `curl | bash` / `wget | sh`，`package.json` 與 lockfile 改動必須在 PR 中說明並接受人工 review
+- TypeScript migration 後，source / config / tooling / test scripts 一律使用 TypeScript（`.ts` / `.tsx`），不得新增 `.js` / `.jsx` / `.mjs` / `.cjs`。需要直接執行 Node TypeScript script 時，依情境使用 `node --experimental-strip-types --no-warnings path/to/script.ts`。
+- 例外只限高層次既有類型：lockfiles、generated build output、archived historical docs、以及明確標示的 test fixtures。
 
 ### Autonomous Worker Profiles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,10 @@ make pr-open TITLE="[type] ..." BODY_FILE=/tmp/pr_body.md AUTO_READY=1
 
 本專案使用 Claude Code + Gemini CLI + Codex CLI 協作開發。
 
+TypeScript migration 後，source / config / tooling / test scripts 一律使用 TypeScript（`.ts` / `.tsx`），不得新增 `.js` / `.jsx` / `.mjs` / `.cjs`。需要直接執行 Node TypeScript script 時，依情境使用 `node --experimental-strip-types --no-warnings path/to/script.ts`。
+
+例外只限高層次既有類型：lockfiles、generated build output、archived historical docs、以及明確標示的 test fixtures。
+
 若使用者授權 autonomous product work，Codex / Claude 應採用 [docs/ai/codex-autonomous-workflow.md](docs/ai/codex-autonomous-workflow.md) 的 Worker Profiles、issue-first、review gate、CodeRabbit fallback 與 PR Scope Police 合約。
 
 Autonomous Worker Profiles 的 follow-up 改善以「約 40% infra 本質複雜、約 60% 工作流自己製造摩擦」為基準：infra 複雜度用固定 readback 與 gate 管住；流程摩擦要靠 `ops_spark` routing、review closeout evidence、subagent lifecycle cleanup、issue-first planning 與 follow-up split 降低。

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev up down logs pr-meta-check pr-open session-index session-find session-index-test supply-chain-check developer-persistence-check
+.PHONY: setup dev up down logs pr-meta-check pr-open session-index session-find session-index-test supply-chain-check typescript-only-check developer-persistence-check
 
 # ── Setup (run once after cloning) ────────────────────────────────────────────
 setup:
@@ -47,6 +47,9 @@ session-index-test:
 # ── Supply-chain guardrails ──────────────────────────────────────────────────
 supply-chain-check:
 	@node --experimental-strip-types --no-warnings infra/scripts/check-supply-chain-guardrails.ts
+
+typescript-only-check:
+	@bash infra/scripts/check-typescript-only.sh
 
 developer-persistence-check:
 	@bash infra/scripts/check-developer-persistence.sh

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jiti": "^2.6.1",
     "jsdom": "^29.0.1",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",

--- a/apps/dashboard/pnpm-lock.yaml
+++ b/apps/dashboard/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       jsdom:
         specifier: ^29.0.1
         version: 29.0.2

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
+    "jiti": "^2.6.1",
     "jsdom": "^29.1.1",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.0",

--- a/apps/extension/pnpm-lock.yaml
+++ b/apps/extension/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.2.1)
+        version: 10.0.1(eslint@10.2.1(jiti@2.6.1))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -47,19 +47,22 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.9(@types/node@25.6.0))
+        version: 6.0.1(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1))
       eslint:
         specifier: ^10.2.1
-        version: 10.2.1
+        version: 10.2.1(jiti@2.6.1)
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@10.2.1)
+        version: 7.1.1(eslint@10.2.1(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
-        version: 0.5.2(eslint@10.2.1)
+        version: 0.5.2(eslint@10.2.1(jiti@2.6.1))
       globals:
         specifier: ^17.5.0
         version: 17.5.0
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -68,13 +71,13 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.59.0
-        version: 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+        version: 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       vite:
         specifier: ^8.0.9
-        version: 8.0.9(@types/node@25.6.0)
+        version: 8.0.9(@types/node@25.6.0)(jiti@2.6.1)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0))
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1))
 
 packages:
 
@@ -930,6 +933,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1611,9 +1618,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.6.1))':
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -1634,9 +1641,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.2.1)':
+  '@eslint/js@10.0.1(eslint@10.2.1(jiti@2.6.1))':
     optionalDependencies:
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -1814,15 +1821,15 @@ snapshots:
 
   '@types/twitch-ext@1.24.9': {}
 
-  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/type-utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.0
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -1830,14 +1837,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.0
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -1860,13 +1867,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.59.0(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -1889,13 +1896,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.59.0
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -1905,10 +1912,10 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.9(@types/node@25.6.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.9(@types/node@25.6.0)
+      vite: 8.0.9(@types/node@25.6.0)(jiti@2.6.1)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1919,13 +1926,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.9(@types/node@25.6.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.9(@types/node@25.6.0)
+      vite: 8.0.9(@types/node@25.6.0)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -2086,20 +2093,20 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.2.1):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.2.1(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 4.3.6
       zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.2(eslint@10.2.1):
+  eslint-plugin-react-refresh@0.5.2(eslint@10.2.1(jiti@2.6.1)):
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -2112,9 +2119,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.2.1:
+  eslint@10.2.1(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.5.5
@@ -2144,6 +2151,8 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2285,6 +2294,8 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   isexe@2.0.0: {}
+
+  jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -2576,13 +2587,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.59.0(eslint@10.2.1)(typescript@6.0.3):
+  typescript-eslint@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
-      eslint: 10.2.1
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      eslint: 10.2.1(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -2607,7 +2618,7 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  vite@8.0.9(@types/node@25.6.0):
+  vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2617,11 +2628,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       fsevents: 2.3.3
+      jiti: 2.6.1
 
-  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)):
+  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.9(@types/node@25.6.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -2638,7 +2650,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.9(@types/node@25.6.0)
+      vite: 8.0.9(@types/node@25.6.0)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,6 +6,7 @@ Repo-level automation that is not product code lives here.
 
 - `scripts/` — local and CI helper scripts for PR metadata checks, commit message checks, setup, and workflow assertions.
 - `scripts/check-supply-chain-guardrails.ts` — local and CI guardrail for dependency install lifecycle scripts, dynamic package execution, and Mini Shai-Hulud indicators.
+- `scripts/check-typescript-only.sh` — local and CI guardrail that rejects tracked `.js`, `.jsx`, `.mjs`, and `.cjs` source/config/tooling/test files. Use `.ts`/`.tsx`; Node-executed TypeScript scripts should run with `node --experimental-strip-types --no-warnings`.
 - `scripts/check-developer-persistence.sh` — local-only check for common Claude / VS Code / LaunchAgent / systemd persistence indicators.
 - `githooks/` — git hooks installed by `make setup` through `core.hooksPath`.
 

--- a/infra/scripts/check-typescript-only.sh
+++ b/infra/scripts/check-typescript-only.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: infra/scripts/check-typescript-only.sh [--root <repo-root>]
+
+Fails when tracked JavaScript-like source/config/tooling/test files are present.
+EOF
+}
+
+root_arg="."
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      if [ "$#" -lt 2 ]; then
+        echo "--root requires a value" >&2
+        exit 2
+      fi
+      root_arg="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+root_dir="$(cd "$root_arg" && pwd)"
+
+if ! git -C "$root_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "TypeScript-only guardrail requires a git worktree: $root_dir" >&2
+  exit 2
+fi
+
+is_allowed_exception() {
+  local file_path="$1"
+
+  case "$file_path" in
+    plans/archive/*|plans/archived/*|docs/archive/*|docs/archived/*|docs/*/archive/*|docs/*/archived/*)
+      return 0
+      ;;
+    dist/*|*/dist/*|build/*|*/build/*|coverage/*|*/coverage/*|generated/*|*/generated/*|.next/*|*/.next/*|storybook-static/*|*/storybook-static/*)
+      return 0
+      ;;
+    fixtures/*|*/fixtures/*|__fixtures__/*|*/__fixtures__/*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+violations=""
+
+while IFS= read -r -d '' file_path; do
+  if is_allowed_exception "$file_path"; then
+    continue
+  fi
+
+  violations="${violations}${file_path}"$'\n'
+done < <(git -C "$root_dir" ls-files -z -- '*.js' '*.jsx' '*.mjs' '*.cjs')
+
+if [ -n "$violations" ]; then
+  {
+    echo "TypeScript-only guardrail failed: tracked .js/.jsx/.mjs/.cjs source/config/tooling/test files are not allowed."
+    echo
+    echo "Use .ts/.tsx instead. For Node-executed TypeScript scripts, run with:"
+    echo "  node --experimental-strip-types --no-warnings <script.ts>"
+    echo
+    echo "Disallowed tracked files:"
+    printf '%s' "$violations" | sed 's/^/  - /'
+    echo
+    echo "Allowed exceptions are limited to archived docs/plans, generated build output, and fixture data paths."
+  } >&2
+  exit 1
+fi
+
+echo "TypeScript-only guardrail passed"

--- a/infra/scripts/check-typescript-only.test.sh
+++ b/infra/scripts/check-typescript-only.test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "$0")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+script="$root_dir/infra/scripts/check-typescript-only.sh"
+
+init_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+}
+
+track_file() {
+  local repo="$1"
+  local file_path="$2"
+  local content="${3:-// fixture}"
+
+  mkdir -p "$(dirname "$repo/$file_path")"
+  printf '%s\n' "$content" > "$repo/$file_path"
+  git -C "$repo" add "$file_path"
+}
+
+write_untracked_file() {
+  local repo="$1"
+  local file_path="$2"
+
+  mkdir -p "$(dirname "$repo/$file_path")"
+  printf '%s\n' '// untracked fixture' > "$repo/$file_path"
+}
+
+run_case() {
+  local name="$1"
+  local expected_exit="$2"
+  local expected_message="${3:-}"
+  shift 3
+
+  local repo="$tmp_dir/$name"
+  init_repo "$repo"
+  "$@" "$repo"
+
+  set +e
+  bash "$script" --root "$repo" > "$tmp_dir/$name.out" 2> "$tmp_dir/$name.err"
+  local exit_code=$?
+  set -e
+
+  if [ "$exit_code" -ne "$expected_exit" ]; then
+    echo "expected exit $expected_exit for $name but got $exit_code" >&2
+    cat "$tmp_dir/$name.out" >&2
+    cat "$tmp_dir/$name.err" >&2
+    exit 1
+  fi
+
+  if [ -n "$expected_message" ]; then
+    if ! grep -q "$expected_message" "$tmp_dir/$name.out" "$tmp_dir/$name.err"; then
+      echo "expected message '$expected_message' for $name" >&2
+      cat "$tmp_dir/$name.out" >&2
+      cat "$tmp_dir/$name.err" >&2
+      exit 1
+    fi
+  fi
+}
+
+clean_typescript_fixture() {
+  local repo="$1"
+  track_file "$repo" src/index.ts "export const ok = true"
+  track_file "$repo" tools/check.ts "console.log('ok')"
+}
+
+source_javascript_fixture() {
+  local repo="$1"
+  track_file "$repo" apps/extension/src/legacy.js "export const legacy = true"
+}
+
+config_javascript_fixture() {
+  local repo="$1"
+  track_file "$repo" apps/dashboard/vite.config.js "export default {}"
+}
+
+tooling_javascript_fixture() {
+  local repo="$1"
+  track_file "$repo" infra/scripts/legacy-tool.mjs "console.log('legacy')"
+}
+
+test_javascript_fixture() {
+  local repo="$1"
+  track_file "$repo" packages/api-client/src/index.test.cjs "module.exports = {}"
+}
+
+untracked_javascript_fixture() {
+  local repo="$1"
+  track_file "$repo" src/index.ts "export const ok = true"
+  write_untracked_file "$repo" src/not-tracked.js
+}
+
+allowed_fixture_data() {
+  local repo="$1"
+  track_file "$repo" infra/scripts/fixtures/input.js "module.exports = {}"
+}
+
+allowed_generated_output() {
+  local repo="$1"
+  track_file "$repo" apps/dashboard/dist/bundle.js "(()=>{})();"
+}
+
+allowed_archived_plan() {
+  local repo="$1"
+  track_file "$repo" plans/archived/old-script.js "// archived historical note"
+}
+
+run_case clean_typescript 0 "TypeScript-only guardrail passed" clean_typescript_fixture
+run_case source_javascript 1 "apps/extension/src/legacy.js" source_javascript_fixture
+run_case source_javascript_guidance 1 "Use .ts/.tsx instead" source_javascript_fixture
+run_case source_javascript_node_guidance 1 "node --experimental-strip-types --no-warnings" source_javascript_fixture
+run_case config_javascript 1 "apps/dashboard/vite.config.js" config_javascript_fixture
+run_case tooling_javascript 1 "infra/scripts/legacy-tool.mjs" tooling_javascript_fixture
+run_case test_javascript 1 "packages/api-client/src/index.test.cjs" test_javascript_fixture
+run_case untracked_javascript 0 "TypeScript-only guardrail passed" untracked_javascript_fixture
+run_case allowed_fixture_data 0 "TypeScript-only guardrail passed" allowed_fixture_data
+run_case allowed_generated_output 0 "TypeScript-only guardrail passed" allowed_generated_output
+run_case allowed_archived_plan 0 "TypeScript-only guardrail passed" allowed_archived_plan
+
+echo "TypeScript-only guardrail regression tests passed"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.2.1(jiti@2.6.1))
+        version: 10.0.1(eslint@10.2.1(jiti@2.7.0))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -83,7 +83,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1))
+        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.5.0(postcss@8.5.12)
@@ -92,16 +92,19 @@ importers:
         version: 2.1.0(axios@1.15.2)
       eslint:
         specifier: ^10.1.0
-        version: 10.2.1(jiti@2.6.1)
+        version: 10.2.1(jiti@2.7.0)
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
-        version: 7.1.1(eslint@10.2.1(jiti@2.6.1))
+        version: 7.1.1(eslint@10.2.1(jiti@2.7.0))
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
-        version: 0.5.2(eslint@10.2.1(jiti@2.6.1))
+        version: 0.5.2(eslint@10.2.1(jiti@2.7.0))
       globals:
         specifier: ^17.4.0
         version: 17.5.0
+      jiti:
+        specifier: ^2.6.1
+        version: 2.7.0
       jsdom:
         specifier: ^29.0.1
         version: 29.1.0
@@ -116,13 +119,13 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.57.0
-        version: 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^8.0.5
-        version: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1)
+        version: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1))
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1))
 
   apps/docs:
     dependencies:
@@ -211,7 +214,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.2.1(jiti@2.6.1))
+        version: 10.0.1(eslint@10.2.1(jiti@2.7.0))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -229,19 +232,22 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1))
+        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1))
       eslint:
         specifier: ^10.2.1
-        version: 10.2.1(jiti@2.6.1)
+        version: 10.2.1(jiti@2.7.0)
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@10.2.1(jiti@2.6.1))
+        version: 7.1.1(eslint@10.2.1(jiti@2.7.0))
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
-        version: 0.5.2(eslint@10.2.1(jiti@2.6.1))
+        version: 0.5.2(eslint@10.2.1(jiti@2.7.0))
       globals:
         specifier: ^17.5.0
         version: 17.5.0
+      jiti:
+        specifier: ^2.6.1
+        version: 2.7.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -250,13 +256,13 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.59.0
-        version: 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.9
-        version: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1)
+        version: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1))
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1))
 
   packages/api-client:
     dependencies:
@@ -4657,8 +4663,8 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   joi@17.13.3:
@@ -9413,9 +9419,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.7.0))':
     dependencies:
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -9436,9 +9442,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.2.1(jiti@2.6.1))':
+  '@eslint/js@10.0.1(eslint@10.2.1(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -10164,7 +10170,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.21.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
@@ -10582,15 +10588,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/type-utils': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.1
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -10598,15 +10604,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/type-utils': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.1
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -10614,26 +10620,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.1
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.1
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -10669,25 +10675,25 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10725,24 +10731,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.59.1
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.59.1
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -10759,10 +10765,10 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -10773,13 +10779,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -12030,20 +12036,20 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.2.1(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.2.1(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.3.6
       zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.2(eslint@10.2.1(jiti@2.6.1)):
+  eslint-plugin-react-refresh@0.5.2(eslint@10.2.1(jiti@2.7.0)):
     dependencies:
-      eslint: 10.2.1(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.7.0)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -12061,9 +12067,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.2.1(jiti@2.6.1):
+  eslint@10.2.1(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.5.5
@@ -12094,7 +12100,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12880,7 +12886,7 @@ snapshots:
 
   jiti@1.21.7: {}
 
-  jiti@2.6.1: {}
+  jiti@2.7.0: {}
 
   joi@17.13.3:
     dependencies:
@@ -15299,24 +15305,24 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 10.2.1(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 10.2.1(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3):
+  typescript-eslint@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
-      eslint: 10.2.1(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.2.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -15458,7 +15464,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1):
+  vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -15468,13 +15474,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       terser: 5.47.1
 
-  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1)):
+  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -15491,7 +15497,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -15499,10 +15505,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1)):
+  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -15519,7 +15525,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(terser@5.47.1)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(terser@5.47.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0


### PR DESCRIPTION
## 什麼改動
新增 TypeScript-only guardrail，讓 repo 內 tracked `.js` / `.jsx` / `.mjs` / `.cjs` 的 source、config、tooling、test 檔案會在本機與 CI 被擋下。

同時更新 `AGENTS.md` / `CLAUDE.md`，明確要求 AI 協作者與工程協作者在 migration 後一律寫 TypeScript。

## 為什麼
closes #849

前一張 migration PR 已把既有 JavaScript entrypoints 轉成 TypeScript。這張 PR 補上可執行的 CI gate，避免之後又重新引入 JavaScript 殘留。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#849
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 product runtime 行為
  - 不修改 backend / frontend 行為
  - 不做 schema / migration
  - 不修改 release workflow
  - 不重做已完成的 JS-to-TS migration

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #849 的 Issue Delegation Plan
- Actual worker profile(s)：
  - repo_scout / test_worker / docs_worker / review_worker / controller
- Model strength：
  - repo_scout = inherited；test_worker = inherited；docs_worker = inherited；review_worker = inherited；controller = high
- Spawn directive(s)：
  - profile=repo_scout model=inherited reasoning=inherited controller_fallback=denied fallback_reason=n/a
  - profile=test_worker model=inherited reasoning=inherited controller_fallback=denied fallback_reason=n/a
  - profile=docs_worker model=inherited reasoning=inherited controller_fallback=denied fallback_reason=n/a
  - profile=review_worker model=inherited reasoning=inherited controller_fallback=denied fallback_reason=n/a
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-849
- spark_readback_evidence: workflow-check:worker:repo-scout-019e4b01-3afe
- worker_5_4_evidence: workflow-check:worker:test-docs-019e4b01
- controller_fallback: denied
- controller_fallback_reason: n/a
- Verification evidence：
  - `bash infra/scripts/check-typescript-only.test.sh`
  - `bash infra/scripts/check-typescript-only.sh`
  - `pnpm install --ignore-workspace --frozen-lockfile --ignore-scripts` in `apps/extension`
  - `pnpm lint` in `apps/extension`
  - `pnpm install --ignore-workspace --frozen-lockfile --ignore-scripts` in `apps/dashboard`
  - `pnpm lint` in `apps/dashboard` (0 errors, 1 existing warning)
  - `make typescript-only-check`
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`
  - `node --experimental-strip-types --no-warnings infra/scripts/check-supply-chain-guardrails.ts`
  - `bash infra/scripts/check-supply-chain-guardrails.test.sh`
  - `git diff --check`
  - `spec workflow-check --repo . --phase commit --pr-body /tmp/tachigo-849-awp/pr-body.md --routing-evidence /tmp/tachigo-849-awp/routing-evidence.json --finding-disposition /tmp/tachigo-849-awp/finding-disposition.json --threshold-evidence /tmp/tachigo-849-awp/threshold-evidence.json`
- Self-review / exception reason：
  - Controller 已讀回 worker 結果，補上 config / tooling / test 負例，修正 review_worker 抓到的 auto-ready required-check snapshot 漏洞，並補上 TypeScript ESLint config 在 isolated app install / Docker lint 路徑所需的 `jiti` devDependency。
- Worker session closeout：
  - repo_scout、test_worker、docs_worker、review_worker、re-review worker 均已完成並 close。
- Workflow friction / follow-up split：
  - 已用 worker routing 分開處理 repo scan、實作、文件與 review；threshold calibration ref 為 `#664`，本 PR 不需要拆 follow-up。

## Review conversation closeout
- Unresolved threads：
  - pending with reason: PR 尚未建立
- CodeRabbit：
  - reviewed previous head; pending rerun after CI fix commit
- chatgpt-codex-connector：
  - pending with reason: PR 尚未建立
- review_triage_ref：
  - CI failure triage: `Frontend build` failed loading `eslint.config.ts` because isolated extension install lacked `jiti`
- root_cause_gate_ref：
  - pending with reason: 尚未觸發重複 review finding
- finding_disposition_status: pass
- finding_disposition_ref: CodeRabbit latest-head findings adopted: checkout credential persistence disabled for `typescript-only-guardrail`; `jiti` direct devDependency changed from exact pin to caret range
- Final reviewer action：
  - 本機 read-only re-review 結果為 `APPROVED_WITH_NOTES`，目前沒有 blocker / major；CI fix rerun pending

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: CI fix commit requires fresh remote checks and non-self review
- Latest head SHA：
  - pending after CI fix commit
- Required checks：
  - pending with reason: CI fix commit requires fresh remote checks
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:commit:issue-849-local
  - threshold_evidence_status: pass
  - threshold_ledger_ref: workflow-check:threshold:issue-849
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 在本機檢查、CI 與共享 AI 指引中強制 post-migration 的 TypeScript-only source/config/tooling/test policy。
- Approx changed lines：~300
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #849 同時要求 CI gate 與 shared agent guidance；文件只描述同一個已被 CI 強制的 policy。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Running the new local guardrail on current `develop` passes.
- [x] Adding a tracked `.js`, `.jsx`, `.mjs`, or `.cjs` source/config/tooling/test file makes the guardrail fail with a clear message.
- [x] CI runs the guardrail.
- [x] Shared agent guidance tells AI collaborators to write TypeScript, not JavaScript.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
bash infra/scripts/check-typescript-only.test.sh
TypeScript-only guardrail regression tests passed

bash infra/scripts/check-typescript-only.sh
TypeScript-only guardrail passed

make typescript-only-check
TypeScript-only guardrail passed

node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
96/96 pass

node --experimental-strip-types --no-warnings infra/scripts/check-supply-chain-guardrails.ts
Supply-chain guardrails passed

bash infra/scripts/check-supply-chain-guardrails.test.sh
supply-chain guardrail regression tests passed

git diff --check
pass

spec workflow-check --phase commit
pass

pnpm install --ignore-workspace --frozen-lockfile --ignore-scripts # apps/extension
pass

pnpm lint # apps/extension
pass

pnpm install --ignore-workspace --frozen-lockfile --ignore-scripts # apps/dashboard
pass

pnpm lint # apps/dashboard
pass with 0 errors, 1 existing react-hooks warning

CodeRabbit latest-head follow-up
- Added `persist-credentials: false` to `typescript-only-guardrail` checkout.
- Changed `jiti` direct devDependency from exact `2.6.1` to `^2.6.1`.
```

## 備註
本 PR 修改 `.github/workflows/**`，因此保守標為 R4，不使用 `auto-ready`。

## Notes for Claude Code Review
- 請特別看 guardrail allowlist 邊界：目前只允許 archived docs/plans、generated build output paths、以及明確 fixture data paths。
