### PR TITLE
[backend] Propagate auth register request context

### DIFF
--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -66,7 +66,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 		return
 	}
 
-	user, tokens, err := h.auth.Register(input)
+	user, tokens, err := h.auth.RegisterContext(c.Request.Context(), input)
 	if err != nil {
 		switch err {
 		case services.ErrEmailExists:

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -67,6 +67,26 @@ func TestRegisterHandler_Success(t *testing.T) {
 	assertTokenPayloadHasBrowserTokens(t, resp)
 }
 
+func TestRegisterHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	key := authHandlerContextKey{}
+	seen := installAuthHandlerDBContextProbe(t, env.db, key, "register")
+
+	body := `{"username":"registerctx","email":"registerctx@example.com","password":"password123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBufferString(body)).
+		WithContext(context.WithValue(context.Background(), key, "register"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected Register DB query/create to use request context")
+	}
+}
+
 func TestRegisterHandler_DuplicateEmail(t *testing.T) {
 	env := newTestEnv(t)
 	env.registerUser(t, "existing", "dup@example.com", "password123")

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -84,13 +84,26 @@ type RegisterInput struct {
 }
 
 func (s *AuthService) Register(input RegisterInput) (*models.User, *TokenPair, error) {
+	return s.RegisterContext(context.Background(), input)
+}
+
+func (s *AuthService) RegisterContext(ctx context.Context, input RegisterInput) (*models.User, *TokenPair, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db := s.db.WithContext(ctx)
+
 	// Check uniqueness
 	var count int64
-	s.db.Model(&models.User{}).Where("email = ?", input.Email).Count(&count)
+	if err := db.Model(&models.User{}).Where("email = ?", input.Email).Count(&count).Error; err != nil {
+		return nil, nil, err
+	}
 	if count > 0 {
 		return nil, nil, ErrEmailExists
 	}
-	s.db.Model(&models.User{}).Where("username = ?", input.Username).Count(&count)
+	if err := db.Model(&models.User{}).Where("username = ?", input.Username).Count(&count).Error; err != nil {
+		return nil, nil, err
+	}
 	if count > 0 {
 		return nil, nil, ErrUsernameExists
 	}
@@ -112,7 +125,7 @@ func (s *AuthService) Register(input RegisterInput) (*models.User, *TokenPair, e
 	}
 
 	var tokens *TokenPair
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(user).Error; err != nil {
 			return err
 		}

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -46,6 +46,32 @@ func TestRegister_Success(t *testing.T) {
 	}
 }
 
+func TestAuthService_RegisterContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	type registerContextKey struct{}
+	key := registerContextKey{}
+	seen := installDBContextProbe(t, db, key, "register")
+	ctx := context.WithValue(context.Background(), key, "register")
+
+	user, tokens, err := svc.RegisterContext(ctx, RegisterInput{
+		Username: "registerctx",
+		Email:    "registerctx@example.com",
+		Password: "password123",
+	})
+
+	if err != nil {
+		t.Fatalf("register context: %v", err)
+	}
+	if user == nil || tokens == nil {
+		t.Fatal("expected user and tokens, got nil")
+	}
+	if seen() == 0 {
+		t.Fatal("expected Register DB query/create to use request context")
+	}
+}
+
 func TestOAuthUser_PersistsOnlyEncryptedTwitchAccessToken(t *testing.T) {
 	db := newTestDB(t)
 	cfg := testConfig()


### PR DESCRIPTION
## 什麼改動
- 讓 `POST /api/v1/auth/register` 把 Gin request context 傳進 auth service。
- 新增 `AuthService.RegisterContext`，讓註冊流程的 uniqueness checks 與 transaction 使用 `db.WithContext(ctx)`。
- 補上 service 與 handler 層的 request context probe 測試。

## 為什麼
- refs #645
- #645 要求 DB 查詢逐步改用 request-scoped context，避免 handler/service 在 request 取消或逾時後仍使用裸 `db` 執行查詢。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 raffle / points / wallet / OAuth / dashboard / frontend。
  - 不修改 schema、migration、API response contract 或 token 發放語意。
  - 不關閉 #645；這只是 long-running audit 的一個 bounded slice。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645（DB query request-context propagation audit）
- Actual worker profile(s)：controller-direct fallback for one bounded auth register context slice
- Model strength：controller = high；implementation kept local because slice is four files and R4 human review remains required
- Spawn directive(s)：profile=controller_direct model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=single bounded request-context propagation slice across existing auth register handler/service and tests; worker spawn overhead would exceed the four-file TDD patch while human R4 review remains required
- Verification evidence：`spec plan 645 --repo . --dry-run --format prompt --verbose`; `spec workflow-check --repo . --phase start --issue 645 --format text`; `go test ./internal/services -run TestAuthService_RegisterContext_UsesRequestContext -count=1`; `go test ./internal/handlers -run TestRegisterHandler_UsesRequestContext -count=1`; `go test ./internal/services ./internal/handlers -count=1`; `git diff --check`
- Self-review / exception reason：controller-direct fallback recorded; diff is limited to auth register context propagation plus tests and remains blocked on human review as R4
- Worker session closeout：no spawned worker handle for this bounded fallback; controller read back diff, focused tests, broader handler/service tests, and diff check
- Workflow friction / follow-up split：minor workflow friction from root dirty worktree and worktree creation ambiguity; contained by isolated worktree. Threshold ledger ref: workflow-check:threshold:issue-645-auth-register-context
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-645-auth-register-context
- controller_fallback: allowed
- controller_fallback_reason: Single bounded request-context propagation slice across existing auth register handler/service and tests; worker spawn overhead would exceed the four-file TDD patch, while R4 human review remains required before merge.
- threshold_evidence_status: pass
- threshold_ledger_ref: workflow-check:threshold:issue-645-auth-register-context
- finding_disposition_status: pass
- finding_disposition_ref: workflow-check:finding-disposition:issue-645-auth-register-context

## Review conversation closeout
- Unresolved threads：0 local pre-PR; GitHub review threads pending after PR creation
- CodeRabbit：reviewed latest head; no actionable comments; tool-run warning is CodeRabbit golangci-lint module-root limitation, not a PR blocker
- chatgpt-codex-connector：n/a; self-authored PR must not be self-reviewed
- review_triage_ref：workflow-check:finding-disposition:issue-645-auth-register-context
- root_cause_gate_ref：workflow-check:start:issue-645-auth-register-context
- finding_disposition_ref：workflow-check:finding-disposition:issue-645-auth-register-context
- Final reviewer action：human owner approved latest head; self-authored PR was not self-reviewed

## Final merge gate
- Ready-to-merge decision：ready; human owner approved latest head and all GitHub checks passed
- Latest head SHA：15929aafb2bb74986090b59190fb94f68a2a3b1b
- Required checks：pass: CI Backend CI gate, backend tests, integration tests, Scope police, Cloudflare Pages, CodeRabbit
- spec workflow-check evidence：spec gate status: pass; spec evidence ref: workflow-check:start:issue-645-auth-register-context; commit gate status: pass; commit gate ref: workflow-check:commit:issue-645-auth-register-context; merge gate manual fallback: spec workflow-check --pr hit gh checks JSON field drift but manual readback passed
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/852#issuecomment-4512858844; CodeRabbit https://github.com/nurockplayer/tachigo/pull/852#issuecomment-4512873145
- ready_to_merge: yes

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 auth register DB 操作使用 request-scoped context。
- Approx changed lines：~67
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - request context 必須從 handler 傳入 service，測試需同時覆蓋 service 與 handler 邊界；沒有 schema 或 response contract 變更。
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] Identify a bounded DB query path in #645 scope.
- [x] Run spec-injector dry-run context before implementation.
- [x] Add tests proving request context reaches DB callbacks.
- [x] Propagate request context through auth register handler/service.
- [x] Validate locally with focused and package-level backend tests.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
spec workflow-check --repo . --phase start --issue 645 --format text
status=pass

go test ./internal/services -run TestAuthService_RegisterContext_UsesRequestContext -count=1
ok github.com/tachigo/tachigo/internal/services 0.669s

go test ./internal/handlers -run TestRegisterHandler_UsesRequestContext -count=1
ok github.com/tachigo/tachigo/internal/handlers 0.701s

go test ./internal/services ./internal/handlers -count=1
ok github.com/tachigo/tachigo/internal/services 2.428s
ok github.com/tachigo/tachigo/internal/handlers 16.211s

git diff --check
pass
```

## 備註
R4 PR；不得使用 `auto-ready`，需要 human reviewer 明確 review / approve。

## Notes for Claude Code Review
- 請特別看 `AuthService.RegisterContext` 是否維持既有註冊/token 語意。
- `Register` 保留既有 API 並委派到 `context.Background()`，避免破壞其他呼叫端。
