### PR TITLE
[backend] Propagate auth login request context

### DIFF
--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -111,7 +111,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	user, tokens, err := h.auth.Login(input)
+	user, tokens, err := h.auth.LoginContext(c.Request.Context(), input)
 	if err != nil {
 		if errors.Is(err, services.ErrInvalidCredentials) {
 			unauthorized(c, "invalid email or password")

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -163,6 +163,27 @@ func TestLoginHandler_Success(t *testing.T) {
 	assertTokenPayloadHasBrowserTokens(t, parseBody(t, w.Body.Bytes()))
 }
 
+func TestLoginHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	env.registerUser(t, "loginctx", "loginctx@example.com", "mypassword")
+	key := authHandlerContextKey{}
+	seen := installAuthHandlerDBContextProbe(t, env.db, key, "login")
+
+	body := `{"email":"loginctx@example.com","password":"mypassword"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBufferString(body)).
+		WithContext(context.WithValue(context.Background(), key, "login"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected Login DB query to use request context")
+	}
+}
+
 func TestLoginHandler_SetsSecureRefreshCookieInProduction(t *testing.T) {
 	env := newTestEnvWithServerEnv(t, "production")
 	env.registerUser(t, "prodlogin", "prodlogin@example.com", "mypassword")

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -156,8 +156,16 @@ type LoginInput struct {
 }
 
 func (s *AuthService) Login(input LoginInput) (*models.User, *TokenPair, error) {
+	return s.LoginContext(context.Background(), input)
+}
+
+func (s *AuthService) LoginContext(ctx context.Context, input LoginInput) (*models.User, *TokenPair, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var user models.User
-	if err := s.db.Where("email = ?", input.Email).First(&user).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("email = ?", input.Email).First(&user).Error; err != nil {
 		return nil, nil, ErrInvalidCredentials
 	}
 	if user.PasswordHash == nil {
@@ -167,7 +175,7 @@ func (s *AuthService) Login(input LoginInput) (*models.User, *TokenPair, error) 
 		return nil, nil, ErrInvalidCredentials
 	}
 
-	tokens, err := s.issueTokenPair(&user)
+	tokens, err := s.issueTokenPairContext(ctx, &user)
 	return &user, tokens, err
 }
 

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -356,6 +356,29 @@ func TestLogin_Success(t *testing.T) {
 	}
 }
 
+func TestAuthService_LoginContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	svc.Register(RegisterInput{Username: "loginctx", Email: "loginctx@example.com", Password: "mypassword"})
+
+	type loginContextKey struct{}
+	key := loginContextKey{}
+	seen := installDBContextProbe(t, db, key, "login")
+	ctx := context.WithValue(context.Background(), key, "login")
+
+	user, tokens, err := svc.LoginContext(ctx, LoginInput{Email: "loginctx@example.com", Password: "mypassword"})
+
+	if err != nil {
+		t.Fatalf("login context: %v", err)
+	}
+	if user == nil || tokens == nil {
+		t.Fatal("expected user and tokens")
+	}
+	if seen() == 0 {
+		t.Fatal("expected Login DB query/create to use request context")
+	}
+}
+
 func TestLogin_WrongPassword(t *testing.T) {
 	svc := NewAuthService(newTestDB(t), testConfig())
 	svc.Register(RegisterInput{Username: "user", Email: "user@example.com", Password: "correctpass"})


### PR DESCRIPTION
## 什麼改動
- 讓 `POST /api/v1/auth/login` 把 Gin request context 傳進 auth service。
- 新增 `AuthService.LoginContext`，讓 email lookup 與 refresh token 建立使用 `WithContext(ctx)`。
- 補上 service 與 handler 層的 request context probe 測試。

## 為什麼
- refs #645
- #645 要求 DB 查詢逐步改用 request-scoped context，避免 handler/service 在 request 取消或逾時後仍使用裸 `db` 執行查詢。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理 register / refresh / logout / OAuth / wallet / frontend。
  - 不修改 schema、migration、API response contract 或 token 發放語意。
  - 不關閉 #645；這只是 long-running audit 的一個 bounded slice。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645（DB query request-context propagation audit）
- Actual worker profile(s)：controller-direct fallback for one bounded auth login context slice
- Model strength：controller = high；implementation kept local because slice is four files and R4 human review remains required
- Spawn directive(s)：profile=controller_direct model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=single bounded request-context propagation slice across existing auth login handler/service and tests; worker spawn overhead would exceed the four-file TDD patch while human R4 review remains required
- Verification evidence：`spec plan 645 --repo . --dry-run --format prompt --verbose`; `spec workflow-check --repo . --phase start --issue 645 --format text`; `go test ./internal/services -run TestAuthService_LoginContext_UsesRequestContext -count=1`; `go test ./internal/handlers -run TestLoginHandler_UsesRequestContext -count=1`; `go test ./internal/services ./internal/handlers -count=1`; `git diff --check`
- Self-review / exception reason：controller-direct fallback recorded; diff is limited to auth login context propagation plus tests and remains blocked on human review as R4
- Worker session closeout：no spawned worker handle for this bounded fallback; controller read back diff, focused tests, broader handler/service tests, and diff check
- Workflow friction / follow-up split：minor workflow friction from #852 merge-gate tool JSON drift; this slice reused the manual-fallback evidence pattern. Threshold ledger ref: workflow-check:threshold:issue-645-auth-login-context
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:issue-645-auth-login-context
- controller_fallback: allowed
- controller_fallback_reason: Single bounded request-context propagation slice across existing auth login handler/service and tests; worker spawn overhead would exceed the four-file TDD patch, while R4 human review remains required before merge.
- threshold_evidence_status: pass
- threshold_ledger_ref: workflow-check:threshold:issue-645-auth-login-context
- finding_disposition_status: pass
- finding_disposition_ref: workflow-check:finding-disposition:issue-645-auth-login-context

## Review conversation closeout
- Unresolved threads：0 local pre-PR; GitHub review threads pending after PR creation
- CodeRabbit：completed with SUCCESS status; rate-limit warning comment only, no actionable review comments generated
- chatgpt-codex-connector：n/a; self-authored PR must not be self-reviewed
- review_triage_ref：workflow-check:finding-disposition:issue-645-auth-login-context
- root_cause_gate_ref：workflow-check:start:issue-645-auth-login-context
- finding_disposition_ref：workflow-check:finding-disposition:issue-645-auth-login-context
- Final reviewer action：blocked by human review after PR creation because this is R4; self-authored PR will not be self-reviewed

## Final merge gate
- Ready-to-merge decision：blocked by required human review; all GitHub checks passed
- Latest head SHA：1211e1e3bda1e21cb80de66661939011595658b2
- Required checks：pass: CI Backend CI gate, backend tests, integration tests, Scope police, Cloudflare Pages, CodeRabbit
- spec workflow-check evidence：spec gate status: pass; spec evidence ref: workflow-check:start:issue-645-auth-login-context; commit gate status: pass; commit gate ref: workflow-check:commit:issue-645-auth-login-context
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/853#issuecomment-4513202510; CodeRabbit https://github.com/nurockplayer/tachigo/pull/853#issuecomment-4513202179
- ready_to_merge: no

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 auth login DB 操作使用 request-scoped context。
- Approx changed lines：~58
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - request context 必須從 handler 傳入 service，測試需同時覆蓋 service 與 handler 邊界；沒有 schema 或 response contract 變更。
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] Identify a bounded DB query path in #645 scope.
- [x] Run spec-injector dry-run context before implementation.
- [x] Add tests proving request context reaches DB callbacks.
- [x] Propagate request context through auth login handler/service.
- [x] Validate locally with focused and package-level backend tests.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
spec workflow-check --repo . --phase start --issue 645 --format text
status=pass

go test ./internal/services -run TestAuthService_LoginContext_UsesRequestContext -count=1
ok github.com/tachigo/tachigo/internal/services 0.620s

go test ./internal/handlers -run TestLoginHandler_UsesRequestContext -count=1
ok github.com/tachigo/tachigo/internal/handlers 0.424s

go test ./internal/services ./internal/handlers -count=1
ok github.com/tachigo/tachigo/internal/services 2.515s
ok github.com/tachigo/tachigo/internal/handlers 16.277s

git diff --check
pass
```

## 備註
R4 PR；不得使用 `auto-ready`，需要 human reviewer 明確 review / approve。

## Notes for Claude Code Review
- 請特別看 `AuthService.LoginContext` 是否維持既有登入/token 語意。
- `Login` 保留既有 API 並委派到 `context.Background()`，避免破壞其他呼叫端。
