### PR TITLE
[backend] Propagate auth refresh request context

### DIFF
--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -142,7 +142,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		return
 	}
 
-	tokens, err := h.auth.Refresh(refreshToken)
+	tokens, err := h.auth.RefreshContext(c.Request.Context(), refreshToken)
 	if err != nil {
 		if errors.Is(err, services.ErrInvalidToken) || errors.Is(err, services.ErrUserNotFound) {
 			unauthorized(c, "invalid or expired refresh token")
@@ -172,7 +172,7 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 		return
 	}
 
-	h.auth.Logout(refreshToken)
+	h.auth.LogoutContext(c.Request.Context(), refreshToken)
 	h.clearRefreshCookie(c)
 	ok(c, gin.H{"message": "logged out"})
 }

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -35,9 +35,17 @@ func installAuthHandlerDBContextProbe(t *testing.T, db *gorm.DB, key, want any) 
 	if err := db.Callback().Query().Before("gorm:query").Register(name+":query", probe); err != nil {
 		t.Fatalf("register query context probe: %v", err)
 	}
+	if err := db.Callback().Create().Before("gorm:create").Register(name+":create", probe); err != nil {
+		t.Fatalf("register create context probe: %v", err)
+	}
+	if err := db.Callback().Delete().Before("gorm:delete").Register(name+":delete", probe); err != nil {
+		t.Fatalf("register delete context probe: %v", err)
+	}
 
 	t.Cleanup(func() {
 		_ = db.Callback().Query().Remove(name + ":query")
+		_ = db.Callback().Create().Remove(name + ":create")
+		_ = db.Callback().Delete().Remove(name + ":delete")
 	})
 
 	return func() int {
@@ -279,6 +287,27 @@ func TestRefreshHandler_Success(t *testing.T) {
 	assertTokenPayloadHasBrowserTokens(t, parseBody(t, w.Body.Bytes()))
 }
 
+func TestRefreshHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	_, refreshToken := env.registerUser(t, "refreshctx", "refreshctx@example.com", "password123")
+	key := authHandlerContextKey{}
+	seen := installAuthHandlerDBContextProbe(t, env.db, key, "refresh")
+
+	body := fmt.Sprintf(`{"refresh_token":"%s"}`, refreshToken)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", bytes.NewBufferString(body)).
+		WithContext(context.WithValue(context.Background(), key, "refresh"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected Refresh handler DB query/delete/create to use request context")
+	}
+}
+
 func TestRefreshHandler_SuccessWithCookie(t *testing.T) {
 	env := newTestEnv(t)
 	_, refreshToken := env.registerUser(t, "cookieuser", "cookie@example.com", "password123")
@@ -358,6 +387,27 @@ func TestLogoutHandler_Success(t *testing.T) {
 		t.Errorf("want 200, got %d", w.Code)
 	}
 	assertRefreshCookieCleared(t, w, http.SameSiteLaxMode, false)
+}
+
+func TestLogoutHandler_UsesRequestContext(t *testing.T) {
+	env := newTestEnv(t)
+	_, refreshToken := env.registerUser(t, "logoutctx", "logoutctx@example.com", "password123")
+	key := authHandlerContextKey{}
+	seen := installAuthHandlerDBContextProbe(t, env.db, key, "logout")
+
+	body := fmt.Sprintf(`{"refresh_token":"%s"}`, refreshToken)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", bytes.NewBufferString(body)).
+		WithContext(context.WithValue(context.Background(), key, "logout"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected Logout handler DB delete to use request context")
+	}
 }
 
 func TestLogoutHandler_SuccessWithCookie(t *testing.T) {

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -182,10 +182,18 @@ func (s *AuthService) LoginContext(ctx context.Context, input LoginInput) (*mode
 // ─── Token Refresh / Logout ──────────────────────────────────────────────────
 
 func (s *AuthService) Refresh(rawRefreshToken string) (*TokenPair, error) {
+	return s.RefreshContext(context.Background(), rawRefreshToken)
+}
+
+func (s *AuthService) RefreshContext(ctx context.Context, rawRefreshToken string) (*TokenPair, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db := s.db.WithContext(ctx)
 	hash := hashToken(rawRefreshToken)
 
 	var tokenPair *TokenPair
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := db.Transaction(func(tx *gorm.DB) error {
 		var stored models.RefreshToken
 		if err := tx.Where("token_hash = ?", hash).First(&stored).Error; err != nil {
 			return ErrInvalidToken
@@ -213,7 +221,7 @@ func (s *AuthService) Refresh(rawRefreshToken string) (*TokenPair, error) {
 		return err
 	})
 	if errors.Is(err, errRefreshTokenExpired) {
-		if err := s.db.Where("token_hash = ?", hash).Delete(&models.RefreshToken{}).Error; err != nil {
+		if err := db.Where("token_hash = ?", hash).Delete(&models.RefreshToken{}).Error; err != nil {
 			return nil, err
 		}
 		return nil, ErrInvalidToken
@@ -225,8 +233,15 @@ func (s *AuthService) Refresh(rawRefreshToken string) (*TokenPair, error) {
 }
 
 func (s *AuthService) Logout(rawRefreshToken string) error {
+	return s.LogoutContext(context.Background(), rawRefreshToken)
+}
+
+func (s *AuthService) LogoutContext(ctx context.Context, rawRefreshToken string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	hash := hashToken(rawRefreshToken)
-	return s.db.Where("token_hash = ?", hash).Delete(&models.RefreshToken{}).Error
+	return s.db.WithContext(ctx).Where("token_hash = ?", hash).Delete(&models.RefreshToken{}).Error
 }
 
 // DeleteExpiredRefreshTokens removes all expired refresh token records.

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -413,6 +413,32 @@ func TestRefresh_Success(t *testing.T) {
 	}
 }
 
+func TestAuthService_RefreshContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	_, tokens, _ := svc.Register(RegisterInput{
+		Username: "refreshctx",
+		Email:    "refreshctx@example.com",
+		Password: "password123",
+	})
+
+	type refreshContextKey struct{}
+	key := refreshContextKey{}
+	seen := installDBContextProbe(t, db, key, "refresh")
+	ctx := context.WithValue(context.Background(), key, "refresh")
+
+	newTokens, err := svc.RefreshContext(ctx, tokens.RefreshToken)
+	if err != nil {
+		t.Fatalf("refresh context: %v", err)
+	}
+	if newTokens == nil || newTokens.RefreshToken == "" {
+		t.Fatal("expected rotated refresh token")
+	}
+	if seen() == 0 {
+		t.Fatal("expected Refresh DB query/delete/create to use request context")
+	}
+}
+
 func TestRefresh_RotatesToken(t *testing.T) {
 	svc := NewAuthService(newTestDB(t), testConfig())
 	_, tokens, _ := svc.Register(RegisterInput{Username: "rotuser", Email: "rot@example.com", Password: "password123"})
@@ -518,6 +544,28 @@ func TestLogout_InvalidatesRefreshToken(t *testing.T) {
 	_, err := svc.Refresh(tokens.RefreshToken)
 	if err != ErrInvalidToken {
 		t.Errorf("want ErrInvalidToken after logout, got %v", err)
+	}
+}
+
+func TestAuthService_LogoutContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	_, tokens, _ := svc.Register(RegisterInput{
+		Username: "logoutctx",
+		Email:    "logoutctx@example.com",
+		Password: "password123",
+	})
+
+	type logoutContextKey struct{}
+	key := logoutContextKey{}
+	seen := installDBContextProbe(t, db, key, "logout")
+	ctx := context.WithValue(context.Background(), key, "logout")
+
+	if err := svc.LogoutContext(ctx, tokens.RefreshToken); err != nil {
+		t.Fatalf("logout context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected Logout DB delete to use request context")
 	}
 }
 

--- a/services/api/internal/services/context_probe_test.go
+++ b/services/api/internal/services/context_probe_test.go
@@ -27,6 +27,9 @@ func installDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int 
 	if err := db.Callback().Update().Before("gorm:update").Register(name+":update", probe); err != nil {
 		t.Fatalf("register update context probe: %v", err)
 	}
+	if err := db.Callback().Delete().Before("gorm:delete").Register(name+":delete", probe); err != nil {
+		t.Fatalf("register delete context probe: %v", err)
+	}
 	if err := db.Callback().Raw().Before("gorm:raw").Register(name+":raw", probe); err != nil {
 		t.Fatalf("register raw context probe: %v", err)
 	}
@@ -38,6 +41,7 @@ func installDBContextProbe(t *testing.T, db *gorm.DB, key, want any) func() int 
 		_ = db.Callback().Create().Remove(name + ":create")
 		_ = db.Callback().Query().Remove(name + ":query")
 		_ = db.Callback().Update().Remove(name + ":update")
+		_ = db.Callback().Delete().Remove(name + ":delete")
 		_ = db.Callback().Raw().Remove(name + ":raw")
 		_ = db.Callback().Row().Remove(name + ":row")
 	})


### PR DESCRIPTION
## 什麼改動
- 新增 `AuthService.RefreshContext` / `LogoutContext`，讓 refresh token rotation 與 logout token deletion 可以使用 caller 的 request context。
- `AuthHandler.Refresh` / `Logout` 改傳 `c.Request.Context()`。
- 補上 service 與 handler 層的 context-probe regression tests，並讓測試 helper 觀察 delete callback。

## 為什麼
refs #645

`request timeout middleware` 已合併，但 refresh/logout DB path 仍透過 background context 執行。這個 PR 補齊 auth refresh/logout 的 request-context propagation，避免 request cancellation 後 refresh token query/delete/create 持續跑。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 timeout policy 調整
  - 不做 queue / worker 架構
  - 不做 schema / migration
  - 不做 airdrop `TodayTotalContext` follow-up slice（AWP scout 建議下一輪處理）

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request-context propagation audit
- Actual worker profile(s)：
  - controller + read-only AWP scout
- Model strength：
  - controller = high；read-only scout = medium
- Spawn directive(s)：
  - profile=read_only_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=controller selected an even smaller auth refresh/logout slice after local scan; scout recommended airdrop TodayTotalContext for the next slice
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - RED: `go test ./internal/services ./internal/handlers -run 'TestAuthService_(RefreshContext|LogoutContext)_UsesRequestContext|Test(Refresh|Logout)Handler_UsesRequestContext' -count=1` failed before production code
  - GREEN: same focused test command passed
  - `go test ./internal/services ./internal/handlers -count=1`
  - `git diff --check`
- Self-review / exception reason：
  - controller self-review completed; R4 requires human reviewer before merge
- Worker session closeout：
  - read-only scout completed and reported `AirdropService.TodayTotalContext` as the next low-collision slice; no worker edits were made
- Workflow friction / follow-up split：
  - start gate passed but reported missing always-read `docs/claude-codex-workflow.md`; this PR remains bounded to auth refresh/logout and records the context warning instead of expanding scope

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - status pass; Review skipped
- chatgpt-codex-connector：
  - n/a at PR creation
- review_triage_ref：
  - local TDD and diff review in this run
- root_cause_gate_ref：
  - latest-head rationale: refresh/logout were the remaining auth DB paths after #852/#853
- finding_disposition_ref：
  - n/a; no review findings yet
- Final reviewer action：
  - pending human R4 review

## Final merge gate
- Ready-to-merge decision：
  - blocked pending human R4 review; GitHub checks pass
- Latest head SHA：
  - c9d36b9772bcbedb64cd67bf7fcdf5851127789d
- Required checks：
  - GitHub Backend CI gate / Scope police / CodeRabbit / Cloudflare pass
- spec workflow-check evidence：
  - spec gate status: pass
  - spec_gate_status: pass
  - workflow-check evidence: workflow-check:commit:issue-645-auth-refresh-context
  - start gate passed at 2026-05-22T00:11:40Z; commit gate passed at 2026-05-22T00:14:33Z
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/854

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request context through auth refresh/logout DB operations.
- Approx changed lines：~127
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - refresh/logout handler must pass the request context into the matching auth service methods; tests cover both service and handler boundaries for the same request path.
- 若已拆分，相關 PR：
  - #852 auth register context；#853 auth login context；airdrop TodayTotalContext deferred to a later #645 slice

## Acceptance Criteria
- [x] All service-layer DB access paths propagate request context — auth refresh/logout slice
- [x] All GORM / sql queries use `WithContext(ctx)` or equivalent — auth refresh/logout slice
- [x] Add regression tests for canceled/request context — context-probe tests for service and handler boundaries
- [ ] Audit all DB queries and transactions under `services/api` — ongoing across split #645 PRs
- [ ] Transaction helpers preserve context — ongoing across split #645 PRs
- [ ] Add at least one integration test proving timeout cancels DB work — deferred to final integration slice
- [ ] Document any intentionally detached async job paths — deferred to audit closeout

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestAuthService_(RefreshContext|LogoutContext)_UsesRequestContext|Test(Refresh|Logout)Handler_UsesRequestContext' -count=1
# expected failure before production code: RefreshContext/LogoutContext undefined and handler probes did not see request context

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestAuthService_(RefreshContext|LogoutContext)_UsesRequestContext|Test(Refresh|Logout)Handler_UsesRequestContext' -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.380s
ok  	github.com/tachigo/tachigo/internal/handlers	0.396s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -count=1
ok  	github.com/tachigo/tachigo/internal/services	2.945s
ok  	github.com/tachigo/tachigo/internal/handlers	16.613s

git diff --check
# pass
```

## 備註
- `spec workflow-check --phase start` reported missing always-read `docs/claude-codex-workflow.md`; no implementation scope was inferred from the missing doc.

## Notes for Claude Code Review
- 請特別看 refresh token rotation transaction 是否正確繼承 `db.WithContext(ctx)`；舊 `Refresh` / `Logout` API 保持相容並 delegate 到 `context.Background()`。
