### PR TITLE
[backend] Add airdrop total request context

### DIFF
--- a/services/api/internal/services/airdrop_service.go
+++ b/services/api/internal/services/airdrop_service.go
@@ -72,7 +72,14 @@ func NewAirdropService(db *gorm.DB, pointsSvc *PointsService, configSvc *Channel
 }
 
 func (s *AirdropService) TodayTotal(channelID string) (int64, error) {
-	return s.todayTotal(s.db, channelID, time.Now().UTC())
+	return s.TodayTotalContext(context.Background(), channelID)
+}
+
+func (s *AirdropService) TodayTotalContext(ctx context.Context, channelID string) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.todayTotal(s.db.WithContext(ctx), channelID, time.Now().UTC())
 }
 
 func (s *AirdropService) Execute(req AirdropRequest) (*AirdropResult, error) {

--- a/services/api/internal/services/airdrop_service_test.go
+++ b/services/api/internal/services/airdrop_service_test.go
@@ -102,6 +102,22 @@ func TestAirdrop_ExecuteContextUsesRequestContext(t *testing.T) {
 	}
 }
 
+func TestAirdrop_TodayTotalContextReturnsCanceledContextError(t *testing.T) {
+	db := newTestDB(t)
+	watchSvc := NewWatchService(db)
+	pointsSvc := NewPointsService(db, watchSvc)
+	configSvc := NewChannelConfigService(db)
+	svc := NewAirdropService(db, pointsSvc, configSvc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	total, err := svc.TodayTotalContext(ctx, "ch_canceled_total")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got total=%d err=%v", total, err)
+	}
+}
+
 func TestAirdrop_NoActiveSessions(t *testing.T) {
 	db := newTestDB(t)
 	watchSvc := NewWatchService(db)


### PR DESCRIPTION
## 什麼改動
- 新增 `AirdropService.TodayTotalContext(ctx, channelID)`，讓公開的 daily airdrop total 查詢可以使用 caller request context。
- 保留既有 `TodayTotal(channelID)` API，改為 delegate 到 `context.Background()`。
- 補上 canceled-context regression test，確保取消的 context 不會退回 background context 繼續查詢。

## 為什麼
refs #645

`TodayTotal` 是 #645 audit 中仍未提供 context-aware 入口的 service-layer DB read path。這個 PR 補上最小 context API，讓後續 handler / integration slice 可以直接沿用 request context。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 timeout policy 調整
  - 不做 handler 行為變更
  - 不做 schema / migration
  - 不做 queue / worker 架構

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request-context propagation audit
- Actual worker profile(s)：
  - controller + prior read-only AWP scout
- Model strength：
  - controller = high；read-only scout = medium
- Spawn directive(s)：
  - profile=read_only_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=read-only scout selected `AirdropService.TodayTotalContext` as a tiny low-collision follow-up; controller implemented directly because the TDD slice touched only two service files
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - RED: `go test ./internal/services -run TestAirdrop_TodayTotalContextReturnsCanceledContextError -count=1` failed because `TodayTotalContext` was undefined
  - GREEN: same focused test passed
  - `go test ./internal/services -run 'TestAirdrop_' -count=1`
  - `go test ./internal/services -count=1`
  - `go test ./...`
  - `git diff --check`
- Self-review / exception reason：
  - controller self-review completed; no public self-review/approval action
- Worker session closeout：
  - scout result consumed from prior heartbeat; no worker edits were made
- Workflow friction / follow-up split：
  - `spec plan` and start gate reported missing always-read `docs/claude-codex-workflow.md`; no scope was inferred from that missing doc

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - pass / Review completed on head 49abc1cab86b55f861778b22bbe8e50405fbda8d
- chatgpt-codex-connector：
  - n/a at PR creation
- review_triage_ref：
  - local TDD and diff review in this run
- root_cause_gate_ref：
  - latest-head rationale: `TodayTotal` was the remaining airdrop read path without a context-aware public service method
- finding_disposition_ref：
  - n/a; no review findings yet
- Final reviewer action：
  - pending human review; no public self-review/approval action

## Final merge gate
- Ready-to-merge decision：
  - checks pass; pending human review
- Latest head SHA：
  - 49abc1cab86b55f861778b22bbe8e50405fbda8d
- Required checks：
  - pass: Backend CI (gate), Scope police, CodeRabbit, Cloudflare Pages, PR metadata, commit messages, supply-chain guardrails
- spec workflow-check evidence：
  - spec gate status: pass
  - spec_gate_status: pass
  - workflow-check evidence: workflow-check:commit:issue-645-airdrop-today-total-context
  - start gate passed at 2026-05-22T01:09:47Z; commit gate passed at 2026-05-22T01:11:05Z and rechecked after commit
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/855

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add a request-context-aware daily airdrop total service method.
- Approx changed lines：~24
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The regression test proves the new service method obeys canceled request context.
- 若已拆分，相關 PR：
  - #854 auth refresh/logout context; #852/#853 auth register/login context

## Acceptance Criteria
- [x] All service-layer DB access paths propagate request context — airdrop TodayTotal slice
- [x] All GORM / sql queries use `WithContext(ctx)` or equivalent — airdrop TodayTotal slice
- [x] Add regression tests for canceled request context — `TestAirdrop_TodayTotalContextReturnsCanceledContextError`
- [ ] Audit all DB queries and transactions under `services/api` — ongoing across split #645 PRs
- [ ] Transaction helpers preserve context — ongoing across split #645 PRs
- [ ] Add at least one integration test proving timeout cancels DB work — deferred to final integration slice
- [ ] Document any intentionally detached async job paths — deferred to audit closeout

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestAirdrop_TodayTotalContextReturnsCanceledContextError -count=1
# expected failure: svc.TodayTotalContext undefined

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestAirdrop_TodayTotalContextReturnsCanceledContextError -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.444s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestAirdrop_' -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.220s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -count=1
ok  	github.com/tachigo/tachigo/internal/services	3.498s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/cmd/loader	0.678s
ok  	github.com/tachigo/tachigo/cmd/server	2.291s
ok  	github.com/tachigo/tachigo/docs	1.462s
ok  	github.com/tachigo/tachigo/internal/config	1.973s
ok  	github.com/tachigo/tachigo/internal/contract	2.971s
ok  	github.com/tachigo/tachigo/internal/handlers	18.830s
ok  	github.com/tachigo/tachigo/internal/metrics	3.196s
ok  	github.com/tachigo/tachigo/internal/middleware	1.208s
ok  	github.com/tachigo/tachigo/internal/models	2.739s
ok  	github.com/tachigo/tachigo/internal/router	2.139s
ok  	github.com/tachigo/tachigo/internal/services	5.083s
ok  	github.com/tachigo/tachigo/internal/tracing	2.391s

git diff --check
# pass
```

## 備註
- `spec plan` / `spec workflow-check --phase start` reported missing always-read `docs/claude-codex-workflow.md`; no implementation scope was inferred from the missing doc.

## Notes for Claude Code Review
- 請看 `TodayTotalContext` 是否是最小、安全的 public service variant；既有 `TodayTotal` 保持相容。
