### PR TITLE
[backend] Add points watch context variants

### DIFF
--- a/services/api/internal/services/points_service.go
+++ b/services/api/internal/services/points_service.go
@@ -253,7 +253,11 @@ func validatePositivePointsAmount(amount int64) error {
 // AddWatchTime accumulates observed seconds for a viewer in a channel.
 // Called after each successful Heartbeat.
 func (s *PointsService) AddWatchTime(userID uuid.UUID, channelID string, seconds int64) error {
-	return s.addWatchTime(s.db, userID, channelID, seconds)
+	return s.AddWatchTimeContext(context.Background(), userID, channelID, seconds)
+}
+
+func (s *PointsService) AddWatchTimeContext(ctx context.Context, userID uuid.UUID, channelID string, seconds int64) error {
+	return s.addWatchTime(s.dbWithContext(ctx), userID, channelID, seconds)
 }
 
 func (s *PointsService) addWatchTime(db *gorm.DB, userID uuid.UUID, channelID string, seconds int64) error {
@@ -269,10 +273,14 @@ func (s *PointsService) addWatchTime(db *gorm.DB, userID uuid.UUID, channelID st
 
 // GetWatchStats returns the total accumulated watch seconds for a viewer in a channel.
 func (s *PointsService) GetWatchStats(userID uuid.UUID, channelID string) (*WatchStats, error) {
+	return s.GetWatchStatsContext(context.Background(), userID, channelID)
+}
+
+func (s *PointsService) GetWatchStatsContext(ctx context.Context, userID uuid.UUID, channelID string) (*WatchStats, error) {
 	var result struct {
 		TotalWatchSeconds int64
 	}
-	err := s.db.Raw(`
+	err := s.dbWithContext(ctx).Raw(`
 		SELECT COALESCE(total_watch_seconds, 0) AS total_watch_seconds
 		FROM watch_time_stats
 		WHERE user_id = ? AND channel_id = ?
@@ -288,7 +296,11 @@ func (s *PointsService) GetWatchStats(userID uuid.UUID, channelID string) (*Watc
 // streamerID is resolved internally from channelID via auth_providers (Twitch provider_id = channelID).
 // If the channelID has no registered streamer, the call is a no-op.
 func (s *PointsService) AddBroadcastTime(channelID string, seconds int64) error {
-	return s.addBroadcastTime(s.db, channelID, seconds)
+	return s.AddBroadcastTimeContext(context.Background(), channelID, seconds)
+}
+
+func (s *PointsService) AddBroadcastTimeContext(ctx context.Context, channelID string, seconds int64) error {
+	return s.addBroadcastTime(s.dbWithContext(ctx), channelID, seconds)
 }
 
 func (s *PointsService) addBroadcastTime(db *gorm.DB, channelID string, seconds int64) error {

--- a/services/api/internal/services/points_service_test.go
+++ b/services/api/internal/services/points_service_test.go
@@ -544,6 +544,21 @@ func TestPointsService_AddWatchTime_Accumulates(t *testing.T) {
 	}
 }
 
+func TestPointsService_AddWatchTimeContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+	key := pointsContextKey("add-watch-time-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-watch-time")
+
+	err := svc.AddWatchTimeContext(context.WithValue(context.Background(), key, "points-watch-time"), userID, "ch_context", 30)
+	if err != nil {
+		t.Fatalf("add watch time with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected AddWatchTimeContext DB operations to carry request context")
+	}
+}
+
 func TestPointsService_GetWatchStats_ZeroWhenNone(t *testing.T) {
 	svc, _ := newPointsSvc(t)
 	userID := seedViewer(t, svc)
@@ -554,6 +569,21 @@ func TestPointsService_GetWatchStats_ZeroWhenNone(t *testing.T) {
 	}
 	if stats.TotalWatchSeconds != 0 {
 		t.Errorf("want 0 s, got %d", stats.TotalWatchSeconds)
+	}
+}
+
+func TestPointsService_GetWatchStatsContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+	key := pointsContextKey("get-watch-stats-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-watch-stats")
+
+	_, err := svc.GetWatchStatsContext(context.WithValue(context.Background(), key, "points-watch-stats"), userID, "ch_context")
+	if err != nil {
+		t.Fatalf("get watch stats with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetWatchStatsContext DB operations to carry request context")
 	}
 }
 
@@ -633,6 +663,22 @@ func TestPointsService_AddBroadcastTime_WritesLogAndStat(t *testing.T) {
 	svc.db.Raw("SELECT COUNT(*) FROM broadcast_time_logs WHERE streamer_id = ?", streamerID).Scan(&count)
 	if count != 2 {
 		t.Errorf("broadcast_time_logs: want 2 entries, got %d", count)
+	}
+}
+
+func TestPointsService_AddBroadcastTimeContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	channelID := "ch_broadcast_context"
+	seedStreamer(t, svc, channelID)
+	key := pointsContextKey("add-broadcast-time-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-broadcast-time")
+
+	err := svc.AddBroadcastTimeContext(context.WithValue(context.Background(), key, "points-broadcast-time"), channelID, 30)
+	if err != nil {
+		t.Fatalf("add broadcast time with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected AddBroadcastTimeContext DB operations to carry request context")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- 新增 `PointsService.AddWatchTimeContext(ctx, ...)`，讓 standalone watch-time 累積可帶 caller request context。
- 新增 `PointsService.GetWatchStatsContext(ctx, ...)`，讓 watch stats read path 使用 `WithContext(ctx)`。
- 新增 `PointsService.AddBroadcastTimeContext(ctx, ...)`，讓 standalone broadcast-time 累積可帶 caller request context。
- 保留既有 `AddWatchTime` / `GetWatchStats` / `AddBroadcastTime` API，改為 delegate 到 `context.Background()`。
- 補上三個 request-context propagation regression tests。

## 為什麼
refs #645

`PointsService` 已有 balance/history/heartbeat/broadcast-stats context variants，但 standalone watch/broadcast helper 仍直接使用 service root DB。這個 PR 補上最小 public context variants，讓後續 request path 或 service caller 可以沿用 request context，而不改 timeout policy 或 handler 行為。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 handler 行為變更
  - 不做 timeout policy 調整
  - 不做 schema / migration
  - 不做 raffle claim / auth / airdrop paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request-context propagation audit
- Actual worker profile(s)：
  - read-only scout + controller-direct implementation
- Model strength：
  - controller = high；read-only scout = inherited explorer
- Spawn directive(s)：
  - profile=read_only_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=scout may return after controller selects a smaller non-overlapping slice target=next #645 slice avoid open self-authored PR #854/#855
  - profile=controller_direct model=gpt-5 reasoning=high controller_fallback=used fallback_reason=controller found and completed an even smaller two-file points watch/broadcast context slice while scout was still running; scout later recommended raffle SubmitClaim as the next non-overlapping follow-up candidate
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - RED: focused points context tests failed because `AddWatchTimeContext`, `GetWatchStatsContext`, and `AddBroadcastTimeContext` were undefined
  - GREEN: focused points context tests passed
  - `go test ./internal/services -run 'TestPointsService_' -count=1`
  - `go test ./internal/services -count=1`
  - `go test ./...`
  - `git diff --check`
- Self-review / exception reason：
  - controller self-review completed; no public self-review/approval action
- Worker session closeout：
  - scout completed read-only; no worker edits were made
- Workflow friction / follow-up split：
  - `spec plan` reported missing always-read `docs/claude-codex-workflow.md`; no scope was inferred from that missing doc
  - scout recommended `RaffleHandler.SubmitClaim` / `RaffleService.SubmitClaimContext` as a next #645 slice; intentionally left out of this PR to keep one independent behavior change

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - pass / Review completed on head 8f88a5b6bab8b951fe782312ea680667ec91f486
- chatgpt-codex-connector：
  - n/a at PR creation
- review_triage_ref：
  - local TDD and diff review in this run
- root_cause_gate_ref：
  - latest-head rationale: standalone points watch/broadcast helper paths still lacked public context-aware service variants
- finding_disposition_ref：
  - n/a; no review findings yet
- Final reviewer action：
  - pending human review; no public self-review/approval action

## Final merge gate
- Ready-to-merge decision：
  - checks pass; pending human review
- Latest head SHA：
  - 8f88a5b6bab8b951fe782312ea680667ec91f486
- Required checks：
  - pass: Backend CI (gate), Scope police, CodeRabbit, Cloudflare Pages, PR metadata, commit messages, supply-chain guardrails
- spec workflow-check evidence：
  - spec gate status: pass
  - spec_gate_status: pass
  - workflow-check evidence: workflow-check:commit:issue-645-points-watch-broadcast-context
  - start gate passed at 2026-05-22T02:14:44Z; commit gate passed at 2026-05-22T02:20:51Z
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/856

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add request-context-aware points watch/broadcast helper variants.
- Approx changed lines：~64
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The regression tests prove the new service methods propagate caller context to GORM.
- 若已拆分，相關 PR：
  - #854 auth refresh/logout context; #855 airdrop total context

## Acceptance Criteria
- [x] All service-layer DB access paths propagate request context — points watch/broadcast helper slice
- [x] All GORM / sql queries use `WithContext(ctx)` or equivalent — points watch/broadcast helper slice
- [x] Add regression tests for canceled/request context — request-context propagation probes for the new context variants
- [ ] Audit all DB queries and transactions under `services/api` — ongoing across split #645 PRs
- [ ] Transaction helpers preserve context — ongoing across split #645 PRs
- [ ] Add at least one integration test proving timeout cancels DB work — deferred to final integration slice
- [ ] Document any intentionally detached async job paths — deferred to audit closeout

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestPointsService_(AddWatchTimeContext|GetWatchStatsContext|AddBroadcastTimeContext)_UsesRequestContext' -count=1
# expected failure: context methods undefined

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestPointsService_(AddWatchTimeContext|GetWatchStatsContext|AddBroadcastTimeContext)_UsesRequestContext' -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.217s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestPointsService_' -count=1
ok  	github.com/tachigo/tachigo/internal/services	0.840s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -count=1
ok  	github.com/tachigo/tachigo/internal/services	2.655s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/cmd/loader	0.673s
ok  	github.com/tachigo/tachigo/cmd/server	2.046s
ok  	github.com/tachigo/tachigo/docs	2.906s
ok  	github.com/tachigo/tachigo/internal/config	3.130s
ok  	github.com/tachigo/tachigo/internal/contract	1.364s
ok  	github.com/tachigo/tachigo/internal/handlers	19.720s
ok  	github.com/tachigo/tachigo/internal/metrics	0.893s
ok  	github.com/tachigo/tachigo/internal/middleware	3.389s
ok  	github.com/tachigo/tachigo/internal/models	0.274s
ok  	github.com/tachigo/tachigo/internal/router	2.691s
ok  	github.com/tachigo/tachigo/internal/services	5.881s
ok  	github.com/tachigo/tachigo/internal/tracing	3.433s

git diff --check
# pass
```

## 備註
- `spec plan` reported missing always-read `docs/claude-codex-workflow.md`; no implementation scope was inferred from the missing doc.

## Notes for Claude Code Review
- 請確認 standalone points watch/broadcast helper context variants 是否是 #645 的合適小切片；raffle SubmitClaim 已由 read-only scout 留作下一輪候選。
