### PR TITLE
[backend] Propagate raffle claim request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -437,7 +437,7 @@ func (h *RaffleHandler) SetDiscordWebhook(c *gin.Context) {
 func (h *RaffleHandler) GetClaim(c *gin.Context) {
 	token := c.Param("token")
 
-	draw, err := h.raffleSvc.GetDrawByToken(token)
+	draw, err := h.raffleSvc.GetDrawByTokenContext(c.Request.Context(), token)
 	if err != nil {
 		if errors.Is(err, services.ErrClaimNotFound) {
 			notFound(c, "claim not found")
@@ -485,7 +485,7 @@ func (h *RaffleHandler) SubmitClaim(c *gin.Context) {
 		return
 	}
 
-	claim, err := h.raffleSvc.SubmitClaim(token, userID, input)
+	claim, err := h.raffleSvc.SubmitClaimContext(c.Request.Context(), token, userID, input)
 	if err != nil {
 		if errors.Is(err, services.ErrClaimNotFound) {
 			notFound(c, "claim not found")

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -658,6 +658,63 @@ func TestRaffle_ClaimFlow(t *testing.T) {
 	}
 }
 
+func TestRaffle_SubmitClaim_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	hostToken := env.registerStreamer(t, "claimctxhost", "claimctxhost@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "claim context flow"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w, req)
+	resp := parseBody(t, w.Body.Bytes())
+	raffleID := resp["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	env.createTwitchLinkedUser(t, "claimctxwinner")
+	winnerJWT := env.loginUser(t, "claimctxwinner")
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("file", "entries.csv")
+	fmt.Fprintln(fw, "claimctxwinner")
+	mw.Close()
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/entries/import-csv", &buf)
+	req2.Header.Set("Content-Type", mw.FormDataContentType())
+	req2.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w2, req2)
+
+	w3 := httptest.NewRecorder()
+	req3, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/draws", nil)
+	req3.Header.Set("Authorization", bearer(hostToken))
+	env.router.ServeHTTP(w3, req3)
+	drawResp := parseBody(t, w3.Body.Bytes())
+	claimToken := drawResp["data"].(map[string]interface{})["draw"].(map[string]interface{})["claim_token"].(string)
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-submit-claim", "raffle_draws", "raffle_claims")
+	ctx := context.WithValue(context.Background(), key, "raffle-submit-claim")
+
+	claimBody, _ := json.Marshal(map[string]string{
+		"recipient_name": "Context Winner",
+		"address_line1":  "Context Address",
+		"city":           "Taipei",
+		"country":        "TW",
+	})
+	w4 := httptest.NewRecorder()
+	req4, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/api/v1/claim/"+claimToken, bytes.NewReader(claimBody))
+	req4.Header.Set("Content-Type", "application/json")
+	req4.Header.Set("Authorization", bearer(winnerJWT))
+	env.router.ServeHTTP(w4, req4)
+	if w4.Code != http.StatusOK {
+		t.Fatalf("submit claim: want 200, got %d: %s", w4.Code, w4.Body.String())
+	}
+	if seen() < 2 {
+		t.Fatal("expected claim token query and claim create operations to use request context")
+	}
+}
+
 func TestRaffle_ClaimExpired(t *testing.T) {
 	env := newRaffleTestEnv(t)
 

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -464,8 +464,16 @@ func (s *RaffleService) Complete(raffleID, userID uuid.UUID) (*models.Raffle, er
 
 // GetDrawByToken fetches a draw by its claim token. Returns ErrClaimTokenExpired if past expiry.
 func (s *RaffleService) GetDrawByToken(token string) (*models.RaffleDraw, error) {
+	return s.GetDrawByTokenContext(context.Background(), token)
+}
+
+func (s *RaffleService) GetDrawByTokenContext(ctx context.Context, token string) (*models.RaffleDraw, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var draw models.RaffleDraw
-	if err := s.db.
+	if err := s.db.WithContext(ctx).
 		Preload("Entry").
 		Where("claim_token = ?", hashClaimToken(token)).
 		First(&draw).Error; err != nil {
@@ -495,7 +503,15 @@ type ClaimInput struct {
 // Duplicate submissions are caught by the unique constraint on draw_id.
 // userID must match the linked user on the winning entry; otherwise ErrClaimForbidden is returned.
 func (s *RaffleService) SubmitClaim(token string, userID uuid.UUID, input ClaimInput) (*models.RaffleClaim, error) {
-	draw, err := s.GetDrawByToken(token)
+	return s.SubmitClaimContext(context.Background(), token, userID, input)
+}
+
+func (s *RaffleService) SubmitClaimContext(ctx context.Context, token string, userID uuid.UUID, input ClaimInput) (*models.RaffleClaim, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	draw, err := s.GetDrawByTokenContext(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -520,7 +536,7 @@ func (s *RaffleService) SubmitClaim(token string, userID uuid.UUID, input ClaimI
 		Country:       country,
 		SubmittedAt:   time.Now(),
 	}
-	if err := s.db.Create(claim).Error; err != nil {
+	if err := s.db.WithContext(ctx).Create(claim).Error; err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			return nil, ErrClaimAlreadyDone
 		}

--- a/services/api/internal/services/raffle_service_hardening_test.go
+++ b/services/api/internal/services/raffle_service_hardening_test.go
@@ -108,6 +108,60 @@ func TestRaffleService_GetDrawsByRafflePublicContext_UsesRequestContext(t *testi
 	}
 }
 
+func TestRaffleService_GetDrawByTokenContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "claim_token_ctx_owner@example.com")
+	winnerID := seedUserWithEmail(t, db, "claim_token_ctx_winner@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	entryID := seedEntry(t, db, raffleID, &winnerID, "claim_token_ctx_player")
+	seedDraw(t, db, raffleID, entryID, "claim-token-context-token")
+
+	key := raffleServiceContextKey{}
+	seen := installDBContextProbe(t, db, key, "raffle-claim-token")
+	ctx := context.WithValue(context.Background(), key, "raffle-claim-token")
+
+	svc := &RaffleService{db: db}
+	draw, err := svc.GetDrawByTokenContext(ctx, "claim-token-context-token")
+	if err != nil {
+		t.Fatalf("GetDrawByTokenContext: %v", err)
+	}
+	if draw.Entry.UserID == nil || *draw.Entry.UserID != winnerID {
+		t.Fatalf("want winner ID %s, got %v", winnerID, draw.Entry.UserID)
+	}
+	if seen() == 0 {
+		t.Fatal("expected GetDrawByTokenContext DB query to use request context")
+	}
+}
+
+func TestRaffleService_SubmitClaimContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "submit_claim_ctx_owner@example.com")
+	winnerID := seedUserWithEmail(t, db, "submit_claim_ctx_winner@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	entryID := seedEntry(t, db, raffleID, &winnerID, "submit_claim_ctx_player")
+	seedDraw(t, db, raffleID, entryID, "submit-claim-context-token")
+
+	key := raffleServiceContextKey{}
+	seen := installDBContextProbe(t, db, key, "raffle-submit-claim")
+	ctx := context.WithValue(context.Background(), key, "raffle-submit-claim")
+
+	svc := &RaffleService{db: db}
+	claim, err := svc.SubmitClaimContext(ctx, "submit-claim-context-token", winnerID, ClaimInput{
+		RecipientName: "Context Winner",
+		AddressLine1:  "Context Address",
+		City:          "Taipei",
+	})
+	if err != nil {
+		t.Fatalf("SubmitClaimContext: %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected non-nil claim")
+	}
+	if seen() < 2 {
+		t.Fatal("expected SubmitClaimContext query and create operations to use request context")
+	}
+}
+
 // TestDrawNext_SkipsAlreadyDrawnEntry verifies that if one entry is already
 // drawn (seeded directly into DB), DrawNext picks the remaining entry rather
 // than misreporting ErrRaffleExhausted.


### PR DESCRIPTION
## 什麼改動

- 新增 `RaffleService.GetDrawByTokenContext` / `SubmitClaimContext`，舊方法保留為 `context.Background()` wrapper。
- 讓 `GET /claim/:token` 與 `POST /claim/:token` 使用 `c.Request.Context()`。
- 補 service 與 handler regression tests，確認 claim token query 與 claim create 都會使用 request context。

## 為什麼

refs #645

#645 要逐步補齊 `services/api` 的 DB request context propagation。本 PR 是其中一個 bounded backend slice，只處理 raffle public claim token / submit path，避免把整個 audit issue 塞成大包。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做全部 DB context audit 收斂。
  - 不改 raffle draw / import / activate / complete / discord webhook / Twitch sync path。
  - 不改 timeout policy、schema、migration、worker architecture。

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：
  - #645 bounded slice: raffle public claim token / submit request context propagation。
- Actual worker profile(s)：
  - prior read-only scout selected this non-overlapping #645 slice; controller-direct fallback used for the tiny TDD implementation.
- Model strength：
  - controller = high; prior read-only scout = medium.
- Spawn directive(s)：
  - profile=read_only_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=prior_scout_selected_raffle_submit_claim_as_next_non_overlapping_645_slice
  - profile=controller_direct model=gpt-5 reasoning=high controller_fallback=used fallback_reason=tiny_tdd_slice_touched_raffle_claim_path_only
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestRaffleService_(GetDrawByTokenContext|SubmitClaimContext)_UsesRequestContext|TestRaffle_SubmitClaim_UsesRequestContext' -count=1`
  - GREEN: same focused command passed after implementation.
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -run 'TestRaffle' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
  - `git diff --check`
- Self-review / exception reason：
  - Completed controller self-review; no self-approval requested.
- Worker session closeout：
  - prior scout result consumed; no live worker handle required for this tiny slice.
- Workflow friction / follow-up split：
  - This PR intentionally keeps #645 incremental; remaining DB context paths stay in #645 / future slices. #664 dogfood comment only after merge.

## Review conversation closeout

- Unresolved threads：
  - n/a - initial PR, no review threads yet.
- CodeRabbit：
  - reviewed latest head; check passed.
- chatgpt-codex-connector：
  - n/a - initial PR, connector review not available yet.
- review_triage_ref：
  - n/a - initial PR.
- root_cause_gate_ref：
  - n/a - first finding for this slice.
- finding_disposition_ref：
  - n/a - no review findings yet.
- Final reviewer action：
  - n/a - awaiting human review.

## Final merge gate

- Ready-to-merge decision：
  - blocked by required human review; self-authored PR is not self-approved.
- Latest head SHA：
  - de373e521f5280351791c151bf086d24b0fb2ce1
- Required checks：
  - pass: local tests, PR Scope Police, Backend CI gate, CodeRabbit, Cloudflare Pages.
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:start:d7a27f61012e39acc57b28fc90e7df9b1a374585
  - start gate pass local-only; commit gate pass local-only.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/857

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - Propagate request context through raffle public claim token lookup and claim submission DB operations.
- Approx changed lines：~137
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler must pass `Request.Context()` into the new service context methods, and tests prove both layers preserve the same request context for this single claim path.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria

- [x] Service-layer claim token lookup accepts request context and uses GORM `WithContext(ctx)`.
- [x] Claim submission create path uses the same request context.
- [x] Handler claim endpoints pass `c.Request.Context()` into the service layer.
- [x] Regression tests prove request context reaches claim query and create DB operations.
- [ ] Full `services/api` DB context audit remains in #645 / follow-up slices.
- [ ] Integration test proving timeout cancels DB work remains in #645 / follow-up slices.

## 超出範圍內容

無
