### PR TITLE
[backend] Add request timeout DB cancellation evidence

### DIFF
--- a/services/api/internal/router/router_test.go
+++ b/services/api/internal/router/router_test.go
@@ -3,6 +3,7 @@ package router_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -237,6 +238,38 @@ func TestMetricsRoute_RecordsTimeoutStatusAfterRequestTimeout(t *testing.T) {
 	}
 	if !strings.Contains(text, `tachigo_http_request_errors_total{route="/test-metrics-timeout",status_family="5xx"} 1`) {
 		t.Fatalf("expected timeout request to be recorded as error, got:\n%s", text)
+	}
+}
+
+func TestRouter_RequestTimeoutCancelsDBWorkUsingRequestContext(t *testing.T) {
+	cfg := routerTestConfig("development", false, false)
+	cfg.Server.RequestTimeout = time.Millisecond
+	env := newRouterTestEnv(t, cfg)
+
+	dbDone := make(chan error, 1)
+	env.router.GET("/test-timeout-db-work", func(c *gin.Context) {
+		<-c.Request.Context().Done()
+
+		var one int
+		err := env.db.WithContext(c.Request.Context()).Raw("SELECT 1").Scan(&one).Error
+		dbDone <- err
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test-timeout-db-work", nil)
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected timeout request to return 504, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case err := <-dbDone:
+		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected DB work to stop with request context error, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for DB work to observe canceled request context")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
新增一個 router integration test，證明 request timeout 發生後，以 request context 執行的 GORM DB work 會收到 cancellation / deadline error。

## 為什麼
這是 #645 的一個 tests-only evidence slice，用來覆蓋「Add at least one integration test proving timeout cancels DB work」這項 AC，避免 timeout response 已回 504 但 DB work 仍用 detached context 繼續跑。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做全 services/api DB query audit
  - 不改 timeout policy value
  - 不改 production service / repository implementation
  - 不導入 background job / queue architecture

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645
- Actual worker profile(s)：
  - repo_scout Newton recommended the timeout DB cancellation evidence slice
  - controller / test_worker implemented the bounded tests-only patch
- Model strength：
  - controller = high
  - repo_scout = inherited / medium
- Spawn directive(s)：
  - profile=repo_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=scout_recommended_timeout_db_cancellation_evidence_slice
  - profile=controller_direct model=gpt-5 reasoning=high controller_fallback=used fallback_reason=tests_only_evidence_slice_after_existing_timeout_plumbing_already_passed
- Verification evidence：
  - spec plan 645 --repo . --dry-run --format prompt --verbose
  - spec workflow-check --repo . --phase start --issue 645 --format text
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/router -run 'TestRouter_RequestTimeoutCancelsDBWorkUsingRequestContext' -count=1
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/router ./internal/middleware -run 'Test.*RequestTimeout|TestMetricsRoute_RecordsTimeoutStatusAfterRequestTimeout' -count=1
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/router ./internal/middleware -count=1
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./...
  - git diff --check
- Self-review / exception reason：
  - 已完成 self-review；這是 tests-only evidence slice，production 行為未變更
- Worker session closeout：
  - 已讀回 scout 結果；不需追加任務的 worker session 已 close
- Workflow friction / follow-up split：
  - 本次約 30% infra/context gathering，約 70% 測試驗證；threshold calibration 留 #664 merge 後 ledger comment

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - reviewed latest head; no actionable comments
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - spec plan dry-run for #645
- root_cause_gate_ref：
  - latest-head rationale: issue #645 requests proof that timeout cancellation reaches DB work
- finding_disposition_ref：
  - n/a; no review findings yet
- Final reviewer action：
  - blocked by required human review; self-authored PR is not self-approved

## Final merge gate
- Ready-to-merge decision：
  - blocked by required human review; all checks passed, but self-authored PR is not self-approved
- Latest head SHA：
  - 6a2a7c08f731199ae913c333f61549288f77c9bc
- Required checks：
  - pass: Scope police, Scope gate, Backend CI (gate), Backend tests, Backend integration tests, Backend security scanners, Atlas migration tooling, Build backend image, PR commit messages, Cloudflare Pages, CodeRabbit
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:start:d7a27f61012e39acc57b28fc90e7df9b1a374585
  - spec commit gate status: pass
  - spec commit evidence ref: workflow-check:commit:6a2a7c08f731199ae913c333f61549288f77c9bc
  - spec merge gate status: pass
  - spec merge evidence ref: workflow-check:merge:6a2a7c08f731199ae913c333f61549288f77c9bc
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/858

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 request timeout 後 DB work 會跟著 request context 被取消的 integration test evidence。
- Approx changed lines：~33
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [ ] Audit all DB queries and transactions under `services/api`
- [ ] All service-layer DB access paths propagate request context
- [ ] All GORM / sql queries use `WithContext(ctx)` or equivalent
- [ ] Transaction helpers preserve context
- [ ] Add regression tests for canceled request context
- [x] Add at least one integration test proving timeout cancels DB work
- [ ] Document any intentionally detached async job paths

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
PASS: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/router -run 'TestRouter_RequestTimeoutCancelsDBWorkUsingRequestContext' -count=1
PASS: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/router ./internal/middleware -run 'Test.*RequestTimeout|TestMetricsRoute_RecordsTimeoutStatusAfterRequestTimeout' -count=1
PASS: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/router ./internal/middleware -count=1
PASS: GOCACHE=/tmp/tachigo-go-build-cache go test ./...
PASS: git diff --check
```

## 備註
這個 PR 只補上 DB cancellation integration evidence；#645 其他 audit / propagation AC 留在 issue 內繼續追蹤。

## Notes for Claude Code Review
- 請特別看 test 是否足以代表 request context cancellation 已傳進 DB work；production code 本身沒有變更。
