### PR TITLE
[backend] Add agency ownership matrix tests

### DIFF
--- a/services/api/internal/handlers/agency_handler_test.go
+++ b/services/api/internal/handlers/agency_handler_test.go
@@ -741,7 +741,10 @@ func runAgencyOwnershipMatrix(t *testing.T, endpoints []agencyOwnershipMatrixEnd
 				}
 
 				w := httptest.NewRecorder()
-				req, _ := http.NewRequest(endpoint.method, endpoint.path(agencyID), bytes.NewBuffer(body))
+				req, err := http.NewRequest(endpoint.method, endpoint.path(agencyID), bytes.NewBuffer(body))
+				if err != nil {
+					t.Fatalf("%s: create request: %v", name, err)
+				}
 				if body != nil {
 					req.Header.Set("Content-Type", "application/json")
 				}

--- a/services/api/internal/handlers/agency_handler_test.go
+++ b/services/api/internal/handlers/agency_handler_test.go
@@ -702,6 +702,154 @@ func seedAgencyUser(t *testing.T, db *gorm.DB, name, email string) uuid.UUID {
 	return id
 }
 
+type agencyOwnershipMatrixWant struct {
+	noToken     int
+	viewer      int
+	streamer    int
+	agencyOwn   int
+	agencyOther int
+	admin       int
+}
+
+type agencyOwnershipMatrixEndpoint struct {
+	name   string
+	method string
+	path   func(uuid.UUID) string
+	body   func() []byte
+	setup  func(t *testing.T, env *testEnv, agencyID uuid.UUID)
+	want   agencyOwnershipMatrixWant
+}
+
+func runAgencyOwnershipMatrix(t *testing.T, endpoints []agencyOwnershipMatrixEndpoint) {
+	t.Helper()
+
+	for _, endpoint := range endpoints {
+		endpoint := endpoint
+		t.Run(endpoint.name, func(t *testing.T) {
+			runAgencyOwnershipCase := func(t *testing.T, name string, token func(uuid.UUID) string, want int) {
+				t.Helper()
+
+				env, r := newFullAgencyTestEnv(t)
+				agencyID := seedAgencyUser(t, env.db, "agency-matrix-"+name, "agency-matrix-"+name+"@example.com")
+				if endpoint.setup != nil {
+					endpoint.setup(t, env, agencyID)
+				}
+
+				var body []byte
+				if endpoint.body != nil {
+					body = endpoint.body()
+				}
+
+				w := httptest.NewRecorder()
+				req, _ := http.NewRequest(endpoint.method, endpoint.path(agencyID), bytes.NewBuffer(body))
+				if body != nil {
+					req.Header.Set("Content-Type", "application/json")
+				}
+				if token != nil {
+					req.Header.Set("Authorization", "Bearer "+token(agencyID))
+				}
+
+				r.ServeHTTP(w, req)
+				if w.Code != want {
+					t.Fatalf("%s: expected %d, got %d: %s", name, want, w.Code, w.Body.String())
+				}
+			}
+
+			cases := []struct {
+				name  string
+				token func(uuid.UUID) string
+				want  int
+			}{
+				{name: "no_token", want: endpoint.want.noToken},
+				{
+					name:  "viewer",
+					token: func(uuid.UUID) string { return makeAccessToken(t, models.RoleViewer) },
+					want:  endpoint.want.viewer,
+				},
+				{
+					name:  "streamer",
+					token: func(uuid.UUID) string { return makeAccessToken(t, models.RoleStreamer) },
+					want:  endpoint.want.streamer,
+				},
+				{
+					name:  "agency_own",
+					token: func(agencyID uuid.UUID) string { return makeAccessTokenForUser(t, agencyID, models.RoleAgency) },
+					want:  endpoint.want.agencyOwn,
+				},
+				{
+					name:  "agency_other",
+					token: func(uuid.UUID) string { return makeAccessTokenForUser(t, uuid.New(), models.RoleAgency) },
+					want:  endpoint.want.agencyOther,
+				},
+				{
+					name:  "admin",
+					token: func(uuid.UUID) string { return makeAccessToken(t, models.RoleAdmin) },
+					want:  endpoint.want.admin,
+				},
+			}
+
+			for _, tc := range cases {
+				tc := tc
+				t.Run(tc.name, func(t *testing.T) {
+					runAgencyOwnershipCase(t, tc.name, tc.token, tc.want)
+				})
+			}
+		})
+	}
+}
+
+func TestAgencyOwnershipMatrix(t *testing.T) {
+	runAgencyOwnershipMatrix(t, []agencyOwnershipMatrixEndpoint{
+		{
+			name:   "get agency profile",
+			method: http.MethodGet,
+			path:   func(agencyID uuid.UUID) string { return "/api/v1/agencies/" + agencyID.String() },
+			want: agencyOwnershipMatrixWant{
+				noToken:     http.StatusUnauthorized,
+				viewer:      http.StatusForbidden,
+				streamer:    http.StatusForbidden,
+				agencyOwn:   http.StatusOK,
+				agencyOther: http.StatusForbidden,
+				admin:       http.StatusOK,
+			},
+		},
+		{
+			name:   "update agency settings",
+			method: http.MethodPut,
+			path:   func(agencyID uuid.UUID) string { return "/api/v1/agencies/" + agencyID.String() + "/settings" },
+			body: func() []byte {
+				body, _ := json.Marshal(map[string]string{"name": "agency-matrix-renamed"})
+				return body
+			},
+			want: agencyOwnershipMatrixWant{
+				noToken:     http.StatusUnauthorized,
+				viewer:      http.StatusForbidden,
+				streamer:    http.StatusForbidden,
+				agencyOwn:   http.StatusOK,
+				agencyOther: http.StatusForbidden,
+				admin:       http.StatusOK,
+			},
+		},
+		{
+			name:   "list agency streamers",
+			method: http.MethodGet,
+			path:   func(agencyID uuid.UUID) string { return "/api/v1/agencies/" + agencyID.String() + "/streamers" },
+			setup: func(t *testing.T, env *testEnv, agencyID uuid.UUID) {
+				t.Helper()
+				seedAgencyStreamerListData(t, env.db, agencyID)
+			},
+			want: agencyOwnershipMatrixWant{
+				noToken:     http.StatusUnauthorized,
+				viewer:      http.StatusForbidden,
+				streamer:    http.StatusForbidden,
+				agencyOwn:   http.StatusOK,
+				agencyOther: http.StatusForbidden,
+				admin:       http.StatusOK,
+			},
+		},
+	})
+}
+
 func TestAgencyHandler_UpdateSettings_AdminSuccess(t *testing.T) {
 	env, r := newAgencyTestEnv(t)
 	agencyID := seedAgencyUser(t, env.db, "agency-orig", "agency-orig@example.com")


### PR DESCRIPTION
## 什麼改動
新增 `TestAgencyOwnershipMatrix`，用集中 table-driven matrix 覆蓋 agency management 三個已實作 endpoint 的 auth / role / ownership 行為：

- `GET /api/v1/agencies/:id`
- `PUT /api/v1/agencies/:id/settings`
- `GET /api/v1/agencies/:id/streamers`

## 為什麼
這是 #646 的第一個 tests-only slice，先把 agency ownership mismatch、unauthenticated、wrong-role、cross-tenant access 變成集中 regression matrix。這不改 production permission policy。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#646
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 production RBAC / ownership policy
  - 不改 router / middleware / handler implementation
  - 不 cover all protected admin / streamer / agency endpoints
  - 不新增 CI route-coverage gate
  - 不改 shared test helper，避免與 open PR #845 的 `testutil_test.go` 風險重疊

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #646
- Actual worker profile(s)：
  - repo_scout Sartre selected the Agency Management ownership matrix tests-only slice
  - controller / test_worker implemented the bounded table-driven test patch
- Model strength：
  - controller = high
  - repo_scout = inherited / medium
- Spawn directive(s)：
  - profile=repo_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=scout_selected_agency_management_matrix_slice
  - profile=test_worker model=gpt-5 reasoning=high controller_fallback=used fallback_reason=tests_only_single_file_slice
- Verification evidence：
  - spec plan 646 --repo . --dry-run --format prompt --verbose
  - spec workflow-check --repo . --phase start --issue 646 --format text
  - RED: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestAgencyOwnershipMatrix' -count=1 failed on undefined matrix helper/types
  - GREEN: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestAgencyOwnershipMatrix' -count=1
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestAgencyHandler|TestAgencyOwnershipMatrix|TestRBAC' -count=1
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -count=1
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./...
  - git diff --check
  - adopted CodeRabbit nit: handle `http.NewRequest` error in matrix helper
- Self-review / exception reason：
  - 已完成 self-review；這是 tests-only evidence slice，production 行為未變更
- Worker session closeout：
  - 已讀回 repo_scout 結果；不需追加任務的 worker session 已 close
- Workflow friction / follow-up split：
  - 本次約 20% context / overlap scouting，約 80% test matrix implementation；threshold calibration 留 #664 merge 後 ledger comment

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pass / review skipped on latest head
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - spec plan dry-run for #646; warning: missing always-read `docs/claude-codex-workflow.md`
- root_cause_gate_ref：
  - latest-head rationale: issue #646 asks for centralized ownership matrix regression coverage
- finding_disposition_ref：
  - adopted CodeRabbit low-value nit for request creation error handling
- Final reviewer action：
  - blocked by required human review; self-authored PR is not self-approved

## Final merge gate
- Ready-to-merge decision：
  - blocked by required human review; all checks passed, but self-authored PR is not self-approved
- Latest head SHA：
  - 1063a86fc040a0a66390b67fb3a8b9d543c84b00
- Required checks：
  - pass: Scope police, Scope gate, Backend CI (gate), Backend tests, Backend integration tests, Backend security scanners, Atlas migration tooling, Build backend image, PR commit messages, Cloudflare Pages, CodeRabbit
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:start:b79f0916f35fcfc26b7101f4742fca832f492aef
  - spec commit gate status: pass
  - spec commit evidence ref: workflow-check:commit:1063a86fc040a0a66390b67fb3a8b9d543c84b00
  - spec merge gate status: pass
  - spec merge evidence ref: workflow-check:merge:1063a86fc040a0a66390b67fb3a8b9d543c84b00
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/859

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 agency management endpoint ownership matrix regression tests。
- Approx changed lines：~148
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Create centralized RBAC ownership matrix tests
- [ ] Cover all protected admin / streamer / agency endpoints
- [x] Cover ownership mismatch scenarios
- [x] Cover unauthenticated / wrong-role / cross-tenant access
- [x] Add reusable permission test helpers
- [ ] CI fails when new protected routes lack RBAC coverage
- [ ] Document expected authorization behavior source-of-truth

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
PASS: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestAgencyOwnershipMatrix' -count=1
PASS: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestAgencyHandler|TestAgencyOwnershipMatrix|TestRBAC' -count=1
PASS: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -count=1
PASS: GOCACHE=/tmp/tachigo-go-build-cache go test ./...
PASS: git diff --check
```

## 備註
`spec plan` 顯示 always-read `docs/claude-codex-workflow.md` 不存在；本 PR 已以可讀的 #646、`docs/backend-permissions.md`、現有 agency handler tests 與 router permission docs 作為 bounded context。

## Notes for Claude Code Review
- 請特別確認這個第一片 matrix 是否適合作為 #646 後續 endpoint coverage 的 local pattern；目前 helper intentionally 留在 `agency_handler_test.go`，避免觸碰 shared test helper。
