### PR TITLE
[discussion] Document CI execution strategy

### DIFF
--- a/docs/ai/claude-codex-workflow.md
+++ b/docs/ai/claude-codex-workflow.md
@@ -50,6 +50,18 @@
 4. Claude Code 只閱讀最後摘要
 5. 若需要取捨或 review，再由 Claude Code 接手
 
+## Autonomous review loop 節流
+
+當 PR review 由 automation 協助時，預設走 metadata-first，而不是每次 label 或 schedule 事件都重新深審：
+
+- 先讀 PR metadata、head SHA、labels、reviewDecision、required checks、CodeRabbit / Cloudflare / repo checks 狀態。
+- 只有 `needs-codex-review` 或等價的新 head 訊號存在，且所有必要 checks / automated review signals 已完成時，才進入第一輪 review。
+- 若同一個 head SHA 已有 blocker 或 `changes-requested`，不要重複 review；等作者 push 新 head 後再重啟。
+- docs-only / lightweight lane 的 PR 先看 Scope Police / Scope gate 是否符合預期，再決定是否需要讀 patch。
+- review 輸出要優先找 blocker；minor / nit 不應造成重複 CR 或無限 review loop。
+
+這個節流規則只改變 agent / reviewer 的操作方式，不代表授權 workflow 自動改 label、重跑 CI、approve 或 merge。任何會修改 GitHub 公開狀態的 automation 仍必須由對應 workflow 或人類明確授權。
+
 ## 快捷指令
 
 完整指令清單與說明見 [CLAUDE.md](https://github.com/nurockplayer/tachigo/blob/develop/CLAUDE.md)（AI 分工 → 建議優先使用的快捷指令）。

--- a/docs/auto-merge-policy.md
+++ b/docs/auto-merge-policy.md
@@ -24,6 +24,19 @@ Scope Police 強制分拆 PR，分拆後的 PR merge 回 develop 會造成其他
 
 Approve 前應確認：CI 全過、scope 正確、無 blocker。
 
+## Lightweight lane 下的 Approve
+
+docs / template / metadata-only PR 可以走 lightweight lane，但 Approve 的語義不變：按下 Approve 仍代表該 PR 可以進 `develop`。
+
+因此 reviewer 在 lightweight lane 仍需確認：
+
+- `PR Scope Police` 通過，且 PR body 的 source of truth / dependency / scope 欄位完整。
+- `Scope gate` 的 skipped heavy CI 符合路徑規則；如果 PR 改到 `.github/workflows/**`，就不應被當成 metadata-only。
+- workflow regression、PR metadata regression、supply-chain / TypeScript guardrail 等保留 checks 沒有失敗。
+- 沒有把 inherited backend / frontend / dashboard 紅燈修補混進 docs-only PR。
+
+若 lightweight lane 的 PR 只是文件化策略，Approve 不代表同意後續 workflow runtime 變更；runtime 調整必須另開 issue/PR，重新經過 Scope Police、workflow regression 與必要的人審。
+
 ## PR Risk Class
 
 Auto-merge 只會在 PR body 剛好勾選一個 `PR Risk Class` 且該 class 不是 `R4` 時被 workflow arm。

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -212,6 +212,31 @@ repo 的 CI 目前改成：
 - 若 PR 是正式 `[release]` 的 `develop -> main` promotion，重型 CI 會照常執行，不因 diff 過大而被 scope gate 跳過
 - 若 PR 是 docs / template / metadata-only，重型 product CI 會直接跳過，避免 inherited product failures 造成無限循環
 
+### #764 CI execution strategy
+
+#764 的目標是讓 CI 成本跟 PR 風險成比例，但第一階段只先同步文件與 reviewer 判斷邊界，不在同一個 PR 修改 workflow runtime。任何實際調整 `.github/workflows/**`、required check snapshot、label mutation 或 auto-merge 行為的 PR，都應視為 workflow/policy 變更，獨立成 R4 或至少高風險 tooling PR，並搭配 workflow regression 測試。
+
+目前的 lightweight lanes 定義如下：
+
+- docs / template / metadata-only lane：只修改 `docs/`、`docs/ai/`、`plans/`、`.github/ISSUE_TEMPLATE/`、`.github/PULL_REQUEST_TEMPLATE.md`、repo root Markdown、`infra/`、`.gitignore` 或 `.gitattributes`。這類 PR 保留 metadata/policy checks，但 `Scope gate` 會略過 backend / frontend / dashboard / contracts heavy CI。
+- workflow lane：任何 `.github/workflows/**` 變更都不算 metadata-only。即使內容只是註解或 policy 調整，也要跑 workflow regression，並重新檢查 required check / auto-ready / Scope Police 語義。
+- frontend / style-only lane：目前尚未有獨立 workflow lane。只要修改 `apps/extension/`、`apps/dashboard/`、`tachimint/` 或 `dashboard/`，就仍屬 frontend surface，至少需要對應 frontend/dashboard checks；若未來要新增 style-only lane，必須先在 `.github/workflows/ci.yml` 與 `.github/workflows/ci.test.ts` 定義路徑規則與 regression case。
+- package / API contract lane：`packages/`、OpenAPI generated docs、frontend API client 或 workspace dependency 變更不可混入 docs-only lane；是否跑 API contract / dependency review 由 `Scope gate` path rules 決定。
+
+第一階段的非目標：
+
+- 不改 `.github/workflows/ci.yml` 的 `scope-gate` outputs 或 job `if` 條件。
+- 不改 `.github/workflows/pr-scope-police.yml` 的 sticky comment、label、自動 close 或 dependency gate。
+- 不改 `auto-ready` / auto-merge workflow，也不調整 branch protection required checks。
+- 不用 docs PR 修 inherited backend / frontend / dashboard 紅燈。
+
+後續若要實作 #764 的 runtime 變更，建議依序拆 PR：
+
+1. workflow regression 先行：為預期 lane 行為新增 `ci.test.ts` case，證明 workflow file 仍不會被誤判為 metadata-only。
+2. path-aware CI runtime：只改 `ci.yml` scope gate 與對應 regression，避免混入 Scope Police 或 auto-merge 行為。
+3. frontend / style-only lane：在有明確路徑定義與可接受 skipped required check 語義後再新增。
+4. autonomous review loop 節流：只改 review flag / rerequest / notification workflow，避免和 CI path gate 同 PR。
+
 ## Conflict / Restack 規則
 
 對 docs / template / metadata-only PR，或任何單一小 scope PR：


### PR DESCRIPTION
## 什麼改動
文件化 #764 的第一階段 CI execution strategy：

- 在 `docs/pr-scope-policy.md` 補 path-aware CI / lightweight lane 的現況定義與後續拆 PR 順序。
- 在 `docs/auto-merge-policy.md` 補 docs/template/metadata lightweight lane 下的 Approve 語義。
- 在 `docs/ai/claude-codex-workflow.md` 補 autonomous review loop 節流原則。

## 為什麼
#764 要降低 CI 與 governance overhead，但直接改 workflow runtime 風險較高。此 PR 先把既有 lane、非目標與後續拆分邊界寫清楚，避免把 docs-only policy sync 誤解成已授權改 `.github/workflows/**`、auto-ready、Scope Police 或 label mutation。

refs #764

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Docs / Policy
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [x] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#764
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 `.github/workflows/**`。
  - 不調整 Scope Police、auto-ready、auto-merge、review label workflow 或 required checks。
  - 不新增 docs-only 以外的 runtime lane。
  - 不修 inherited backend / frontend / dashboard CI 紅燈。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #764 live issue readback and `spec plan 764 --repo . --dry-run --format prompt --verbose`.
- Actual worker profile(s)：
  - repo_scout: read-only CI/workflow/docs surface scan and first-PR boundary recommendation.
  - controller: selected docs-only first slice, implemented docs changes, ran validation, and prepared PR evidence.
- Model strength：
  - repo_scout = inherited explorer, low reasoning.
  - controller = GPT-5.5 medium.
- Spawn directive(s)：
  - profile=repo_scout model=inherited reasoning=low controller_fallback=allowed fallback_reason=controller_owned_final_scope_and_docs_patch_after_readonly_surface_scan
- Verification evidence：
  - `spec plan 764 --repo . --dry-run --format prompt --verbose` passed with `ci/frontend/docs` domains and workflow/docs guardrails.
  - `spec workflow-check --repo . --phase start --issue 764 --format text` passed.
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts` passed: 96 tests.
  - `bash infra/scripts/commit-message-check.test.sh` passed.
  - `git diff --check` passed.
- Self-review / exception reason：
  - Controller kept this PR docs-only after repo_scout identified `.github/workflows/**`, Scope Police, auto-ready and review-label workflows as high-risk runtime surfaces.
- Worker session closeout：
  - repo_scout completed read-only and reported files_to_read_first, recommended docs-only first PR, high-risk surfaces to avoid, and validation commands; no worker edits remain to integrate.
- Workflow friction / follow-up split：
  - Local `pr-metadata-check.test.sh` hit a pre-existing ambiguous local branch named `origin/develop`; formal PR metadata preflight is run separately against this branch/body. `spec workflow-check` also reported an old auto-discovered path `docs/claude-codex-workflow.md`; the actual file is `docs/ai/claude-codex-workflow.md`.

## Review conversation closeout
- Unresolved threads：
  - none observed after PR #860 initial check readback.
- CodeRabbit：
  - pass; review completed on head `980548f40bc33699b760913e7e89bbb57f6d3827`.
- chatgpt-codex-connector：
  - skipped; self-authored PR, no self-review performed.
- review_triage_ref：
  - initial-readback: PR #860 checks and automated review signals pass; no blocker thread observed.
- root_cause_gate_ref：
  - root cause: #764 needs a low-risk policy baseline before workflow runtime changes; direct workflow changes were split out to future PRs.
- finding_disposition_ref：
  - adopted: repo_scout recommendation to keep first PR docs-only and avoid workflow/runtime surface changes.
- Final reviewer action：
  - blocked with reason: self-authored PR awaits human review; Codex did not review or approve its own PR.

## Final merge gate
- Ready-to-merge decision：
  - blocked with reason: self-authored PR awaits human review approval; required checks and automated signals pass.
- Latest head SHA：
  - 980548f40bc33699b760913e7e89bbb57f6d3827
- Required checks：
  - pass or expected skip: Scope Police, Scope gate, workflow regression, PR metadata regression, commit messages, supply-chain guardrails, TypeScript-only guardrail, Backend CI gate, Cloudflare Pages, CodeRabbit.
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:start+commit:issue-764.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/860

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 文件化 #764 的 CI execution strategy 與 lightweight lane/review-loop 邊界，不改 workflow runtime。
- Approx changed lines：50
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - Future PRs should separately cover workflow regression-first changes, runtime path-aware CI changes, frontend/style-only lane, and autonomous review-loop workflow changes.

## Acceptance Criteria
- [x] CI execution rules are predictable and documented for the first docs-only strategy slice.
- [x] Docs-only/lightweight lane boundaries are explicit.
- [x] Workflow/runtime changes are split out and not mixed into this PR.

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
spec plan 764 --repo . --dry-run --format prompt --verbose
PASS: bounded context generated

spec workflow-check --repo . --phase start --issue 764 --format text
PASS

spec workflow-check --repo . --phase commit --issue 764 --pr-body /tmp/tachigo-764-pr-body.md --format text
PASS

node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
PASS: 96 tests

bash infra/scripts/commit-message-check.test.sh
PASS

git diff --check
PASS

make pr-meta-check TITLE='[discussion] Document CI execution strategy' BODY_FILE=/tmp/tachigo-764-pr-body.md
PASS: docs_only=1 risk_class=R0
```

## 備註
`bash infra/scripts/pr-metadata-check.test.sh` was also attempted, but the local repo has a pre-existing branch named `origin/develop`, causing that test helper's short ref to become ambiguous. This PR does not modify the helper; it records the local verification caveat and keeps the branch/body preflight separate.
