### PR TITLE
[chore] Harden PR metadata base ref regression

### DIFF
--- a/infra/scripts/pr-metadata-check.test.sh
+++ b/infra/scripts/pr-metadata-check.test.sh
@@ -10,13 +10,13 @@ trap 'git branch -D "$head_branch" >/dev/null 2>&1 || true; rm -rf "$tmpdir"' EX
 
 resolve_base_ref() {
   if git show-ref --verify --quiet refs/remotes/origin/develop; then
-    printf '%s\n' "origin/develop"
+    printf '%s\n' "refs/remotes/origin/develop"
     return 0
   fi
 
   if git show-ref --verify --quiet refs/heads/develop; then
     echo "warning: refs/remotes/origin/develop not found; falling back to local develop" >&2
-    printf '%s\n' "develop"
+    printf '%s\n' "refs/heads/develop"
     return 0
   fi
 


### PR DESCRIPTION
## 什麼改動
修正 `infra/scripts/pr-metadata-check.test.sh` 的 base ref resolution：

- `resolve_base_ref()` 驗證 remote-tracking ref 存在後，改回傳完整 `refs/remotes/origin/develop`。
- local `develop` fallback 也改回傳完整 `refs/heads/develop`。

## 為什麼
#860 closeout 時發現本機若同時存在 local branch `origin/develop`，測試 harness 回傳短名 `origin/develop` 會被 Git 判定為 ambiguous ref，導致 `pr-metadata-check.test.sh` 在 local regression 環境不穩。正式 `pr-metadata-check.sh` 已使用 fully-qualified ref candidates；本 PR 只補齊測試 harness。

refs #764

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#764
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 `.github/workflows/**` runtime。
  - 不修改正式 `pr-metadata-check.sh` 行為。
  - 不調整 Scope Police、auto-ready、auto-merge、required checks 或 label mutation。
  - 不修 inherited backend / frontend / dashboard CI 紅燈。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #764 live issue list/readback and `spec plan 764 --repo . --dry-run --format prompt --verbose`.
- Actual worker profile(s)：
  - repo_scout: read-only root-cause confirmation for ambiguous `origin/develop` test harness failure.
  - controller: RED/GREEN fix, validation, PR body/check readback.
- Model strength：
  - repo_scout = inherited explorer, low reasoning.
  - controller = GPT-5.5 medium.
- Spawn directive(s)：
  - profile=repo_scout model=inherited reasoning=low controller_fallback=allowed fallback_reason=controller_owned_minimal_test_harness_patch_after_readonly_root_cause_scan
- Verification evidence：
  - RED: `bash -x infra/scripts/pr-metadata-check.test.sh` failed before the fix with `git branch -f tmp-pr-metadata-check-test origin/develop` because local `refs/heads/origin/develop` made the short ref ambiguous.
  - GREEN: `bash infra/scripts/pr-metadata-check.test.sh` passed.
  - `bash infra/scripts/pr-open.test.sh` passed.
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts` passed: 96 tests.
  - `git diff --check` passed.
  - `spec workflow-check --repo . --phase start --issue 764 --format text` passed.
- Self-review / exception reason：
  - Controller kept the patch to the test harness only after verifying production checker already uses fully-qualified refs.
- Worker session closeout：
  - repo_scout completed read-only and reported root cause, files_to_change, validation_commands, and scope risks; no worker edits remain to integrate.
- Workflow friction / follow-up split：
  - `spec workflow-check` still reports old auto-discovered path `docs/claude-codex-workflow.md`; actual repo file is `docs/ai/claude-codex-workflow.md`. That is recorded as a spec-injector reference wrinkle, not fixed in this PR.

## Review conversation closeout
- Unresolved threads：
  - none observed in latest readback.
- CodeRabbit：
  - pass / review skipped on head `5dfe71525257c7694ae63a01a722463c9e4817f0`.
- chatgpt-codex-connector：
  - skipped by policy: self-authored PR, no self-review / approve performed.
- review_triage_ref：
  - latest #861 readback shows automated signals complete and no blocker thread observed.
- root_cause_gate_ref：
  - root cause: test harness returned a short `origin/develop` ref after verifying full `refs/remotes/origin/develop`, which becomes ambiguous when a local branch has the same short name.
- finding_disposition_ref：
  - adopted: repo_scout recommendation to keep fix scoped to `infra/scripts/pr-metadata-check.test.sh`.
- Final reviewer action：
  - blocked with reason: self-authored PR awaits human review; Codex did not review / approve its own PR.

## Final merge gate
- Ready-to-merge decision：
  - blocked with reason: self-authored PR awaits human review approval.
- Latest head SHA：
  - 5dfe71525257c7694ae63a01a722463c9e4817f0
- Required checks：
  - pass or expected skip: Scope Police, Scope gate, Workflow regression tests, PR metadata check regression tests, Backend CI (gate), CodeRabbit, Cloudflare Pages.
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:start+commit:issue-764
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/861

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 修正 PR metadata regression test 在 ambiguous local `origin/develop` branch 下的 base ref resolution。
- Approx changed lines：4
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #860 documented the #764 first-stage CI execution strategy; this PR only fixes the regression-test harness wrinkle discovered during that closeout.

## Acceptance Criteria
- [x] `pr-metadata-check.test.sh` no longer relies on ambiguous `origin/develop` shorthand.
- [x] PR metadata regression test passes while local `refs/heads/origin/develop` exists.
- [x] Workflow regression tests still pass.

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
spec plan 764 --repo . --dry-run --format prompt --verbose
PASS: bounded context generated

spec workflow-check --repo . --phase start --issue 764 --format text
PASS

bash -x infra/scripts/pr-metadata-check.test.sh
RED before fix: failed on ambiguous `origin/develop`

bash infra/scripts/pr-metadata-check.test.sh
PASS

bash infra/scripts/pr-open.test.sh
PASS

node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
PASS: 96 tests

git diff --check
PASS
```

## 備註
This is a test-harness hardening PR. Runtime CI behavior remains unchanged.
