### PR TITLE
[backend] fix: propagate web3 nonce request context

### DIFF
--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -298,7 +298,7 @@ func (h *AuthHandler) Web3Nonce(c *gin.Context) {
 		return
 	}
 
-	nonce, issuedAt, err := h.auth.Web3Nonce(body.Address)
+	nonce, issuedAt, err := h.auth.Web3NonceContext(c.Request.Context(), body.Address)
 	if err != nil {
 		internal(c)
 		return

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -302,6 +302,13 @@ func (s *AuthService) GoogleCallback(ctx context.Context, code string) (*models.
 // ─── Web3 / SIWE ─────────────────────────────────────────────────────────────
 
 func (s *AuthService) Web3Nonce(address string) (string, time.Time, error) {
+	return s.Web3NonceContext(context.Background(), address)
+}
+
+func (s *AuthService) Web3NonceContext(ctx context.Context, address string) (string, time.Time, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	address = strings.ToLower(common.HexToAddress(address).Hex())
 	nonce, err := generateNonce()
 	if err != nil {
@@ -313,7 +320,7 @@ func (s *AuthService) Web3Nonce(address string) (string, time.Time, error) {
 		Address:   address,
 		ExpiresAt: time.Now().Add(5 * time.Minute),
 	}
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Delete any existing nonces for this address.
 		if err := tx.Where("address = ?", address).Delete(&models.Web3Nonce{}).Error; err != nil {
 			return err

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -642,7 +642,9 @@ func TestWeb3NonceContext_CanceledRequestStopsDBWrite(t *testing.T) {
 	}
 
 	var count int64
-	db.Model(&models.Web3Nonce{}).Where("address = ?", strings.ToLower(address)).Count(&count)
+	if err := db.Model(&models.Web3Nonce{}).Where("address = ?", strings.ToLower(address)).Count(&count).Error; err != nil {
+		t.Fatalf("count web3 nonce rows: %v", err)
+	}
 	if count != 0 {
 		t.Fatalf("canceled request should not create nonce rows, got %d", count)
 	}

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -628,6 +628,26 @@ func TestWeb3Nonce_Success(t *testing.T) {
 	}
 }
 
+func TestWeb3NonceContext_CanceledRequestStopsDBWrite(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+	address := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	nonce, _, err := svc.Web3NonceContext(ctx, address)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got nonce=%q err=%v", nonce, err)
+	}
+
+	var count int64
+	db.Model(&models.Web3Nonce{}).Where("address = ?", strings.ToLower(address)).Count(&count)
+	if count != 0 {
+		t.Fatalf("canceled request should not create nonce rows, got %d", count)
+	}
+}
+
 func TestWeb3Nonce_ReplacesExisting(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewAuthService(db, testConfig())


### PR DESCRIPTION
## 什麼改動
- 新增 `AuthService.Web3NonceContext(ctx, address)`，讓 Web3 nonce replacement transaction 使用 request context。
- `AuthHandler.Web3Nonce` 改為傳入 `c.Request.Context()`。
- 新增 canceled-context regression test，確認 request 已取消時不會建立 nonce row。

## 為什麼
refs #645。#645 要求 audit request timeout cancellation 的 DB context propagation；本 PR 先處理 Web3 nonce request path 的小切片。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 `Web3Verify`、OAuth、refresh token、或其他 auth flows。
  - 不處理 Claim/Spend 鏈上補償交易的 context policy，避免把補償語意混進本切片。
  - 不關閉 #645；#645 仍需要後續 DB query context audit slices。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645 + `spec plan 645 --repo . --dry-run --format prompt --verbose`
- Actual worker profile(s)：repo_scout / test_scout / controller
- Model strength：controller = high；repo_scout = inherited；test_scout = inherited
- Spawn directive(s)：profile=repo_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=controller-integrated-after-scout-candidates
- Verification evidence：local focused tests + `go test ./...`; commands listed in 測試方式 / 驗證結果
- Self-review / exception reason：self-authored R4 PR; no Codex review action per automation rule; CodeRabbit completed latest head
- Worker session closeout：repo/test scout output consumed; no worker-owned code changes pending
- Workflow friction / follow-up split：remaining #645 audit slices deferred to separate PRs; this PR keeps Web3 nonce only

## Review conversation closeout
- Unresolved threads：0 at latest readback; no human review threads yet
- CodeRabbit：completed latest head 49a90552d305a2c8b91b5a8d7cf247d44e7dd108
- chatgpt-codex-connector：self-authored PR, no Codex review action per automation rule
- review_triage_ref：latest-head self-review + local validation recorded in this PR body for head 49a90552d305a2c8b91b5a8d7cf247d44e7dd108
- root_cause_gate_ref：#645 spec-injector dry-run context; scope narrowed to Web3 nonce to avoid Claim/Spend compensation-policy ambiguity
- finding_disposition_ref：CodeRabbit count-query finding addressed in commit 609f8a507864e46be1f2f26eaf45466c42f53ff2; review thread resolved; scope-police body-format findings addressed by PR body updates
- Final reviewer action：pending human review/approval because R4 PR

## Final merge gate
- Ready-to-merge decision：blocked pending human review because R4 PR
- Latest head SHA：609f8a507864e46be1f2f26eaf45466c42f53ff2
- Required checks：Backend CI gate pass; Backend tests pass; Backend integration tests pass; Backend security scanners pass; Cloudflare Pages pass; CodeRabbit completed; Scope Police pass
- spec workflow-check evidence：`spec plan 645 --repo . --dry-run --format prompt --verbose` local-only context generation completed
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/864

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 Web3 nonce DB transaction 遵守 request cancellation context。
- Approx changed lines：~31
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler 只負責把 request context 傳入 service；service 與 regression test 是同一個 request cancellation 行為的最小可驗證單元。
- 若已拆分，相關 PR：none

## Acceptance Criteria
- [x] Web3 nonce request path 使用 request context 執行 DB transaction。
- [x] canceled request regression test 驗證不會建立 nonce row。
- [x] 本 PR 不擴張到其他 auth/claim/spend flows。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestWeb3NonceContext_CanceledRequestStopsDBWrite -count=1
ok github.com/tachigo/tachigo/internal/services 0.702s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestWeb3Nonce' -count=1
ok github.com/tachigo/tachigo/internal/services 0.902s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestWeb3NonceHandler' -count=1
ok github.com/tachigo/tachigo/internal/handlers 0.870s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -count=1
ok github.com/tachigo/tachigo/internal/services 2.749s
ok github.com/tachigo/tachigo/internal/handlers 17.986s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok all services/api packages
```

## 備註
R4 PR 需要 human reviewer 明確 review/approve 後再 merge；本 PR 不使用 auto-ready。

## Notes for Claude Code Review
- 請特別注意這個 PR 刻意不改 `Web3Verify`，避免把 #645 的下一個 auth slice 混入同一張 PR。