### PR TITLE
[frontend] Raffle Prize Tiers — Dashboard UI + API Client

### DIFF
--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -2,8 +2,8 @@ import { useOne } from '@refinedev/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { activateRaffle, completeRaffle, drawNext, importCSV, listDraws, setDiscordWebhook } from '@/services/raffles'
-import type { Raffle, RaffleDraw, RaffleStatus } from '@/services/raffles'
+import { activateRaffle, completeRaffle, createPrizeTier, deletePrizeTier, drawFromTier, drawNext, importCSV, listDraws, listPrizeTiers, setDiscordWebhook } from '@/services/raffles'
+import type { Raffle, RaffleDraw, RafflePrizeTier, RaffleStatus } from '@/services/raffles'
 import gachaBg from '../assets/raffle-bg.jpg.png'
 
 const OCEAN_KEYFRAMES = `
@@ -132,6 +132,17 @@ function WinnerList({ draws }: { draws: RaffleDraw[] }) {
             #{draws.length - index}
           </span>
           <span className="flex-1 text-sm font-medium">
+            {draw.prize_tier && (
+              <span style={{
+                background: '#e8f0fe',
+                borderRadius: 4,
+                padding: '0 6px',
+                fontSize: '0.8rem',
+                marginRight: '0.5rem',
+              }}>
+                {draw.prize_tier.name}
+              </span>
+            )}
             {draw.entry.display_name || draw.entry.twitch_login}
           </span>
           <span className="text-[10px] text-white/30">{formatRelativeTime(draw.drawn_at)}</span>
@@ -558,6 +569,12 @@ export default function RaffleDetailPage() {
   const [shaking, setShaking] = useState(false)
   const [popBallColor, setPopBallColor] = useState<string | null>(null)
   const [modalWinner, setModalWinner] = useState<string | null>(null)
+  const [tiers, setTiers] = useState<RafflePrizeTier[]>([])
+  const [tierDrawing, setTierDrawing] = useState<Record<string, boolean>>({})
+  const [tierExhausted, setTierExhausted] = useState<Record<string, boolean>>({})
+  const [showAddTier, setShowAddTier] = useState(false)
+  const [newTier, setNewTier] = useState({ name: '', prize_description: '', winner_count: 1 })
+  const [addingTier, setAddingTier] = useState(false)
 
   const pendingTimers = useRef<number[]>([])
 
@@ -579,10 +596,21 @@ export default function RaffleDetailPage() {
     }
   }, [raffleId])
 
+  const fetchTiers = useCallback(async () => {
+    if (!raffleId) return
+    try {
+      const result = await listPrizeTiers(raffleId)
+      setTiers(result)
+    } catch {
+      setTiers([])
+    }
+  }, [raffleId])
+
   useEffect(() => {
     if (!raffleId) return
     const initialLoadId = window.setTimeout(() => {
       void fetchDraws()
+      void fetchTiers()
     }, 0)
 
     if (effectiveStatus === 'completed') {
@@ -597,7 +625,7 @@ export default function RaffleDetailPage() {
       window.clearTimeout(initialLoadId)
       window.clearInterval(timerId)
     }
-  }, [effectiveStatus, fetchDraws, raffleId])
+  }, [effectiveStatus, fetchDraws, fetchTiers, raffleId])
 
   async function handleDraw() {
     if (!raffleId || drawing) return
@@ -662,6 +690,49 @@ export default function RaffleDetailPage() {
       setConfirmEnd(false)
     } finally {
       setEnding(false)
+    }
+  }
+
+  async function handleAddTier() {
+    if (!raffleId || addingTier) return
+    if (!newTier.name.trim() || newTier.winner_count < 1) return
+    setAddingTier(true)
+    try {
+      await createPrizeTier(raffleId, newTier)
+      await fetchTiers()
+      setNewTier({ name: '', prize_description: '', winner_count: 1 })
+      setShowAddTier(false)
+    } finally {
+      setAddingTier(false)
+    }
+  }
+
+  async function handleDrawFromTier(tierId: string) {
+    if (!raffleId || tierDrawing[tierId]) return
+    setTierDrawing(prev => ({ ...prev, [tierId]: true }))
+    try {
+      await drawFromTier(raffleId, tierId)
+      await Promise.all([fetchTiers(), fetchDraws()])
+      setTierExhausted(prev => ({ ...prev, [tierId]: false }))
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'response' in error) {
+        const res = (error as { response?: { status?: number } }).response
+        if (res?.status === 409) {
+          setTierExhausted(prev => ({ ...prev, [tierId]: true }))
+        }
+      }
+    } finally {
+      setTierDrawing(prev => ({ ...prev, [tierId]: false }))
+    }
+  }
+
+  async function handleDeleteTier(tierId: string) {
+    if (!raffleId) return
+    try {
+      await deletePrizeTier(raffleId, tierId)
+      await fetchTiers()
+    } catch {
+      // tier has draws — silently ignore, UI hides delete button for drawn tiers
     }
   }
 
@@ -808,6 +879,112 @@ export default function RaffleDetailPage() {
           </div>
         </div>
       </div>
+
+      {/* Prize Tiers Section */}
+      {effectiveStatus !== 'draft' && (
+        <section style={{ marginBottom: '2rem', maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+            <h3 style={{ margin: 0 }}>獎項</h3>
+            {effectiveStatus === 'active' && (
+              <button onClick={() => setShowAddTier(v => !v)}>+ 新增獎項</button>
+            )}
+          </div>
+
+          {showAddTier && (
+            <div style={{ border: '1px solid #ccc', padding: '1rem', borderRadius: 8, marginBottom: '1rem' }}>
+              <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'flex-end' }}>
+                <div>
+                  <label>獎項名稱</label>
+                  <input
+                    value={newTier.name}
+                    onChange={e => setNewTier(p => ({ ...p, name: e.target.value }))}
+                    placeholder="例：一等獎"
+                  />
+                </div>
+                <div>
+                  <label>獎品描述</label>
+                  <input
+                    value={newTier.prize_description}
+                    onChange={e => setNewTier(p => ({ ...p, prize_description: e.target.value }))}
+                    placeholder="例：Switch 主機"
+                  />
+                </div>
+                <div>
+                  <label>抽幾人</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={newTier.winner_count}
+                    onChange={e => setNewTier(p => ({ ...p, winner_count: Number(e.target.value) }))}
+                  />
+                </div>
+                <button onClick={() => { void handleAddTier() }} disabled={addingTier}>
+                  {addingTier ? '新增中...' : '確認新增'}
+                </button>
+                <button onClick={() => setShowAddTier(false)}>取消</button>
+              </div>
+            </div>
+          )}
+
+          {tiers.length === 0 && !showAddTier && (
+            <p style={{ color: '#888', fontSize: '0.9rem' }}>尚未設定獎項。</p>
+          )}
+
+          {tiers.map(tier => {
+            const isDone = tier.drawn_count >= tier.winner_count
+            const isDrawing = tierDrawing[tier.id] ?? false
+            const isExhausted = tierExhausted[tier.id] ?? false
+            return (
+              <div
+                key={tier.id}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  padding: '0.75rem 1rem',
+                  border: '1px solid #eee',
+                  borderRadius: 8,
+                  marginBottom: '0.5rem',
+                  background: isDone ? '#f5f5f5' : '#fff',
+                }}
+              >
+                <div>
+                  <strong>{tier.name}</strong>
+                  {tier.prize_description && (
+                    <span style={{ color: '#666', marginLeft: '0.5rem' }}>｜{tier.prize_description}</span>
+                  )}
+                  <span style={{ marginLeft: '1rem', color: isDone ? '#888' : '#333' }}>
+                    已抽 {tier.drawn_count} / {tier.winner_count} 人
+                  </span>
+                  {isExhausted && (
+                    <span style={{ color: '#c00', marginLeft: '0.5rem', fontSize: '0.85rem' }}>名單已耗盡</span>
+                  )}
+                </div>
+                <div style={{ display: 'flex', gap: '0.5rem' }}>
+                  {effectiveStatus === 'active' && (
+                    <>
+                      <button
+                        onClick={() => void handleDrawFromTier(tier.id)}
+                        disabled={isDone || isDrawing}
+                      >
+                        {isDrawing ? '抽取中...' : isDone ? '已完成' : '抽一人'}
+                      </button>
+                      {tier.drawn_count === 0 && (
+                        <button
+                          onClick={() => void handleDeleteTier(tier.id)}
+                          style={{ color: '#c00' }}
+                        >
+                          刪除
+                        </button>
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </section>
+      )}
 
       <WinnerModal name={modalWinner} onClose={() => setModalWinner(null)} />
     </div>

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -29,6 +29,32 @@ export interface RaffleDraw {
   claim_expires_at: string
   drawn_at: string
   entry: RaffleEntry
+  prize_tier_id?: string
+  prize_tier?: RafflePrizeTier
+}
+
+export interface RafflePrizeTier {
+  id: string
+  raffle_id: string
+  name: string
+  prize_description: string
+  winner_count: number
+  drawn_count: number
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+export interface CreatePrizeTierInput {
+  name: string
+  prize_description: string
+  winner_count: number
+}
+
+export interface UpdatePrizeTierInput {
+  name?: string
+  prize_description?: string
+  winner_count?: number
 }
 
 export async function listRaffles(): Promise<Raffle[]> {
@@ -98,4 +124,46 @@ export async function setDiscordWebhook(
     { discord_webhook_url: webhookUrl },
   )
   return data.data.discord_webhook_configured
+}
+
+export async function listPrizeTiers(raffleId: string): Promise<RafflePrizeTier[]> {
+  const { data } = await client.get<ApiResponse<{ tiers: RafflePrizeTier[] }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/prize-tiers`,
+  )
+  return data.data.tiers
+}
+
+export async function createPrizeTier(
+  raffleId: string,
+  input: CreatePrizeTierInput,
+): Promise<RafflePrizeTier> {
+  const { data } = await client.post<ApiResponse<{ tier: RafflePrizeTier }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/prize-tiers`,
+    input,
+  )
+  return data.data.tier
+}
+
+export async function updatePrizeTier(
+  raffleId: string,
+  tierId: string,
+  input: UpdatePrizeTierInput,
+): Promise<RafflePrizeTier> {
+  const { data } = await client.patch<ApiResponse<{ tier: RafflePrizeTier }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/prize-tiers/${tierId}`,
+    input,
+  )
+  return data.data.tier
+}
+
+export async function deletePrizeTier(raffleId: string, tierId: string): Promise<void> {
+  await client.delete(`/api/v1/dashboard/raffles/${raffleId}/prize-tiers/${tierId}`)
+}
+
+export async function drawFromTier(raffleId: string, tierId: string): Promise<RaffleDraw> {
+  const { data } = await client.post<ApiResponse<{ draw: RaffleDraw }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/prize-tiers/${tierId}/draws`,
+    undefined,
+  )
+  return data.data.draw
 }


### PR DESCRIPTION
## 什麼改動

為 Raffle Prize Tier 功能新增 Dashboard UI 與 API client。後端 API 已在 PR #845 完成並 merge 至 develop。

## 為什麼

refs #907

本 PR 為 #845 的前端配套，讓 Streamer 在 Dashboard 上使用多獎項抽獎功能。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: #907（已明確列出實作範圍、介面規格與完成條件）

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#907
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改後端任何檔案
  - 不改 Extension 畫面
  - 不改 /claim 頁面
  - 不實作每個獎項各自的 Discord webhook 設定
  - 不實作 Campaign 多場抽獎層（#234 討論範圍）

## Delegation Execution Log
- Source issue delegation plan：#907，backend contract from PR #845（merged）
- Actual worker profile(s)：frontend_worker（cherry-pick from feat/raffle-prize-tiers-234）
- Model strength：frontend_worker = sonnet
- Spawn directive(s)：
  - profile=frontend_worker model=sonnet reasoning=medium controller_fallback=allowed fallback_reason=frontend_cherry_pick_from_reviewed_branch
- Verification evidence：
  - `npx tsc --noEmit` → 零 TypeScript 錯誤
  - 兩個 commits cherry-picked from feat/raffle-prize-tiers-234（已在 subagent-driven-development 流程中通過 spec + quality review）
- Self-review / exception reason：程式碼原本在 feat/raffle-prize-tiers-234 已通過 spec compliance review 和 quality review（Task 5、Task 6）
- Worker session closeout：cherry-pick 完成，TypeScript 無錯誤，無 pending session
- Workflow friction / follow-up split：後端 PR #845 已 merge，此 PR 為獨立前端 PR

## Review conversation closeout
- Unresolved threads：0 at PR creation
- CodeRabbit：pending
- review_triage_ref：程式碼 cherry-pick 自 feat/raffle-prize-tiers-234，已在 Task 5/6 雙階段 spec + quality review 通過，無新 finding
- root_cause_gate_ref：n/a — 非 debug 流程，功能實作 cherry-pick，無 root cause 分析需求
- finding_disposition_ref：Task 5 spec COMPLIANT、quality APPROVED；Task 6 spec COMPLIANT、quality APPROVED；無 open finding
- Final reviewer action：pending，需人工審查

## Final merge gate
- Ready-to-merge decision：blocked by human review
- Latest head SHA：5a4272a
- Required checks：pending

## PR 拆分檢查
- 這個 PR 的單一句子目的：新增 Prize Tier API client 函式與 Dashboard 抽獎詳情頁的獎項 UI 區塊。
- Approx changed lines：248
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？n/a
- 若已拆分，相關 PR：#845（已 merge）

## Acceptance Criteria
- [x] `listPrizeTiers`、`createPrizeTier`、`updatePrizeTier`、`deletePrizeTier`、`drawFromTier` API 函式
- [x] `RafflePrizeTier` TypeScript interface
- [x] `RaffleDraw` 加 `prize_tier_id?`、`prize_tier?` 欄位
- [x] `RaffleDetailPage` 顯示獎項區塊（新增/抽一人/刪除）
- [x] 中獎記錄顯示獎項名稱 badge
- [x] TypeScript 零錯誤

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試（前端 E2E 不在本 PR 範圍）

**驗證結果**
```
npx tsc --noEmit → 零錯誤
```

## 備註
API client 和 UI 均 cherry-pick 自 feat/raffle-prize-tiers-234（已在前次實作流程通過 Task 5、Task 6 的雙階段 review）。source issue 已補開 #907，明確列出本 PR 前端實作範圍、介面規格與完成條件。