### PR TITLE
[frontend] fix: reset heartbeat baseline on channel changes

### DIFF
--- a/apps/extension/src/hooks/useHeartbeat.ts
+++ b/apps/extension/src/hooks/useHeartbeat.ts
@@ -23,18 +23,23 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
     }
   }, [])
 
-  const resetSession = useCallback(() => {
+  const resetSessionBaseline = useCallback(() => {
     clearAnimationTimer()
     lastBalanceRef.current = null
+  }, [clearAnimationTimer])
+
+  const resetSession = useCallback(() => {
+    resetSessionBaseline()
     setBalance(null)
     setCumulativeTotal(null)
     setGain(null)
     setIsAnimating(false)
     setError(null)
-  }, [clearAnimationTimer])
+  }, [resetSessionBaseline])
 
   useEffect(() => {
     if (previousChannelIdRef.current !== channelId) {
+      resetSessionBaseline()
       const resetTimer = window.setTimeout(() => {
         resetSession()
       }, 0)
@@ -43,19 +48,20 @@ export function useHeartbeat(channelId: string | undefined, options: UseHeartbea
         window.clearTimeout(resetTimer)
       }
     }
-  }, [channelId, resetSession])
+  }, [channelId, resetSession, resetSessionBaseline])
 
   useEffect(() => {
     if (enabled && channelId) {
       return
     }
+    resetSessionBaseline()
     const resetTimer = window.setTimeout(() => {
       resetSession()
     }, 0)
     return () => {
       window.clearTimeout(resetTimer)
     }
-  }, [channelId, enabled, resetSession])
+  }, [channelId, enabled, resetSession, resetSessionBaseline])
 
   useEffect(() => {
     if (!enabled || !channelId) return


### PR DESCRIPTION
## 什麼改動
- Split heartbeat session baseline reset from UI state reset.
- Clear `lastBalanceRef` synchronously when the channel changes or heartbeat is disabled.
- Keep UI state reset deferred so React Hooks lint does not flag synchronous setState in effects.

## 為什麼
Issue #412 asks for confirmed frontend hook correctness bugs to be fixed in independent PRs. `useHeartbeat` previously scheduled the whole reset on `setTimeout(..., 0)`, which could let the next heartbeat read the previous channel baseline before the reset callback ran.

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#412
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不重構 hook API
  - 不修改 test 檔案
  - 不處理其他 #412 audit findings
  - 不做 dead-code cleanup

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #412 frontend hook/API/component bug audit
- Actual worker profile(s)：
  - AWP read-only explorer sidecar + controller implementation
- Model strength：
  - controller = high; explorer = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=denied task=#412-read-only-hook-api-component-audit
- Verification evidence：
  - `spec plan 412 --repo . --dry-run --format prompt --verbose`
  - `pnpm --filter tachimint test -- useHeartbeat`
  - `pnpm --filter tachimint lint`
  - `pnpm --filter tachimint build`
- Self-review / exception reason：
  - self-review complete; single-file confirmed hook baseline reset fix
- Worker session closeout：
  - explorer result read back; adopted the `useHeartbeat` channel reset race finding as a separate PR
- Workflow friction / follow-up split：
  - n/a

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - awaiting initial automated review on head c4aa7e3
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/new/fix/heartbeat-channel-reset-412 latest-head self-review and AWP sidecar readback before PR creation
- root_cause_gate_ref：
  - https://github.com/nurockplayer/tachigo/pull/new/fix/heartbeat-channel-reset-412 root cause is deferred session reset allowing `lastBalanceRef` to remain available before the next heartbeat loop starts
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/new/fix/heartbeat-channel-reset-412 adopted: synchronous baseline reset; UI state reset remains deferred to satisfy React Hooks lint
- Final reviewer action：
  - awaiting human reviewer

## Final merge gate
- Ready-to-merge decision：
  - blocked until GitHub checks and human review complete
- Latest head SHA：
  - c4aa7e3
- Required checks：
  - local checks pass; GitHub checks pending
- spec workflow-check evidence：
  - local-only spec-injector dry-run context generated for #412
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/new/fix/heartbeat-channel-reset-412

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Clear the heartbeat baseline immediately when the channel/session changes so the next heartbeat cannot reuse the previous channel balance.
- Approx changed lines：~14
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] One confirmed frontend hook bug is fixed in an independent PR.
- [x] Test files remain unchanged.
- [x] Local CI-equivalent extension checks pass.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
pnpm --filter tachimint test -- useHeartbeat
Test Files 16 passed (16), Tests 64 passed (64)

pnpm --filter tachimint lint
pass

pnpm --filter tachimint build
pass
```

## 備註
This PR intentionally does not close #412; the issue tracks a broader audit and asks each confirmed bug to be fixed independently.

## Notes for Claude Code Review
- Please focus on whether clearing the baseline ref synchronously while deferring UI state reset is the right balance for race prevention and React Hooks lint compatibility.
