### PR TITLE
[backend] fix: propagate web3 verify request context

### DIFF
--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -327,7 +327,7 @@ func (h *AuthHandler) Web3Verify(c *gin.Context) {
 		return
 	}
 
-	user, tokens, err := h.auth.Web3Verify(input)
+	user, tokens, err := h.auth.Web3VerifyContext(c.Request.Context(), input)
 	if err != nil {
 		switch err {
 		case services.ErrInvalidNonce:

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -1028,6 +1028,52 @@ func TestWeb3VerifyHandler_SuccessSetsRefreshCookieAndConsumesNonce(t *testing.T
 	}
 }
 
+func TestWeb3VerifyHandler_CanceledRequestStopsDBWrite(t *testing.T) {
+	env := newTestEnv(t)
+	key, addr := newHandlerTestWallet(t)
+	lookupAddr := strings.ToLower(addr)
+	nonce := "handler-web3-verify-canceled"
+	nonceRecord := seedHandlerWalletNonce(t, env, addr, nonce)
+	msg := handlerSIWEMessage(lookupAddr, nonce, nonceRecord.CreatedAt.UTC().Format(time.RFC3339))
+	sig := handlerSignSIWE(t, msg, key)
+	body := fmt.Sprintf(`{"address":%q,"nonce":%q,"signature":%q}`, addr, nonce, sig)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/web3/verify", bytes.NewBufferString(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 for canceled request, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var providerCount int64
+	if err := env.db.Model(&models.AuthProvider{}).Where("provider = ?", models.ProviderWeb3).Count(&providerCount).Error; err != nil {
+		t.Fatalf("count web3 providers: %v", err)
+	}
+	if providerCount != 0 {
+		t.Fatalf("canceled request should not create web3 provider rows, got %d", providerCount)
+	}
+
+	var tokenCount int64
+	if err := env.db.Model(&models.RefreshToken{}).Count(&tokenCount).Error; err != nil {
+		t.Fatalf("count refresh token rows: %v", err)
+	}
+	if tokenCount != 0 {
+		t.Fatalf("canceled request should not create refresh token rows, got %d", tokenCount)
+	}
+
+	var nonceCount int64
+	if err := env.db.Model(&models.Web3Nonce{}).Where("nonce = ?", nonce).Count(&nonceCount).Error; err != nil {
+		t.Fatalf("count web3 nonce rows: %v", err)
+	}
+	if nonceCount != 1 {
+		t.Fatalf("canceled request should keep nonce available, got %d rows", nonceCount)
+	}
+}
+
 func assertTokenPayloadHasBrowserTokens(t *testing.T, resp map[string]interface{}) {
 	t.Helper()
 

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -339,14 +339,25 @@ type Web3VerifyInput struct {
 }
 
 func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPair, error) {
+	return s.Web3VerifyContext(context.Background(), input)
+}
+
+func (s *AuthService) Web3VerifyContext(ctx context.Context, input Web3VerifyInput) (*models.User, *TokenPair, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	address := strings.ToLower(input.Address)
+	db := s.db.WithContext(ctx)
 
 	var nonceRecord models.Web3Nonce
-	if err := s.db.Where("nonce = ? AND address = ?", input.Nonce, address).First(&nonceRecord).Error; err != nil {
+	if err := db.Where("nonce = ? AND address = ?", input.Nonce, address).First(&nonceRecord).Error; err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, nil, err
+		}
 		return nil, nil, ErrInvalidNonce
 	}
 	if nonceRecord.IsExpired() {
-		s.db.Delete(&nonceRecord)
+		db.Delete(&nonceRecord)
 		return nil, nil, ErrInvalidNonce
 	}
 
@@ -360,7 +371,7 @@ func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPai
 	checksumAddr := common.HexToAddress(input.Address).Hex()
 	var user *models.User
 	var tokens *TokenPair
-	if err := s.db.Transaction(func(tx *gorm.DB) error {
+	if err := db.Transaction(func(tx *gorm.DB) error {
 		result := tx.Delete(&nonceRecord)
 		if result.Error != nil {
 			return result.Error
@@ -372,7 +383,7 @@ func (s *AuthService) Web3Verify(input Web3VerifyInput) (*models.User, *TokenPai
 		txSvc := *s
 		txSvc.db = tx
 		var err error
-		user, tokens, err = txSvc.upsertOAuthUser(context.Background(), models.ProviderWeb3, checksumAddr, "", "", nil, nil)
+		user, tokens, err = txSvc.upsertOAuthUser(ctx, models.ProviderWeb3, checksumAddr, "", "", nil, nil)
 		return err
 	}); err != nil {
 		return nil, nil, err

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -354,6 +354,9 @@ func (s *AuthService) Web3VerifyContext(ctx context.Context, input Web3VerifyInp
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, nil, err
 		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil, err
+		}
 		return nil, nil, ErrInvalidNonce
 	}
 	if nonceRecord.IsExpired() {


### PR DESCRIPTION
## 什麼改動
- Add `Web3VerifyContext(ctx, input)` and keep the existing `Web3Verify(input)` wrapper.
- Run web3 verify nonce lookup, expired cleanup, transaction, and auth upsert under the request context.
- Pass `c.Request.Context()` from the `/auth/web3/verify` handler.
- Add a canceled-request regression test that proves web3 verify does not create provider/token rows or consume the nonce after cancellation.

## 為什麼
Issue #645 tracks request timeout DB cancellation propagation. After #864 fixed nonce creation, `/auth/web3/verify` still used the background context for service DB work and auth upsert, so canceled requests could continue creating auth state.

## Release Context
- Release type：internal backend bug fix

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 timeout policy values
  - 不改 queue / worker architecture
  - 不引入 background job framework
  - 不掃全 repo context cleanup

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request timeout DB cancellation audit
- Actual worker profile(s)：
  - AWP read-only explorer sidecar + controller implementation
- Model strength：
  - controller = high; explorer = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=denied task=#645-web3-verify-context-read-only-audit
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestWeb3VerifyHandler_CanceledRequestStopsDBWrite -count=1` failed with 200 success before implementation
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestWeb3VerifyHandler_CanceledRequestStopsDBWrite -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestWeb3(Nonce|Verify)' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestWeb3(Nonce|Verify)' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -count=1`
- Self-review / exception reason：
  - self-review completed for a single web3 verify request-context slice; no self-authored PR approval or review action was performed
- Worker session closeout：
  - Explorer sidecar returned a bounded audit confirming `Web3Verify` as a high-confidence independent #645 slice, including `Web3Verify(input)` without request context and `upsertOAuthUser(context.Background(), ...)` inside the transaction; controller implemented and validated that exact slice.
- Workflow friction / follow-up split：
  - Follow-up split remains issue #645 itself; this PR intentionally handles only `/auth/web3/verify` and leaves unrelated endpoint audits for separate PRs.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - completed successfully on head `86f5c67cf6147a9af5d60e2fa0b20b09a088f887`
- chatgpt-codex-connector：
  - no connector review exists for this self-authored PR; heartbeat rules require no self-review/approval action
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/868 latest-head self-review and AWP sidecar readback before PR creation
- root_cause_gate_ref：
  - https://github.com/nurockplayer/tachigo/pull/868 root cause is `/auth/web3/verify` using `Web3Verify(input)` without request context and `upsertOAuthUser(context.Background(), ...)` inside the transaction
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/868 adopted: `Web3VerifyContext` plus handler request context propagation and canceled-request regression
- Final reviewer action：
  - awaiting human reviewer

## Final merge gate
- Ready-to-merge decision：
  - blocked until GitHub checks, CodeRabbit, Cloudflare, and human review complete
- Latest head SHA：
  - `86f5c67cf6147a9af5d60e2fa0b20b09a088f887`
- Required checks：
  - local checks pass; GitHub checks, Scope Police, CodeRabbit, and Cloudflare pass on latest head
- spec workflow-check evidence：
  - local-only spec-injector dry-run context generated for #645 before implementation
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/868

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request cancellation through `/auth/web3/verify` DB reads, transaction, and auth upsert.
- Approx changed lines：~67
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler, service, and regression test are the minimum path to propagate request context through one endpoint.
- 若已拆分，相關 PR：
  - #864 fixed the sibling `/auth/web3/nonce` path.

## Acceptance Criteria
- [x] Service-layer DB access for the web3 verify path propagates request context.
- [x] GORM queries and transaction in the web3 verify path use `WithContext(ctx)`.
- [x] Regression test covers canceled request context.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestWeb3VerifyHandler_CanceledRequestStopsDBWrite -count=1
ok github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestWeb3(Nonce|Verify)' -count=1
ok github.com/tachigo/tachigo/internal/services

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestWeb3(Nonce|Verify)' -count=1
ok github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -count=1
ok github.com/tachigo/tachigo/internal/services
ok github.com/tachigo/tachigo/internal/handlers
```

## 備註
This PR intentionally does not close #645; it is one request-context audit slice.

## Notes for Claude Code Review
- Please focus on whether context cancellation should surface as the existing internal handler path instead of being folded into `ErrInvalidNonce`. CodeRabbit database-error propagation finding was adopted in commit `86f5c67`.



