### PR TITLE
[backend] fix: propagate raffle CSV import request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -170,7 +170,7 @@ func (h *RaffleHandler) ImportCSV(c *gin.Context) {
 		return
 	}
 
-	result, err := h.raffleSvc.ImportCSV(raffleID, userID, file)
+	result, err := h.raffleSvc.ImportCSVContext(c.Request.Context(), raffleID, userID, file)
 	if err != nil {
 		if errors.Is(err, services.ErrRaffleNotFound) {
 			notFound(c, "raffle not found")

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -1002,6 +1002,27 @@ func TestRaffle_ImportCSV_ValidUploadStillWorks(t *testing.T) {
 	}
 }
 
+func TestRaffle_ImportCSV_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "csvctx", "csvctx@test.com", "pass1234")
+	raffleID := env.createRaffle(t, token, "context csv")
+	env.createTwitchLinkedUser(t, "csv_context_user")
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-import-csv",
+		"raffles", "auth_providers", "raffle_entries")
+	ctx := context.WithValue(context.Background(), key, "raffle-import-csv")
+
+	w := env.uploadCSVWithContext(t, ctx, token, raffleID, "csv_context_user,CSV Context User\n")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() == 0 {
+		t.Fatal("expected ImportCSV DB work to use request context")
+	}
+}
+
 func TestRaffle_ImportCSV_OversizedUploadReturns413(t *testing.T) {
 	env := newRaffleTestEnv(t)
 	token := env.registerStreamer(t, "csvlarge", "csvlarge@test.com", "pass1234")
@@ -1037,6 +1058,11 @@ func (e *raffleTestEnv) createRaffle(t *testing.T, token, title string) string {
 
 func (e *raffleTestEnv) uploadCSV(t *testing.T, token, raffleID, csvBody string) *httptest.ResponseRecorder {
 	t.Helper()
+	return e.uploadCSVWithContext(t, context.Background(), token, raffleID, csvBody)
+}
+
+func (e *raffleTestEnv) uploadCSVWithContext(t *testing.T, ctx context.Context, token, raffleID, csvBody string) *httptest.ResponseRecorder {
+	t.Helper()
 
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
@@ -1052,7 +1078,7 @@ func (e *raffleTestEnv) uploadCSV(t *testing.T, token, raffleID, csvBody string)
 	}
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/entries/import-csv", &buf)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/entries/import-csv", &buf)
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 	req.Header.Set("Authorization", bearer(token))
 	e.router.ServeHTTP(w, req)

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -172,7 +172,16 @@ type ImportCSVResult struct {
 // First column must be twitch_login; an optional second column is display_name.
 // Rows whose twitch_login is already in the raffle are skipped (idempotent).
 func (s *RaffleService) ImportCSV(raffleID, userID uuid.UUID, r io.Reader) (*ImportCSVResult, error) {
-	raffle, err := s.GetByID(raffleID, userID)
+	return s.ImportCSVContext(context.Background(), raffleID, userID, r)
+}
+
+func (s *RaffleService) ImportCSVContext(ctx context.Context, raffleID, userID uuid.UUID, r io.Reader) (*ImportCSVResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db := s.db.WithContext(ctx)
+
+	raffle, err := s.GetByIDContext(ctx, raffleID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +219,7 @@ func (s *RaffleService) ImportCSV(raffleID, userID uuid.UUID, r io.Reader) (*Imp
 
 		// Check for duplicate within this raffle
 		var count int64
-		if err := s.db.Model(&models.RaffleEntry{}).
+		if err := db.Model(&models.RaffleEntry{}).
 			Where("raffle_id = ? AND twitch_login = ?", raffleID, twitchLogin).
 			Count(&count).Error; err != nil {
 			return nil, err
@@ -222,7 +231,7 @@ func (s *RaffleService) ImportCSV(raffleID, userID uuid.UUID, r io.Reader) (*Imp
 
 		// Only import users who have a tachigo account linked to this Twitch login.
 		var provider models.AuthProvider
-		if err := s.db.
+		if err := db.
 			Joins("JOIN users ON users.id = auth_providers.user_id AND users.deleted_at IS NULL").
 			Where("auth_providers.provider = ? AND users.username = ?", models.ProviderTwitch, twitchLogin).
 			First(&provider).Error; err != nil {
@@ -240,7 +249,7 @@ func (s *RaffleService) ImportCSV(raffleID, userID uuid.UUID, r io.Reader) (*Imp
 			TwitchLogin: twitchLogin,
 			DisplayName: displayName,
 		}
-		if err := s.db.Create(entry).Error; err != nil {
+		if err := db.Create(entry).Error; err != nil {
 			return nil, err
 		}
 		result.Imported++


### PR DESCRIPTION
## 什麼改動
- Add `RaffleService.ImportCSVContext(ctx, raffleID, userID, r)` and keep the existing `ImportCSV(...)` wrapper.
- Run raffle lookup, duplicate checks, Twitch provider lookup, and raffle entry creation under the request context.
- Pass `c.Request.Context()` from `RaffleHandler.ImportCSV`.
- Add a handler regression test proving CSV import DB work carries request context.

## 為什麼
Issue #645 tracks request timeout DB cancellation propagation. After prior raffle/context slices, CSV import still entered the service through `ImportCSV(...)`, which used `context.Background()` through `GetByID(...)` and bare `s.db` for duplicate/provider/create DB work. This PR keeps the behavior unchanged while wiring the request context through that endpoint path.

## Release Context
- Release type：internal backend bug fix

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 timeout policy values
  - 不改 queue / worker architecture
  - 不引入 background job framework
  - 不改 CSV parsing / import semantics
  - 不改 draw / snapshot / Twitch sync paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request timeout DB cancellation audit
- Actual worker profile(s)：
  - AWP read-only explorer sidecar + controller implementation
- Model strength：
  - controller = high; explorer = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=denied task=#645-next-context-slice-read-only-audit
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRaffle_ImportCSV_UsesRequestContext -count=1` failed with missing request context before implementation
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRaffle_ImportCSV_UsesRequestContext -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_ImportCSV|TestRaffle_CSVDuplicateSkipped' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestRaffle|Test.*ImportCSV' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -count=1`
- Self-review / exception reason：
  - self-review completed for a single raffle CSV import request-context slice; no self-authored PR approval or review action was performed
- Worker session closeout：
  - Explorer sidecar returned a bounded audit identifying `RaffleHandler.ImportCSV` / `RaffleService.ImportCSV` as the best low-risk remaining #645 slice, with evidence on the handler calling the non-context method and service DB work using `GetByID(...)` / bare `s.db`; controller implemented and validated that exact slice.
- Workflow friction / follow-up split：
  - Follow-up split remains issue #645 itself; this PR intentionally handles only CSV import and leaves draw, snapshot, Twitch sync, or broader raffle cleanup for separate PRs.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - completed successfully on head `9b9a3f3baadd9ddf921c20e15bbfbe30c1b5b009`
- chatgpt-codex-connector：
  - no connector review exists for this self-authored PR; heartbeat rules require no self-review/approval action
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/869 latest-head self-review and AWP sidecar readback before PR creation
- root_cause_gate_ref：
  - https://github.com/nurockplayer/tachigo/pull/869 root cause is `/dashboard/raffles/{id}/entries/import-csv` using `ImportCSV(...)`, which fell back to background context and bare service DB operations
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/869 adopted: `ImportCSVContext` plus handler request context propagation and handler context-probe regression
- Final reviewer action：
  - awaiting human reviewer

## Final merge gate
- Ready-to-merge decision：
  - blocked until GitHub checks, CodeRabbit, Cloudflare, and human review complete
- Latest head SHA：
  - `9b9a3f3baadd9ddf921c20e15bbfbe30c1b5b009`
- Required checks：
  - local checks pass; GitHub checks, Scope Police, CodeRabbit, and Cloudflare pass on latest head
- spec workflow-check evidence：
  - local-only spec-injector dry-run context generated for #645 before implementation
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/869

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request cancellation through raffle CSV import DB reads and entry writes.
- Approx changed lines：~47
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler, service, and regression test are the minimum path to propagate request context through one endpoint.
- 若已拆分，相關 PR：
  - Prior #645 slices covered other endpoint paths; this PR is the CSV import slice.

## Acceptance Criteria
- [x] Service-layer DB access for the raffle CSV import path propagates request context.
- [x] GORM queries and create in the raffle CSV import path use `WithContext(ctx)`.
- [x] Regression test covers request context propagation.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRaffle_ImportCSV_UsesRequestContext -count=1
ok github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_ImportCSV|TestRaffle_CSVDuplicateSkipped' -count=1
ok github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestRaffle|Test.*ImportCSV' -count=1
ok github.com/tachigo/tachigo/internal/services

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services ./internal/handlers -count=1
ok github.com/tachigo/tachigo/internal/services
ok github.com/tachigo/tachigo/internal/handlers
```

## 備註
This PR intentionally does not close #645; it is one request-context audit slice.

## Notes for Claude Code Review
- Please focus on whether the CSV import loop should share one `db.WithContext(ctx)` across raffle lookup, duplicate checks, Twitch provider lookup, and entry creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * CSV 导入功能已优化，确保数据库操作在请求上下文中正确执行，提升了数据处理的准确性和可靠性。

* **测试**
  * 新增测试用例，验证请求上下文的正确传递和使用。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
