### PR TITLE
[backend] fix: propagate raffle Discord webhook request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -405,7 +405,7 @@ func (h *RaffleHandler) SetDiscordWebhook(c *gin.Context) {
 		return
 	}
 
-	raffle, err := h.raffleSvc.SetDiscordWebhook(raffleID, userID, *body.DiscordWebhookURL)
+	raffle, err := h.raffleSvc.SetDiscordWebhookContext(c.Request.Context(), raffleID, userID, *body.DiscordWebhookURL)
 	if err != nil {
 		switch {
 		case errors.Is(err, services.ErrRaffleNotFound):

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -360,7 +360,15 @@ func (s *RaffleService) DrawNext(raffleID, userID uuid.UUID) (*models.RaffleDraw
 // SetDiscordWebhook sets or clears the Discord webhook URL for a raffle.
 // An empty webhookURL clears the setting.
 func (s *RaffleService) SetDiscordWebhook(raffleID, userID uuid.UUID, webhookURL string) (*models.Raffle, error) {
-	raffle, err := s.GetByID(raffleID, userID)
+	return s.SetDiscordWebhookContext(context.Background(), raffleID, userID, webhookURL)
+}
+
+func (s *RaffleService) SetDiscordWebhookContext(ctx context.Context, raffleID, userID uuid.UUID, webhookURL string) (*models.Raffle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	raffle, err := s.GetByIDContext(ctx, raffleID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +380,7 @@ func (s *RaffleService) SetDiscordWebhook(raffleID, userID uuid.UUID, webhookURL
 		}
 		val = &webhookURL
 	}
-	if err := s.db.Model(raffle).Update("discord_webhook_url", val).Error; err != nil {
+	if err := s.db.WithContext(ctx).Model(raffle).Update("discord_webhook_url", val).Error; err != nil {
 		return nil, err
 	}
 	raffle.DiscordWebhookURL = val

--- a/services/api/internal/services/raffle_service_discord_test.go
+++ b/services/api/internal/services/raffle_service_discord_test.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -104,6 +106,21 @@ func TestSetDiscordWebhook_RejectsInvalidURL(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid Discord webhook URL") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSetDiscordWebhookContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "owner-context@example.com")
+	raffleID := seedRaffle(t, db, ownerID)
+	svc := &RaffleService{db: db}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.SetDiscordWebhookContext(ctx, raffleID, ownerID, "https://discord.com/api/webhooks/123/abc")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- Add `RaffleService.SetDiscordWebhookContext(ctx, raffleID, userID, webhookURL)` and keep the existing `SetDiscordWebhook(...)` wrapper.
- Run raffle ownership lookup and Discord webhook URL update under the request context.
- Pass `c.Request.Context()` from `RaffleHandler.SetDiscordWebhook`.
- Add a service regression test proving canceled request context reaches the webhook DB path.

## 為什麼
Issue #645 tracks request timeout DB cancellation propagation. After prior #645 raffle slices, the dashboard Discord webhook update endpoint still entered the service through `SetDiscordWebhook(...)`, which used `context.Background()` via `GetByID(...)` and a bare `s.db.Model(...).Update(...)`. This PR keeps behavior unchanged while wiring request context through that endpoint path.

## Release Context
- Release type：internal backend bug fix

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 timeout policy values
  - 不改 queue / worker architecture
  - 不引入 background job framework
  - 不改 Discord webhook URL validation semantics
  - 不改 raffle draw / claim / import / lifecycle paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request timeout DB cancellation audit
- Actual worker profile(s)：
  - AWP read-only explorer sidecar + controller implementation
- Model strength：
  - controller = high; explorer = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=denied task=#645-next-context-slice-read-only-audit
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestSetDiscordWebhookContext_UsesRequestContext -count=1` failed before implementation because `SetDiscordWebhookContext` was undefined
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestSetDiscordWebhook|TestDrawNext_SendsDiscordNotification' -count=1`
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_SetDiscordWebhook' -count=1`
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./...` from `services/api`
- Self-review / exception reason：
  - self-review completed for a single raffle Discord webhook request-context slice; no self-authored PR approval or review action was performed
- Worker session closeout：
  - Explorer sidecar returned a bounded audit identifying `RaffleHandler.SetDiscordWebhook` / `RaffleService.SetDiscordWebhook` as the best low-risk remaining #645 slice, with evidence on the handler calling the non-context method and service DB work using `GetByID(...)` / bare `s.db`; controller implemented and validated that exact slice.
- Workflow friction / follow-up split：
  - Follow-up split remains issue #645 itself; this PR intentionally handles only the Discord webhook update path and leaves draw, activate, complete, snapshot, Twitch sync, or broader raffle cleanup for separate PRs.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - status context reported success at PR creation, but the bot comment says review capacity was rate-limited; await human / automated follow-up before merge
- chatgpt-codex-connector：
  - no connector review exists for this self-authored PR; heartbeat rules require no self-review/approval action
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/870 latest-head self-review and AWP sidecar readback before PR creation
- root_cause_gate_ref：
  - https://github.com/nurockplayer/tachigo/pull/870 root cause is `/dashboard/raffles/{id}/discord-webhook` using `SetDiscordWebhook(...)`, which fell back to background context and bare service DB operations
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/870 adopted: `SetDiscordWebhookContext` plus handler request context propagation and service context-probe regression
- Final reviewer action：
  - awaiting human reviewer

## Final merge gate
- Ready-to-merge decision：
  - blocked until GitHub checks, CodeRabbit / automated review signals, Cloudflare, and human review complete
- Latest head SHA：
  - `7e1c7b9c25e403b6dfce2aeeba19d889745a62b4`
- Required checks：
  - local checks pass; GitHub checks are still running on latest head at PR creation
- spec workflow-check evidence：
  - local-only spec-injector dry-run context generated for #645 before implementation
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/870

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request cancellation through raffle Discord webhook update DB reads and writes.
- Approx changed lines：~31
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler, service, and regression test are the minimum path to propagate request context through one endpoint.
- 若已拆分，相關 PR：
  - Prior #645 slices covered other endpoint paths; this PR is the Discord webhook update slice.

## Acceptance Criteria
- [x] Service-layer DB access for the raffle Discord webhook update path propagates request context.
- [x] GORM lookup and update in the raffle Discord webhook update path use `WithContext(ctx)`.
- [x] Regression test covers request context propagation.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestSetDiscordWebhookContext_UsesRequestContext -count=1
# before implementation: failed because SetDiscordWebhookContext was undefined

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestSetDiscordWebhook|TestDrawNext_SendsDiscordNotification' -count=1
ok github.com/tachigo/tachigo/internal/services

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_SetDiscordWebhook' -count=1
ok github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok github.com/tachigo/tachigo/... from services/api
```

## 備註
This PR intentionally does not close #645; it is one request-context audit slice.

## Notes for Claude Code Review
- Please focus on whether `SetDiscordWebhookContext` should share the same request context for ownership lookup and webhook URL update.
