### PR TITLE
[backend] fix: propagate raffle activate request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -349,7 +349,7 @@ func (h *RaffleHandler) Activate(c *gin.Context) {
 		return
 	}
 
-	raffle, err := h.raffleSvc.Activate(raffleID, userID)
+	raffle, err := h.raffleSvc.ActivateContext(c.Request.Context(), raffleID, userID)
 	if err != nil {
 		switch {
 		case errors.Is(err, services.ErrRaffleNotFound):

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -65,10 +65,14 @@ func installRaffleHandlerDBContextProbeForTables(t *testing.T, db *gorm.DB, key,
 	if err := db.Callback().Create().Before("gorm:create").Register(name+":create", probe); err != nil {
 		t.Fatalf("register create context probe: %v", err)
 	}
+	if err := db.Callback().Update().Before("gorm:update").Register(name+":update", probe); err != nil {
+		t.Fatalf("register update context probe: %v", err)
+	}
 
 	t.Cleanup(func() {
 		_ = db.Callback().Query().Remove(name + ":query")
 		_ = db.Callback().Create().Remove(name + ":create")
+		_ = db.Callback().Update().Remove(name + ":update")
 	})
 
 	return func() int {
@@ -1426,6 +1430,28 @@ func TestRaffle_Activate_Success(t *testing.T) {
 	raffle := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})
 	if raffle["status"] != "active" {
 		t.Errorf("expected status active, got %v", raffle["status"])
+	}
+}
+
+func TestRaffle_Activate_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "activatectx", "activatectx@test.com", "pass1234")
+	raffleID := env.createRaffle(t, token, "Activate Context Raffle")
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-activate", "raffles")
+	ctx := context.WithValue(context.Background(), key, "raffle-activate")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/activate", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() < 2 {
+		t.Fatal("expected raffle activate lookup and update DB operations to use request context")
 	}
 }
 

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -463,11 +463,19 @@ func (s *RaffleService) ListDrawsContext(ctx context.Context, raffleID, userID u
 // After activation, ImportCSV will reject further uploads.
 // The update is conditional on status = draft to avoid a read-then-write race.
 func (s *RaffleService) Activate(raffleID, userID uuid.UUID) (*models.Raffle, error) {
-	raffle, err := s.GetByID(raffleID, userID)
+	return s.ActivateContext(context.Background(), raffleID, userID)
+}
+
+func (s *RaffleService) ActivateContext(ctx context.Context, raffleID, userID uuid.UUID) (*models.Raffle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	raffle, err := s.GetByIDContext(ctx, raffleID, userID)
 	if err != nil {
 		return nil, err
 	}
-	res := s.db.Model(&models.Raffle{}).
+	res := s.db.WithContext(ctx).Model(&models.Raffle{}).
 		Where("id = ? AND status = ?", raffle.ID, models.RaffleStatusDraft).
 		Update("status", models.RaffleStatusActive)
 	if res.Error != nil {

--- a/services/api/internal/services/raffle_service_activate_test.go
+++ b/services/api/internal/services/raffle_service_activate_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -34,6 +35,28 @@ func TestActivate_SuccessFromDraft(t *testing.T) {
 	}
 	if raffle.Status != models.RaffleStatusActive {
 		t.Errorf("expected status active, got %q", raffle.Status)
+	}
+}
+
+func TestActivateContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "activate_context_owner@example.com")
+	raffleID := seedDraftRaffle(t, db, ownerID)
+
+	key := raffleServiceContextKey{}
+	seen := installDBContextProbe(t, db, key, "raffle-activate")
+	ctx := context.WithValue(context.Background(), key, "raffle-activate")
+
+	svc := &RaffleService{db: db}
+	raffle, err := svc.ActivateContext(ctx, raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("ActivateContext: %v", err)
+	}
+	if raffle.Status != models.RaffleStatusActive {
+		t.Fatalf("want status active, got %q", raffle.Status)
+	}
+	if seen() < 2 {
+		t.Fatal("expected ActivateContext lookup and update operations to use request context")
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- Add `RaffleService.ActivateContext(ctx, raffleID, userID)` and keep the existing `Activate(...)` wrapper.
- Run raffle ownership lookup and conditional draft-to-active update under the request context.
- Pass `c.Request.Context()` from `RaffleHandler.Activate`.
- Add service and handler regression tests proving the activate DB lookup/update path carries request context.

## 為什麼
Issue #645 tracks request timeout DB cancellation propagation. After prior #645 raffle slices, the dashboard activate endpoint still entered the service through `Activate(...)`, which used `context.Background()` via `GetByID(...)` and a bare conditional `s.db.Model(...).Update(...)`. This PR keeps behavior unchanged while wiring request context through that endpoint path.

## Release Context
- Release type：internal backend bug fix

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 timeout policy values
  - 不改 queue / worker architecture
  - 不引入 background job framework
  - 不改 raffle activation state machine or conditional update semantics
  - 不改 raffle complete / draw / claim / import / Discord webhook paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 request timeout DB cancellation audit
- Actual worker profile(s)：
  - AWP read-only explorer sidecar + controller implementation
- Model strength：
  - controller = high; explorer = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=denied task=#645-raffle-lifecycle-context-slice-read-only-audit
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestActivateContext_UsesRequestContext -count=1` failed before implementation because `ActivateContext` was undefined
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestActivate|TestImportCSV_ReturnsErrRaffleNotDraft_WhenActive' -count=1`
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_Activate' -count=1`
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./...` from `services/api`
- Self-review / exception reason：
  - self-review completed for a single raffle activate request-context slice; no self-authored PR approval or review action was performed
- Worker session closeout：
  - Explorer sidecar returned a bounded audit recommending `RaffleHandler.Activate` / `RaffleService.Activate` as the next low-risk remaining #645 slice, with evidence on the handler calling the non-context method, service DB work using `GetByID(...)` / bare `s.db`, and `Complete` left as a later independent slice.
- Workflow friction / follow-up split：
  - Follow-up split remains issue #645 itself; this PR intentionally handles only the activate path and leaves complete, draw, snapshot, Twitch sync, or broader raffle cleanup for separate PRs.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - awaiting automated signal on this head
- chatgpt-codex-connector：
  - no connector review exists for this self-authored PR; heartbeat rules require no self-review/approval action
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/871 latest-head self-review and AWP sidecar readback before PR creation
- root_cause_gate_ref：
  - https://github.com/nurockplayer/tachigo/pull/871 root cause is `/dashboard/raffles/{id}/activate` using `Activate(...)`, which fell back to background context and bare service DB operations
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/871 adopted: `ActivateContext` plus handler request context propagation and service/handler context-probe regressions
- Final reviewer action：
  - awaiting human reviewer

## Final merge gate
- Ready-to-merge decision：
  - blocked until GitHub checks, CodeRabbit / automated review signals, Cloudflare, and human review complete
- Latest head SHA：
  - `32ff02afcf8f9ddcfed927d75082f64d8fffb4a2`
- Required checks：
  - local checks pass; GitHub checks are pending at PR creation
- spec workflow-check evidence：
  - local-only spec-injector dry-run context generated for #645 before implementation
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/871

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Propagate request cancellation through raffle activate DB lookup and conditional update.
- Approx changed lines：~63
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Handler, service, and regression tests are the minimum path to propagate request context through one endpoint.
- 若已拆分，相關 PR：
  - Prior #645 slices covered other endpoint paths; this PR is the activate slice.

## Acceptance Criteria
- [x] Service-layer DB access for the raffle activate path propagates request context.
- [x] GORM lookup and conditional update in the raffle activate path use `WithContext(ctx)`.
- [x] Regression tests cover request context propagation at service and handler levels.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestActivateContext_UsesRequestContext -count=1
# before implementation: failed because ActivateContext was undefined

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestActivate|TestImportCSV_ReturnsErrRaffleNotDraft_WhenActive' -count=1
ok github.com/tachigo/tachigo/internal/services

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRaffle_Activate' -count=1
ok github.com/tachigo/tachigo/internal/handlers

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok github.com/tachigo/tachigo/... from services/api
```

## 備註
This PR intentionally does not close #645; it is one request-context audit slice.

## Notes for Claude Code Review
- Please focus on whether `ActivateContext` preserves the existing conditional `status = draft` race guard while carrying request context through both lookup and update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **Refactor**
  * 优化抽奖激活操作，改进请求上下文在整个处理流程中的传播机制。
  * 新增请求上下文传播的测试用例，验证数据库操作正确使用上下文。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->