### PR TITLE
[backend] fix: propagate extension login request context

### DIFF
--- a/services/api/internal/handlers/extension_handler.go
+++ b/services/api/internal/handlers/extension_handler.go
@@ -33,7 +33,7 @@ func (h *ExtensionHandler) Login(c *gin.Context) {
 		return
 	}
 
-	user, tokens, err := h.ext.LoginWithExtension(body.ExtensionJWT)
+	user, tokens, err := h.ext.LoginWithExtensionContext(c.Request.Context(), body.ExtensionJWT)
 	if err != nil {
 		switch err {
 		case services.ErrInvalidExtJWT:

--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -114,12 +114,6 @@ func (s *ExtensionService) VerifyReceiptJWT(receiptStr string) (*ReceiptClaims, 
 // Returns ErrInvalidExtJWT if the JWT is invalid or the viewer has not authorized
 // the Extension (UserID is empty). Returns ErrUserNotFound if no tachigo account
 // is linked to the Twitch identity.
-// lookupExtensionUser resolves a Twitch identity to a tachigo User.
-// It does not issue tokens; call issueTokenPair separately.
-func (s *ExtensionService) lookupExtensionUser(claims *ExtensionClaims) (*models.User, error) {
-	return s.lookupExtensionUserContext(context.Background(), claims)
-}
-
 func (s *ExtensionService) lookupExtensionUserContext(ctx context.Context, claims *ExtensionClaims) (*models.User, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -146,16 +146,24 @@ func (s *ExtensionService) lookupExtensionUserContext(ctx context.Context, claim
 }
 
 func (s *ExtensionService) LoginWithExtension(extJWT string) (*models.User, *TokenPair, error) {
+	return s.LoginWithExtensionContext(context.Background(), extJWT)
+}
+
+func (s *ExtensionService) LoginWithExtensionContext(ctx context.Context, extJWT string) (*models.User, *TokenPair, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	claims, err := s.VerifyExtJWT(extJWT)
 	if err != nil {
 		return nil, nil, err
 	}
-	user, err := s.lookupExtensionUser(claims)
+	user, err := s.lookupExtensionUserContext(ctx, claims)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	tokens, err := s.authSvc.issueTokenPair(user)
+	tokens, err := s.authSvc.issueTokenPairContext(ctx, user)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -218,6 +218,69 @@ func TestCompleteTPointTransactionContext_UsesRequestContextForPointsWriteAndTok
 	}
 }
 
+func TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	_, twitchID := seedTwitchUser(t, svc.db)
+	extJWT := makeExtJWT(t, twitchID, "channel-login-context")
+
+	key := extensionServiceContextKey{}
+	ctx := context.WithValue(context.Background(), key, "extension-login")
+	var seenUserLookup bool
+	var seenRefreshTokenWrite bool
+
+	callbackName := "test:extension_login_context:" + uuid.NewString()
+	probe := func(tx *gorm.DB) {
+		if tx.Statement == nil || tx.Statement.Schema == nil {
+			return
+		}
+		table := tx.Statement.Schema.Table
+		if table != "auth_providers" && table != "users" && table != "refresh_tokens" {
+			return
+		}
+		if tx.Statement.Context.Value(key) != "extension-login" {
+			tx.AddError(fmt.Errorf("missing request context for %s", table))
+			return
+		}
+		switch table {
+		case "auth_providers", "users":
+			seenUserLookup = true
+		case "refresh_tokens":
+			seenRefreshTokenWrite = true
+		}
+	}
+	if err := svc.db.Callback().Query().Before("gorm:query").Register(callbackName+":query", probe); err != nil {
+		t.Fatalf("register login query context probe: %v", err)
+	}
+	if err := svc.db.Callback().Create().Before("gorm:create").Register(callbackName+":create", probe); err != nil {
+		t.Fatalf("register login create context probe: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := svc.db.Callback().Query().Remove(callbackName + ":query"); err != nil {
+			t.Fatalf("remove login query context probe: %v", err)
+		}
+		if err := svc.db.Callback().Create().Remove(callbackName + ":create"); err != nil {
+			t.Fatalf("remove login create context probe: %v", err)
+		}
+	})
+
+	user, tokens, err := svc.LoginWithExtensionContext(ctx, extJWT)
+	if err != nil {
+		t.Fatalf("LoginWithExtensionContext: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user")
+	}
+	if tokens == nil {
+		t.Fatal("expected tokens")
+	}
+	if !seenUserLookup {
+		t.Fatal("expected extension login user lookup to carry request context")
+	}
+	if !seenRefreshTokenWrite {
+		t.Fatal("expected extension login refresh token write to carry request context")
+	}
+}
+
 func TestCompleteTPointTransaction_DuplicateTransactionID_ReturnsErrDuplicate(t *testing.T) {
 	svc, pointsSvc := newExtSvc(t)
 	userID, twitchID := seedTwitchUser(t, svc.db)

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -225,6 +225,7 @@ func TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue(
 
 	key := extensionServiceContextKey{}
 	ctx := context.WithValue(context.Background(), key, "extension-login")
+	var seenAuthProviderLookup bool
 	var seenUserLookup bool
 	var seenRefreshTokenWrite bool
 
@@ -242,7 +243,9 @@ func TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue(
 			return
 		}
 		switch table {
-		case "auth_providers", "users":
+		case "auth_providers":
+			seenAuthProviderLookup = true
+		case "users":
 			seenUserLookup = true
 		case "refresh_tokens":
 			seenRefreshTokenWrite = true
@@ -272,6 +275,9 @@ func TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue(
 	}
 	if tokens == nil {
 		t.Fatal("expected tokens")
+	}
+	if !seenAuthProviderLookup {
+		t.Fatal("expected extension login auth provider lookup to carry request context")
 	}
 	if !seenUserLookup {
 		t.Fatal("expected extension login user lookup to carry request context")


### PR DESCRIPTION
## 什麼改動
- add `LoginWithExtensionContext` so extension login user lookup and refresh token issue share the request context
- route `/extension/auth/login` through `c.Request.Context()`
- add a DB context propagation regression test for lookup + refresh token writes

## 為什麼
#645 tracks request-timeout DB context propagation. `/extension/auth/login` still used the legacy `LoginWithExtension` path, so linked-user lookup and refresh-token writes used `context.Background()` instead of the request context.

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Does not change extension JWT validation semantics
  - Does not change token payloads, token TTLs, or refresh-token storage format
  - Does not modify raffle, T-point completion, points accounting, frontend, schema, or docs
  - Does not close #645; this is one bounded follow-up slice

## Delegation Execution Log
- Source issue delegation plan：#645 via heartbeat automation instruction
- Actual worker profile(s)：AWP explorer `019e5347-c8bf-7610-a679-d1fafc27b0e6` for non-raffle #645 slice selection; controller implemented the patch
- Model strength：controller=current Codex; explorer=medium
- Spawn directive(s)：profile=explorer model=inherited reasoning=medium controller_fallback=not_used fallback_reason=n/a
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestLoginWithExtensionContext|TestCompleteTPointTransactionContext' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestExtension|TestTPoint|TestBits' -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：self-reviewed diff and scope; no exception requested
- Worker session closeout：explorer returned candidate analysis; no additional worker patch was merged
- Workflow friction / follow-up split：n/a; #664 dogfood only after merge

## Review conversation closeout
- Unresolved threads：0 at PR creation; no external review threads existed for head `5d634412e99be7bc4157677317c8762b6c839474`
- CodeRabbit：pending first automated review for head `5d634412e99be7bc4157677317c8762b6c839474`
- chatgpt-codex-connector：self-authored PR, so no self-review requested or posted
- review_triage_ref：local self-review of diff for head `5d634412e99be7bc4157677317c8762b6c839474`; scope limited to extension login request context
- root_cause_gate_ref：RED test proved missing `LoginWithExtensionContext`; no production code was changed before RED
- finding_disposition_ref：no external findings yet; local verification passed all listed focused tests and `go test ./...`
- Final reviewer action：pending human review

## Final merge gate
- Ready-to-merge decision：blocked until human review and all required checks complete
- Latest head SHA：5d634412e99be7bc4157677317c8762b6c839474
- Required checks：pending Scope Police rerun and CodeRabbit at latest body update
- spec workflow-check evidence：`spec plan 645 --repo . --dry-run --format prompt --verbose`
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/872

## Tests
- RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue -count=1` failed because `LoginWithExtensionContext` did not exist
- GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue -count=1`
- `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestLoginWithExtensionContext|TestCompleteTPointTransactionContext' -count=1`
- `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestExtension|TestTPoint|TestBits' -count=1`
- `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`

refs #645
