### PR TITLE
[backend] test: add dashboard RBAC matrix coverage

### DIFF
--- a/services/api/internal/handlers/rbac_handler_test.go
+++ b/services/api/internal/handlers/rbac_handler_test.go
@@ -55,6 +55,24 @@ func newRBACTestEnv(t *testing.T) *rbacEnv {
 		admin.GET("/users", func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) })
 	}
 
+	dashboard := v1.Group("/dashboard")
+	dashboard.Use(middleware.JWTAuth(base.authSvc))
+	dashboard.Use(middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency))
+	{
+		dashboard.POST("/streamers",
+			middleware.RequireRole(models.RoleAdmin),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		dashboard.GET("/streamers",
+			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		dashboard.GET("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+	}
+
 	return &rbacEnv{base}
 }
 
@@ -99,6 +117,84 @@ func doRequest(router *gin.Engine, method, path, token string) int {
 	}
 	router.ServeHTTP(w, req)
 	return w.Code
+}
+
+type rbacMatrixCase struct {
+	name string
+	role models.UserRole
+	want int
+}
+
+func assertRBACMatrix(t *testing.T, env *rbacEnv, method, path string, cases []rbacMatrixCase) {
+	t.Helper()
+
+	t.Run("no token", func(t *testing.T) {
+		if got := doRequest(env.router, method, path, ""); got != http.StatusUnauthorized {
+			t.Fatalf("no token: want %d, got %d", http.StatusUnauthorized, got)
+		}
+	})
+
+	tokens := map[models.UserRole]string{}
+	for _, tc := range cases {
+		if _, ok := tokens[tc.role]; !ok {
+			tokens[tc.role] = env.tokenForRole(t, tc.role)
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := doRequest(env.router, method, path, tokens[tc.role]); got != tc.want {
+				t.Fatalf("%s: want %d, got %d", tc.role, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRBACMatrix_DashboardRoutes(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		cases  []rbacMatrixCase
+	}{
+		{
+			name:   "create streamer is admin only",
+			method: http.MethodPost,
+			path:   "/api/v1/dashboard/streamers",
+			cases: []rbacMatrixCase{
+				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+				{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
+				{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
+				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+			},
+		},
+		{
+			name:   "list streamers is agency or admin only",
+			method: http.MethodGet,
+			path:   "/api/v1/dashboard/streamers",
+			cases: []rbacMatrixCase{
+				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+				{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
+				{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
+				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+			},
+		},
+		{
+			name:   "channel config read allows dashboard operators",
+			method: http.MethodGet,
+			path:   "/api/v1/dashboard/channels/ch_ctx/config",
+			cases: []rbacMatrixCase{
+				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+				{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
+				{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
+				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newRBACTestEnv(t)
+			assertRBACMatrix(t, env, tt.method, tt.path, tt.cases)
+		})
+	}
 }
 
 // ── GET /admin/users ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## 什麼改動
新增 dashboard 受保護 route 的 RBAC matrix 測試覆蓋，讓未帶 token、viewer、streamer、agency、admin 的預期狀態碼能被同一組 table-driven helper 驗證。

## 為什麼
#646 要求補齊 Role-Based Access Control 的集中測試矩陣。本 PR 先切 dashboard routes 的 tests-only slice，避免一次把所有 protected endpoints 混成大 PR。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#646
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不補齊所有 protected endpoints
  - 不改 production route / middleware / permission behavior
  - 不改 frontend / dashboard UI
  - 不關閉 #646；此 PR 只交付第一個 dashboard matrix slice

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #646 沒有明示 worker profile；本輪依 tachigo AWP automation 選擇 tests-only bounded slice
- Actual worker profile(s)：
  - explorer: 019e5395-5845-7c43-8f28-f5a56644a308
  - controller: implemented bounded tests-only patch after explorer candidate selection
- Model strength：
  - explorer = inherited medium
  - controller = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=not_used fallback_reason=n/a
- Verification evidence：
  - `spec plan 646 --repo . --dry-run --format prompt --verbose`
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBACMatrix_DashboardRoutes -count=1` failed on expected missing dashboard route coverage before patch
  - GREEN: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBACMatrix_DashboardRoutes -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBAC -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -count=1`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
- Self-review / exception reason：
  - 已完成 controller self-review；本 PR 仍等待 human reviewer，Codex 不自審 approve
- Worker session closeout：
  - explorer result consumed and session closed; no additional worker task needed for this slice
- Workflow friction / follow-up split：
  - 約 30% infra/context friction: spec-injector always-read reported missing `docs/claude-codex-workflow.md`, treated as context risk only
  - 約 70% implementation/test loop: narrowed to one dashboard route matrix slice; broader #646 endpoint coverage remains future PR work
  - threshold calibration / dogfood ledger：#664 after merge

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation for head 5b4a6505568bb88bc7bf576cfe8824c3cd80da06
- CodeRabbit：
  - no CodeRabbit findings existed at PR creation for head 5b4a6505568bb88bc7bf576cfe8824c3cd80da06; awaiting automated review if triggered
- chatgpt-codex-connector：
  - no connector findings existed at PR creation; Codex will not self-review this PR
- review_triage_ref：
  - #646 + local `spec plan 646 --repo . --dry-run --format prompt --verbose` bounded the tests-only dashboard route matrix slice
- root_cause_gate_ref：
  - RED test demonstrated dashboard route matrix coverage gap returned 404 before test env stubs were added
- finding_disposition_ref：
  - adopted dashboard route matrix coverage only; deferred broader protected endpoint matrix to follow-up PRs under #646
- Final reviewer action：
  - pending human review after CI and automated signals complete

## Final merge gate
- Ready-to-merge decision：
  - blocked until required GitHub checks, automated review signals, and human review complete
- Latest head SHA：
  - 5b4a6505568bb88bc7bf576cfe8824c3cd80da06
- Required checks：
  - pending GitHub checks at PR creation; local Go verification passed before push
- spec workflow-check evidence：
  - local-only context gate completed via `spec plan 646 --repo . --dry-run --format prompt --verbose`; missing always-read `docs/claude-codex-workflow.md` recorded as non-blocking context risk
- Evidence URL：
  - this PR initial body; final closeout comment to be added only after merge if needed

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add the first dashboard-route RBAC matrix test slice for #646.
- Approx changed lines：~96
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Covers unauthorized access with no token for the new dashboard matrix routes
- [x] Covers role-specific allow/deny expectations for viewer, streamer, agency, and admin
- [x] Keeps this PR tests-only and limited to the first dashboard route slice
- [ ] Full #646 protected endpoint matrix remains incomplete and should continue in later PRs

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```bash
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBACMatrix_DashboardRoutes -count=1
# ok github.com/tachigo/tachigo/internal/handlers 1.737s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBAC -count=1
# ok github.com/tachigo/tachigo/internal/handlers 3.627s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -count=1
# ok github.com/tachigo/tachigo/internal/handlers 19.040s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
# ok github.com/tachigo/tachigo/cmd/loader 0.443s
# ok github.com/tachigo/tachigo/cmd/server 1.006s
# ok github.com/tachigo/tachigo/docs 2.435s
# ok github.com/tachigo/tachigo/internal/config 0.662s
# ok github.com/tachigo/tachigo/internal/contract 1.185s
# ok github.com/tachigo/tachigo/internal/handlers 20.972s
# ok github.com/tachigo/tachigo/internal/metrics 1.953s
# ok github.com/tachigo/tachigo/internal/middleware 2.198s
# ok github.com/tachigo/tachigo/internal/models 2.672s
# ok github.com/tachigo/tachigo/internal/router 1.910s
# ok github.com/tachigo/tachigo/internal/services 5.148s
# ok github.com/tachigo/tachigo/internal/tracing 2.505s
```

## 備註
refs #646

## Notes for Claude Code Review
- 本 PR 在測試檔內新增 dashboard route stubs，目的是測 middleware/role matrix，不改 production route 註冊。
- `docs/claude-codex-workflow.md` 在 spec-injector always-read 中缺失，已當作 context 風險紀錄，未擴 scope。
