### PR TITLE
[infra] test: cover CI scope gate lightweight lanes

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -2020,6 +2020,37 @@ test('docs/template-only PRs skip heavy product CI in scope gate', async () => {
   )
 })
 
+test('scope gate emits skipped product outputs for docs-only PRs', async () => {
+  const result = await runCiScopeGateWorkflow({
+    prOverrides: { title: '[discussion] Document CI execution strategy' },
+    files: [{ filename: 'docs/pr-scope-policy.md', additions: 12, deletions: 3, status: 'modified' }],
+  })
+
+  assert.deepEqual(result.outputs, {
+    run_ci: 'false',
+    run_backend: 'false',
+    run_backend_integration: 'false',
+    run_backend_scanners: 'false',
+    run_dependency_review: 'false',
+    run_api_contracts: 'false',
+    run_frontend: 'false',
+    run_dashboard: 'false',
+    run_contracts: 'false',
+    run_contracts_slither: 'false',
+    run_contracts_gas_report: 'false',
+  })
+  assert.equal(
+    result.notices.some((notice) =>
+      notice.includes('Skipping heavy product CI because this PR only changes docs/templates/metadata.'),
+    ),
+    true,
+  )
+  assert.equal(
+    result.notices.some((notice) => notice.includes('Skipping backend integration tests')),
+    false,
+  )
+})
+
 test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
   const result = await runCiScopeGateWorkflow({
     files: [{ filename: 'apps/extension/src/App.tsx', additions: 12, deletions: 3, status: 'modified' }],
@@ -2038,6 +2069,35 @@ test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
     run_contracts_slither: 'false',
     run_contracts_gas_report: 'false',
   })
+})
+
+test('scope gate emits full CI outputs for workflow file PRs', async () => {
+  const fullOutputs = {
+    run_ci: 'true',
+    run_backend: 'true',
+    run_backend_integration: 'true',
+    run_backend_scanners: 'true',
+    run_dependency_review: 'false',
+    run_api_contracts: 'true',
+    run_frontend: 'true',
+    run_dashboard: 'true',
+    run_contracts: 'true',
+    run_contracts_slither: 'true',
+    run_contracts_gas_report: 'true',
+  }
+  const ciRuntime = await runCiScopeGateWorkflow({
+    prOverrides: { title: '[infra] Update CI scope gate' },
+    files: [{ filename: '.github/workflows/ci.yml', additions: 8, deletions: 2, status: 'modified' }],
+  })
+  const ciRegression = await runCiScopeGateWorkflow({
+    prOverrides: { title: '[infra] Update CI regression coverage' },
+    files: [{ filename: '.github/workflows/ci.test.ts', additions: 8, deletions: 2, status: 'modified' }],
+  })
+
+  assert.deepEqual(ciRuntime.outputs, fullOutputs)
+  assert.deepEqual(ciRegression.outputs, fullOutputs)
+  assert.equal(ciRuntime.notices.some((notice) => notice.includes('Skipping heavy')), false)
+  assert.equal(ciRegression.notices.some((notice) => notice.includes('Skipping heavy')), false)
 })
 
 test('scope gate emits dependency review output only for dependency file PRs', async () => {


### PR DESCRIPTION
## 什麼改動
新增 `.github/workflows/ci.test.ts` regression coverage，直接驗證：

- docs-only PR 會輸出 skipped product CI outputs，並留下 docs/templates/metadata skip notice
- workflow-file PR 會走 full CI outputs，不會被誤判成 metadata-only 或 partial product lane

## 為什麼
#764 的第一階段已文件化 CI execution strategy，後續 runtime 調整前需要先補 lane 行為的 regression guard。本 PR 只補測試，不改 `.github/workflows/ci.yml` runtime。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#764
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 `.github/workflows/ci.yml` runtime
  - 不改 Scope Police / auto-ready / auto-merge 行為
  - 不改 backend / frontend / dashboard / contracts 產品程式碼
  - 不新增 frontend/style-only lane runtime
  - 不關閉 #764

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #764 沒有明示 worker profile；本輪依 tachigo AWP automation 選擇 workflow regression 先行的 test-only slice
- Actual worker profile(s)：
  - explorer: 019e53da-690f-7f21-8ad6-428bdbcda88f
  - controller: implemented the bounded test-only patch after explorer confirmed the remaining safe slice
- Model strength：
  - explorer = inherited medium
  - controller = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=not_used fallback_reason=n/a
- Verification evidence：
  - `spec plan 764 --repo . --dry-run --format prompt --verbose`
  - RED: temporarily removed `.github/workflows/ci.test.ts` from the workflow full-CI path and observed `scope gate emits full CI outputs for workflow file PRs` fail
  - RED: temporarily removed `docs/` from metadata-only detection and observed `scope gate emits skipped product outputs for docs-only PRs` fail
  - GREEN: `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts --test-name-pattern "scope gate emits (skipped product outputs for docs-only PRs|full CI outputs for workflow file PRs)"`
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`
  - `git diff --check`
- Self-review / exception reason：
  - controller self-reviewed the single-file test diff; R4 workflow/test PR still requires human review
- Worker session closeout：
  - explorer result consumed and session closed; no additional worker task needed for this slice
- Workflow friction / follow-up split：
  - #764 already has docs baseline (#860) and metadata harness fix (#861); this PR only adds regression coverage before any future CI runtime changes
  - threshold calibration / dogfood ledger：#664 after merge

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation for head c23a8b2a1ad2452617b1744843f82e4f7211e043
- CodeRabbit：
  - no CodeRabbit findings existed at PR creation for head c23a8b2a1ad2452617b1744843f82e4f7211e043; awaiting automated review if triggered
- chatgpt-codex-connector：
  - no connector findings existed at PR creation; Codex will not self-review this PR
- review_triage_ref：
  - #764 + Godel read-only explorer result selected workflow regression test-only slice
- root_cause_gate_ref：
  - RED runs proved the two new tests fail when docs-only detection or workflow full-CI path rules regress
- finding_disposition_ref：
  - adopted regression coverage only; deferred actual CI runtime changes and frontend/style-only lane to later #764 PRs
- Final reviewer action：
  - pending human review after CI and automated signals complete

## Final merge gate
- Ready-to-merge decision：
  - blocked until required GitHub checks, automated review signals, and human review complete
- Latest head SHA：
  - c23a8b2a1ad2452617b1744843f82e4f7211e043
- Required checks：
  - pending GitHub checks at PR creation; local workflow regression passed before push
- spec workflow-check evidence：
  - local-only context gate completed via `spec plan 764 --repo . --dry-run --format prompt --verbose`; missing always-read `docs/claude-codex-workflow.md` recorded as non-blocking context risk
- Evidence URL：
  - this PR initial body; final closeout comment to be added only after merge if needed

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add regression coverage for #764 CI lightweight lane semantics before future runtime changes.
- Approx changed lines：~60
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #860 docs strategy baseline, #861 metadata regression harness fix

## Acceptance Criteria
- [x] Add regression coverage for docs-only lightweight lane outputs
- [x] Add regression coverage that workflow-file PRs run full CI outputs
- [x] Do not change workflow runtime behavior in this PR
- [x] Keep the PR test-only and independent from product backend/frontend work

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```bash
node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts --test-name-pattern "scope gate emits (skipped product outputs for docs-only PRs|full CI outputs for workflow file PRs)"
# tests 98, pass 98, fail 0

node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
# tests 98, pass 98, fail 0

git diff --check
# pass
```

## 備註
refs #764

## Notes for Claude Code Review
- 本 PR 只新增 regression tests；沒有修改 `ci.yml` runtime。
- 因為修改 `.github/workflows/**`，依 repo policy 標 R4 並等待 human review，不走 self-approval。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 增强持续集成作用域验证测试，确保文档专属更改时自动跳过非必要检查
  * 完善工作流配置变更场景的CI覆盖，验证完整检查流程执行

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->