### PR TITLE
[backend] fix: propagate raffle complete request context

### DIFF
--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -308,7 +308,7 @@ func (h *RaffleHandler) Complete(c *gin.Context) {
 		return
 	}
 
-	raffle, err := h.raffleSvc.Complete(raffleID, userID)
+	raffle, err := h.raffleSvc.CompleteContext(c.Request.Context(), raffleID, userID)
 	if err != nil {
 		if errors.Is(err, services.ErrRaffleNotFound) {
 			notFound(c, "raffle not found")

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -525,6 +525,29 @@ func TestRaffle_Complete(t *testing.T) {
 	}
 }
 
+func TestRaffle_Complete_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "completectx", "completectx@test.com", "pass1234")
+	raffleID := env.createRaffle(t, token, "Complete Context Raffle")
+
+	key := raffleHandlerContextKey{}
+	seen := installRaffleHandlerDBContextProbeForTables(t, env.db, key, "raffle-complete", "raffles")
+	ctx := context.WithValue(context.Background(), key, "raffle-complete")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		"/api/v1/dashboard/raffles/"+raffleID+"/complete", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("complete: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen() < 2 {
+		t.Fatal("expected raffle complete lookup and update DB operations to use request context")
+	}
+}
+
 func TestRaffle_SetDiscordWebhook_RequiresField(t *testing.T) {
 	env := newRaffleTestEnv(t)
 	token := env.registerStreamer(t, "webhookhost", "webhookhost@test.com", "pass1234")

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -490,14 +490,22 @@ func (s *RaffleService) ActivateContext(ctx context.Context, raffleID, userID uu
 
 // Complete marks a raffle as completed.
 func (s *RaffleService) Complete(raffleID, userID uuid.UUID) (*models.Raffle, error) {
-	raffle, err := s.GetByID(raffleID, userID)
+	return s.CompleteContext(context.Background(), raffleID, userID)
+}
+
+func (s *RaffleService) CompleteContext(ctx context.Context, raffleID, userID uuid.UUID) (*models.Raffle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	raffle, err := s.GetByIDContext(ctx, raffleID, userID)
 	if err != nil {
 		return nil, err
 	}
 	if raffle.Status == models.RaffleStatusCompleted {
 		return raffle, nil
 	}
-	if err := s.db.Model(raffle).Update("status", models.RaffleStatusCompleted).Error; err != nil {
+	if err := s.db.WithContext(ctx).Model(raffle).Update("status", models.RaffleStatusCompleted).Error; err != nil {
 		return nil, err
 	}
 	return raffle, nil

--- a/services/api/internal/services/raffle_service_hardening_test.go
+++ b/services/api/internal/services/raffle_service_hardening_test.go
@@ -133,6 +133,28 @@ func TestRaffleService_GetDrawByTokenContext_UsesRequestContext(t *testing.T) {
 	}
 }
 
+func TestRaffleService_CompleteContext_UsesRequestContext(t *testing.T) {
+	db := newTestDB(t)
+	ownerID := seedUserWithEmail(t, db, "complete_context_owner@example.com")
+	raffleID := seedDraftRaffle(t, db, ownerID)
+
+	key := raffleServiceContextKey{}
+	seen := installDBContextProbe(t, db, key, "raffle-complete")
+	ctx := context.WithValue(context.Background(), key, "raffle-complete")
+
+	svc := &RaffleService{db: db}
+	raffle, err := svc.CompleteContext(ctx, raffleID, ownerID)
+	if err != nil {
+		t.Fatalf("CompleteContext: %v", err)
+	}
+	if raffle.Status != models.RaffleStatusCompleted {
+		t.Fatalf("want status completed, got %q", raffle.Status)
+	}
+	if seen() < 2 {
+		t.Fatal("expected CompleteContext lookup and update operations to use request context")
+	}
+}
+
 func TestRaffleService_SubmitClaimContext_UsesRequestContext(t *testing.T) {
 	db := newTestDB(t)
 	ownerID := seedUserWithEmail(t, db, "submit_claim_ctx_owner@example.com")


### PR DESCRIPTION
## 什麼改動
- Add `RaffleService.CompleteContext` and keep `Complete` as the background-context compatibility wrapper.
- Pass Gin request context from `RaffleHandler.Complete` into the service.
- Add service and handler context-probe regressions for raffle complete lookup/update DB operations.

## 為什麼
refs #645

`/dashboard/raffles/{id}/complete` still used the non-context complete path, so request timeout cancellation would not propagate to the raffle lookup/update DB work. This PR is a bounded #645 slice for the raffle complete endpoint only.

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不處理其他 raffle endpoints
  - 不碰 extension login / #872 surface
  - 不改 schema / swagger / frontend

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645
- Actual worker profile(s)：controller + AWP explorer Avicenna read-only candidate triage
- Model strength：controller inherited current model；explorer inherited current model
- Spawn directive(s)：profile=explorer model=inherited reasoning=medium controller_fallback=denied task=read-only-candidate-analysis-for-407-645-390 no-writes no-github-mutations
- Verification evidence：`spec plan 645 --repo . --dry-run --format prompt --verbose`; RED `go test ./internal/services -run TestRaffleService_CompleteContext_UsesRequestContext -count=1`; RED `go test ./internal/handlers -run TestRaffle_Complete_UsesRequestContext -count=1`; GREEN commands listed below
- Self-review / exception reason：controller reviewed diff and scope before push
- Worker session closeout：explorer result read; no further worker task needed
- Workflow friction / follow-up split：n/a; #664 dogfood comment only after merge

## Review conversation closeout
- Unresolved threads：0 at PR creation
- CodeRabbit：pending
- chatgpt-codex-connector：n/a
- review_triage_ref：spec dry-run + local RED/GREEN evidence in this PR body
- root_cause_gate_ref：latest-head rationale: raffle complete lacked request-context path while adjacent activate already had it
- finding_disposition_ref：adopted by adding CompleteContext and handler call-site propagation
- Final reviewer action：pending

## Final merge gate
- Ready-to-merge decision：blocked by CI/review at PR creation
- Latest head SHA：`5b31acf62f19544665b7121bc59b986841440eee`
- Required checks：pending GitHub checks
- spec workflow-check evidence：local-only `spec plan 645 --repo . --dry-run --format prompt --verbose`; warning: `docs/claude-codex-workflow.md` missing from always_read in clean worktree
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：Propagate request context through raffle complete DB lookup/update.
- Approx changed lines：~59
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The handler must call the new service context path for the request timeout behavior to be observable end to end.
- 若已拆分，相關 PR：
  - Existing #645 slices remain separate; this PR only covers raffle complete.

## Acceptance Criteria
- [x] All service-layer DB access paths for this selected slice propagate request context
- [x] GORM queries in this slice use `WithContext(ctx)`
- [x] Added regression tests for canceled/request context propagation via DB context probes

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
RED: go test ./internal/services -run TestRaffleService_CompleteContext_UsesRequestContext -count=1
FAIL: svc.CompleteContext undefined

RED: go test ./internal/handlers -run TestRaffle_Complete_UsesRequestContext -count=1
FAIL: expected raffle complete lookup and update DB operations to use request context

GREEN: go test ./internal/services -run TestRaffleService_CompleteContext_UsesRequestContext -count=1
ok   github.com/tachigo/tachigo/internal/services 0.363s

GREEN: go test ./internal/handlers -run TestRaffle_Complete_UsesRequestContext -count=1
ok   github.com/tachigo/tachigo/internal/handlers 0.466s

go test ./internal/services -run 'TestRaffleService_(CompleteContext_UsesRequestContext|ActivateContext_UsesRequestContext|GetByIDContext_UsesRequestContext)' -count=1
ok   github.com/tachigo/tachigo/internal/services 0.274s

go test ./internal/handlers -run 'TestRaffle_(Complete_UsesRequestContext|Complete|Activate_UsesRequestContext)' -count=1
ok   github.com/tachigo/tachigo/internal/handlers 0.871s

go test ./internal/services ./internal/handlers
ok   github.com/tachigo/tachigo/internal/services 3.190s
ok   github.com/tachigo/tachigo/internal/handlers 19.430s

go test ./...
ok   github.com/tachigo/tachigo/cmd/loader 1.567s
ok   github.com/tachigo/tachigo/cmd/server 0.517s
ok   github.com/tachigo/tachigo/docs 1.269s
ok   github.com/tachigo/tachigo/internal/config 1.002s
ok   github.com/tachigo/tachigo/internal/contract 0.776s
ok   github.com/tachigo/tachigo/internal/handlers (cached)
ok   github.com/tachigo/tachigo/internal/metrics 1.813s
ok   github.com/tachigo/tachigo/internal/middleware 2.129s
ok   github.com/tachigo/tachigo/internal/models 3.025s
ok   github.com/tachigo/tachigo/internal/router 2.861s
ok   github.com/tachigo/tachigo/internal/services (cached)
ok   github.com/tachigo/tachigo/internal/tracing 2.663s
```

## 備註
- `spec plan` clean-worktree rerun still reported missing always-read `docs/claude-codex-workflow.md`; no implementation scope was expanded from that missing reference.

## Notes for Claude Code Review
- Please focus on whether the new `CompleteContext` preserves existing idempotent complete behavior while adding request-context propagation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 改进了抽奖完成功能的请求上下文处理，确保操作与当前请求的生命周期保持一致。

* **测试**
  * 新增测试覆盖，验证抽奖完成操作正确使用请求上下文。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
