### PR TITLE
[backend] test: add agency RBAC matrix coverage

### DIFF
--- a/services/api/internal/handlers/rbac_handler_test.go
+++ b/services/api/internal/handlers/rbac_handler_test.go
@@ -30,12 +30,20 @@ func newRBACTestEnv(t *testing.T) *rbacEnv {
 		agencies.POST("", middleware.RequireRole(models.RoleAdmin), func(c *gin.Context) {
 			c.JSON(501, gin.H{"error": "not implemented"})
 		})
+		agencies.GET("/:id",
+			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
 		agencies.PUT("/:id/settings",
 			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
 			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
 		)
 		agencies.GET("/:id/streamers",
 			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		agencies.POST("/:id/resend-setup",
+			middleware.RequireRole(models.RoleAdmin),
 			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
 		)
 	}
@@ -184,6 +192,45 @@ func TestRBACMatrix_DashboardRoutes(t *testing.T) {
 				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
 				{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
 				{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
+				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newRBACTestEnv(t)
+			assertRBACMatrix(t, env, tt.method, tt.path, tt.cases)
+		})
+	}
+}
+
+func TestRBACMatrix_AgencyReadAndSetupRoutes(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		cases  []rbacMatrixCase
+	}{
+		{
+			name:   "agency detail allows agency or admin only",
+			method: http.MethodGet,
+			path:   "/api/v1/agencies/agency_1",
+			cases: []rbacMatrixCase{
+				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+				{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
+				{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
+				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+			},
+		},
+		{
+			name:   "resend setup is admin only",
+			method: http.MethodPost,
+			path:   "/api/v1/agencies/agency_1/resend-setup",
+			cases: []rbacMatrixCase{
+				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+				{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
+				{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
 				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
 			},
 		},


### PR DESCRIPTION
## 什麼改動
新增 agency detail 與 resend setup 兩條 protected routes 的 centralized RBAC matrix regression coverage，並在 RBAC 測試 stub 中對齊 production router 的 role gate。

## 為什麼
#646 要求補齊 protected endpoints 的 RBAC ownership / role matrix 回歸測試；這是一個 tests-only 小切片，覆蓋目前 centralized matrix 尚未涵蓋的 agency read/setup 端點。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#646
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 production router / middleware / handler behavior
  - 不關閉 #646 的全部 AC
  - 不處理 ownership mismatch / route coverage gate 的後續切片

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#646 issue body / spec-injector dry-run context
- Actual worker profile(s)：controller-direct fallback；sidecar explorer Popper `019e5538-bc74-72f2-bd28-25f63fd8e173` read-only 掃描 #645 候選後已 close，未修改本 PR 檔案
- Model strength：controller = medium；sidecar explorer = inherited
- Spawn directive(s)：profile=controller_direct model=inherited reasoning=medium controller_fallback=used fallback_reason=one-file tests-only RBAC matrix slice; worker dispatch not needed
- Verification evidence：`spec plan 646 --repo . --dry-run --format prompt --verbose`; RED `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBACMatrix_AgencyReadAndSetupRoutes -count=1` failed with 404 before stubs; GREEN focused/RBAC/full backend tests passed; `git diff --check` passed
- Self-review / exception reason：tests-only one-file RBAC matrix slice；self-review completed locally before PR creation
- Worker session closeout：sidecar explorer result read back and closed; no open worker-owned files
- Workflow friction / follow-up split：#646 remains broad, so this PR keeps only agency read/setup role-matrix coverage; broader route inventory / ownership mismatch / coverage gate stays split for later #646 PRs

## Review conversation closeout
- Unresolved threads：0 at PR creation
- CodeRabbit：pending
- chatgpt-codex-connector：n/a; self-authored PR, no self-review requested
- review_triage_ref：spec plan 646 local dry-run; PR body evidence
- root_cause_gate_ref：latest-head rationale in PR body; not a repeated finding
- finding_disposition_ref：adopted tests-only slice; broader #646 AC deferred to follow-up slices
- Final reviewer action：pending human review

## Final merge gate
- Ready-to-merge decision：pending CI / human review
- Latest head SHA：e5c92fa
- Required checks：pending GitHub checks at PR creation
- spec workflow-check evidence：local-only dry-run `spec plan 646 --repo . --dry-run --format prompt --verbose`; context risk: `docs/claude-codex-workflow.md` missing in dry-run output
- Evidence URL：n/a at PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：Add centralized RBAC matrix coverage for agency detail and resend setup protected routes.
- Approx changed lines：~47
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #859, #873

## Acceptance Criteria
- [x] Add reusable centralized RBAC matrix coverage for this agency endpoint slice
- [x] Cover unauthenticated / wrong-role access for agency detail and resend setup routes
- [x] Keep production behavior unchanged while aligning test stubs with existing protected routes
- [ ] Full all-endpoint route inventory / CI coverage gate remains for later #646 slices
- [ ] Ownership mismatch / cross-tenant cases remain for later #646 slices
- [ ] Documentation source-of-truth update remains for later #646 slices

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
RED: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBACMatrix_AgencyReadAndSetupRoutes -count=1
FAIL: got 404 for agency detail / resend setup before RBAC test stubs were registered

GREEN: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBACMatrix_AgencyReadAndSetupRoutes -count=1
ok   github.com/tachigo/tachigo/internal/handlers 2.396s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBAC -count=1
ok   github.com/tachigo/tachigo/internal/handlers 4.505s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok   github.com/tachigo/tachigo/internal/handlers 23.369s
ok   github.com/tachigo/tachigo/internal/services 5.303s
... all services/api packages passed or had no test files

git diff --check
pass
```

## 備註
`spec plan 646` reported missing `docs/claude-codex-workflow.md`; this PR treats that as context risk and only uses verified issue/router/test evidence.

## Notes for Claude Code Review
- 請特別看 `rbac_handler_test.go` 的 agency GET / resend setup role matrix 是否和 production router role gate 一致。
- 這張刻意不宣稱完成 #646 全部 AC，只是補一個安全的小切片。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 增强了权限控制测试覆盖，采用参数化测试矩阵验证机构数据读取及重新发送设置功能在不同角色下的访问权限，确保系统权限控制的完整性和正确性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->