### PR TITLE
[discussion] Add Track B AI Native product docs

### DIFF
--- a/docs/product/ai-copilot-principles.md
+++ b/docs/product/ai-copilot-principles.md
@@ -1,0 +1,190 @@
+# AI Copilot Product Principles
+
+## Purpose
+
+This document defines the safety, privacy, execution, and provider principles for future AI-powered product features in tachigo.
+
+It supports [`ai-native-roadmap.md`](./ai-native-roadmap.md), which describes Track B: AI-native product direction.
+
+This document is a planning reference. It is not an implementation source of truth until converted into issues, specs, acceptance criteria, and small PRs.
+
+## Core Rule
+
+```txt
+AI can suggest.
+Backend decides.
+Human confirms.
+Ledger remains deterministic.
+```
+
+This matters because tachigo touches points, tokens, wallets, claims, spending, and agency ownership.
+
+## Safety Boundary
+
+AI must not directly:
+
+```txt
+- issue tokens
+- modify points ledger
+- modify wallet ownership
+- approve claims
+- bypass Twitch auth
+- modify agency/channel ownership
+- publish campaigns automatically
+- issue high-value rewards automatically
+- modify reward economy parameters automatically
+- execute chain transactions automatically
+```
+
+AI may:
+
+```txt
+- generate campaign drafts
+- explain data
+- suggest reward parameters
+- flag risks
+- generate SQL / API proposals
+- generate test cases
+- generate migration drafts
+- generate dashboard copy
+```
+
+## Human Confirmation
+
+AI-generated output should enter the product as a draft or recommendation.
+
+Recommended pattern:
+
+```txt
+AI generates draft
+→ backend validates structure and permissions
+→ human reviews and edits
+→ backend executes deterministic behavior
+→ system records feedback and outcome
+```
+
+AI should not be the final authority for behavior that affects value, identity, permissions, or blockchain activity.
+
+## Deterministic Backend Execution
+
+The backend owns final decisions for:
+
+```txt
+- points calculation
+- ledger mutation
+- spendable balance updates
+- claim eligibility
+- wallet ownership checks
+- agency/channel permissions
+- campaign publication
+- reward issuance
+- chain transaction execution
+```
+
+AI output should be validated as input data, not trusted as policy.
+
+## Privacy / Data Minimization
+
+AI Native does not mean sending all data to an LLM.
+
+Allowed input candidates:
+
+```txt
+- aggregated watch stats
+- anonymized viewer segments
+- campaign metadata
+- reward economy summaries
+- non-sensitive dashboard context
+```
+
+Do not send directly:
+
+```txt
+- raw access tokens
+- refresh tokens
+- wallet private keys
+- secrets
+- full OAuth payloads
+- raw personally identifiable data
+- unnecessary Twitch identity details
+```
+
+Any future LLM integration should include a redaction layer before data leaves the backend boundary.
+
+## Provider Strategy
+
+Do not bind the first implementation directly to a specific LLM provider.
+
+Before using a real LLM, build:
+
+```txt
+TemplateProvider / MockProvider
+```
+
+This validates the domain boundary, API contract, dashboard workflow, persistence, feedback loop, and permission checks.
+
+Then introduce an interface such as:
+
+```go
+type LLMClient interface {
+    GenerateJSON(ctx context.Context, req GenerateJSONRequest) (*GenerateJSONResponse, error)
+}
+```
+
+The adapter should include timeout, retry policy, JSON schema validation, prompt versioning, model tracking, token usage tracking, redaction, audit logs, and fallback behavior.
+
+## Recommendation Lifecycle
+
+Future AI product work should treat AI output as a lifecycle, not one-off text generation.
+
+The system should track:
+
+```txt
+- what AI recommended
+- whether the user accepted it
+- whether the user rejected it
+- why it was rejected
+- whether accepted recommendations improved product metrics
+```
+
+Candidate data areas:
+
+```txt
+ai_recommendations
+ai_recommendation_feedback
+ai_insight_snapshots
+```
+
+## Product UX Principle
+
+AI should be embedded into concrete workflows instead of defaulting to a generic chatbot.
+
+Recommended dashboard surfaces:
+
+```txt
+Campaign Creation → Create Campaign with AI
+Viewer Insights → AI-generated segments and recommended actions
+Economy Health → issuance / sink / balance risk recommendations
+```
+
+The product should make AI useful at the moment a streamer or agency is making a decision.
+
+## Non-goals
+
+This principles document does not require the current PR to:
+
+- implement backend AI services
+- add migrations
+- add dashboard UI
+- connect to an LLM provider
+- change ledger logic
+- change wallet logic
+- change claim logic
+- add dependencies
+- permit autonomous product actions
+
+## Summary
+
+```txt
+Suggestive AI, deterministic backend, human confirmation, auditable outcomes.
+```

--- a/docs/product/ai-native-roadmap.md
+++ b/docs/product/ai-native-roadmap.md
@@ -1,0 +1,252 @@
+# tachigo AI Native Product Roadmap
+
+## Purpose
+
+This document captures **Track B: AI-native product direction** for tachigo.
+
+It complements Discussion #877, which remains the short-term source of truth for **Track A: AI-native repo / workflow foundation**.
+
+This is a planning reference, not an implementation source of truth. Before implementation, each section must be converted into issues, specs, acceptance criteria, and small PRs.
+
+## Relationship to Discussion #877
+
+Recommended split:
+
+```txt
+Track A: AI-native repo / workflow foundation
+- Source of truth: Discussion #877
+- Focus: Dev Portal, Wiki, AI Agent Start Here, domain cards, issue templates, PR gates, review / merge guardrails
+- Timing: short term
+
+Track B: AI-native product roadmap
+- Source of truth: this document, after scope is accepted
+- Focus: Campaign Copilot, viewer insights, economy advisor, recommendation feedback loop
+- Timing: medium term
+```
+
+Short-term priority:
+
+```txt
+Make tachigo AI-readable and AI-safe before making tachigo product features AI-powered.
+```
+
+## Product Positioning
+
+Recommended positioning:
+
+> tachigo is an AI-native creator rewards OS for Twitch streamers, agencies, and viewers.
+
+AI should help streamers and agencies:
+
+- understand viewer behavior
+- design reward campaigns
+- manage token economy health
+- detect suspicious reward farming
+- turn dashboard data into operational actions
+
+## AI Native Definition
+
+For tachigo, AI Native means:
+
+```txt
+AI is embedded into creator operations, reward design, viewer insight, and economy optimization.
+```
+
+The product should evolve from:
+
+```txt
+viewer watches stream → heartbeat → points increase → token claim / spend
+```
+
+Into:
+
+```txt
+viewer activity → AI insight / recommendation → streamer review → deterministic backend execution → feedback loop
+```
+
+Core principle:
+
+```txt
+AI is not the authority.
+AI is the operating layer for recommendations, insights, and optimization.
+```
+
+## Recommended First Product Feature
+
+Do not start with a generic chatbot.
+
+The first AI-native product feature should be embedded into a concrete dashboard workflow:
+
+```txt
+Dashboard Campaign Copilot
+```
+
+Recommended workflow:
+
+```txt
+Create Campaign
+  → streamer inputs goal
+  → AI generates campaign draft
+  → backend calculates cost / risk
+  → streamer edits
+  → streamer confirms
+  → campaign is saved / published
+```
+
+The first version should generate a campaign draft, not publish it automatically.
+
+Detailed safety, privacy, and execution rules live in [`ai-copilot-principles.md`](./ai-copilot-principles.md).
+
+## Product Feature Phases
+
+### Phase 1: Dashboard Campaign Copilot
+
+Help streamers and agencies create reward campaigns from goals.
+
+Example draft components:
+
+```txt
+- Watch Streak Mission
+- Chat Burst Mission
+- TACHI Sink
+- New Viewer Bonus
+- Risk controls
+```
+
+### Phase 2: Viewer Segment Insight
+
+Help streamers and agencies understand viewer behavior and convert analytics into actions.
+
+Example segments:
+
+```txt
+- Core fans
+- Silent loyal viewers
+- Reward hunters
+- New viewers
+- Dormant viewers
+```
+
+### Phase 3: Token Economy Advisor
+
+Help streamers and agencies manage reward economy health.
+
+Metrics to analyze:
+
+```txt
+- weekly point issuance
+- weekly point spending
+- sink ratio
+- spendable balance growth
+- whale concentration
+- reward farming pattern
+- inactive token accumulation
+```
+
+Differentiation:
+
+```txt
+Generic tool: helps issue points.
+tachigo: helps design, monitor, and adjust the creator reward economy.
+```
+
+### Phase 4: Recommendation Feedback Loop
+
+The product should track:
+
+```txt
+What did AI recommend?
+Did the streamer accept it?
+Why was it rejected?
+Did accepted recommendations improve metrics?
+```
+
+Candidate data areas:
+
+```txt
+ai_recommendations
+ai_recommendation_feedback
+ai_insight_snapshots
+```
+
+## Backend Direction
+
+Add an independent AI bounded context only after Track A has made the repo AI-readable and AI-safe.
+
+Boundary rule:
+
+```txt
+AI reads multiple domains and produces recommendations.
+It does not own ledger, auth, wallet, or campaign execution.
+```
+
+Recommended ownership:
+
+```txt
+points service owns points.
+agency service owns agency/channel permissions.
+campaign service owns campaign lifecycle.
+AI service owns recommendation lifecycle.
+```
+
+## Suggested Roadmap
+
+```txt
+Phase 0: AI-native repo / workflow foundation from #877
+Phase 1: Product roadmap and AI copilot principles docs
+Phase 2: Campaign Copilot MVP with deterministic TemplateProvider
+Phase 3: LLM-backed Campaign Copilot with redaction and schema validation
+Phase 4: Viewer Insight
+Phase 5: Economy Advisor
+Phase 6: Semi-autonomous creator operations with human approval
+```
+
+## Suggested PR Breakdown
+
+```txt
+PR 1: Track B product roadmap and copilot principles docs
+PR 2: AI recommendation domain skeleton
+PR 3: AI recommendation persistence
+PR 4: Campaign Copilot API with deterministic TemplateProvider
+PR 5: Dashboard Campaign Copilot UI
+PR 6: LLM provider adapter
+PR 7: Viewer Segment Insight
+PR 8: Economy Advisor
+```
+
+Each implementation PR should have its own source issue, explicit non-goals, acceptance criteria, and test plan.
+
+## North Star Metrics
+
+Measure product impact, not whether AI output looks smart.
+
+```txt
+Streamer: campaign creation time decreases, accepted AI recommendation ratio increases.
+Viewer: repeat viewer ratio, watch retention, reward redemption, and chat participation improve.
+Economy: sink ratio improves, token inflation risk and suspicious farming decrease.
+AI loop: accepted recommendation → measurable product metric improvement.
+```
+
+## Non-goals
+
+This roadmap does not require the current PR to:
+
+- implement backend AI services
+- add migrations
+- add dashboard UI
+- connect to an LLM provider
+- modify points or token ledger behavior
+- change wallet or claim logic
+- add dependencies
+- add autonomous campaign publishing
+- replace Discussion #877 as the Track A source of truth
+
+## Conclusion
+
+The short-term priority remains Track A from Discussion #877:
+
+```txt
+Make the repo AI-readable and AI-safe first.
+```
+
+Then Track B can proceed as an AI-native creator rewards OS, starting with Dashboard Campaign Copilot.


### PR DESCRIPTION
## 什麼改動
新增 Track B：AI-native product 方向文件，並將原本較長的 roadmap 拆成兩份較容易 review 的 docs：

- `docs/product/ai-native-roadmap.md`
- `docs/product/ai-copilot-principles.md`

## 為什麼
#877 目前應維持為 Track A：AI-native repo / workflow foundation 的 source of truth。

本 PR 則作為 Track B：AI-native product candidate docs，保留中期產品方向，例如 Dashboard Campaign Copilot、Viewer Segment Insight、Token Economy Advisor、recommendation feedback loop，以及 AI product safety / privacy / human confirmation 原則。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [x] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：Discussion #877 / PR #879 review comments
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不取代 #877 作為 Track A source of truth
  - 不實作 backend AI service
  - 不新增 migration
  - 不修改 dashboard UI
  - 不接 LLM provider
  - 不修改 points / token / wallet / claim / spend 邏輯
  - 不新增依賴

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - n/a — docs-only follow-up from #877 / #879 comments
- Actual worker profile(s)：
  - controller/self-only docs pass
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller model=gpt-5.5-thinking reasoning=high controller_fallback=approved
- Verification evidence：
  - GitHub compare: 2 docs files changed, 442 total added lines, no code / migration / UI changes
- Self-review / exception reason：
  - trivial/self-only exception: this PR only updates planning docs and does not require worker delegation
- Worker session closeout：
  - No worker session was spawned. Controller completed docs-only split, trimmed the diff under the 600-line soft limit, and verified scope remains limited to `docs/product/**`.
- Workflow friction / follow-up split：
  - Original single long roadmap was split into roadmap + principles to reduce review cost and keep safety/privacy rules reusable.

## Review conversation closeout
- Unresolved threads：
  - 0 known inline threads; PR-level Scope Police comment addressed by updating PR body and reducing diff size
- CodeRabbit：
  - n/a
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - PR #879 comments; latest response reduces scope and keeps #877 as Track A source of truth
- root_cause_gate_ref：
  - PR was flagged because body shape looked autonomous while fields were n/a; fields now include explicit self-only exception and closeout
- finding_disposition_ref：
  - adopted: Option C split into `ai-native-roadmap.md` and `ai-copilot-principles.md`; adopted: trim under 600 soft limit
- Final reviewer action：
  - pending reviewer / CI after latest push

## Final merge gate
- Ready-to-merge decision：
  - blocked until latest Scope Police / CI rerun passes
- Latest head SHA：
  - fb6973cc3cbab5adc374ddf233594ab2037fa30e
- Required checks：
  - pending after latest docs update
- spec workflow-check evidence：
  - n/a — no spec-injector used
- Evidence URL：
  - PR #879 comments and latest GitHub compare result

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 Track B AI-native product docs，作為 #877 Track A 之外的中期產品方向候選。
- Approx changed lines：~442 docs-only
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `docs/product/ai-native-roadmap.md` exists
- [x] `docs/product/ai-copilot-principles.md` exists
- [x] #877 remains Track A source of truth
- [x] Product roadmap is clearly positioned as Track B candidate
- [x] Safety / privacy / human confirmation rules are separated into reusable principles doc
- [x] PR does not implement backend / frontend / migration / provider changes

## 超出範圍內容
無

## 測試方式
- [ ] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```txt
GitHub compare result:
- docs/product/ai-native-roadmap.md: +252
- docs/product/ai-copilot-principles.md: +190
- total: +442 docs-only
- no backend / frontend / migration / dependency changes
```

## 備註
這兩份文件是 product planning reference，不是 implementation source of truth。後續實作前仍需拆成 issue / spec / small PR。

## Notes for Claude Code Review
- 請確認 #877 / #879 的分層是否清楚：#877 = Track A repo/workflow foundation；#879 = Track B product candidate docs。
- 請確認 core rule 是否足夠明確：AI can suggest, backend decides, human confirms, ledger remains deterministic。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 新增 AI 助手核心原则文档，涵盖安全边界、人类确认流程、隐私保护和产品工作流 UX 原则。
  * 新增 AI 原生产品路线图文档，阐述产品方向、分阶段规划和后端能力边界。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->