### PR TITLE
[backend] fix: propagate auth token cleanup context

### DIFF
--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -247,7 +247,14 @@ func (s *AuthService) LogoutContext(ctx context.Context, rawRefreshToken string)
 // DeleteExpiredRefreshTokens removes all expired refresh token records.
 // Returns the number of rows deleted.
 func (s *AuthService) DeleteExpiredRefreshTokens() (int64, error) {
-	result := s.db.Where("expires_at < ?", time.Now()).Delete(&models.RefreshToken{})
+	return s.DeleteExpiredRefreshTokensContext(context.Background())
+}
+
+func (s *AuthService) DeleteExpiredRefreshTokensContext(ctx context.Context) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result := s.db.WithContext(ctx).Where("expires_at < ?", time.Now()).Delete(&models.RefreshToken{})
 	return result.RowsAffected, result.Error
 }
 

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -1303,6 +1303,21 @@ func TestDeleteExpiredRefreshTokens_RemovesExpiredOnly(t *testing.T) {
 	}
 }
 
+func TestDeleteExpiredRefreshTokensContext_CanceledContext(t *testing.T) {
+	svc := NewAuthService(newTestDB(t), testConfig())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deleted, err := svc.DeleteExpiredRefreshTokensContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got deleted=%d err=%v", deleted, err)
+	}
+	if deleted != 0 {
+		t.Errorf("canceled cleanup should not report deleted rows, got %d", deleted)
+	}
+}
+
 func TestRefresh_SecondUseOfSameToken_ReturnsErrInvalidToken(t *testing.T) {
 	svc := NewAuthService(newTestDB(t), testConfig())
 	_, tokens, err := svc.Register(RegisterInput{


### PR DESCRIPTION
## 什麼改動
- 新增 `AuthService.DeleteExpiredRefreshTokensContext(ctx)`，讓 expired refresh token cleanup 的 GORM delete 使用 `db.WithContext(ctx)`。
- 保留既有 `DeleteExpiredRefreshTokens()` 作為 `context.Background()` 相容 wrapper。
- 新增 canceled context regression test，確認已取消 context 不會回報刪除列數。

## 為什麼
refs #645

#645 要求 audit `services/api` 的 DB query context propagation。這張只處理 auth refresh token cleanup 的單一 service-layer DB delete 缺口，不擴張到其他 still-pending DB/transaction paths。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 handler / router / API contract
  - 不改 schema / migration
  - 不處理 claim / spend / raffle 等其他 remaining context paths

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#645 bounded DB context propagation slice; `spec plan 645 --repo . --dry-run --format prompt --verbose`
- Actual worker profile(s)：controller-direct fallback
- Model strength：controller = high
- Spawn directive(s)：profile=controller model=gpt-5-codex reasoning=high controller_fallback=true fallback_reason=single-method auth cleanup DB context slice; no spawned worker needed after live PR/readback de-duplication
- Verification evidence：RED/GREEN focused test; `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestDeleteExpiredRefreshTokens' -count=1`; `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -count=1`; `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`; `git diff --check`
- Self-review / exception reason：self-reviewed local diff; R4 merge remains blocked on human owner review/approval
- Worker session closeout：no child worker opened for this PR; controller-direct fallback recorded here, and prior stale/duplicate candidate branches were not modified
- Workflow friction / follow-up split：spec-injector still reports missing stale always-read `docs/claude-codex-workflow.md`; follow-up signal belongs to #664 ledger after merge, not this patch

## Review conversation closeout
- Unresolved threads：0 at PR creation
- CodeRabbit：pending new PR review
- chatgpt-codex-connector：n/a; self-authored PR must not be self-reviewed
- review_triage_ref：PR body latest-head rationale at creation
- root_cause_gate_ref：single DB delete uses `s.db` without `WithContext(ctx)` in `DeleteExpiredRefreshTokens`; fixed by context-aware wrapper
- finding_disposition_ref：adopted: add context variant and canceled-context regression; deferred: unrelated remaining #645 paths
- Final reviewer action：pending human owner review

## Final merge gate
- Ready-to-merge decision：pending until GitHub checks and human owner review complete
- Latest head SHA：ccc1afccd70c504e1445afd9af15ff21a556bf7d
- Required checks：pending after PR creation
- spec workflow-check evidence：start gate pass at 2026-05-23T16:23:58Z; commit gate manual fallback because PR body was not yet available and staged state was clean
- Evidence URL：n/a at PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：讓 expired refresh token cleanup 的 DB delete 可接收 context cancellation。
- Approx changed lines：~23
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service behavior and regression test are the same bounded context-propagation slice
- 若已拆分，相關 PR：
  - #852, #853, #854, #864, #868, #869, #870, #871, #875 等已處理其他 #645 endpoint slices；本 PR 不依賴未合併 PR

## Acceptance Criteria
- [x] All GORM / sql queries use `WithContext(ctx)` or equivalent — this PR covers `DeleteExpiredRefreshTokensContext`
- [x] Add regression tests for canceled request context — added canceled cleanup service regression
- [ ] Audit all DB queries and transactions under `services/api` — partial slice only; #645 remains open
- [ ] All service-layer DB access paths propagate request context — partial slice only; #645 remains open
- [ ] Transaction helpers preserve context — n/a for this non-transaction cleanup delete
- [ ] Add at least one integration test proving timeout cancels DB work — covered by prior #858; not duplicated here
- [ ] Document any intentionally detached async job paths — out of scope for this slice

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
RED: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestDeleteExpiredRefreshTokens' -count=1
FAIL: DeleteExpiredRefreshTokensContext undefined

GREEN: GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestDeleteExpiredRefreshTokens' -count=1
ok github.com/tachigo/tachigo/internal/services 0.556s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -count=1
ok github.com/tachigo/tachigo/internal/services 2.715s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok github.com/tachigo/tachigo/internal/handlers 21.144s
ok github.com/tachigo/tachigo/internal/services 5.737s
(all backend packages passed)

git diff --check
(no output)
```

## 備註
R4 auth-adjacent cleanup PR：請由 human owner review/approve；不要 auto-ready / self-approve。

## Notes for Claude Code Review
- 這張是 #645 的小型 partial slice，不應 `closes #645`。
- 既有 wrapper 行為維持 background context，避免影響既有呼叫點。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本发布说明

* **重构**
  * 改进身份验证服务的上下文处理机制，增强对异步操作的支持和错误处理能力。

* **测试**
  * 新增上下文取消场景的测试用例。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->