### PR TITLE
[chore] add AI-safe make command surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev up down logs pr-meta-check pr-open session-index session-find session-index-test supply-chain-check typescript-only-check developer-persistence-check
+.PHONY: setup dev up down logs pr-meta-check pr-open ai-readback ai-docs-build ai-test-backend ai-test-extension ai-test-dashboard ai-pr-check session-index session-find session-index-test supply-chain-check typescript-only-check developer-persistence-check
 
 # ── Setup (run once after cloning) ────────────────────────────────────────────
 setup:
@@ -31,6 +31,64 @@ pr-open:
 	@test -n "$(TITLE)" || (echo "TITLE is required"; exit 2)
 	@test -n "$(BODY_FILE)" || (echo "BODY_FILE is required"; exit 2)
 	@./infra/scripts/pr-open.sh --title "$(TITLE)" --body-file "$(BODY_FILE)" --base "$(or $(BASE),develop)" $(if $(HEAD),--head "$(HEAD)",) $(if $(filter 1,$(DRAFT)),--draft,) $(if $(filter 1,$(AUTO_READY)),--auto-ready,)
+
+# ── AI-safe command surface ─────────────────────────────────────────────────
+ai-readback:
+	@echo "branch: $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unavailable)"
+	@develop_tip="$$(git rev-parse --verify refs/remotes/origin/develop^{commit} 2>/dev/null || true)"; \
+	if [ -n "$$develop_tip" ]; then echo "origin/develop: $$develop_tip"; else echo "origin/develop: unavailable"; fi
+	@if status="$$(git status --short 2>&1)"; then \
+		if [ -z "$$status" ]; then echo "working tree: clean"; else echo "working tree: dirty"; printf '%s\n' "$$status"; fi; \
+	else \
+		echo "working tree: unavailable"; printf '%s\n' "$$status"; \
+	fi
+	@echo "pointers: CLAUDE.md docs/ai/ .claude/rules/"
+
+ai-docs-build:
+	@if [ ! -f apps/docs/package.json ]; then \
+		echo "skipped/unavailable: apps/docs/package.json not found"; \
+	elif ! command -v pnpm >/dev/null 2>&1; then \
+		echo "skipped/unavailable: pnpm is not installed"; \
+	else \
+		pnpm build:docs; \
+	fi
+
+ai-test-backend:
+	@if ! command -v docker >/dev/null 2>&1; then \
+		echo "skipped/unavailable: docker is not installed"; \
+	elif ! docker compose version >/dev/null 2>&1; then \
+		echo "skipped/unavailable: docker compose is not available"; \
+	elif ! docker info >/dev/null 2>&1; then \
+		echo "skipped/unavailable: docker daemon is not available"; \
+	else \
+		docker compose run --no-deps --rm app go test ./...; \
+	fi
+
+ai-test-extension:
+	@if [ ! -f apps/extension/package.json ]; then \
+		echo "skipped/unavailable: apps/extension/package.json not found"; \
+	elif ! command -v pnpm >/dev/null 2>&1; then \
+		echo "skipped/unavailable: pnpm is not installed"; \
+	else \
+		pnpm --filter ./apps/extension test; \
+	fi
+
+ai-test-dashboard:
+	@if [ ! -f apps/dashboard/package.json ]; then \
+		echo "skipped/unavailable: apps/dashboard/package.json not found"; \
+	elif ! command -v pnpm >/dev/null 2>&1; then \
+		echo "skipped/unavailable: pnpm is not installed"; \
+	else \
+		pnpm --filter ./apps/dashboard test; \
+	fi
+
+ai-pr-check:
+	@if [ -z "$(TITLE)" ] || [ -z "$(BODY_FILE)" ]; then \
+		echo "Usage: make ai-pr-check TITLE=\"[chore] ...\" BODY_FILE=/tmp/pr_body.md [BASE=develop] [HEAD=branch] [AUTO_READY=1]"; \
+		echo "Runs existing pr-meta-check; no PR or GitHub write operation is performed."; \
+	else \
+		$(MAKE) pr-meta-check TITLE="$(TITLE)" BODY_FILE="$(BODY_FILE)" BASE="$(or $(BASE),develop)" $(if $(HEAD),HEAD="$(HEAD)",) $(if $(AUTO_READY),AUTO_READY="$(AUTO_READY)",); \
+	fi
 
 # ── Local Codex session lookup ───────────────────────────────────────────────
 session-index:


### PR DESCRIPTION
## 什麼改動
在根目錄 `Makefile` 新增一段 `# ── AI-safe command surface ──`，提供 6 個 `ai-*` readback / 驗證 target：`ai-readback`、`ai-docs-build`、`ai-test-backend`、`ai-test-extension`、`ai-test-dashboard`、`ai-pr-check`。全部加進 `.PHONY`，復用既有 repo command 與 script，不新增任何邏輯重複。

## 為什麼
closes #882

Discussion #877 收斂出的 Track A「no-regret」動作之一：讓 AI agent 不用猜要跑什麼指令。可執行的 Makefile target 比再寫一頁「應該跑什麼」的散文文件更不容易 rot（指令能跑就是對的）。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#882
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增依賴
  - 不修改 CI workflow
  - 不修改 `.github/PULL_REQUEST_TEMPLATE.md` 或 Scope Police
  - `ai-*` target 不藏任何 GitHub 寫入操作（push / PR / merge）

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #882 — 單一 bounded Makefile tooling 任務；controller（Claude）規劃後委派實作給一個 Codex rescue worker。
- Actual worker profile(s)：
  - controller（Claude Opus）+ codex rescue worker（implementer）
- Model strength：
  - controller = high；worker = codex rescue
- Spawn directive(s)：
  - profile=codex-rescue model=codex-cli reasoning=high controller_fallback=approved fallback_reason=n/a（在隔離 worktree 內實作 Makefile）
- Verification evidence：
  - `make ai-readback` 實跑輸出正確；6 個 target `make -n` dry-run 無語法錯；核實 `pnpm@10.33.0` 與 `build:docs` / extension `test` / dashboard `test` script 皆存在；`git status` 僅 Makefile 變更
- Self-review / exception reason：
  - controller 已 self-review worker 產出，移除了 worker 原本在 `ai-readback` 加的硬編 `lfs.storage=/tmp/...` workaround，並逐一核實指令假設
- Worker session closeout：
  - codex rescue session 已完成並讀回；controller 驗證與定稿；無需追加 worker 任務
- Workflow friction / follow-up split：
  - 摩擦極低；唯一 controller-side 修正為移除 lfs 硬編路徑。threshold calibration：n/a

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pending — 開 PR 後於 latest head 審查
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - n/a — controller-led、human-checkpointed PR，非 autonomous gate flow
- root_cause_gate_ref：
  - n/a — 尚未觸發同概念第二次 finding
- finding_disposition_ref：
  - adopted：移除 worker 的硬編 `lfs.storage` workaround
- Final reviewer action：
  - pending reviewer / CI（開 PR 後）

## Final merge gate
- Ready-to-merge decision：
  - blocked until CI / Scope Police pass
- Latest head SHA：
  - 7718cdb
- Required checks：
  - pending（開 PR 後）
- spec workflow-check evidence：
  - n/a — 未使用 spec-injector
- Evidence URL：
  - PR CI run（開 PR 後）

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 AI-safe `make ai-*` readback / 驗證 command surface
- Approx changed lines：~59（僅 Makefile）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a — 僅 tooling（Makefile）單層級
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] The added command surface is documented by executable targets.
- [x] Each target either runs an existing repo command or prints a clear unavailable / skipped reason.
- [x] The PR verifies the changed targets locally where practical.
- [x] The command surface is scoped to safe readback / verification tasks.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
$ make ai-readback
branch: chore/ai-safe-make-command-surface
origin/develop: f4616a1ef7c771030c5126ad85bd2ac40c461ba0
working tree: dirty
 M Makefile
pointers: CLAUDE.md docs/ai/ .claude/rules/

$ make -n ai-docs-build ai-test-backend ai-test-extension ai-test-dashboard ai-pr-check
# 全部 dry-run 無 Make syntax error；pnpm/docker 指令展開正確，缺工具時走 graceful skip
```

## 備註
實作由 Codex rescue worker 完成、Claude controller 審查定稿。審查時移除了 worker 在 `ai-readback` 加入的 machine-specific 硬編路徑 `git -c lfs.storage=/tmp/tachigo-ai-lfs status`，改回可攜的 `git status --short`（已驗證行為一致）。

## Notes for Claude Code Review
- 套件管理器假設為 pnpm，已核實 `package.json` 的 `packageManager: pnpm@10.33.0` 與相關 script 名稱真實存在。
- 所有 `ai-*` target 在缺 docker / pnpm / 對應 package.json 時都印 `skipped/unavailable: <reason>` 並 exit 0，不會 fail。
- `ai-pr-check` 僅包裝既有 `pr-meta-check`，無參數時印 usage，不執行任何 GitHub 寫入。
