### PR TITLE
[backend] consolidate event/admin RBAC matrix tests

### DIFF
--- a/services/api/internal/handlers/rbac_handler_test.go
+++ b/services/api/internal/handlers/rbac_handler_test.go
@@ -197,54 +197,51 @@ func TestRBACMatrix_DashboardRoutes(t *testing.T) {
 	}
 }
 
-// ── GET /admin/users ──────────────────────────────────────────────────────────
-
-// viewer token → 403
-func TestRBAC_AdminUsers_ViewerForbidden(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleViewer)
-
-	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", token); got != http.StatusForbidden {
-		t.Errorf("viewer: want 403, got %d", got)
+func TestRBACMatrix_EventAndAdminStubRoutes(t *testing.T) {
+	eventOperatorCases := []rbacMatrixCase{
+		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+		{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
+		{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
+		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
 	}
-}
-
-// streamer token → 403
-func TestRBAC_AdminUsers_StreamerForbidden(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleStreamer)
-
-	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", token); got != http.StatusForbidden {
-		t.Errorf("streamer: want 403, got %d", got)
+	adminOnlyCases := []rbacMatrixCase{
+		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+		{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
+		{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
+		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
 	}
-}
 
-// agency token → 403
-func TestRBAC_AdminUsers_AgencyForbidden(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleAgency)
-
-	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", token); got != http.StatusForbidden {
-		t.Errorf("agency: want 403, got %d", got)
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		cases  []rbacMatrixCase
+	}{
+		{
+			name:   "create event allows event operators",
+			method: http.MethodPost,
+			path:   "/api/v1/events/create",
+			cases:  eventOperatorCases,
+		},
+		{
+			name:   "settle event allows event operators",
+			method: http.MethodPost,
+			path:   "/api/v1/events/1/settle",
+			cases:  eventOperatorCases,
+		},
+		{
+			name:   "admin users is admin only",
+			method: http.MethodGet,
+			path:   "/api/v1/admin/users",
+			cases:  adminOnlyCases,
+		},
 	}
-}
 
-// admin token → 501（handler 尚未實作，但通過授權）
-func TestRBAC_AdminUsers_AdminAllowed(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleAdmin)
-
-	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", token); got != http.StatusNotImplemented {
-		t.Errorf("admin: want 501, got %d", got)
-	}
-}
-
-// 無 token → 401
-func TestRBAC_AdminUsers_NoToken(t *testing.T) {
-	env := newRBACTestEnv(t)
-
-	if got := doRequest(env.router, http.MethodGet, "/api/v1/admin/users", ""); got != http.StatusUnauthorized {
-		t.Errorf("no token: want 401, got %d", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newRBACTestEnv(t)
+			assertRBACMatrix(t, env, tt.method, tt.path, tt.cases)
+		})
 	}
 }
 
@@ -275,57 +272,6 @@ func TestRBAC_CreateAgency_AdminAllowed(t *testing.T) {
 	token := env.tokenForRole(t, models.RoleAdmin)
 
 	if got := doRequest(env.router, http.MethodPost, "/api/v1/agencies", token); got != http.StatusNotImplemented {
-		t.Errorf("admin: want 501, got %d", got)
-	}
-}
-
-// ── POST /events/create ───────────────────────────────────────────────────────
-
-// 無 token → 401
-func TestRBAC_CreateEvent_NoToken(t *testing.T) {
-	env := newRBACTestEnv(t)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/create", ""); got != http.StatusUnauthorized {
-		t.Errorf("no token: want 401, got %d", got)
-	}
-}
-
-// viewer → 403
-func TestRBAC_CreateEvent_ViewerForbidden(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleViewer)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/create", token); got != http.StatusForbidden {
-		t.Errorf("viewer: want 403, got %d", got)
-	}
-}
-
-// streamer → 501（通過授權）
-func TestRBAC_CreateEvent_StreamerAllowed(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleStreamer)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/create", token); got != http.StatusNotImplemented {
-		t.Errorf("streamer: want 501, got %d", got)
-	}
-}
-
-// agency → 501（通過授權）
-func TestRBAC_CreateEvent_AgencyAllowed(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleAgency)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/create", token); got != http.StatusNotImplemented {
-		t.Errorf("agency: want 501, got %d", got)
-	}
-}
-
-// admin → 501（通過授權）
-func TestRBAC_CreateEvent_AdminAllowed(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleAdmin)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/create", token); got != http.StatusNotImplemented {
 		t.Errorf("admin: want 501, got %d", got)
 	}
 }
@@ -450,57 +396,6 @@ func TestRBAC_ListAgencyStreamers_AdminAllowed(t *testing.T) {
 	token := env.tokenForRole(t, models.RoleAdmin)
 
 	if got := doRequest(env.router, http.MethodGet, "/api/v1/agencies/1/streamers", token); got != http.StatusNotImplemented {
-		t.Errorf("admin: want 501, got %d", got)
-	}
-}
-
-// ── POST /events/:id/settle ───────────────────────────────────────────────────
-
-// 無 token → 401
-func TestRBAC_SettleEvent_NoToken(t *testing.T) {
-	env := newRBACTestEnv(t)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/1/settle", ""); got != http.StatusUnauthorized {
-		t.Errorf("no token: want 401, got %d", got)
-	}
-}
-
-// viewer → 403（有 token 但角色不符，應回 403 而非 401）
-func TestRBAC_SettleEvent_ViewerForbidden(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleViewer)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/1/settle", token); got != http.StatusForbidden {
-		t.Errorf("viewer: want 403, got %d", got)
-	}
-}
-
-// streamer → 501（通過授權）
-func TestRBAC_SettleEvent_StreamerAllowed(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleStreamer)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/1/settle", token); got != http.StatusNotImplemented {
-		t.Errorf("streamer: want 501, got %d", got)
-	}
-}
-
-// agency → 501（通過授權）
-func TestRBAC_SettleEvent_AgencyAllowed(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleAgency)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/1/settle", token); got != http.StatusNotImplemented {
-		t.Errorf("agency: want 501, got %d", got)
-	}
-}
-
-// admin → 501（通過授權）
-func TestRBAC_SettleEvent_AdminAllowed(t *testing.T) {
-	env := newRBACTestEnv(t)
-	token := env.tokenForRole(t, models.RoleAdmin)
-
-	if got := doRequest(env.router, http.MethodPost, "/api/v1/events/1/settle", token); got != http.StatusNotImplemented {
 		t.Errorf("admin: want 501, got %d", got)
 	}
 }


### PR DESCRIPTION
## 什麼改動

- Convert the `/events/create`, `/events/:id/settle`, and `/admin/users` RBAC stub route tests into one centralized matrix test.
- Keep the existing agency route scattered tests unchanged for a follow-up #646 slice.

## 為什麼

- #646 asks for centralized RBAC matrix regression coverage.
- This small cut removes duplicated event/admin role assertions while preserving the same unauthenticated, wrong-role, and allowed-role expectations.

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#646
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Does not change production auth/RBAC behavior.
  - Does not expand to all #646 protected endpoints.
  - Does not change router wiring or handler implementations.
  - Does not update permission docs.

## Local validation

- `spec plan 646 --repo . --dry-run --format prompt --verbose`
- `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRBACMatrix|TestRBAC_(CreateEvent|SettleEvent|AdminUsers|CreateAgency)' -count=1`
- `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRBACMatrix|TestRBAC_(CreateAgency|UpdateAgencySettings|ListAgencyStreamers)' -count=1`
- `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -count=1`
- `git diff --check`
- spec gate status: pass
- spec_evidence_ref: local dry-run `spec plan 646 --repo . --dry-run --format prompt --verbose`

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：
  - #646 has broad matrix-test acceptance criteria; this PR intentionally selects one small event/admin tests-only slice.
- Actual worker profile(s)：
  - controller_direct
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller_direct model=gpt-5.5 reasoning=medium controller_fallback=allowed fallback_reason=single-file tests-only matrix refactor was cheaper and safer than a subagent merge path
- Verification evidence：
  - `go test ./internal/handlers` plus focused RBAC matrix runs listed above.
- Self-review / exception reason：
  - trivial/self-only exception reason: no production code changed; only duplicated tests were consolidated into an existing helper shape.
- Worker session closeout：
  - No child worker was opened for this cut; controller-direct fallback recorded above and no stale worker remains.
- Workflow friction / follow-up split：
  - Follow-up #646 slices should cover remaining agency ownership/endpoints and route coverage gating separately.

## Final merge gate

- Ready-to-merge decision：
  - blocked until GitHub checks and human review complete
- Latest head SHA：
  - n/a before PR creation
- Required checks：
  - local handler tests pass; GitHub checks not created yet
- spec workflow-check evidence：
  - pass via `spec workflow-check --repo . --phase commit --issue 646 --pr-body /tmp/tachigo-pr-646-event-admin-body.md --format text`
- Evidence URL：
  - n/a before PR creation
