### PR TITLE
[frontend] Fix raffle result stale state on id change

### DIFF
--- a/apps/extension/src/hooks/useRaffleResult.ts
+++ b/apps/extension/src/hooks/useRaffleResult.ts
@@ -6,6 +6,7 @@ const POLL_INTERVAL_MS = 5_000
 
 export function useRaffleResult(raffleId: string | null) {
   const [draws, setDraws] = useState<RaffleResultDraw[]>([])
+  const [loadedRaffleId, setLoadedRaffleId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -20,11 +21,14 @@ export function useRaffleResult(raffleId: string | null) {
         const result = await getRaffleResult(raffleId)
         if (!isDisposed) {
           setDraws(result)
+          setLoadedRaffleId(raffleId)
           setError(null)
           setLoading(false)
         }
       } catch {
         if (!isDisposed) {
+          setDraws([])
+          setLoadedRaffleId(raffleId)
           setError('load_failed')
           setLoading(false)
         }
@@ -44,14 +48,10 @@ export function useRaffleResult(raffleId: string | null) {
       }
     }
 
-    const loadingTimer = window.setTimeout(() => {
-      if (!isDisposed) setLoading(true)
-    }, 0)
     void pollLoop()
 
     return () => {
       isDisposed = true
-      window.clearTimeout(loadingTimer)
       if (timer !== null) {
         window.clearTimeout(timer)
       }
@@ -62,5 +62,10 @@ export function useRaffleResult(raffleId: string | null) {
     return { draws: [], loading: false, error: null }
   }
 
-  return { draws, loading, error }
+  const isCurrentRaffle = loadedRaffleId === raffleId
+  return {
+    draws: isCurrentRaffle ? draws : [],
+    loading: isCurrentRaffle ? loading : true,
+    error: isCurrentRaffle ? error : null,
+  }
 }


### PR DESCRIPTION
## 什麼改動

- 修正 `useRaffleResult` 在 `raffleId` 切換時會暫時回傳上一個 raffle draws/error 的 stale state。
- 以 `loadedRaffleId` 將已載入資料和目前 prop 對齊；當新 raffle 尚未載入完成時，hook 會回傳空 draws、`loading: true`、`error: null`。
- 保留原本 polling / cleanup 行為，不新增或修改 test 檔案。

## 為什麼

refs #412

#412 要求審查 extension hooks / state 管理與 race condition，且每個 confirmed bug 各開獨立 PR 修復。`useRaffleResult` 在 raffle 切換時舊結果可能短暫顯示在新 raffle UI 上，屬於 state ownership mismatch；這張 PR 只修這個 hook 的 stale state 顯示。

## Release Context

- Release type：n/a

## Workflow Type

- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#412
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 test 檔案
  - 不重構 hooks 或 API client
  - 不修改 raffle API contract
  - 不改 App flow、components、i18n、dashboard、backend 或 docs
  - 不關閉 #412；這只是其中一個 confirmed hook/state bug slice

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：
  - #412 hook/state audit; selected one confirmed stale-state slice in `useRaffleResult`.
- Actual worker profile(s)：
  - controller-direct fallback
- Model strength：
  - controller = current Codex; reasoning = medium
- Spawn directive(s)：
  - profile=controller_direct model=current-codex reasoning=medium controller_fallback=allowed fallback_reason=single_hook_stale_state_fix_no_parallel_write_surface
- Verification evidence：
  - spec gate status: pass
  - `spec plan 412 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 412`
  - `git diff --check`
  - `pnpm install --frozen-lockfile --ignore-scripts`
  - `pnpm --filter tachimint lint`
  - `pnpm --filter tachimint build`
  - `pnpm --filter tachimint test -- useRaffleResult`
  - `spec workflow-check --repo . --phase commit --issue 412 --pr-body /tmp/tachigo-pr-412-raffle-result-body.md --format text`
- Self-review / exception reason：
  - controller-direct fallback is used because this is a single-hook frontend behavior fix with one-file diff and no test-file changes, matching #412's independent confirmed-bug requirement.
- Worker session closeout：
  - No worker session was opened; controller-direct fallback recorded before commit and no child-owned files exist.
- Workflow friction / follow-up split：
  - #412 remains broad; this PR intentionally handles only the `useRaffleResult` stale result slice. Other hook/component/API findings remain separate future PRs.

## Review conversation closeout

- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - pending after PR creation
- chatgpt-codex-connector：
  - self-authored PR, no self-review requested
- review_triage_ref：
  - pending with reason: no external review findings exist at PR creation
- root_cause_gate_ref：
  - latest-head rationale in this PR body; state ownership is now keyed by `loadedRaffleId`
- finding_disposition_ref：
  - pending with reason: no findings exist at PR creation
- Final reviewer action：
  - pending human review

## Final merge gate

- Ready-to-merge decision：
  - blocked until GitHub checks and human review complete
- Latest head SHA：
  - n/a before PR creation
- Required checks：
  - pending with reason: GitHub checks start after PR creation
- spec workflow-check evidence：
  - local start/commit gates pass; commit gate evidence listed above
- Evidence URL：
  - n/a before PR creation

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - Prevent `useRaffleResult` from exposing stale raffle draws while a newly selected raffle is loading.
- Approx changed lines：~15
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria

- [x] Fix one confirmed hook/state bug as an independent PR.
- [x] Avoid stale raffle result rendering when `raffleId` changes.
- [x] Preserve existing polling and cleanup behavior.
- [x] Do not touch test files or unrelated extension surfaces.
- [x] CI/local validation passes.

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [ ] 有寫 / 更新測試（#412 明確不動 test 檔案）

**驗證結果**
```text
spec plan 412 --repo . --dry-run --format prompt --verbose
pass; warning: stale old-path references `docs/claude-codex-workflow.md` and `src/TwitchApp.tsx`

spec workflow-check --repo . --phase start --issue 412
pass

git diff --check
pass

pnpm --filter tachimint lint
pass

pnpm --filter tachimint build
pass

pnpm --filter tachimint test -- useRaffleResult
16 test files passed, 66 tests passed

spec workflow-check --repo . --phase commit --issue 412 --pr-body /tmp/tachigo-pr-412-raffle-result-body.md --format text
pass
```

## 備註

第一次驗證時新 worktree 沒有 `node_modules`，因此先執行 `pnpm install --frozen-lockfile --ignore-scripts`；lockfile 未變更，`node_modules` / `dist` 皆為 ignored。

## Notes for Claude Code Review

- 請確認 render-time guard 是否比 effect 內同步清 state 更符合 React hooks lint 規則。
- 請確認這張 PR 沒有擴大成 #412 的完整 audit closeout。

