### PR TITLE
[backend] docs: document request-context detached paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ tachigo/
 | System architecture | [docs/architecture.md](docs/architecture.md) |
 | Auth baseline | [docs/auth-architecture.md](docs/auth-architecture.md) |
 | Backend permissions | [docs/backend-permissions.md](docs/backend-permissions.md) |
+| Backend request context | [docs/backend-request-context.md](docs/backend-request-context.md) |
 | Backend staging deploy | [docs/backend-staging-deploy.md](docs/backend-staging-deploy.md) |
 | Cross-surface smoke baseline | [docs/cross-surface-smoke.md](docs/cross-surface-smoke.md) |
 | Chrome sidepanel migration | [docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md](docs/history/2026-04-16-tachimint-chrome-sidepanel-migration.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@
 | [`architecture.md`](architecture.md) | 系統整體架構與主要資料流 |
 | [`auth-architecture.md`](auth-architecture.md) | Auth 現況與 migration guardrails |
 | [`backend-permissions.md`](backend-permissions.md) | Backend role / permission 現況與變更 guardrails |
+| [`backend-request-context.md`](backend-request-context.md) | Backend request context 與刻意 detached DB 路徑 baseline |
 | [`auto-merge-policy.md`](auto-merge-policy.md) | Auto-merge 與 approve 語義 |
 | [`dependabot-update-policy.md`](dependabot-update-policy.md) | Dependabot 更新政策 |
 | [`draft-pr-auto-ready.md`](draft-pr-auto-ready.md) | Draft PR auto-ready 現行流程 |

--- a/docs/backend-request-context.md
+++ b/docs/backend-request-context.md
@@ -1,0 +1,59 @@
+# Backend Request Context Baseline
+
+## Purpose
+
+This document records the current request-context boundary for backend DB work
+tracked by #645. It is a review aid for request timeout cancellation work; it
+does not introduce new timeout policy, queue architecture, or worker behavior.
+
+## Request-scoped DB rule
+
+HTTP handlers should pass `c.Request.Context()` into service methods that accept
+`context.Context`. Service-layer DB reads, writes, and transactions that belong
+to that request should use `db.WithContext(ctx)` or a transaction that inherited
+that context.
+
+Legacy wrapper methods that do not accept a context may use
+`context.Background()` only as a compatibility boundary for non-request callers
+and tests. New request-serving paths should prefer the `*Context` form.
+
+## Transaction context rule
+
+Transactions started from `db.WithContext(ctx).Transaction(...)` carry the
+request context through `tx.Statement.Context`. Helpers that need to re-enter
+GORM with an explicit context should preserve that statement context rather than
+falling back to a fresh background context.
+
+Example: `loadTachiBalanceValue(ctx, db, userID)` accepts an explicit context,
+and `finalizeClaim` calls it with `gormStatementContext(tx)` so balance readback
+stays aligned with the transaction context.
+
+## Intentionally detached DB paths
+
+The following paths are intentionally not a mechanical `WithContext(requestCtx)`
+replacement target. Some are true async jobs; others are synchronous
+post-side-effect persistence paths where cancellation semantics must preserve
+reconciliation evidence before they are changed.
+
+| Path | Current boundary | Why detached |
+| --- | --- | --- |
+| `RaffleScheduler.Start` scheduled snapshots | The scheduler is launched with its own lifecycle context. Each run creates a five-minute child context and passes it through `RunScheduledSnapshots`, `snapshotOne`, and DB calls that use `s.db.WithContext(ctx)`. | This is not tied to an HTTP request. The scheduler should stop on process/service lifecycle cancellation, not on any viewer/admin request cancellation. |
+| Raffle winner email / Discord notification goroutines | `DrawNext` / `DrawFromTier` start short-lived goroutines that create a fresh 30-second background timeout before calling notification helpers. Those helpers use that timeout for DB lookup and outbound delivery. | Notification delivery is intentionally best-effort after the draw is already committed. It should not inherit a canceled request context and undo or block the draw response path. |
+| `ClaimService.Claim` post-mint / compensation transactions | The initial reservation transaction uses `s.db.WithContext(ctx)`. Rollback, broadcast recording, receipt-unknown recording, failure compensation, finalize, and finalize-failed marking currently use service DB transactions without the request context. | After a mint transaction is broadcast, a canceled HTTP request must not prevent local claim status, compensation, or reconciliation markers from being persisted. A future change needs dedicated tests for canceled requests after broadcast and receipt uncertainty. |
+| `SpendService.Redeem` after burn / Tachiya handoff | The initial reservation transaction uses `s.db.WithContext(ctx)`. Burn uses a child timeout of the request context. Coupon redemption recording, post-burn status updates, and reservation rollback currently use service DB operations without the request context; Tachiya redemption uses its own background timeout. | After a burn is broadcast, local `coupon_redemptions` rows and compensation-needed state are the recovery trail. Existing tests assert the Tachiya call can outlive a canceled request after burn. |
+
+## Change requirements
+
+Any PR that converts one of the detached paths above to request-scoped DB work
+must include regression coverage for the cancellation point it changes. At
+minimum, tests should prove that a canceled request cannot leave one of these
+states without a durable recovery marker:
+
+- claim reservation consumed but no claim status or compensation marker;
+- mint broadcast recorded by chain but missing local claim broadcast evidence;
+- burn broadcast recorded by chain but missing local coupon redemption evidence;
+- Tachiya voucher issued but local redemption status missing reconciliation data.
+
+If the desired behavior is to keep post-chain persistence detached, keep that
+decision documented here instead of hiding it in broad context-propagation
+cleanup.


### PR DESCRIPTION
## 什麼改動

- 新增 `docs/backend-request-context.md`，記錄 backend request context baseline、transaction context 規則、以及 #645 目前不該機械套 request context 的 detached paths。
- 在 `README.md` 與 `docs/README.md` 加上文件索引連結。

## 為什麼

refs #645

#645 的 AC 包含「Document any intentionally detached async job paths」。這張 PR 先把已知的 async job / post-side-effect persistence 邊界寫清楚，避免後續 context-propagation PR 把鏈上 mint/burn 後的補償紀錄誤改成會被 HTTP request cancellation 中斷。

## Release Context

- Release type：n/a

## Workflow Type

- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [x] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [ ] yes
  - [ ] no
  - n/a：docs-only，未改 backend contract
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 service / handler behavior
  - 不改 timeout policy values
  - 不引入 queue / worker architecture redesign
  - 不宣稱完成 #645 全部 context-propagation AC

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：
  - #645 無 issue delegation plan；依 heartbeat AWP loop 執行
- Actual worker profile(s)：
  - explorer / controller
- Model strength：
  - controller = current Codex session
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=inherited controller_fallback=allowed fallback_reason=parallel issue-candidate scan before bounded implementation
  - profile=controller model=current-codex-session reasoning=current controller_fallback=allowed fallback_reason=tiny docs-only implementation after explorer scan
- Verification evidence：
  - `spec plan 645 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase start --issue 645 --format text`
  - `git diff --check`
  - `make ai-docs-build`
- Self-review / exception reason：
  - docs-only self-review performed locally; no self GitHub review requested
- Worker session closeout：
  - explorer session closed after candidate scan
- Workflow friction / follow-up split：
  - This PR records a narrow #645 documentation slice only. Remaining request-context code/test AC stay on #645 or future scoped PRs.

## Review conversation closeout

- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - pending PR creation
- chatgpt-codex-connector：
  - n/a; self-authored PR should not be reviewed by Codex in the heartbeat loop
- review_triage_ref：
  - local spec plan/workflow-check evidence above
- root_cause_gate_ref：
  - local spec plan/workflow-check evidence above
- finding_disposition_ref：
  - n/a at PR creation
- Final reviewer action：
  - pending human/automated review

## Final merge gate

- Ready-to-merge decision：
  - pending PR checks/review
- Latest head SHA：
  - 6375503c77bcf099f7289bcbc9b358592552a268
- Required checks：
  - pending after PR creation
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:start:issue-645
- Evidence URL：
  - n/a before PR creation

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - Document #645 backend request-context detached paths.
- Approx changed lines：~75
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria

- [ ] Audit all DB queries and transactions under `services/api`
- [ ] All service-layer DB access paths propagate request context
- [ ] All GORM / sql queries use `WithContext(ctx)` or equivalent
- [ ] Transaction helpers preserve context
- [ ] Add regression tests for canceled request context
- [ ] Add at least one integration test proving timeout cancels DB work
- [x] Document any intentionally detached async job paths

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**

```text
spec workflow-check --repo . --phase start --issue 645 --format text
status=pass
warnings=Not found: docs/claude-codex-workflow.md

spec workflow-check --repo . --phase commit --issue 645 --pr-body /tmp/tachigo-pr-645-request-context.md --format text
status=pass
missing_fields=none

git diff --check
pass

make ai-docs-build
[SUCCESS] Generated static files in "build".
```

## 備註

- `make ai-docs-build` 第一次在新 worktree 因 `node_modules` 不存在而找不到 `docusaurus`；已用 `pnpm install --frozen-lockfile` 補齊依賴後重跑通過，lockfile 未變更。
- Docusaurus build 對新未追蹤文件顯示 update-date warning，提交後應消失。

## Notes for Claude Code Review

- 這張 PR 不改 production behavior，只把 #645 後續 code PR 不能機械修改的 cancellation 邊界寫成 review baseline。
- `docs/claude-codex-workflow.md` 是 spec-injector always-read 缺檔；本 PR 未嘗試補該文件，避免 scope pollution。
