### PR TITLE
[backend] fix: propagate points deduct request context

### DIFF
--- a/services/api/internal/services/points_service.go
+++ b/services/api/internal/services/points_service.go
@@ -108,11 +108,15 @@ func (s *PointsService) ListTransactionsContext(ctx context.Context, userID uuid
 // cumulative_total is never modified by a deduction.
 // Returns ErrInsufficientBalance if the current spendable balance is too low.
 func (s *PointsService) DeductPoints(userID uuid.UUID, channelID string, amount int64, note string) error {
+	return s.DeductPointsContext(context.Background(), userID, channelID, amount, note)
+}
+
+func (s *PointsService) DeductPointsContext(ctx context.Context, userID uuid.UUID, channelID string, amount int64, note string) error {
 	if err := validatePositivePointsAmount(amount); err != nil {
 		return err
 	}
 
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	return s.dbWithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var ledger models.PointsLedger
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 			Where("user_id = ? AND channel_id = ?", userID, channelID).

--- a/services/api/internal/services/points_service_test.go
+++ b/services/api/internal/services/points_service_test.go
@@ -159,6 +159,31 @@ func TestPointsService_DeductPoints_Success(t *testing.T) {
 	}
 }
 
+func TestPointsService_DeductPointsContext_UsesRequestContext(t *testing.T) {
+	svc, _ := newPointsSvc(t)
+	userID := seedViewer(t, svc)
+	key := pointsContextKey("points-deduct-context")
+	seen := installDBContextProbe(t, svc.db, key, "points-deduct")
+
+	if err := svc.AddPoints(userID, "ch_abc", models.TxSourceTPoint, 100); err != nil {
+		t.Fatalf("seed points: %v", err)
+	}
+
+	err := svc.DeductPointsContext(
+		context.WithValue(context.Background(), key, "points-deduct"),
+		userID,
+		"ch_abc",
+		30,
+		"avatar",
+	)
+	if err != nil {
+		t.Fatalf("deduct points with context: %v", err)
+	}
+	if seen() == 0 {
+		t.Fatal("expected DeductPointsContext DB operations to carry request context")
+	}
+}
+
 // ─── AddPoints ───────────────────────────────────────────────────────────────
 
 func TestPointsService_AddPoints_IncreasesBothBalances(t *testing.T) {


### PR DESCRIPTION
## 什麼改動
新增 `PointsService.DeductPointsContext`，讓扣點交易可沿用 request context 執行 DB transaction；既有 `DeductPoints` 保持相容，改為包一層 `context.Background()` 呼叫。

## 為什麼
refs #645。這是 request-scoped DB baseline 的一個小切片，先把 points deduct 的 service 層 DB work 從 detached context 改成可注入 context，並用 regression test 鎖住。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#645
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不關閉 #645 的全部範圍
  - 不改 raffle / extension claim / spend 其他 detached DB paths
  - 不新增 timeout policy、worker queue 或跨 service context architecture
  - 不改 API handler / router / schema / migration

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #645 未附專門 delegation plan；依 heartbeat AWP + spec-injector loop 執行小切片。
- Actual worker profile(s)：
  - controller
- Model strength：
  - controller = current Codex session
- Spawn directive(s)：
  - profile=controller model=current-codex-session reasoning=current controller_fallback=allowed fallback_reason=tiny-service-test-slice-after-overlap-scan
- Verification evidence：
  - spec plan 645 --repo . --dry-run --format prompt --verbose
  - spec workflow-check --repo . --phase start --issue 645 --format text
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestPointsService_DeductPointsContext_UsesRequestContext -count=1
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestPointsService_(DeductPoints|AddPoints|ListTransactions|GetBalance)' -count=1
  - GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -count=1
  - git diff --check
- Self-review / exception reason：
  - trivial self-only service/test slice；no GitHub self-review requested or performed。
- Worker session closeout：
  - controller-direct fallback recorded；no spawned implementation worker to close。
- Workflow friction / follow-up split：
  - n/a；本 PR 只補 #645 的 points deduct context propagation 小切片。

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - Awaiting automated review after PR creation.
- chatgpt-codex-connector：
  - n/a；self-authored PR will not be reviewed by Codex loop.
- review_triage_ref：
  - local latest-head rationale: points deduct service/test only, no open PR overlap.
- root_cause_gate_ref：
  - local TDD red/green evidence: missing DeductPointsContext compiled red before implementation.
- finding_disposition_ref：
  - local disposition: no external findings before PR creation; scope intentionally deferred for remaining #645 paths.
- Final reviewer action：
  - Awaiting human/automated review after PR creation.

## Final merge gate
- Ready-to-merge decision：
  - not ready yet; awaiting PR checks and external review after PR creation
- Latest head SHA：
  - 2247a52dfc72477f60b402001bd43dc44319e94a
- Required checks：
  - not run yet; PR not created when this body was drafted
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:start:issue-645
- Evidence URL：
  - n/a before PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 PointsService 扣點交易支援 request context 傳遞。
- Approx changed lines：~35
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Regression test 與 service 行為變更必須同 PR，才能證明 request context 確實進到 DB operation。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 使用 `db.WithContext` / equivalent 讓 points deduct DB work 攜帶 request context。
- [x] 保留既有 `DeductPoints` call site 相容性。
- [x] 新增 regression test 驗證 `DeductPointsContext` 的 DB operation 可讀到 injected context value。
- [ ] 完成 #645 全部 detached path audit / conversion。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
spec plan 645 --repo . --dry-run --format prompt --verbose
pass; warning: Not found: docs/claude-codex-workflow.md

spec workflow-check --repo . --phase start --issue 645 --format text
phase=start
status=pass
missing_fields=none
warnings=Not found: docs/claude-codex-workflow.md

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestPointsService_DeductPointsContext_UsesRequestContext -count=1
ok github.com/tachigo/tachigo/internal/services 0.407s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestPointsService_(DeductPoints|AddPoints|ListTransactions|GetBalance)' -count=1
ok github.com/tachigo/tachigo/internal/services 0.252s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -count=1
ok github.com/tachigo/tachigo/internal/services 2.687s

git diff --check
pass
```

## 備註
`spec plan` / `workflow-check` 目前提示 `docs/claude-codex-workflow.md` missing；本 PR 沒有擴張 scope 去補 workflow 文件。

## Notes for Claude Code Review
- 請特別看 `DeductPoints` wrapper 是否符合既有 call site 相容需求，以及 `DeductPointsContext` 是否足以代表 #645 的 points deduct 小切片。
