### PR TITLE
[frontend] fix: reset click boost transient state

### DIFF
--- a/apps/extension/src/hooks/useClickBoost.ts
+++ b/apps/extension/src/hooks/useClickBoost.ts
@@ -46,6 +46,25 @@ export function useClickBoost(
     [stopCooldown],
   )
 
+  const stopAnimation = useCallback(() => {
+    if (animTimerRef.current !== null) {
+      clearTimeout(animTimerRef.current)
+      animTimerRef.current = null
+    }
+    setIsAnimating(false)
+    setGain(null)
+  }, [])
+
+  useEffect(() => {
+    const resetTimer = window.setTimeout(() => {
+      stopCooldown()
+      stopAnimation()
+    }, 0)
+    return () => {
+      window.clearTimeout(resetTimer)
+    }
+  }, [channelId, enabled, stopAnimation, stopCooldown])
+
   const handleClick = useCallback(async () => {
     if (!channelId || !enabled || onCooldownRef.current) return
 
@@ -62,6 +81,7 @@ export function useClickBoost(
       animTimerRef.current = window.setTimeout(() => {
         setIsAnimating(false)
         setGain(null)
+        animTimerRef.current = null
       }, ANIM_DURATION_MS)
     } catch (err: unknown) {
       if (!mountedRef.current) return


### PR DESCRIPTION
## 什麼改動
修正 `useClickBoost` 在 `channelId` 變更或 click boost 停用時沒有清掉 cooldown / gain animation 的 transient state，避免上一個 channel/session 的冷卻狀態擋住下一次互動。

## 為什麼
refs #412。這是 hooks/state race audit 的 confirmed bug 小切片：`useClickBoost` 的 cooldown 是 per channel/session UI state，但原本只在 unmount 或倒數結束時清除，channel 切換或 backend readiness 改變時會沿用舊狀態。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#412
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不關閉 #412 全部 audit 範圍
  - 不改 API client、其他 hooks、App 主流程或 UI 文案
  - 不新增/修改 test 檔案（#412 明確寫「不動 test 檔案」）
  - 不混入 dead code 移除或重構

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #412 未附專門 delegation plan；依 heartbeat AWP + spec-injector loop 執行 confirmed bug 小切片。
- Actual worker profile(s)：
  - controller
- Model strength：
  - controller = current Codex session
- Spawn directive(s)：
  - profile=controller model=current-codex-session reasoning=current controller_fallback=allowed fallback_reason=tiny-single-hook-confirmed-bug-after-readonly-audit
- Verification evidence：
  - spec plan 412 --repo . --dry-run --format prompt --verbose
  - spec workflow-check --repo . --phase start --issue 412 --format text
  - pnpm install --frozen-lockfile
  - pnpm --filter ./apps/extension lint
  - pnpm --filter ./apps/extension build
  - pnpm --filter ./apps/extension test
  - git diff --check
- Self-review / exception reason：
  - trivial self-only single-hook fix；no GitHub self-review requested or performed。
- Worker session closeout：
  - controller-direct fallback recorded；no spawned implementation worker to close。
- Workflow friction / follow-up split：
  - `spec plan` still surfaces legacy `src/TwitchApp.tsx` alias hints even though #412 body now points to `apps/extension`; kept this PR to one hook and did not broaden audit scope.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - Awaiting automated review after PR creation.
- chatgpt-codex-connector：
  - n/a；self-authored PR will not be reviewed by Codex loop.
- review_triage_ref：
  - local latest-head rationale: #412 hook audit found one confirmed `useClickBoost` transient state leak; no open PR overlap.
- root_cause_gate_ref：
  - local lint gate: first implementation triggered `react-hooks/set-state-in-effect`; fixed by following existing deferred reset pattern.
- finding_disposition_ref：
  - local disposition: adopted lint finding; deferred remaining #412 audit surfaces to separate PRs.
- Final reviewer action：
  - Awaiting human/automated review after PR creation.

## Final merge gate
- Ready-to-merge decision：
  - not ready yet; awaiting PR checks and external review after PR creation
- Latest head SHA：
  - 01d472a8eeaefaa9bcd6087a1e25d3212c695a6f
- Required checks：
  - not run yet; PR not created when this body was drafted
- spec workflow-check evidence：
  - spec gate status: pass
  - spec evidence ref: workflow-check:start:issue-412
- Evidence URL：
  - n/a before PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 重置 click boost 在 channel/session 變更時的冷卻與動畫暫態。
- Approx changed lines：~20
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 審查 `apps/extension/src/hooks/useClickBoost.ts` 的 cleanup / race condition。
- [x] 修正一個 confirmed hook state bug。
- [x] 不修改 test 檔案、不混入其他 audit surface。
- [ ] 完成 #412 全部 hooks / API / App audit。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
spec plan 412 --repo . --dry-run --format prompt --verbose
pass; warning: Not found: docs/claude-codex-workflow.md; legacy src/TwitchApp.tsx alias hint

spec workflow-check --repo . --phase start --issue 412 --format text
phase=start
status=pass
missing_fields=none

pnpm --filter ./apps/extension lint
pass

pnpm --filter ./apps/extension build
pass

pnpm --filter ./apps/extension test
Test Files 16 passed (16)
Tests 66 passed (66)

git diff --check
pass
```

## 備註
第一次 lint 抓到 `react-hooks/set-state-in-effect`，已改成與既有 hook pattern 相同的 deferred reset。

## Notes for Claude Code Review
- 請特別看 channel/session 變更時清 transient state 是否符合 click boost UX；本 PR 刻意不新增 test，因 #412 source issue 明確要求不動 test 檔案。
