### PR TITLE
[frontend] fix: recover coupon redeem auth

### DIFF
--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -242,15 +242,20 @@ export async function redeemCoupon(
   token: string,
 ): Promise<RedeemCouponResponse> {
   try {
-    const { data } = await client.post<{ success: boolean; data: RedeemCouponResponse }>(
-      '/spend/redeem',
-      { coupon_id: couponId, amount },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
+    const { data } = await runWithAuthRecovery((config) =>
+      client.post<{ success: boolean; data: RedeemCouponResponse }>(
+        '/spend/redeem',
+        { coupon_id: couponId, amount },
+        {
+          ...config,
+          headers: client.defaults.headers.common.Authorization
+            ? config?.headers
+            : {
+                ...config?.headers,
+                Authorization: `Bearer ${token}`,
+              },
         },
-      },
+      ),
     )
     return data.data
   } catch (error) {


### PR DESCRIPTION
## 什麼改動
- 將 extension coupon redeem request 納入既有 `runWithAuthRecovery`。
- 保留既有 coupon redeem endpoint contract，只有在沒有 tachigo bearer default header 時才使用呼叫端傳入的 fallback token。

## 為什麼
refs #412

#412 要求審查 `apps/extension/src/services/api.ts` 的 error handling 與 retry 邏輯。原本 `redeemCoupon` 直接呼叫 axios，遇到 401 不會走 extension JWT recovery，而且每次都用呼叫端 token 覆蓋 client 上已設定的 tachigo access token。這會讓已 refresh 的 bearer 無法在 redeem flow 中生效。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#412
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不動 test 檔案（遵守 #412）
  - 不改 coupon redeem endpoint contract
  - 不做 UI / state refactor

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #412
- Actual worker profile(s)：
  - controller-direct fallback
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller model=gpt-5 reasoning=high controller_fallback=true fallback_reason=one-file confirmed #412 API recovery slice below delegation threshold
- Verification evidence：
  - `spec plan 412 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --phase start --issue 412 --repo .`
  - `pnpm --filter ./apps/extension lint`
  - `pnpm --filter ./apps/extension build`
  - `pnpm --filter ./apps/extension test`
  - `git diff --check`
- Self-review / exception reason：
  - Self-reviewed locally; no public self-review requested.
- Worker session closeout：
  - Controller-direct fallback completed in the active session; no child worker session was spawned, no stale worker handles remain, and local verification evidence was read back before publish.
- Workflow friction / follow-up split：
  - n/a; compact dogfood datapoint will be posted to #664 after merge.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pending
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - local spec dry-run for #412
- root_cause_gate_ref：
  - local source trace: `executeCouponRedeem` -> `redeemCoupon` -> direct axios call bypassed `runWithAuthRecovery`
- finding_disposition_ref：
  - adopted
- Final reviewer action：
  - pending

## Final merge gate
- Ready-to-merge decision：
  - pending GitHub checks/review
- Latest head SHA：
  - n/a
- Required checks：
  - pending after PR creation
- spec workflow-check evidence：
  - spec workflow-check: pass
  - workflow-check evidence: local:start+commit-gate-412-coupon-redeem
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Make coupon redeem use the extension API client's existing auth recovery without overriding a refreshed tachigo bearer.
- Approx changed lines：~12
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 修復一個 confirmed `apps/extension/src/services/api.ts` API retry/auth recovery bug
- [x] 不動 test 檔案
- [x] CI 前本機 lint/build/test 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
pnpm --filter ./apps/extension lint
pass

pnpm --filter ./apps/extension build
pass

pnpm --filter ./apps/extension test
Test Files  16 passed (16)
Tests  66 passed (66)

git diff --check
pass
```

## 備註
- #412 明確要求不動 test 檔案；本 PR 只改 production code，使用既有 regression tests 驗證。

## Notes for Claude Code Review
- 這裡刻意保留 `/spend/redeem` endpoint contract，避免把 path contract / test contract 改動混進同一張 #412 bugfix PR。
