### PR TITLE
[chore] clarify CI scope router naming

### DIFF
--- a/.github/workflows/auto-ready-pr.yml
+++ b/.github/workflows/auto-ready-pr.yml
@@ -45,7 +45,7 @@ jobs:
             ])
             const requiredCheckSnapshots = {
               develop: [
-                { context: 'Scope gate', appId: 15368 },
+                { context: 'CI scope router', appId: 15368 },
                 { context: 'Supply-chain guardrails', appId: 15368 },
                 { context: 'TypeScript-only guardrail', appId: 15368 },
                 { context: 'Dependency Review', appId: 15368 },

--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -40,7 +40,7 @@ const contractsGasSnapshotPolicyPath = path.join(repoRoot, 'docs', 'contracts-ga
 const dependencyInventoryPolicyPath = path.join(repoRoot, 'docs', 'dependency-inventory-policy.md')
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 const developRequiredCheckRuns = [
-  'Scope gate',
+  'CI scope router',
   'Supply-chain guardrails',
   'TypeScript-only guardrail',
   'Dependency Review',
@@ -903,7 +903,7 @@ test('backend CI vet assertion does not match vet steps from later jobs', () => 
   )
 })
 
-test('scope gate and scope police use rename-aware allFilePaths for touches', async () => {
+test('CI scope router and scope police use rename-aware allFilePaths for touches', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
   const scopePolice = await readFile(scopePolicePath, 'utf8')
 
@@ -923,7 +923,7 @@ test('scope gate and scope police use rename-aware allFilePaths for touches', as
   )
 })
 
-test('scope gate and scope police recognize legacy and monorepo frontend/backend paths', async () => {
+test('CI scope router and scope police recognize legacy and monorepo frontend/backend paths', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
   const scopePolice = await readFile(scopePolicePath, 'utf8')
 
@@ -1160,7 +1160,7 @@ test('backend Docker runtime applies Atlas migrations before starting the API', 
   assert.match(composeOverride, /target: dev/)
 })
 
-test('scope gate backend contract regex accepts full-width and half-width colons', async () => {
+test('CI scope router backend contract regex accepts full-width and half-width colons', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
   const scopePolice = await readFile(scopePolicePath, 'utf8')
   const backendContractYesPattern =
@@ -2077,7 +2077,7 @@ Depends on PR: none
   )
 })
 
-test('docs/template-only PRs skip heavy product CI in scope gate', async () => {
+test('docs/template-only PRs skip heavy product CI in CI scope router', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
 
   assert.match(workflow, /const isDocsTemplateOrMetadataOnly =/)
@@ -2103,7 +2103,7 @@ test('docs/template-only PRs skip heavy product CI in scope gate', async () => {
   )
 })
 
-test('scope gate emits skipped product outputs for docs-only PRs', async () => {
+test('CI scope router emits skipped product outputs for docs-only PRs', async () => {
   const result = await runCiScopeGateWorkflow({
     prOverrides: { title: '[discussion] Document CI execution strategy' },
     files: [{ filename: 'docs/pr-scope-policy.md', additions: 12, deletions: 3, status: 'modified' }],
@@ -2134,7 +2134,7 @@ test('scope gate emits skipped product outputs for docs-only PRs', async () => {
   )
 })
 
-test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
+test('CI scope router emits path-aware outputs for frontend-only PRs', async () => {
   const result = await runCiScopeGateWorkflow({
     files: [{ filename: 'apps/extension/src/App.tsx', additions: 12, deletions: 3, status: 'modified' }],
   })
@@ -2154,7 +2154,7 @@ test('scope gate emits path-aware outputs for frontend-only PRs', async () => {
   })
 })
 
-test('scope gate emits full CI outputs for workflow file PRs', async () => {
+test('CI scope router emits full CI outputs for workflow file PRs', async () => {
   const fullOutputs = {
     run_ci: 'true',
     run_backend: 'true',
@@ -2169,7 +2169,7 @@ test('scope gate emits full CI outputs for workflow file PRs', async () => {
     run_contracts_gas_report: 'true',
   }
   const ciRuntime = await runCiScopeGateWorkflow({
-    prOverrides: { title: '[infra] Update CI scope gate' },
+    prOverrides: { title: '[infra] Update CI scope router' },
     files: [{ filename: '.github/workflows/ci.yml', additions: 8, deletions: 2, status: 'modified' }],
   })
   const ciRegression = await runCiScopeGateWorkflow({
@@ -2183,7 +2183,7 @@ test('scope gate emits full CI outputs for workflow file PRs', async () => {
   assert.equal(ciRegression.notices.some((notice) => notice.includes('Skipping heavy')), false)
 })
 
-test('scope gate emits dependency review output only for dependency file PRs', async () => {
+test('CI scope router emits dependency review output only for dependency file PRs', async () => {
   const extensionLockfile = await runCiScopeGateWorkflow({
     files: [{ filename: 'apps/extension/pnpm-lock.yaml', additions: 9, deletions: 2, status: 'modified' }],
   })
@@ -2199,7 +2199,7 @@ test('scope gate emits dependency review output only for dependency file PRs', a
   assert.equal(frontendSource.outputs.run_dependency_review, 'false')
 })
 
-test('scope gate emits API contract drift output for generated contract surfaces', async () => {
+test('CI scope router emits API contract drift output for generated contract surfaces', async () => {
   const sharedTypes = await runCiScopeGateWorkflow({
     files: [{ filename: 'packages/shared-types/src/index.ts', additions: 9, deletions: 2, status: 'modified' }],
   })
@@ -2216,7 +2216,7 @@ test('scope gate emits API contract drift output for generated contract surfaces
   assert.equal(frontendSource.outputs.run_api_contracts, 'false')
 })
 
-test('scope gate emits backend scanner outputs for backend PRs and scheduled scans', async () => {
+test('CI scope router emits backend scanner outputs for backend PRs and scheduled scans', async () => {
   const backendPr = await runCiScopeGateWorkflow({
     files: [{ filename: 'services/api/internal/services/watch_service.go', additions: 3, deletions: 1, status: 'modified' }],
   })
@@ -2250,7 +2250,7 @@ test('scope gate emits backend scanner outputs for backend PRs and scheduled sca
   })
 })
 
-test('scope gate emits contracts report outputs for contracts PRs', async () => {
+test('CI scope router emits contracts report outputs for contracts PRs', async () => {
   const result = await runCiScopeGateWorkflow({
     prOverrides: { title: '[contract] Update TachiToken' },
     files: [{ filename: 'contracts/src/TachiToken.sol', additions: 4, deletions: 1, status: 'modified' }],
@@ -2271,7 +2271,7 @@ test('scope gate emits contracts report outputs for contracts PRs', async () => 
   })
 })
 
-test('scope gate emits full CI outputs for push events and release promotion PRs', async () => {
+test('CI scope router emits full CI outputs for push events and release promotion PRs', async () => {
   const push = await runCiScopeGateWorkflow({ eventName: 'push' })
   const releasePromotion = await runCiScopeGateWorkflow({
     prOverrides: {
@@ -2516,7 +2516,7 @@ test('Dependabot auto-merge keeps production dependency updates on manual review
   assert.match(jobBlock, /reason="production dependency requires manual review"/)
 })
 
-test('CI scope gate runs product validation for Dependabot maintenance PRs', async () => {
+test('CI scope router runs product validation for Dependabot maintenance PRs', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
 
   assert.match(workflow, /const isDependabotPr = pr\.user\?\.login === 'dependabot\[bot\]'/)
@@ -2976,7 +2976,8 @@ test('auto-ready workflow checks required contexts and excludes its own run', as
 
   assert.match(workflow, /const requiredCheckSnapshots = \{/)
   assert.match(workflow, /develop: \[/)
-  assert.match(workflow, /\{ context: 'Scope gate', appId: 15368 \}/)
+  assert.match(workflow, /\{ context: 'CI scope router', appId: 15368 \}/)
+  assert.doesNotMatch(workflow, /\{ context: 'Scope gate', appId: 15368 \}/)
   assert.match(workflow, /\{ context: 'Supply-chain guardrails', appId: 15368 \}/)
   assert.match(workflow, /\{ context: 'TypeScript-only guardrail', appId: 15368 \}/)
   assert.match(workflow, /\{ context: 'Dependency Review', appId: 15368 \}/)
@@ -3072,7 +3073,8 @@ test('CI workflow wakes auto-ready draft PRs after required CI jobs finish', asy
   assert.match(jobBlock, /github\.rest\.issues\.removeLabel/)
   assert.match(jobBlock, /github\.rest\.pulls\.get/)
   assert.match(jobBlock, /const requiredCheckSnapshots = \{/)
-  assert.match(jobBlock, /\{ context: 'Scope gate', appId: 15368 \}/)
+  assert.match(jobBlock, /\{ context: 'CI scope router', appId: 15368 \}/)
+  assert.doesNotMatch(jobBlock, /\{ context: 'Scope gate', appId: 15368 \}/)
   assert.match(jobBlock, /\{ context: 'Supply-chain guardrails', appId: 15368 \}/)
   assert.match(jobBlock, /\{ context: 'TypeScript-only guardrail', appId: 15368 \}/)
   assert.match(jobBlock, /\{ context: 'Dependency Review', appId: 15368 \}/)
@@ -3333,7 +3335,7 @@ test('auto-ready workflow treats skipped required checks as passing', async () =
   const result = await runAutoReadyWorkflow({
     checkRuns: successfulDevelopRequiredCheckRuns(
       {
-        name: 'Scope gate',
+        name: 'CI scope router',
         status: 'completed',
         conclusion: 'skipped',
         app: { id: 15368 },
@@ -3381,10 +3383,10 @@ test('auto-ready workflow refreshes live PR state before marking ready', async (
 
 test('auto-ready workflow does not let a successful status mask a failed check run with the same name', async () => {
   const result = await runAutoReadyWorkflow({
-    statuses: [{ context: 'Scope gate', state: 'success', updated_at: '2026-05-03T00:00:00Z' }],
+    statuses: [{ context: 'CI scope router', state: 'success', updated_at: '2026-05-03T00:00:00Z' }],
     checkRuns: successfulDevelopRequiredCheckRuns(
       {
-        name: 'Scope gate',
+        name: 'CI scope router',
         status: 'completed',
         conclusion: 'failure',
         app: { id: 15368 },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   scope-gate:
     timeout-minutes: 5
-    name: Scope gate
+    name: CI scope router
     runs-on: ubuntu-latest
     outputs:
       run_ci: ${{ steps.evaluate.outputs.run_ci }}
@@ -114,7 +114,7 @@ jobs:
                 })
                 return
               }
-              core.notice('Non-PR event detected; running CI without scope gate restrictions.')
+              core.notice('Non-PR event detected; running CI without CI scope router restrictions.')
               setFullCiOutputs()
               return
             }
@@ -130,7 +130,7 @@ jobs:
             const bypassLabels = new Set(['scope-exception'])
             const labels = (pr.labels || []).map((label) => label.name)
             if (labels.some((label) => bypassLabels.has(label))) {
-              core.notice('Scope gate bypassed by scope-exception label.')
+              core.notice('CI scope router bypassed by scope-exception label.')
               setFullCiOutputs()
               return
             }
@@ -888,7 +888,7 @@ jobs:
             const currentHeadSha = context.payload.pull_request?.head?.sha
             const requiredCheckSnapshots = {
               develop: [
-                { context: 'Scope gate', appId: 15368 },
+                { context: 'CI scope router', appId: 15368 },
                 { context: 'Supply-chain guardrails', appId: 15368 },
                 { context: 'TypeScript-only guardrail', appId: 15368 },
                 { context: 'Dependency Review', appId: 15368 },

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -11,7 +11,7 @@ AI-facing collaboration guidance lives here unless a tool requires a specific pa
 - `autonomous-pr-gates.md` — autonomous evidence gates, review triage refs, spec workflow-check boundaries, and threshold ledger rules.
 - `code-review-refactor.md` — local Claude Code review workflow notes.
 - `github-ssh-443-push.md` — playbook for GitHub SSH over 443 when `git push` is unstable.
-- `github-actions-debugging.md` — playbook for PR, CI, scope gate, and auto-ready debugging.
+- `github-actions-debugging.md` — playbook for PR, CI, CI scope router, and auto-ready debugging.
 - `supply-chain-security.md` — dependency install, AI-agent package use, and developer-machine persistence guardrails.
 - `token-budget.md` — token budget guidance for AI-assisted work.
 - `workflow-metrics-baseline.md` — baseline GitHub metadata metrics for AI-native repo workflow friction and gate-weight audits.

--- a/docs/ai/claude-codex-workflow.md
+++ b/docs/ai/claude-codex-workflow.md
@@ -57,7 +57,7 @@
 - 先讀 PR metadata、head SHA、labels、reviewDecision、required checks、CodeRabbit / Cloudflare / repo checks 狀態。
 - 只有 `needs-codex-review` 或等價的新 head 訊號存在，且所有必要 checks / automated review signals 已完成時，才進入第一輪 review。
 - 若同一個 head SHA 已有 blocker 或 `changes-requested`，不要重複 review；等作者 push 新 head 後再重啟。
-- docs-only / lightweight lane 的 PR 先看 Scope Police / Scope gate 是否符合預期，再決定是否需要讀 patch。
+- docs-only / lightweight lane 的 PR 先看 Scope Police / CI scope router 是否符合預期，再決定是否需要讀 patch。
 - review 輸出要優先找 blocker；minor / nit 不應造成重複 CR 或無限 review loop。
 
 這個節流規則只改變 agent / reviewer 的操作方式，不代表授權 workflow 自動改 label、重跑 CI、approve 或 merge。任何會修改 GitHub 公開狀態的 automation 仍必須由對應 workflow 或人類明確授權。

--- a/docs/ai/github-actions-debugging.md
+++ b/docs/ai/github-actions-debugging.md
@@ -17,7 +17,7 @@
 | 層級 | 代表訊號 | 先看哪裡 |
 | --- | --- | --- |
 | PR metadata | title/body/template 欄位不合規 | `docs/pr-scope-policy.md`、`.github/PULL_REQUEST_TEMPLATE.md` |
-| Scope gate | 重型 CI 被跳過 | `.github/workflows/ci.yml` 的 `scope-gate` job |
+| CI scope router | 重型 CI 被跳過 | `.github/workflows/ci.yml` 的 `scope-gate` job |
 | Scope police | PR 被標記或擋下 | `.github/workflows/pr-scope-police.yml` |
 | Workflow regression | workflow script 本身壞掉 | `.github/workflows/ci.test.ts` |
 | Product CI | backend/frontend/dashboard/contract 測試失敗 | 對應 product surface 的 job log |
@@ -64,7 +64,7 @@ make pr-meta-check TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md
 
 `develop` 的 required check snapshot 目前在 `.github/workflows/auto-ready-pr.yml`：
 
-- `Scope gate`
+- `CI scope router`
 - `Frontend build`
 - `Dashboard build`
 - `Contracts build`

--- a/docs/auto-merge-policy.md
+++ b/docs/auto-merge-policy.md
@@ -31,7 +31,7 @@ docs / template / metadata-only PR 可以走 lightweight lane，但 Approve 的�
 因此 reviewer 在 lightweight lane 仍需確認：
 
 - `PR Scope Police` 通過，且 PR body 的 source of truth / dependency / scope 欄位完整。
-- `Scope gate` 的 skipped heavy CI 符合路徑規則；如果 PR 改到 `.github/workflows/**`，就不應被當成 metadata-only。
+- `CI scope router` 的 skipped heavy CI 符合路徑規則；如果 PR 改到 `.github/workflows/**`，就不應被當成 metadata-only。
 - workflow regression、PR metadata regression、supply-chain / TypeScript guardrail 等保留 checks 沒有失敗。
 - 沒有把 inherited backend / frontend / dashboard 紅燈修補混進 docs-only PR。
 

--- a/docs/draft-pr-auto-ready.md
+++ b/docs/draft-pr-auto-ready.md
@@ -106,7 +106,7 @@ Snapshot as of 2026-05-04:
 
 | Branch | Required check contexts |
 |---|---|
-| `develop` | `Scope gate` |
+| `develop` | `CI scope router` |
 | `develop` | `Backend CI (gate)` |
 | `develop` | `Frontend build` |
 | `develop` | `Dashboard build` |

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -116,7 +116,7 @@ Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的
 
 另外，這類 PR 不應再被 product surface 的 inherited 紅燈拖住 review 流程，因此：
 
-- `Scope gate` 會直接略過 backend / frontend / dashboard 的 heavy CI
+- `CI scope router` 會直接略過 backend / frontend / dashboard 的 heavy CI
 - 仍保留 `PR Scope Police`、workflow regression 與其他 metadata / policy 檢查
 - 若 docs/template PR 因為 restack 需求碰到 `develop` 上的產品線紅燈，應拆成獨立 product fix PR，不可把 inherited 修補留在 docs PR
 
@@ -207,10 +207,10 @@ Autonomous Worker Profiles v2 的完整 evidence discipline 與 `spec workflow-c
 repo 的 CI 目前改成：
 
 - PR 先跑 `PR Scope Police`
-- `.github/workflows/ci.yml` 也會直接跑在 PR 上，但會先經過一個輕量 `Scope gate`
+- `.github/workflows/ci.yml` 也會直接跑在 PR 上，但會先經過一個輕量 `CI scope router`
 - 只有目前符合同一套 scope 規則、且沒有被 dependency gate 擋住的 PR，才會繼續跑 backend / frontend / dashboard 的 docker build 與測試
 - 若 `[frontend]` PR 依賴尚未 merge 的 backend contract，重型 CI 會直接跳過
-- 若 PR 是正式 `[release]` 的 `develop -> main` promotion，重型 CI 會照常執行，不因 diff 過大而被 scope gate 跳過
+- 若 PR 是正式 `[release]` 的 `develop -> main` promotion，重型 CI 會照常執行，不因 diff 過大而被 CI scope router 跳過
 - 若 PR 是 docs / template / metadata-only，重型 product CI 會直接跳過，避免 inherited product failures 造成無限循環
 
 ### #764 CI execution strategy
@@ -219,10 +219,10 @@ repo 的 CI 目前改成：
 
 目前的 lightweight lanes 定義如下：
 
-- docs / template / metadata-only lane：只修改 `docs/`、`docs/ai/`、`plans/`、`.github/ISSUE_TEMPLATE/`、`.github/PULL_REQUEST_TEMPLATE.md`、repo root Markdown、`infra/`、`.gitignore` 或 `.gitattributes`。這類 PR 保留 metadata/policy checks，但 `Scope gate` 會略過 backend / frontend / dashboard / contracts heavy CI。
+- docs / template / metadata-only lane：只修改 `docs/`、`docs/ai/`、`plans/`、`.github/ISSUE_TEMPLATE/`、`.github/PULL_REQUEST_TEMPLATE.md`、repo root Markdown、`infra/`、`.gitignore` 或 `.gitattributes`。這類 PR 保留 metadata/policy checks，但 `CI scope router` 會略過 backend / frontend / dashboard / contracts heavy CI。
 - workflow lane：任何 `.github/workflows/**` 變更都不算 metadata-only。即使內容只是註解或 policy 調整，也要跑 workflow regression，並重新檢查 required check / auto-ready / Scope Police 語義。
 - frontend / style-only lane：目前尚未有獨立 workflow lane。只要修改 `apps/extension/`、`apps/dashboard/`、`tachimint/` 或 `dashboard/`，就仍屬 frontend surface，至少需要對應 frontend/dashboard checks；若未來要新增 style-only lane，必須先在 `.github/workflows/ci.yml` 與 `.github/workflows/ci.test.ts` 定義路徑規則與 regression case。
-- package / API contract lane：`packages/`、OpenAPI generated docs、frontend API client 或 workspace dependency 變更不可混入 docs-only lane；是否跑 API contract / dependency review 由 `Scope gate` path rules 決定。
+- package / API contract lane：`packages/`、OpenAPI generated docs、frontend API client 或 workspace dependency 變更不可混入 docs-only lane；是否跑 API contract / dependency review 由 `CI scope router` path rules 決定。
 
 第一階段的非目標：
 
@@ -234,7 +234,7 @@ repo 的 CI 目前改成：
 後續若要實作 #764 的 runtime 變更，建議依序拆 PR：
 
 1. workflow regression 先行：為預期 lane 行為新增 `ci.test.ts` case，證明 workflow file 仍不會被誤判為 metadata-only。
-2. path-aware CI runtime：只改 `ci.yml` scope gate 與對應 regression，避免混入 Scope Police 或 auto-merge 行為。
+2. path-aware CI runtime：只改 `ci.yml` 的 `scope-gate` job（PR check 顯示為 `CI scope router`）與對應 regression，避免混入 Scope Police 或 auto-merge 行為。
 3. frontend / style-only lane：在有明確路徑定義與可接受 skipped required check 語義後再新增。
 4. autonomous review loop 節流：只改 review flag / rerequest / notification workflow，避免和 CI path gate 同 PR。
 
@@ -327,7 +327,7 @@ Codex task PR 應使用 `AUTO_READY=1`，讓 wrapper 一次建立 draft PR 並�
 注意：
 
 - `PR Scope Police` 應該是第一道 gate
-- 後面三個 CI checks 會直接出現在 PR 上；若 scope 不合格，job 會在 `Scope gate` 後被略過
+- 後面三個 CI checks 會直接出現在 PR 上；若 scope 不合格，job 會在 `CI scope router` 後被略過
 
 ## Reviewer 指南
 


### PR DESCRIPTION
## 什麼改動
- 將 CI required check 的顯示名稱從 `Scope gate` 改為 `CI scope router`。
- 保留內部 workflow job id `scope-gate`，只更新 PR check 名稱、auto-ready required snapshot、workflow regression 與相關文件。
- 補上回歸斷言，防止 auto-ready snapshot 再引用舊的 `Scope gate` check context。

## 為什麼
Closes #899

`Scope gate` 與 `Scope police` 名稱太接近，review / CI 文件容易誤以為兩者是重複 gate。這次把 CI fanout / heavy-CI 路由職責命名為 `CI scope router`，並保留 `Scope police` 作為 PR policy enforcement。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#899
- Depends on PR：`none`
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 scope decision logic
  - 不合併 `Scope police` 與 CI router workflow
  - 不改 auto-merge / review label 行為

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #899
- Actual worker profile(s)：
  - controller + AWP read-only explorer (`Carver`, session `019e569a-e20a-7dc3-b035-0be05b1042d0`)
- Model strength：
  - controller = high；worker = medium
- Spawn directive(s)：
  - profile=read-only-explorer model=gpt-5-codex reasoning=medium controller_fallback=not_used task=classify `Scope gate` vs `Scope police` overlap and propose minimal bounded fix
- Verification evidence：
  - `spec plan 899 --repo . --dry-run --format prompt --verbose`
  - `node --test .github/workflows/ci.test.ts --test-name-pattern 'auto-ready workflow checks required contexts|CI workflow wakes auto-ready draft PRs|auto-ready required-check snapshots|auto-ready workflow treats skipped required checks|auto-ready workflow does not let a successful status mask|auto-ready workflow uses the latest rerun result'`
  - `node --test .github/workflows/ci.test.ts`
  - `git diff --check`
- Self-review / exception reason：
  - Self-review completed locally; workflow behavior limited to check display name / required snapshot naming.
- Worker session closeout：
  - Worker result read back; recommendation adopted: document distinction and rename CI gate display without merging workflows.
- Workflow friction / follow-up split：
  - Local-only spec-injector dogfood; #664 comment pending merge.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - skipped by rate limit; StatusContext is success
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - local `spec plan 899` dry-run output
- root_cause_gate_ref：
  - #899
- finding_disposition_ref：
  - adopted minimal rename / docs clarification; no scope logic change
- Final reviewer action：
  - pending human reviewer

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review; R4 workflow PR has `REVIEW_REQUIRED`
- Latest head SHA：
  - e22031e79f95a209f30e99e93b96594b0124f4e1
- Required checks：
  - pending with reason: branch rebased to latest develop; waiting for GitHub checks on head `e22031e79f95a209f30e99e93b96594b0124f4e1`
- spec workflow-check evidence：
  - local-only: `spec plan 899 --repo . --dry-run --format prompt --verbose`
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/901

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 釐清 CI scope router 與 Scope police 的職責命名，移除 required check list 的重複感。
- Approx changed lines：~80
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - workflow check 名稱、auto-ready required snapshot、regression tests 與 reviewer 文件必須同步，否則會留下不一致的 required check 語義。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Clarify responsibilities
- [x] De-dupe/merge or document distinction
- [x] CI check list no longer redundant

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --test .github/workflows/ci.test.ts --test-name-pattern 'auto-ready workflow checks required contexts|CI workflow wakes auto-ready draft PRs|auto-ready required-check snapshots|auto-ready workflow treats skipped required checks|auto-ready workflow does not let a successful status mask|auto-ready workflow uses the latest rerun result'
pass: 98, fail: 0

node --test .github/workflows/ci.test.ts
pass: 98, fail: 0

git diff --check
pass
```

## 備註

## Notes for Claude Code Review
- `spec plan` 回報 stale always-read hint：`docs/claude-codex-workflow.md` missing；本 PR 使用現有 `docs/ai/claude-codex-workflow.md` 更新，不因此擴張 scope。


