### PR TITLE
[chore] downgrade dependency block label gate

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -341,6 +341,7 @@ async function runScopePoliceWorkflow({
   existingComments = [],
   prOverrides = {},
   includeDefaultRiskClass = true,
+  dependencyPrState = 'open',
 } = {}) {
   const parsedWorkflow = parseYaml(scopePolicePath)
   const script = parsedWorkflow.jobs['scope-police'].steps[0].with.script
@@ -373,6 +374,7 @@ async function runScopePoliceWorkflow({
     rest: {
       pulls: {
         listFiles: async () => ({ data: files }),
+        get: async () => ({ data: { state: dependencyPrState } }),
         update: async () => ({ data: { state: 'closed' } }),
       },
       issues: {
@@ -1434,6 +1436,38 @@ ${validAutonomousEvidence}`,
   })
   assert.equal(extraCheckedRiskOutsideSectionRun.failures.length, 0)
   assert.match(extraCheckedRiskOutsideSectionRun.comments[0].body, /- PR risk class: R2/)
+})
+
+test('PR scope police keeps dependency protection but does not manage blocked-by-dependency label', async () => {
+  const body = `
+## Scope 對齊
+- Source of truth：#897
+- Depends on PR：#123
+- Backend contract already in develop:
+  - [ ] yes
+  - [x] no
+- If no, this PR is:
+  - [ ] stacked on dependency branch
+  - [x] intentionally blocked until dependency merges
+- 本 PR 明確不做：
+  - 不繞過 dependency gate
+`
+
+  const run = await runScopePoliceWorkflow({
+    title: '[frontend] Use pending backend contract',
+    body,
+    files: [{ filename: 'apps/extension/src/app/App.tsx', status: 'modified', additions: 3, deletions: 1 }],
+    dependencyPrState: 'open',
+  })
+
+  assert.equal(run.failures.length, 1)
+  assert.match(run.comments[0].body, /### Dependency blocks/)
+  assert.match(run.comments[0].body, /This frontend PR depends on #123/)
+  assert.match(run.comments[0].body, /- Dependency blocked: yes/)
+  assert.doesNotMatch(run.comments[0].body, /Dependency block label/)
+  assert.deepEqual(run.labelsCreated, [])
+  assert.deepEqual(run.labelsAdded, [])
+  assert.deepEqual(run.labelsRemoved, [])
 })
 
 test('PR scope police only treats a delegation log as autonomous when it has real content', async () => {

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -447,7 +447,6 @@ jobs:
             const hardMaxDiffLines = 1000
             const warningDiffLines = 600
             const autoCloseLabel = 'scope-violation'
-            const dependencyLabel = 'blocked-by-dependency'
             const owner = context.repo.owner
             const repo = context.repo.repo
 
@@ -832,7 +831,6 @@ jobs:
               `- Auto-close triggered: ${severeFailures.length > 0 ? 'yes' : 'no'}`,
             )
             summaryLines.push(`- Auto-close label: \`${autoCloseLabel}\``)
-            summaryLines.push(`- Dependency block label: \`${dependencyLabel}\``)
             summaryLines.push('- Bypass label: `scope-exception`')
 
             const commentBody = summaryLines.join('\n')
@@ -921,31 +919,6 @@ jobs:
                   repo,
                   issue_number: pr.number,
                   name: autoCloseLabel,
-                })
-              } catch (error) {
-                if (error.status !== 404) throw error
-              }
-            }
-
-            if (dependencyFailures.length > 0) {
-              await ensureLabel(
-                dependencyLabel,
-                '1D76DB',
-                'PR is blocked by an unmerged dependency or undeployed backend contract',
-              )
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: pr.number,
-                labels: [dependencyLabel],
-              })
-            } else if (labels.includes(dependencyLabel)) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner,
-                  repo,
-                  issue_number: pr.number,
-                  name: dependencyLabel,
                 })
               } catch (error) {
                 if (error.status !== 404) throw error

--- a/docs/ai/workflow-gate-weight-audit.md
+++ b/docs/ai/workflow-gate-weight-audit.md
@@ -78,6 +78,7 @@ These should not become new mandatory fields or checks without more evidence.
 | Adding `spawn_count`, CI rerun count, or review-thread count to the PR template | #664 already stores threshold data. Duplicating it in every PR adds weight without improving merge safety. |
 | Automated gates based on elapsed time from issue creation | The #881 sample is noisy because umbrella issues stay open across many small cuts. |
 | Parsing full review triage schema inside tachigo Scope Police | The source of truth is spec-injector. tachigo should keep thin evidence refs instead of duplicating parser logic. |
+| `blocked-by-dependency` label side-effect | `gh label list --search blocked-by-dependency` and `gh pr list --label blocked-by-dependency` both return no active label/PR signal. Keep the dependency failure and sticky comment, but remove the unused label management. |
 | Making CodeRabbit / connector timing a hard initial-review blocker for all R0/R1 PRs | Useful as review input, but rate limits and skipped contexts should not freeze low-risk docs/tooling work when human review is available. |
 | New product-AI planning fields in the PR template | Track B product docs are planning references, not implementation contracts. Product AI features still need their own issues and specs. |
 
@@ -133,4 +134,3 @@ Do not weaken high-risk protection. Instead:
 - consolidate autonomous evidence into short refs;
 - stop adding template fields unless the #881 baseline shows a concrete missed
   risk that existing fields cannot catch.
-

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -147,7 +147,7 @@ Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的
 - `PR Scope Police` check 會 fail
 - PR 會收到一則可更新的 sticky comment
 - 嚴重 scope 違規會自動加上 `scope-violation` label
-- 依賴未落地的前端 PR 會自動加上 `blocked-by-dependency` label
+- 依賴未落地的前端 PR 會 fail 並在 sticky comment 顯示 dependency block；不再另加 `blocked-by-dependency` label
 - 若屬於嚴重違規，PR 會被自動關閉
 
 目前視為嚴重違規的情況：


### PR DESCRIPTION
## 什麼改動
- 保留 `[frontend]` PR 依賴未落地 backend contract 時的 `dependencyFailures` blocker。
- 移除 `blocked-by-dependency` label 的自動建立 / 加上 / 移除 side-effect。
- 更新 Scope Police sticky comment / 文件，讓 dependency block 只透過 failed check + sticky comment 表達。
- 新增 workflow regression，確認 dependency protection 仍 fail，但不管理 `blocked-by-dependency` label。

## 為什麼
Closes #897

#884 / #877 的 gate 重量審計指出 `blocked-by-dependency` 沒有觀測到實際觸發價值。這次採取最小降級：移除低訊號 label side-effect，但不弱化真正的 dependency/backend-contract 保護。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#897
- Depends on PR：`none`
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不移除真正的 dependency / backend-contract blocker
  - 不改 `.github/workflows/ci.yml` 的 heavy CI dependencyBlocked gate
  - 不改 diff/file-count/product-surface scope rules

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #897
- Actual worker profile(s)：
  - controller + AWP read-only explorer (`Ohm`, session `019e56ab-c530-7a70-8198-fc4e2cbc98a4`)
- Model strength：
  - controller = high；worker = medium
- Spawn directive(s)：
  - profile=read-only-explorer model=gpt-5-codex reasoning=medium controller_fallback=not_used task=inspect blocked-by-dependency history and propose minimal downgrade path
- Verification evidence：
  - `spec plan 897 --repo . --dry-run --format prompt --verbose`
  - `gh label list --repo nurockplayer/tachigo --search blocked-by-dependency --json name,description,color`
  - `gh pr list --repo nurockplayer/tachigo --state all --label blocked-by-dependency --limit 100 --json number,title,state,author,labels,createdAt,updatedAt,closedAt,url`
  - `node --test .github/workflows/ci.test.ts --test-name-pattern 'PR scope police keeps dependency protection but does not manage blocked-by-dependency label'`
  - `node --test .github/workflows/ci.test.ts`
  - `bash infra/scripts/pr-metadata-check.test.sh`
  - `git diff --check`
- Self-review / exception reason：
  - Self-review completed locally; change is constrained to removing an unused label side-effect while preserving dependency failure semantics.
- Worker session closeout：
  - Worker result read back and closed; conclusion matched controller implementation.
- Workflow friction / follow-up split：
  - Local-only spec-injector dogfood; #664 comment pending merge.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - reviewed latest head; status context success
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - local `spec plan 897` dry-run output
- root_cause_gate_ref：
  - #897
- finding_disposition_ref：
  - adopted: remove/downgrade unused label side-effect; preserve dependency blocker
- Final reviewer action：
  - pending human reviewer

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review; R4 workflow PR has `REVIEW_REQUIRED`
- Latest head SHA：
  - a9b1a3af47471ac7270582bea2477ee75ffafb3e
- Required checks：
  - pass as of head `a9b1a3af47471ac7270582bea2477ee75ffafb3e`; product heavy checks skipped by Scope gate
- spec workflow-check evidence：
  - local-only: `spec plan 897 --repo . --dry-run --format prompt --verbose`
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/902

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 移除未觀測到使用價值的 `blocked-by-dependency` label side-effect，同時保留 dependency blocker。
- Approx changed lines：~65
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Scope Police 行為、regression test、policy docs 必須同步，否則 reviewer 會看到過期的 label 行為承諾。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 有 `blocked-by-dependency` 歷史觸發次數的證據
- [x] 依證據移除或降級該 check
- [x] 若移除，確認沒有其他 gate 依賴它

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
gh label list --repo nurockplayer/tachigo --search blocked-by-dependency --json name,description,color
exact blocked-by-dependency label not present

gh pr list --repo nurockplayer/tachigo --state all --label blocked-by-dependency --limit 100 --json ...
[]

node --test .github/workflows/ci.test.ts --test-name-pattern 'PR scope police keeps dependency protection but does not manage blocked-by-dependency label'
pass: 99, fail: 0

node --test .github/workflows/ci.test.ts
pass: 99, fail: 0

bash infra/scripts/pr-metadata-check.test.sh
pr-metadata-check regression tests passed

git diff --check
pass
```

## 備註

## Notes for Claude Code Review
- `spec plan` 回報 stale always-read hint：`docs/claude-codex-workflow.md` missing；本 PR 未因此擴張 scope。
- AWP sidecar 另以 read-only GitHub checks 確認 open/closed/all PR/issue 目前沒有 `blocked-by-dependency` label 使用，issue events labeled count 也為 0。
