### PR TITLE
[chore] scale auto-ready evidence gate by risk

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -1754,7 +1754,7 @@ test('PR scope police only treats a delegation log as autonomous when it has rea
     /Autonomous PR must include a meaningful `Worker session closeout` value/,
   )
 
-  const labelsToTrigger = ['codex', 'codex-automation', 'auto-ready']
+  const labelsToTrigger = ['codex', 'codex-automation']
   for (const label of labelsToTrigger) {
     const labelTriggeredRun = await runScopePoliceWorkflow({
       body: prTemplateBody,
@@ -1767,6 +1767,54 @@ test('PR scope police only treats a delegation log as autonomous when it has rea
       /Autonomous PR must include a `Delegation Execution Log` section\./,
     )
   }
+
+  const r0AutoReadyOnlyRun = await runScopePoliceWorkflow({
+    body: selectRiskClass(prTemplateBody, 'R0'),
+    labels: [{ name: 'auto-ready' }],
+    includeDefaultRiskClass: false,
+  })
+  assert.equal(r0AutoReadyOnlyRun.failures.length, 0)
+  assert.match(r0AutoReadyOnlyRun.comments[0].body, /- Autonomous PR: no/)
+  assert.doesNotMatch(
+    r0AutoReadyOnlyRun.comments[0].body,
+    /Autonomous PR must include a `Delegation Execution Log` section\./,
+  )
+
+  const r1AutoReadyOnlyRun = await runScopePoliceWorkflow({
+    body: selectRiskClass(prTemplateBody, 'R1'),
+    labels: [{ name: 'auto-ready' }],
+    includeDefaultRiskClass: false,
+  })
+  assert.equal(r1AutoReadyOnlyRun.failures.length, 0)
+  assert.match(r1AutoReadyOnlyRun.comments[0].body, /- Autonomous PR: no/)
+  assert.doesNotMatch(
+    r1AutoReadyOnlyRun.comments[0].body,
+    /Autonomous PR must include a `Delegation Execution Log` section\./,
+  )
+
+  const r2AutoReadyOnlyRun = await runScopePoliceWorkflow({
+    body: selectRiskClass(prTemplateBody, 'R2'),
+    labels: [{ name: 'auto-ready' }],
+    includeDefaultRiskClass: false,
+  })
+  assert.equal(r2AutoReadyOnlyRun.failures.length, 1)
+  assert.match(r2AutoReadyOnlyRun.comments[0].body, /- Autonomous PR: yes/)
+  assert.match(
+    r2AutoReadyOnlyRun.comments[0].body,
+    /Autonomous PR must include a `Delegation Execution Log` section\./,
+  )
+
+  const r3AutoReadyOnlyRun = await runScopePoliceWorkflow({
+    body: selectRiskClass(prTemplateBody, 'R3'),
+    labels: [{ name: 'auto-ready' }],
+    includeDefaultRiskClass: false,
+  })
+  assert.equal(r3AutoReadyOnlyRun.failures.length, 1)
+  assert.match(r3AutoReadyOnlyRun.comments[0].body, /- Autonomous PR: yes/)
+  assert.match(
+    r3AutoReadyOnlyRun.comments[0].body,
+    /Autonomous PR must include a `Delegation Execution Log` section\./,
+  )
 
   const autonomousLabelRun = await runScopePoliceWorkflow({
     body: prTemplateBody,

--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -1309,6 +1309,7 @@ test('AWP v2 docs wire AGENTS and PR scope policy to autonomous evidence gates a
   assert.match(autonomousPrGates, /controller_fallback_reason|fallback_reason/)
   assert.match(autonomousPrGates, /Review conversation closeout/)
   assert.match(autonomousPrGates, /Final merge gate/)
+  assert.match(autonomousPrGates, /codex-automation/)
   assert.match(autonomousPrGates, /spec workflow-check/)
   assert.match(autonomousPrGates, /necessity assessment/)
   assert.match(autonomousPrGates, /25-30%/)

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -37,7 +37,7 @@ jobs:
             const labels = (pr.labels || []).map((label) => label.name)
             const bypassed = labels.some((label) => bypassLabels.has(label))
 
-            const autonomousLabels = new Set(['autonomous', 'codex', 'codex-automation', 'codex-workflow', 'auto-ready'])
+            const autonomousLabels = new Set(['autonomous', 'codex', 'codex-automation', 'codex-workflow'])
             const bodyForAutonomousGate = (pr.body || '').replace(/<!--[\s\S]*?-->/g, '')
             const riskClassDefinitions = [
               { id: 'R0', label: 'docs / template / metadata only' },
@@ -77,6 +77,8 @@ jobs:
             const hasAutoReadyLabel = labels.includes('auto-ready')
             const autoReadyAllowedByRiskClass =
               checkedRiskClassIds.length === 1 && selectedRiskClassId !== 'R4'
+            const autoReadyTriggersAutonomousGate =
+              hasAutoReadyLabel && !['R0', 'R1', 'unclassified', 'invalid'].includes(selectedRiskClassId)
             const delegationExecutionLogSection = extractMarkdownSection(
               bodyForAutonomousGate,
               'Delegation Execution Log',
@@ -379,6 +381,7 @@ jobs:
               /(?:^|\n)\s*-?\s*(?:Autonomous PR|Codex workflow)\s*[：:]\s*(?:yes|true|enabled)/i.test(bodyForAutonomousGate)
             const isAutonomousPr =
               labels.some((label) => autonomousLabels.has(label)) ||
+              autoReadyTriggersAutonomousGate ||
               hasAutonomousBranchSignal ||
               hasAutonomousBodySignal ||
               hasDelegationExecutionLog

--- a/docs/ai/autonomous-pr-gates.md
+++ b/docs/ai/autonomous-pr-gates.md
@@ -24,7 +24,7 @@
 
 ## PR Initial Body And Final Closeout
 
-PR body 一開始就要完整合規，包含 Source of truth、Depends on PR、本 PR 明確不做、Delegation Execution Log、Review conversation closeout、Final merge gate。開 PR 時尚未穩定的欄位可填 `pending with reason` 或 `n/a`，但 ready-to-merge closeout 不可留下裸 `pending`。對 R0/R1 `auto-ready`-only PR，`Delegation Execution Log` 可維持 `n/a`，除非另有 autonomous / codex label、branch/body signal，或正式 delegation 欄位已有實質內容。
+PR body 一開始就要完整合規，包含 Source of truth、Depends on PR、本 PR 明確不做、Delegation Execution Log、Review conversation closeout、Final merge gate。開 PR 時尚未穩定的欄位可填 `pending with reason` 或 `n/a`，但 ready-to-merge closeout 不可留下裸 `pending`。對 R0/R1 `auto-ready`-only PR，`Delegation Execution Log` 可維持 `n/a`，除非另有 autonomous / codex / codex-automation label、branch/body signal，或正式 delegation 欄位已有實質內容。
 
 final closeout 只在 merge 前狀態穩定後更新一次，避免每個 CI tick 都修改 PR body。final closeout 至少讀回 latest head SHA、CI / Scope Police、review threads、CodeRabbit、chatgpt-codex-connector、每個 finding 的採納或不採納狀態。
 
@@ -113,6 +113,6 @@ Threshold 校正是暫時性的 autonomous workflow 分析資料，不是 tachig
 
 ## Scope Police Contract
 
-Autonomous evidence gate 只對 autonomous PR 嚴格啟用。判定方式包含 `Delegation Execution Log` 有正式欄位內容，或 label / branch / body 明確標示 autonomous / codex workflow。`auto-ready` label 會依 `PR Risk Class` 縮放：R0/R1 只有 `auto-ready` 不會單獨觸發完整 evidence gate；R2-R4 仍會觸發，其中 R4 仍不可搭配 `auto-ready`。
+Autonomous evidence gate 只對 autonomous PR 嚴格啟用。判定方式包含 `Delegation Execution Log` 有正式欄位內容，或 label / branch / body 明確標示 autonomous / codex / codex-automation workflow。`auto-ready` label 會依 `PR Risk Class` 縮放：R0/R1 只有 `auto-ready` 不會單獨觸發完整 evidence gate；R2-R4 仍會觸發，其中 R4 仍不可搭配 `auto-ready`。
 
 Scope Police sticky comment 應顯示 `Autonomous evidence snapshot`，讓 reviewer 快速看見 delegation log、spawn directives、controller fallback、review closeout、final merge gate 與 pending 是否清乾淨。

--- a/docs/ai/autonomous-pr-gates.md
+++ b/docs/ai/autonomous-pr-gates.md
@@ -24,7 +24,7 @@
 
 ## PR Initial Body And Final Closeout
 
-PR body 一開始就要完整合規，包含 Source of truth、Depends on PR、本 PR 明確不做、Delegation Execution Log、Review conversation closeout、Final merge gate。開 PR 時尚未穩定的欄位可填 `pending with reason` 或 `n/a`，但 ready-to-merge closeout 不可留下裸 `pending`。
+PR body 一開始就要完整合規，包含 Source of truth、Depends on PR、本 PR 明確不做、Delegation Execution Log、Review conversation closeout、Final merge gate。開 PR 時尚未穩定的欄位可填 `pending with reason` 或 `n/a`，但 ready-to-merge closeout 不可留下裸 `pending`。對 R0/R1 `auto-ready`-only PR，`Delegation Execution Log` 可維持 `n/a`，除非另有 autonomous / codex label、branch/body signal，或正式 delegation 欄位已有實質內容。
 
 final closeout 只在 merge 前狀態穩定後更新一次，避免每個 CI tick 都修改 PR body。final closeout 至少讀回 latest head SHA、CI / Scope Police、review threads、CodeRabbit、chatgpt-codex-connector、每個 finding 的採納或不採納狀態。
 
@@ -113,6 +113,6 @@ Threshold 校正是暫時性的 autonomous workflow 分析資料，不是 tachig
 
 ## Scope Police Contract
 
-Autonomous evidence gate 只對 autonomous PR 嚴格啟用。判定方式包含 `Delegation Execution Log` 有正式欄位內容，或 label / branch / body 明確標示 autonomous / codex workflow。
+Autonomous evidence gate 只對 autonomous PR 嚴格啟用。判定方式包含 `Delegation Execution Log` 有正式欄位內容，或 label / branch / body 明確標示 autonomous / codex workflow。`auto-ready` label 會依 `PR Risk Class` 縮放：R0/R1 只有 `auto-ready` 不會單獨觸發完整 evidence gate；R2-R4 仍會觸發，其中 R4 仍不可搭配 `auto-ready`。
 
 Scope Police sticky comment 應顯示 `Autonomous evidence snapshot`，讓 reviewer 快速看見 delegation log、spawn directives、controller fallback、review closeout、final merge gate 與 pending 是否清乾淨。

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -33,7 +33,7 @@
 | R3 | backend / API behavior | 可用，但若涉及 auth、permission、schema、migration、security、payment、wallet、workflow 或 release，必須升級為 R4 |
 | R4 | auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release | 不可用，必須 human review |
 
-`R4` 是 auto-ready / automation 的硬邊界。PR 若勾選 `R4` 且帶有 `auto-ready` label，`PR Scope Police` 會 fail，要求移除 `auto-ready` 並由 human reviewer 明確 review / approve。
+`auto-ready` 可用只代表 PR 可進入 draft-to-ready 自動化路徑，不代表一律要啟動完整 autonomous evidence gate。`R0` / `R1` PR 只有 `auto-ready` label 時走輕量路徑；`R2` / `R3` 若使用 `auto-ready`，仍會被視為 autonomous PR 並要求 delegation / closeout evidence。`R4` 是 auto-ready / automation 的硬邊界。PR 若勾選 `R4` 且帶有 `auto-ready` label，`PR Scope Police` 會 fail，要求移除 `auto-ready` 並由 human reviewer 明確 review / approve。
 
 目前 `PR Risk Class` 是作者自我宣告的治理欄位，`PR Scope Police` 只驗證「剛好勾選一項」與「R4 不可搭配 auto-ready」。它尚未實作 diff-based floor 或路徑自動升級；也就是說，若 PR 修改 `.github/workflows/**`、migration、auth、wallet、security、payment 或 release 相關檔案，系統目前不會自動把 R1/R2/R3 升級為 R4。Reviewer 仍需依 diff 判斷風險，必要時要求作者改填 R4、移除 `auto-ready`，或拆 follow-up issue/PR。
 
@@ -170,7 +170,8 @@ Dependabot maintenance PR 目前不會套用 frontend/backend 依賴關係用的
 
 關於 autonomous PR 的判定與觸發條件：
 
-- `codex` / `codex-automation` / `auto-ready` label 或 `Delegation Execution Log` 在正式欄位（`Source issue delegation plan`、`Actual worker profile(s)`、`Model strength`、`Verification evidence`、`Self-review / exception reason`）有實質內容時，視為 autonomous PR。
+- `codex` / `codex-automation` label、`R2`-`R4` PR 的 `auto-ready` label，或 `Delegation Execution Log` 在正式欄位（`Source issue delegation plan`、`Actual worker profile(s)`、`Model strength`、`Verification evidence`、`Self-review / exception reason`）有實質內容時，視為 autonomous PR。
+- `R0` / `R1` PR 只有 `auto-ready` label 時不會單獨觸發完整 autonomous evidence gate；若另有 `codex` / `codex-automation` label、autonomous branch/body signal，或 delegation 欄位有實質內容，仍會照 autonomous PR 檢查。
 - autonomous PR 仍必須勾選 `PR Risk Class`；若屬 `R4`，不得使用 `auto-ready`，也不得讓 automation 自行完成 ready / merge path。
 - 自動化 PR 還須在同區塊填寫 `Worker session closeout`，且內容不可空白、`n/a`、`none`、`無`、`不適用`。
 - 自動化 PR 必須至少有一條 spawn directive，且同時包含 `profile=`、`model=`、`reasoning=`、`controller_fallback=`；若 `controller_fallback=allowed`，同一行必須有非空 `fallback_reason=`。


### PR DESCRIPTION
refs #896
closes #896

Source of truth: #896

Depends on PR: none

本 PR 明確不做
- 不調整 R2-R4 / high-risk autonomous evidence requirements
- 不改 auto-ready workflow 或 native auto-merge workflow
- 不改 branch protection / required checks
- 不實作 diff-based risk floor 或 path auto-upgrade

## Summary

- Decouple `auto-ready` from full autonomous evidence gate for R0/R1 PRs.
- Keep R2/R3 `auto-ready` PRs on the full autonomous evidence gate.
- Keep R4 `auto-ready` hard-blocked and human-review-only.
- Add workflow regression coverage and sync policy docs.

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth: #896
- Scope: `.github/workflows/pr-scope-police.yml`, workflow regression tests, and matching docs only.
- Non-goals: no product behavior, no auto-merge workflow change, no branch protection change.

## Delegation Execution Log

- Source issue delegation plan: `spec plan 896 --repo . --dry-run --format prompt --verbose`
- Actual worker profile(s): repo_scout (Nash AWP explorer) / controller
- Model strength: repo_scout = inherited; controller = current session
- Spawn directive(s): profile=repo_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=controller_owned_TDD_workflow_policy_patch_and_final_gate
- Verification evidence: RED focused workflow regression failed on old R0 `auto-ready` behavior; GREEN `node --test .github/workflows/ci.test.ts`; `bash infra/scripts/pr-metadata-check.test.sh`; `git diff --check`
- Self-review / exception reason: controller reviewed workflow/test/docs diff after AWP explorer readback
- Worker session closeout: Nash read-only explorer completed and was closed after confirming R0/R1 vs R2/R3/R4 gate semantics

## Review conversation closeout

- CodeRabbit first-head finding: docs precision issue was valid and fixed in `7128dfbd8975d62065e331a7b043a64064c11ba2`
- CodeRabbit latest status: success; latest walkthrough also reported review-capacity rate limit, so no fresh blocker was posted for the second head
- chatgpt-codex-connector: not requested for self-authored PR; no self-review per automation policy
- review_triage_ref: https://github.com/nurockplayer/tachigo/pull/903
- root_cause_gate_ref: https://github.com/nurockplayer/tachigo/pull/903
- finding_disposition_ref: https://github.com/nurockplayer/tachigo/pull/903
- Final reviewer action: blocked by human review required for R4 workflow policy PR

## Final merge gate

- Ready-to-merge decision: blocked by human review required; all automated checks passed on latest head
- Latest head SHA: 7128dfbd8975d62065e331a7b043a64064c11ba2
- Required checks: pass; product-heavy jobs skipped by Scope gate for workflow/docs-only lane as expected
- spec workflow-check evidence: `spec plan 896 --repo . --dry-run --format prompt --verbose`
- Evidence URL: https://github.com/nurockplayer/tachigo/pull/903

## Validation

- `node --test .github/workflows/ci.test.ts` - 98 pass
- `bash infra/scripts/pr-metadata-check.test.sh` - pass
- `git diff --check` - pass
- GitHub checks: Scope police, Scope gate, Workflow regression tests, PR metadata checks, PR commit messages, Backend CI gate, Cloudflare Pages, CodeRabbit status all pass/success at latest-head readback

## spec-injector context notes

- `docs/claude-codex-workflow.md` was still listed as always-read but missing.
- `pr-scope-police.yml` appeared as a stale issue-mentioned alias; actual file is `.github/workflows/pr-scope-police.yml`.
- Detected auth/schema/wallet guardrails were treated as conservative policy context only, not product-code scope.
