### PR TITLE
[infra] record Dev Portal public readback

### DIFF
--- a/docs/dev-portal/deployment.md
+++ b/docs/dev-portal/deployment.md
@@ -2,7 +2,7 @@
 title: 部署追蹤
 status: active
 owner: engineering
-last_reviewed: 2026-05-14
+last_reviewed: 2026-05-24
 source_of_truth: true
 code_areas:
   - docs
@@ -38,7 +38,7 @@ related_issues:
 | Node / package manager | Node 24 via `.node-version` / `pnpm@10.33.0` / lockfile |
 | Base path | `/tachigo/` via static `_redirects` rewrites |
 | Environment variables | optional `DOCS_SITE_URL`; Cloudflare injects `CF_PAGES_URL` |
-| Initial public URL | Cloudflare `*.pages.dev` URL |
+| Initial public URL | `https://tachigo-dev-portal.pages.dev/tachigo/` |
 | Custom domain | 延後決定；目前偏好 `wiki.tachigo.dev` |
 
 Cloudflare 後台操作重點：
@@ -68,6 +68,27 @@ Cloudflare Pages 的 preview 行為不能只靠填一個欄位宣稱完成。連
 | Public URL | 初期使用 Cloudflare `*.pages.dev` URL，不要求 custom domain |
 
 若 production deploy 或 PR preview 沒有出現在 dashboard，先不要把 #699 關成完成；補 Cloudflare Pages 設定或另開 issue 追蹤。
+
+## Current public readback
+
+Last verified: 2026-05-24 06:08 Asia/Taipei.
+
+Production URL: [https://tachigo-dev-portal.pages.dev/tachigo/](https://tachigo-dev-portal.pages.dev/tachigo/)
+
+| Path | Expected | Readback |
+|---|---|---|
+| `/tachigo/` | Dev Portal homepage | `200 text/html; charset=utf-8` |
+| `/tachigo/dev-portal/start-here` | core docs page | `200 text/html; charset=utf-8` |
+| `/tachigo/dev-portal/deployment` | deployment tracker page | `200 text/html; charset=utf-8` |
+| `/tachigo/dev-portal/source-index` | source index page | `200 text/html; charset=utf-8` |
+| `/tachigo/llms.txt` | public LLM index | `200 text/plain; charset=utf-8` |
+| `/tachigo/manifest.json` | public docs manifest | `200 application/json`; `jq` valid; `docs_count=9` |
+| `/tachigo/search` | search page | `200 text/html; charset=utf-8` |
+| `/tachigo/search-index.json` | search index payload | `200 application/json`; contains deployment and start-here docs |
+
+The public `pages.dev` URL is sufficient for the initial #699 readback. The
+custom domain gate remains deferred until the team decides whether to bind
+`wiki.tachigo.dev`.
 
 ## Branch 部署模型
 


### PR DESCRIPTION
refs #699

Source of truth: #699

Depends on PR: none

本 PR 明確不做
- 不改 Cloudflare Pages account/dashboard settings
- 不改 `.github/workflows/**`
- 不改 backend / API / database / hosted runtime
- 不引入 Cloudflare Workers / Functions / Access
- 不關閉 #699；PR preview / account-side ownership / dashboard readback 仍需 human confirmation

## Summary

- Record the current public Cloudflare Pages production URL in `docs/dev-portal/deployment.md`.
- Add the 2026-05-24 public readback table for `/tachigo/`, core docs pages, `llms.txt`, `manifest.json`, search, and `search-index.json`.
- Preserve the deferred custom-domain gate for `wiki.tachigo.dev`.

## PR Risk Class

- [x] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth: #699
- Scope: `docs/dev-portal/deployment.md` readback evidence only.
- Non-goals: no runtime, workflow, Cloudflare account, PR preview, or domain configuration change.

## Delegation Execution Log

- Source issue delegation plan: `spec plan 699 --repo . --dry-run --format prompt --verbose`
- Actual worker profile(s): repo_scout (Ampere AWP explorer) / controller
- Model strength: repo_scout = inherited; controller = current session
- Spawn directive(s): profile=repo_scout model=inherited reasoning=medium controller_fallback=allowed fallback_reason=controller_owned_docs_readback_patch_and_pr_publish
- Verification evidence: `git diff --check`; `pnpm install --frozen-lockfile --filter ./apps/docs...`; `make ai-docs-build`; public URL `curl` readback; manifest/search-index `jq` readback
- Self-review / exception reason: controller reviewed docs-only readback against Ampere read-only URL summary before publishing
- Worker session closeout: Ampere completed public Pages URL readback and was closed; it did not edit files, comment, or review PRs

## Review conversation closeout

- Unresolved threads: none found on first public head
- CodeRabbit: pass; Review completed
- chatgpt-codex-connector: not requested for self-authored PR; no self-review per automation policy
- review_triage_ref: no review threads on first public head
- root_cause_gate_ref: no review threads on first public head
- finding_disposition_ref: no review threads on first public head
- Final reviewer action: pending with reason: waiting for human review; self-authored PR is not self-reviewed

## Final merge gate

- Ready-to-merge decision: blocked only by required human review
- Latest head SHA: b0ac9cd0f8398f535ba36db9e64307787a85e8b3
- Required checks: pass or expected skipped; Cloudflare Pages pass; CodeRabbit pass
- spec workflow-check evidence: `spec plan 699 --repo . --dry-run --format prompt --verbose`
- Evidence URL: https://github.com/nurockplayer/tachigo/pull/905

## Validation

- `git diff --check` - pass
- `git diff --check HEAD~1..HEAD` - pass
- `pnpm install --frozen-lockfile --filter ./apps/docs...` - pass; installed ignored local dependencies only
- `make ai-docs-build` - pass
- Public URL readback - pass:
  - `/tachigo/` - `200 text/html; charset=utf-8`
  - `/tachigo/dev-portal/start-here` - `200 text/html; charset=utf-8`
  - `/tachigo/dev-portal/deployment` - `200 text/html; charset=utf-8`
  - `/tachigo/dev-portal/source-index` - `200 text/html; charset=utf-8`
  - `/tachigo/llms.txt` - `200 text/plain; charset=utf-8`
  - `/tachigo/manifest.json` - `200 application/json`; `jq` valid; `docs_count=9`
  - `/tachigo/search` - `200 text/html; charset=utf-8`
  - `/tachigo/search-index.json` - `200 application/json`; contains deployment and start-here docs

## spec-injector context notes

- `docs/claude-codex-workflow.md` was still listed as always-read but missing at root; actual AI docs path is `docs/ai/claude-codex-workflow.md`.
- `.github/workflows/deploy-docs.yml` appeared as an issue-mentioned alternative route, but #699 chose Cloudflare Pages GitHub integration, so this PR intentionally does not add that workflow.
- Detected frontend / infra / docs / tooling / backend signals were treated as conservative context only; this PR stays docs-only.
