### PR TITLE
[backend] test: add RBAC matrix route coverage gate

### DIFF
--- a/services/api/internal/handlers/rbac_handler_test.go
+++ b/services/api/internal/handlers/rbac_handler_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -133,6 +134,179 @@ type rbacMatrixCase struct {
 	want int
 }
 
+type rbacRouteKey struct {
+	method string
+	path   string
+}
+
+type rbacMatrixRoute struct {
+	name        string
+	method      string
+	routePath   string
+	requestPath string
+	cases       []rbacMatrixCase
+}
+
+func adminOnlyRBACCases() []rbacMatrixCase {
+	return []rbacMatrixCase{
+		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+		{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
+		{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
+		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+	}
+}
+
+func agencyOperatorRBACCases() []rbacMatrixCase {
+	return []rbacMatrixCase{
+		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+		{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
+		{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
+		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+	}
+}
+
+func eventOperatorRBACCases() []rbacMatrixCase {
+	return []rbacMatrixCase{
+		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+		{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
+		{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
+		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+	}
+}
+
+func dashboardOperatorRBACCases() []rbacMatrixCase {
+	return []rbacMatrixCase{
+		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+		{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
+		{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
+		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+	}
+}
+
+func centralizedRBACMatrixRoutes() []rbacMatrixRoute {
+	return []rbacMatrixRoute{
+		{
+			name:        "create agency is admin only",
+			method:      http.MethodPost,
+			routePath:   "/api/v1/agencies",
+			requestPath: "/api/v1/agencies",
+			cases:       adminOnlyRBACCases(),
+		},
+		{
+			name:        "agency detail allows agency or admin only",
+			method:      http.MethodGet,
+			routePath:   "/api/v1/agencies/:id",
+			requestPath: "/api/v1/agencies/agency_1",
+			cases:       agencyOperatorRBACCases(),
+		},
+		{
+			name:        "update agency settings allows agency or admin only",
+			method:      http.MethodPut,
+			routePath:   "/api/v1/agencies/:id/settings",
+			requestPath: "/api/v1/agencies/agency_1/settings",
+			cases:       agencyOperatorRBACCases(),
+		},
+		{
+			name:        "list agency streamers allows agency or admin only",
+			method:      http.MethodGet,
+			routePath:   "/api/v1/agencies/:id/streamers",
+			requestPath: "/api/v1/agencies/agency_1/streamers",
+			cases:       agencyOperatorRBACCases(),
+		},
+		{
+			name:        "resend setup is admin only",
+			method:      http.MethodPost,
+			routePath:   "/api/v1/agencies/:id/resend-setup",
+			requestPath: "/api/v1/agencies/agency_1/resend-setup",
+			cases:       adminOnlyRBACCases(),
+		},
+		{
+			name:        "create streamer is admin only",
+			method:      http.MethodPost,
+			routePath:   "/api/v1/dashboard/streamers",
+			requestPath: "/api/v1/dashboard/streamers",
+			cases:       adminOnlyRBACCases(),
+		},
+		{
+			name:        "list streamers is agency or admin only",
+			method:      http.MethodGet,
+			routePath:   "/api/v1/dashboard/streamers",
+			requestPath: "/api/v1/dashboard/streamers",
+			cases:       agencyOperatorRBACCases(),
+		},
+		{
+			name:        "channel config read allows dashboard operators",
+			method:      http.MethodGet,
+			routePath:   "/api/v1/dashboard/channels/:channel_id/config",
+			requestPath: "/api/v1/dashboard/channels/ch_ctx/config",
+			cases:       dashboardOperatorRBACCases(),
+		},
+		{
+			name:        "create event allows event operators",
+			method:      http.MethodPost,
+			routePath:   "/api/v1/events/create",
+			requestPath: "/api/v1/events/create",
+			cases:       eventOperatorRBACCases(),
+		},
+		{
+			name:        "settle event allows event operators",
+			method:      http.MethodPost,
+			routePath:   "/api/v1/events/:id/settle",
+			requestPath: "/api/v1/events/1/settle",
+			cases:       eventOperatorRBACCases(),
+		},
+		{
+			name:        "admin users is admin only",
+			method:      http.MethodGet,
+			routePath:   "/api/v1/admin/users",
+			requestPath: "/api/v1/admin/users",
+			cases:       adminOnlyRBACCases(),
+		},
+	}
+}
+
+func isRBACStubRoute(path string) bool {
+	switch {
+	case path == "/api/v1/agencies" || strings.HasPrefix(path, "/api/v1/agencies/"):
+		return true
+	case strings.HasPrefix(path, "/api/v1/dashboard/"):
+		return true
+	case strings.HasPrefix(path, "/api/v1/events/"):
+		return true
+	case strings.HasPrefix(path, "/api/v1/admin/"):
+		return true
+	default:
+		return false
+	}
+}
+
+func TestRBACMatrix_CoversAllProtectedStubRoutes(t *testing.T) {
+	env := newRBACTestEnv(t)
+
+	actualRoutes := map[rbacRouteKey]bool{}
+	for _, route := range env.router.Routes() {
+		if isRBACStubRoute(route.Path) {
+			actualRoutes[rbacRouteKey{method: route.Method, path: route.Path}] = true
+		}
+	}
+
+	matrixRoutes := map[rbacRouteKey]bool{}
+	for _, route := range centralizedRBACMatrixRoutes() {
+		matrixRoutes[rbacRouteKey{method: route.method, path: route.routePath}] = true
+	}
+
+	for route := range actualRoutes {
+		if !matrixRoutes[route] {
+			t.Errorf("%s %s is missing centralized RBAC matrix coverage", route.method, route.path)
+		}
+	}
+	for route := range matrixRoutes {
+		if !actualRoutes[route] {
+			t.Errorf("%s %s has stale centralized RBAC matrix coverage", route.method, route.path)
+		}
+	}
+}
+
 func assertRBACMatrix(t *testing.T, env *rbacEnv, method, path string, cases []rbacMatrixCase) {
 	t.Helper()
 
@@ -155,139 +329,11 @@ func assertRBACMatrix(t *testing.T, env *rbacEnv, method, path string, cases []r
 	}
 }
 
-func TestRBACMatrix_DashboardRoutes(t *testing.T) {
-	tests := []struct {
-		name   string
-		method string
-		path   string
-		cases  []rbacMatrixCase
-	}{
-		{
-			name:   "create streamer is admin only",
-			method: http.MethodPost,
-			path:   "/api/v1/dashboard/streamers",
-			cases: []rbacMatrixCase{
-				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
-				{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
-				{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
-				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
-			},
-		},
-		{
-			name:   "list streamers is agency or admin only",
-			method: http.MethodGet,
-			path:   "/api/v1/dashboard/streamers",
-			cases: []rbacMatrixCase{
-				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
-				{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
-				{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
-				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
-			},
-		},
-		{
-			name:   "channel config read allows dashboard operators",
-			method: http.MethodGet,
-			path:   "/api/v1/dashboard/channels/ch_ctx/config",
-			cases: []rbacMatrixCase{
-				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
-				{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
-				{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
-				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+func TestRBACMatrix_ProtectedStubRoutes(t *testing.T) {
+	for _, route := range centralizedRBACMatrixRoutes() {
+		t.Run(route.name, func(t *testing.T) {
 			env := newRBACTestEnv(t)
-			assertRBACMatrix(t, env, tt.method, tt.path, tt.cases)
-		})
-	}
-}
-
-func TestRBACMatrix_AgencyReadAndSetupRoutes(t *testing.T) {
-	tests := []struct {
-		name   string
-		method string
-		path   string
-		cases  []rbacMatrixCase
-	}{
-		{
-			name:   "agency detail allows agency or admin only",
-			method: http.MethodGet,
-			path:   "/api/v1/agencies/agency_1",
-			cases: []rbacMatrixCase{
-				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
-				{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
-				{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
-				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
-			},
-		},
-		{
-			name:   "resend setup is admin only",
-			method: http.MethodPost,
-			path:   "/api/v1/agencies/agency_1/resend-setup",
-			cases: []rbacMatrixCase{
-				{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
-				{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
-				{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
-				{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			env := newRBACTestEnv(t)
-			assertRBACMatrix(t, env, tt.method, tt.path, tt.cases)
-		})
-	}
-}
-
-func TestRBACMatrix_EventAndAdminStubRoutes(t *testing.T) {
-	eventOperatorCases := []rbacMatrixCase{
-		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
-		{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
-		{name: "agency allowed", role: models.RoleAgency, want: http.StatusNotImplemented},
-		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
-	}
-	adminOnlyCases := []rbacMatrixCase{
-		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
-		{name: "streamer forbidden", role: models.RoleStreamer, want: http.StatusForbidden},
-		{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
-		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
-	}
-
-	tests := []struct {
-		name   string
-		method string
-		path   string
-		cases  []rbacMatrixCase
-	}{
-		{
-			name:   "create event allows event operators",
-			method: http.MethodPost,
-			path:   "/api/v1/events/create",
-			cases:  eventOperatorCases,
-		},
-		{
-			name:   "settle event allows event operators",
-			method: http.MethodPost,
-			path:   "/api/v1/events/1/settle",
-			cases:  eventOperatorCases,
-		},
-		{
-			name:   "admin users is admin only",
-			method: http.MethodGet,
-			path:   "/api/v1/admin/users",
-			cases:  adminOnlyCases,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			env := newRBACTestEnv(t)
-			assertRBACMatrix(t, env, tt.method, tt.path, tt.cases)
+			assertRBACMatrix(t, env, route.method, route.requestPath, route.cases)
 		})
 	}
 }

--- a/services/api/internal/handlers/rbac_handler_test.go
+++ b/services/api/internal/handlers/rbac_handler_test.go
@@ -269,14 +269,37 @@ func isRBACStubRoute(path string) bool {
 	switch {
 	case path == "/api/v1/agencies" || strings.HasPrefix(path, "/api/v1/agencies/"):
 		return true
-	case strings.HasPrefix(path, "/api/v1/dashboard/"):
+	case path == "/api/v1/dashboard" || strings.HasPrefix(path, "/api/v1/dashboard/"):
 		return true
-	case strings.HasPrefix(path, "/api/v1/events/"):
+	case path == "/api/v1/events" || strings.HasPrefix(path, "/api/v1/events/"):
 		return true
-	case strings.HasPrefix(path, "/api/v1/admin/"):
+	case path == "/api/v1/admin" || strings.HasPrefix(path, "/api/v1/admin/"):
 		return true
 	default:
 		return false
+	}
+}
+
+func TestRBACMatrix_StubRouteFilterIncludesTopLevelProtectedSegments(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "agencies root", path: "/api/v1/agencies", want: true},
+		{name: "dashboard root", path: "/api/v1/dashboard", want: true},
+		{name: "events root", path: "/api/v1/events", want: true},
+		{name: "admin root", path: "/api/v1/admin", want: true},
+		{name: "dashboard child", path: "/api/v1/dashboard/streamers", want: true},
+		{name: "public route", path: "/api/v1/health", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRBACStubRoute(tt.path); got != tt.want {
+				t.Fatalf("isRBACStubRoute(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
新增 `rbac_handler_test.go` 的 centralized RBAC matrix route coverage gate，讓 `newRBACTestEnv` 內的受保護 stub route 必須都有同一份 matrix row。

## 為什麼
延續 #646 的 RBAC ownership / protected endpoint regression coverage 工作。先前 PR 已補多批 route-level / ownership 測試，這個切片補上最後一個 coverage gate：新增 protected stub route 時若忘記加入 centralized matrix，CI 會失敗。

refs #646

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#646
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 production router / middleware / handler 行為
  - 不新增 schema / migration / API contract
  - 不把 ownership / cross-tenant 行為塞進這個 coverage gate
  - 不掃完整 production router；只檢查 `newRBACTestEnv` 的 lightweight protected stubs

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #646；無正式 Issue Delegation Plan，本 PR 依 heartbeat AWP contract 採 issue-scoped controller + read-only worker dispatch
- Actual worker profile(s)：
  - controller：實作、驗證、PR 發布
  - Lovelace `019e57f2-c198-7191-81b4-46f74b02e52b`：read-only RBAC matrix route inventory / gate design 建議
- Model strength：
  - controller = high；Lovelace = inherited
- Spawn directive(s)：
  - profile=worker model=inherited reasoning=inherited controller_fallback=allowed fallback_reason=controller implemented after read-only worker inventory; worker_session=019e57f2-c198-7191-81b4-46f74b02e52b
- Verification evidence：
  - `spec plan 646 --repo . --dry-run --format prompt --verbose`
  - RED：`GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run TestRBACMatrix_CoversAllProtectedStubRoutes -count=1` 先失敗並列出 3 條缺 coverage 的 stub route
  - GREEN：`GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRBACMatrix_(CoversAllProtectedStubRoutes|ProtectedStubRoutes)$' -count=1`
  - full backend：`GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
  - `git diff --check`
- Self-review / exception reason：
  - 已做 self-review；tests-only route coverage gate，無 production behavior change
- Worker session closeout：
  - Lovelace read-only worker result 已讀回，session 已 close
- Workflow friction / follow-up split：
  - #664 dogfood ledger comment 會在 PR merge 後補一筆 compact datapoint；本 PR 不新增 workflow / threshold 變更

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - pending with reason: PR 尚未建立，等待 GitHub automated review
- chatgpt-codex-connector：
  - pending with reason: PR 尚未建立，等待 GitHub automated review
- review_triage_ref：
  - pending with reason: no review findings at PR creation
- root_cause_gate_ref：
  - pending with reason: no repeated finding at PR creation
- finding_disposition_ref：
  - pending with reason: no review finding disposition at PR creation
- Final reviewer action：
  - n/a at PR creation

## Final merge gate
- Ready-to-merge decision：
  - pending with reason: PR 尚未建立，等待 GitHub checks / reviewer
- Latest head SHA：
  - n/a before push
- Required checks：
  - pending with reason: PR 尚未建立
- spec workflow-check evidence：
  - spec gate status: pass
  - spec_evidence_ref=workflow-check:commit:issue-646
- Evidence URL：
  - n/a at PR creation

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 RBAC centralized matrix 對 `newRBACTestEnv` 的所有 protected stub routes 有雙向 coverage gate。
- Approx changed lines：~300
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #859, #873, #876, #878, #889

## Acceptance Criteria
- [x] Centralized RBAC matrix now covers all protected stub routes registered by `newRBACTestEnv`
- [x] CI fails when a protected stub route is added without a centralized matrix row
- [x] Matrix still verifies unauthenticated / wrong-role access for protected stub routes
- [x] Ownership / cross-tenant behavior remains in handler-specific tests and is not expanded in this gate

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestRBACMatrix_(CoversAllProtectedStubRoutes|ProtectedStubRoutes)$' -count=1
ok  	github.com/tachigo/tachigo/internal/handlers	4.464s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok  	github.com/tachigo/tachigo/internal/handlers	20.718s
ok  	github.com/tachigo/tachigo/internal/services	(cached)
ok  	(all services/api packages)

git diff --check
pass
```

## 備註
`spec plan` 回報 repo always-read `docs/claude-codex-workflow.md` missing；實際存在的是 `docs/ai/claude-codex-workflow.md`。本 PR 未修改 spec-injector config。

## Notes for Claude Code Review
- 請特別看 `TestRBACMatrix_CoversAllProtectedStubRoutes` 的 route inventory 是否只鎖定 `newRBACTestEnv` 的 protected stubs，避免誤以為它涵蓋完整 production router。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 将基于角色的访问控制测试重构为统一的矩阵化测试结构，替代原先的分组式测试
  * 新增完整性校验，确保所有受保护路由均被纳入测试矩阵
  * 新增受保护顶级路由匹配规则的验证测试
  * 移除并替换若干过时的分组测试，优化多角色权限断言流程

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
