### PR TITLE
[frontend] Raffle Prize Tiers — Dashboard UI + API Client

### DIFF
--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -2,8 +2,8 @@ import { useOne } from '@refinedev/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { activateRaffle, completeRaffle, drawNext, importCSV, listDraws, setDiscordWebhook } from '@/services/raffles'
-import type { Raffle, RaffleDraw, RaffleStatus } from '@/services/raffles'
+import { activateRaffle, completeRaffle, createPrizeTier, deletePrizeTier, drawFromTier, drawNext, importCSV, listDraws, listPrizeTiers, setDiscordWebhook } from '@/services/raffles'
+import type { Raffle, RaffleDraw, RafflePrizeTier, RaffleStatus } from '@/services/raffles'
 import gachaBg from '../assets/raffle-bg.jpg.png'
 
 const OCEAN_KEYFRAMES = `
@@ -132,6 +132,11 @@ function WinnerList({ draws }: { draws: RaffleDraw[] }) {
             #{draws.length - index}
           </span>
           <span className="flex-1 text-sm font-medium">
+            {draw.prize_tier && (
+              <span className="mr-1.5 rounded bg-blue-900/60 px-1.5 py-0.5 text-[10px] font-semibold text-blue-300">
+                {draw.prize_tier.name}
+              </span>
+            )}
             {draw.entry.display_name || draw.entry.twitch_login}
           </span>
           <span className="text-[10px] text-white/30">{formatRelativeTime(draw.drawn_at)}</span>
@@ -558,6 +563,13 @@ export default function RaffleDetailPage() {
   const [shaking, setShaking] = useState(false)
   const [popBallColor, setPopBallColor] = useState<string | null>(null)
   const [modalWinner, setModalWinner] = useState<string | null>(null)
+  const [tiers, setTiers] = useState<RafflePrizeTier[]>([])
+  const [tierDrawing, setTierDrawing] = useState<Record<string, boolean>>({})
+  const [tierExhausted, setTierExhausted] = useState<Record<string, boolean>>({})
+  const [showAddTier, setShowAddTier] = useState(false)
+  const [newTier, setNewTier] = useState({ name: '', prize_description: '', winner_count: 1 })
+  const [addingTier, setAddingTier] = useState(false)
+  const [addTierError, setAddTierError] = useState<string | null>(null)
 
   const pendingTimers = useRef<number[]>([])
 
@@ -566,6 +578,15 @@ export default function RaffleDetailPage() {
   }, [])
 
   const effectiveStatus = localCompleted ? 'completed' : localActivated ? 'active' : (raffle?.status ?? '')
+
+  const fetchTiers = useCallback(async () => {
+    if (!raffleId) return
+    try {
+      setTiers(await listPrizeTiers(raffleId))
+    } catch {
+      setTiers([])
+    }
+  }, [raffleId])
 
   const fetchDraws = useCallback(async (): Promise<RaffleDraw[]> => {
     if (!raffleId) return []
@@ -583,6 +604,7 @@ export default function RaffleDetailPage() {
     if (!raffleId) return
     const initialLoadId = window.setTimeout(() => {
       void fetchDraws()
+      void fetchTiers()
     }, 0)
 
     if (effectiveStatus === 'completed') {
@@ -597,7 +619,7 @@ export default function RaffleDetailPage() {
       window.clearTimeout(initialLoadId)
       window.clearInterval(timerId)
     }
-  }, [effectiveStatus, fetchDraws, raffleId])
+  }, [effectiveStatus, fetchDraws, fetchTiers, raffleId])
 
   async function handleDraw() {
     if (!raffleId || drawing) return
@@ -662,6 +684,48 @@ export default function RaffleDetailPage() {
       setConfirmEnd(false)
     } finally {
       setEnding(false)
+    }
+  }
+
+  async function handleAddTier() {
+    if (!raffleId || addingTier || !newTier.name.trim() || newTier.winner_count < 1) return
+    setAddingTier(true)
+    setAddTierError(null)
+    try {
+      await createPrizeTier(raffleId, newTier)
+      await fetchTiers()
+      setNewTier({ name: '', prize_description: '', winner_count: 1 })
+      setShowAddTier(false)
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } } }
+      setAddTierError(e?.response?.data?.error ?? '新增失敗，請稍後再試')
+    } finally {
+      setAddingTier(false)
+    }
+  }
+
+  async function handleDrawFromTier(tierId: string) {
+    if (!raffleId || tierDrawing[tierId]) return
+    setTierDrawing(prev => ({ ...prev, [tierId]: true }))
+    try {
+      await drawFromTier(raffleId, tierId)
+      await Promise.all([fetchTiers(), fetchDraws()])
+      setTierExhausted(prev => ({ ...prev, [tierId]: false }))
+    } catch (error: unknown) {
+      const res = (error as { response?: { status?: number } }).response
+      if (res?.status === 409) setTierExhausted(prev => ({ ...prev, [tierId]: true }))
+    } finally {
+      setTierDrawing(prev => ({ ...prev, [tierId]: false }))
+    }
+  }
+
+  async function handleDeleteTier(tierId: string) {
+    if (!raffleId) return
+    try {
+      await deletePrizeTier(raffleId, tierId)
+      await fetchTiers()
+    } catch {
+      // tier has draws — ignore silently
     }
   }
 
@@ -808,6 +872,73 @@ export default function RaffleDetailPage() {
           </div>
         </div>
       </div>
+
+      {/* Prize Tiers */}
+      {effectiveStatus === 'active' && (
+        <div style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
+          <div style={{ ...glassStyle, padding: '16px 20px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+              <span style={{ fontSize: 13, fontWeight: 700, color: '#e0f2fe', letterSpacing: '.04em' }}>🏆 獎項設定</span>
+              <button
+                onClick={() => setShowAddTier(v => !v)}
+                style={{ background: 'rgba(56,189,248,.12)', border: '1px solid rgba(56,189,248,.3)', color: '#7dd3fc', borderRadius: 6, padding: '4px 12px', fontSize: 12, cursor: 'pointer' }}
+              >
+                {showAddTier ? '取消' : '+ 新增獎項'}
+              </button>
+            </div>
+
+            {showAddTier && (
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: 12, padding: '10px 12px', background: 'rgba(56,189,248,.06)', borderRadius: 8, border: '1px solid rgba(56,189,248,.15)' }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                  <label style={{ fontSize: 10, color: 'rgba(148,210,255,.6)' }}>獎項名稱</label>
+                  <input value={newTier.name} onChange={e => setNewTier(p => ({ ...p, name: e.target.value }))} placeholder="例：一等獎" style={{ background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                  <label style={{ fontSize: 10, color: 'rgba(148,210,255,.6)' }}>獎品描述</label>
+                  <input value={newTier.prize_description} onChange={e => setNewTier(p => ({ ...p, prize_description: e.target.value }))} placeholder="例：Switch 主機" style={{ background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                  <label style={{ fontSize: 10, color: 'rgba(148,210,255,.6)' }}>抽幾人</label>
+                  <input type="number" min={1} value={newTier.winner_count} onChange={e => setNewTier(p => ({ ...p, winner_count: Number(e.target.value) }))} style={{ width: 60, background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
+                </div>
+                <button onClick={() => { void handleAddTier() }} disabled={addingTier || !newTier.name.trim()} style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 6, padding: '6px 14px', fontSize: 12, cursor: 'pointer', opacity: (addingTier || !newTier.name.trim()) ? .5 : 1 }}>
+                  {addingTier ? '新增中...' : '確認新增'}
+                </button>
+                {addTierError && (
+                  <p style={{ fontSize: 11, color: '#f87171', marginTop: 6, width: '100%' }}>{addTierError}</p>
+                )}
+              </div>
+            )}
+
+            {tiers.length === 0 && !showAddTier && (
+              <p style={{ fontSize: 12, color: 'rgba(148,210,255,.4)', textAlign: 'center', padding: '8px 0' }}>尚未設定獎項</p>
+            )}
+
+            {tiers.map(tier => {
+              const isDone = tier.drawn_count >= tier.winner_count
+              const isDrawing = tierDrawing[tier.id] ?? false
+              const isExhausted = tierExhausted[tier.id] ?? false
+              return (
+                <div key={tier.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px', borderRadius: 8, marginBottom: 6, background: isDone ? 'rgba(255,255,255,.03)' : 'rgba(56,189,248,.05)', border: `1px solid ${isDone ? 'rgba(255,255,255,.08)' : 'rgba(56,189,248,.18)'}` }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: isDone ? 'rgba(148,210,255,.5)' : '#e0f2fe' }}>{tier.name}</span>
+                    {tier.prize_description && <span style={{ fontSize: 11, color: 'rgba(148,210,255,.5)' }}>{tier.prize_description}</span>}
+                    <span style={{ fontSize: 10, color: isDone ? '#4ade80' : 'rgba(148,210,255,.4)' }}>{tier.drawn_count} / {tier.winner_count} 人已抽出</span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                    <button onClick={() => { void handleDrawFromTier(tier.id) }} disabled={isDone || isDrawing || isExhausted} style={{ background: 'rgba(14,165,233,.15)', border: '1px solid rgba(14,165,233,.3)', color: '#38bdf8', borderRadius: 6, padding: '5px 12px', fontSize: 11, cursor: 'pointer', opacity: (isDone || isDrawing || isExhausted) ? .4 : 1 }}>
+                      {isDrawing ? '抽中...' : isExhausted ? '已抽完' : '抽一人'}
+                    </button>
+                    {tier.drawn_count === 0 && (
+                      <button onClick={() => { void handleDeleteTier(tier.id) }} style={{ background: 'rgba(239,68,68,.1)', border: '1px solid rgba(239,68,68,.25)', color: '#f87171', borderRadius: 6, padding: '5px 10px', fontSize: 11, cursor: 'pointer' }}>✕</button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
 
       <WinnerModal name={modalWinner} onClose={() => setModalWinner(null)} />
     </div>

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -21,6 +21,16 @@ export interface RaffleEntry {
   created_at: string
 }
 
+export interface RafflePrizeTier {
+  id: string
+  raffle_id: string
+  name: string
+  prize_description: string
+  winner_count: number
+  drawn_count: number
+  created_at: string
+}
+
 export interface RaffleDraw {
   id: string
   raffle_id: string
@@ -29,6 +39,8 @@ export interface RaffleDraw {
   claim_expires_at: string
   drawn_at: string
   entry: RaffleEntry
+  prize_tier_id?: string
+  prize_tier?: RafflePrizeTier
 }
 
 export async function listRaffles(): Promise<Raffle[]> {
@@ -87,6 +99,36 @@ export async function completeRaffle(raffleId: string): Promise<void> {
     `/api/v1/dashboard/raffles/${raffleId}/complete`,
     undefined,
   )
+}
+
+export async function listPrizeTiers(raffleId: string): Promise<RafflePrizeTier[]> {
+  const { data } = await client.get<ApiResponse<{ tiers: RafflePrizeTier[] }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/prize-tiers`,
+  )
+  return data.data.tiers
+}
+
+export async function createPrizeTier(
+  raffleId: string,
+  payload: { name: string; prize_description: string; winner_count: number },
+): Promise<RafflePrizeTier> {
+  const { data } = await client.post<ApiResponse<{ tier: RafflePrizeTier }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/prize-tiers`,
+    payload,
+  )
+  return data.data.tier
+}
+
+export async function deletePrizeTier(raffleId: string, tierId: string): Promise<void> {
+  await client.delete(`/api/v1/dashboard/raffles/${raffleId}/prize-tiers/${tierId}`)
+}
+
+export async function drawFromTier(raffleId: string, tierId: string): Promise<RaffleDraw> {
+  const { data } = await client.post<ApiResponse<{ draw: RaffleDraw }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/prize-tiers/${tierId}/draws`,
+    undefined,
+  )
+  return data.data.draw
 }
 
 export async function setDiscordWebhook(


### PR DESCRIPTION
## 什麼改動

為 Raffle Prize Tier 功能新增 Dashboard API client 與 UI 區塊。

## 為什麼

closes #907

後端 Prize Tier API 已於 PR #845 merge 至 develop。本 PR 實作對應的 Dashboard 前端：API client 函式、RafflePrizeTier TypeScript interface，以及 RaffleDetailPage 的獎項管理 UI。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#907
- Depends on PR:none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改後端任何檔案
  - 不改 Extension 畫面
  - 不改 /claim 頁面
  - 不實作每個獎項各自的 Discord webhook 設定
  - 不實作 Campaign 多場抽獎層（#234 討論範圍）

## PR 拆分檢查
- 這個 PR 的單一句子目的：新增 Prize Tier API client 函式與 Dashboard RaffleDetailPage 獎項管理 UI 區塊
- Approx changed lines：~189
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [ ] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？n/a
- 若已拆分，相關 PR：#845（已 merge）

## Acceptance Criteria
- [x] `listPrizeTiers`、`createPrizeTier`、`deletePrizeTier`、`drawFromTier` API 函式（response keys 符合後端 contract）
- [x] `RafflePrizeTier` TypeScript interface
- [x] `RaffleDraw` 加 `prize_tier_id?`、`prize_tier?` 欄位
- [x] `RaffleDetailPage` 顯示獎項區塊（新增/抽一人/刪除），僅 active 狀態顯示
- [x] 新增獎項失敗時顯示錯誤訊息
- [x] 中獎記錄顯示獎項名稱 badge
- [x] TypeScript 零錯誤

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試（前端 E2E 不在本 PR 範圍）

**驗證結果**
```
npx tsc --noEmit → 零錯誤
npx vitest run → 14 test files, 109 tests passed
```

## 備註
本 PR 取代 PR #865（cherry-pick 版本），從最新 develop 乾淨實作。CodeRabbit review 已修正三個 API contract 錯誤（response keys: tiers/tier/draws）與 handleAddTier 錯誤處理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 獎項分級管理：支持新增、刪除獎項分級，含名稱/描述/抽幾人設定與表單重置
  * 分級抽獎：可從指定獎項分級進行單次抽獎，介面顯示抽一人按鈕與抽取進度
  * 獲獎資訊增強：獲獎名單旁顯示對應獎項分級名稱
  * 初次載入與刷新：頁面會在載入及依賴變更時同步取得並更新分級列表

* **改善**
  * 衝突處理：當抽獎回傳衝突（已無名額）時標示該分級為已抽完
  * 刪除容錯：刪除失敗時靜默忽略，避免中斷介面流程

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->