### PR TITLE
[frontend] add menu hub visual

### DIFF
--- a/apps/extension/src/app/navigation/OverlayHost.test.tsx
+++ b/apps/extension/src/app/navigation/OverlayHost.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { afterEach, expect, test } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { NavigationProvider } from './NavigationProvider'
+import { OverlayHost } from './OverlayHost'
+import { useNavigation } from './useNavigation'
+
+function Harness() {
+  const { state, pushOverlay } = useNavigation()
+  const topOverlay = state.overlayStack.at(-1)?.kind ?? 'none'
+
+  return (
+    <>
+      <button type="button" onClick={() => pushOverlay({ kind: 'menu' })}>
+        open menu
+      </button>
+      <output aria-label="top overlay">{topOverlay}</output>
+      <OverlayHost
+        cpcBalance={0}
+        tcgBalance={0}
+        redeemedCouponIds={[]}
+        voucherCodes={{}}
+        onClaim={() => undefined}
+        onCouponRedeem={async () => 'error'}
+      />
+    </>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+test('menu hub exposes all MVP destination buttons and opens a panel', () => {
+  render(
+    <NavigationProvider>
+      <Harness />
+    </NavigationProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'open menu' }))
+
+  for (const label of ['Account', 'Settings', 'Character', 'Collection', 'Missions', 'Equipment']) {
+    expect(screen.getByRole('button', { name: label })).toBeTruthy()
+  }
+
+  fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+
+  expect(screen.getByLabelText('top overlay').textContent).toBe('settings')
+})

--- a/apps/extension/src/app/navigation/OverlayHost.tsx
+++ b/apps/extension/src/app/navigation/OverlayHost.tsx
@@ -4,6 +4,7 @@ import { RaffleResultPanel } from '../components/RaffleResultPanel'
 import { PlaceholderSurface } from './PlaceholderSurface'
 import { useNavigation } from './useNavigation'
 import type { CouponRedeemOutcome } from '../couponRedeem'
+import type { Overlay } from './types'
 
 interface OverlayHostProps {
   cpcBalance: number
@@ -14,27 +15,139 @@ interface OverlayHostProps {
   onCouponRedeem: (couponId: string, cost: number) => Promise<CouponRedeemOutcome>
 }
 
+const menuEntries: Array<{
+  kind: Extract<Overlay, 'account' | 'settings' | 'character-switch' | 'collection' | 'missions' | 'equipment'>
+  label: string
+  code: string
+  accent: string
+}> = [
+  { kind: 'account', label: 'Account', code: 'AC', accent: '#38bdf8' },
+  { kind: 'settings', label: 'Settings', code: 'ST', accent: '#facc15' },
+  { kind: 'character-switch', label: 'Character', code: 'CH', accent: '#34d399' },
+  { kind: 'collection', label: 'Collection', code: 'CO', accent: '#f472b6' },
+  { kind: 'missions', label: 'Missions', code: 'MS', accent: '#a78bfa' },
+  { kind: 'equipment', label: 'Equipment', code: 'EQ', accent: '#fb923c' },
+]
+
 function MenuOverlay() {
   const { popOverlay, pushOverlay } = useNavigation()
 
   return (
-    <PlaceholderSurface
-      eyebrow="Menu"
-      title="Gear Hub"
-      body="Dev-only navigation hub for the extension MVP skeleton."
-      action={
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {(['account', 'settings', 'character-switch', 'collection', 'missions', 'equipment'] as const).map((kind) => (
-            <button key={kind} type="button" onClick={() => pushOverlay({ kind })} style={menuButtonStyle}>
-              {kind}
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        minHeight: 600,
+        overflow: 'hidden',
+        padding: '28px 22px 24px',
+        boxSizing: 'border-box',
+        background:
+          'linear-gradient(180deg, rgba(12, 18, 32, 0.98), rgba(4, 47, 46, 0.96) 56%, rgba(17, 24, 39, 0.98))',
+        color: '#f8fafc',
+        fontFamily: 'var(--ui-font-family)',
+      }}
+    >
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background:
+            'linear-gradient(90deg, rgba(125,211,252,0.08) 1px, transparent 1px), linear-gradient(180deg, rgba(125,211,252,0.06) 1px, transparent 1px)',
+          backgroundSize: '28px 28px',
+          opacity: 0.7,
+        }}
+      />
+      <div style={{ position: 'relative', zIndex: 1, display: 'grid', height: '100%', gap: 18 }}>
+        <header style={{ display: 'grid', gap: 8 }}>
+          <div
+            style={{
+              color: '#7dd3fc',
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 9,
+              letterSpacing: 0,
+              textTransform: 'uppercase',
+            }}
+          >
+            Menu
+          </div>
+          <h1 style={{ margin: 0, fontFamily: 'var(--pixel-font-family)', fontSize: 28, lineHeight: 1 }}>
+            Gear Hub
+          </h1>
+        </header>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+            alignContent: 'start',
+            gap: 10,
+          }}
+        >
+          {menuEntries.map((entry) => (
+            <button
+              key={entry.kind}
+              type="button"
+              aria-label={entry.label}
+              onClick={() => pushOverlay({ kind: entry.kind })}
+              style={{
+                minHeight: 92,
+                border: '1px solid rgba(226, 232, 240, 0.12)',
+                borderRadius: 8,
+                padding: 12,
+                background: 'rgba(15, 23, 42, 0.78)',
+                color: '#f8fafc',
+                cursor: 'pointer',
+                textAlign: 'left',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 12,
+                boxShadow: `inset 0 3px 0 ${entry.accent}, 0 10px 26px rgba(2, 6, 23, 0.24)`,
+                fontFamily: 'var(--ui-font-family)',
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  display: 'inline-grid',
+                  placeItems: 'center',
+                  width: 28,
+                  height: 28,
+                  borderRadius: 999,
+                  background: entry.accent,
+                  color: '#020617',
+                  fontFamily: 'var(--pixel-font-family)',
+                  fontSize: 9,
+                }}
+              >
+                {entry.code}
+              </span>
+              <span style={{ flex: 1, fontWeight: 700, fontSize: 13, lineHeight: 1.2 }}>{entry.label}</span>
             </button>
           ))}
-          <button type="button" onClick={popOverlay} style={menuButtonStyle}>
-            close
-          </button>
         </div>
-      }
-    />
+
+        <button
+          type="button"
+          onClick={popOverlay}
+          style={{
+            alignSelf: 'end',
+            minHeight: 36,
+            border: '1px solid rgba(148, 163, 184, 0.22)',
+            borderRadius: 8,
+            background: 'rgba(15, 23, 42, 0.58)',
+            color: '#e2e8f0',
+            cursor: 'pointer',
+            fontFamily: 'var(--pixel-font-family)',
+            fontSize: 9,
+          }}
+        >
+          Close
+        </button>
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
## 什麼改動
- 將 `menu` overlay 從 placeholder 改成 Gear Hub 視覺。
- 新增 account / settings / character / collection / missions / equipment 六個入口按鈕。
- 補 `OverlayHost` 測試，驗證 hub 入口可 push 對應 overlay。

## 為什麼
closes #745

#737 / PR #911 的導航骨架已合併，menu overlay 已能接線；本 PR 只補齒輪 hub 的可用視覺與入口按鈕，不實作各子面板內容。

## Release Context
- Release type：`n/a`

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#745
- Depends on PR：#911
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 settings / account / character / collection / missions / equipment 子面板內容
  - 不做 settings store 或 chrome storage 持久化（#746）
  - 不做 HUD / 音效 / 角色系統行為變更

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #745 did not define a separate worker plan.
- Actual worker profile(s)：
  - controller-direct fallback
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller model=gpt-5 reasoning=high controller_fallback=used fallback_reason=small_single_surface_frontend_overlay_visual_test_slice_no_worker_spawned
- Verification evidence：
  - `spec plan 745 --repo . --dry-run --format prompt --verbose`
  - `spec workflow-check --repo . --phase commit --format text` -> manual fallback, PR body pending at command time
  - `pnpm --dir apps/extension test`
  - `pnpm --dir apps/extension build`
  - `pnpm --dir apps/extension lint`
  - `git diff --check`
- Self-review / exception reason：
  - Self-review completed; no worker because this is a two-file UI/test slice in an isolated worktree.
- Worker session closeout：
  - n/a; no worker spawned.
- Workflow friction / follow-up split：
  - #664 ledger comment after merge; no follow-up opened because #746 already tracks settings/store behavior.

## Review conversation closeout
- Unresolved threads：
  - pending initial review
- CodeRabbit：
  - pending
- chatgpt-codex-connector：
  - pending
- review_triage_ref：
  - this PR body / latest head
- root_cause_gate_ref：
  - n/a; no repeated finding yet
- finding_disposition_ref：
  - n/a; no findings yet
- Final reviewer action：
  - pending

## Final merge gate
- Ready-to-merge decision：
  - pending GitHub checks and non-author review
- Latest head SHA：
  - `815dfccf482686f1d60e65e8390e7c7eeff76124`
- Required checks：
  - pending after PR creation
- spec workflow-check evidence：
  - commit phase manual fallback: PR body was pending at command time; repo-local staged state clean after commit
- Evidence URL：
  - n/a until final closeout

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 把 menu overlay 從 placeholder 變成可用的 Gear Hub 視覺入口。
- Approx changed lines：~192
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #745 acceptance requires menu entry behavior plus test coverage in the same frontend slice.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 齒輪 hub 選單視覺設計實作
- [x] 入口按鈕：account / settings / character-switch / collection / missions / equipment
- [x] 流式佈局
- [x] hub 視覺完成、各入口可開對應面板；`pnpm test` 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm --dir apps/extension test
Test Files 20 passed (20); Tests 71 passed (71)

pnpm --dir apps/extension build
built successfully

pnpm --dir apps/extension lint
pass

git diff --check
pass
```

## 備註
- 子面板仍沿用既有 placeholder overlay；本 PR 只交付 hub 入口視覺與 navigation wiring。

## Notes for Claude Code Review
- Please focus on whether the Gear Hub visual is enough for #745 while keeping each destination panel out of scope for follow-up issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 改进菜单界面和交互体验，提供更直观的导航设计和视觉样式。
  * 扩展菜单项功能，用户可快速访问账户、设置、角色、收藏、任务和装备等主要功能模块。

* **测试**
  * 新增菜单导航功能测试用例。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->