### PR TITLE
[frontend] animate entry scene

### DIFF
--- a/apps/extension/src/app/components/EntryScene.tsx
+++ b/apps/extension/src/app/components/EntryScene.tsx
@@ -13,6 +13,14 @@ const bubbleStyle: CSSProperties = {
   boxShadow: '0 0 16px rgba(125, 211, 252, 0.25)',
 }
 
+const motionBubbles: Array<CSSProperties> = [
+  { top: '16%', left: '18%', width: 11, height: 11, animationDelay: '0ms' },
+  { top: '23%', right: '22%', width: 17, height: 17, animationDelay: '480ms' },
+  { bottom: '33%', left: '12%', width: 8, height: 8, animationDelay: '960ms' },
+  { top: '42%', right: '11%', width: 10, height: 10, animationDelay: '1320ms' },
+  { bottom: '20%', left: '42%', width: 14, height: 14, animationDelay: '1740ms' },
+]
+
 export function EntryScene({ onEnter }: EntrySceneProps) {
   const { t } = useTranslation()
 
@@ -48,12 +56,44 @@ export function EntryScene({ onEnter }: EntrySceneProps) {
             'radial-gradient(circle at 20% 12%, rgba(224,242,254,0.28), transparent 20%), radial-gradient(circle at 75% 28%, rgba(45,212,191,0.28), transparent 24%), linear-gradient(180deg, transparent 55%, rgba(8,47,73,0.44) 100%)',
         }}
       />
-      <div style={{ ...bubbleStyle, top: '16%', left: '18%', width: 11, height: 11 }} />
-      <div style={{ ...bubbleStyle, top: '23%', right: '22%', width: 17, height: 17 }} />
-      <div style={{ ...bubbleStyle, bottom: '33%', left: '12%', width: 8, height: 8 }} />
+      <div
+        aria-hidden="true"
+        className="entry-motion-layer"
+        data-testid="entry-motion-layer"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+        }}
+      >
+        {motionBubbles.map((style, index) => (
+          <div
+            key={index}
+            className="entry-motion-bubble"
+            data-testid="entry-motion-bubble"
+            style={{ ...bubbleStyle, ...style }}
+          />
+        ))}
+        <div
+          className="entry-current-ribbon"
+          data-testid="entry-current-ribbon"
+          style={{
+            position: 'absolute',
+            top: '50%',
+            left: '-18%',
+            width: '136%',
+            height: 44,
+            borderRadius: 999,
+            background:
+              'linear-gradient(90deg, transparent 0%, rgba(186,230,253,0.12) 24%, rgba(45,212,191,0.22) 52%, rgba(14,165,233,0.12) 76%, transparent 100%)',
+            filter: 'blur(0.2px)',
+          }}
+        />
+      </div>
 
       <div
         aria-hidden="true"
+        className="entry-whale"
         style={{
           position: 'absolute',
           left: '50%',

--- a/apps/extension/src/app/navigation/SceneRenderer.test.tsx
+++ b/apps/extension/src/app/navigation/SceneRenderer.test.tsx
@@ -49,6 +49,9 @@ test('renders entry scene and enters login on press', () => {
 
   expect(screen.getByRole('heading', { name: 'TACHIGO' })).toBeTruthy()
   expect(screen.getByText('PRESS ANYWHERE TO DIVE IN')).toBeTruthy()
+  expect(screen.getByTestId('entry-motion-layer')).toBeTruthy()
+  expect(screen.getAllByTestId('entry-motion-bubble')).toHaveLength(5)
+  expect(screen.getByTestId('entry-current-ribbon')).toBeTruthy()
 
   fireEvent.click(screen.getByRole('button', { name: /PRESS ANYWHERE TO DIVE IN/i }))
 

--- a/apps/extension/src/styles/index.css
+++ b/apps/extension/src/styles/index.css
@@ -286,6 +286,37 @@
   animation: capy-hud-big-mining-pickaxe 500ms ease-in-out;
 }
 
+/* ─── Entry Scene: lightweight ambient motion ─── */
+@keyframes entry-bubble-rise {
+  0%, 100% { opacity: 0.55; transform: translate3d(0, 4px, 0) scale(0.92); }
+  50%      { opacity: 1; transform: translate3d(6px, -16px, 0) scale(1.08); }
+}
+
+@keyframes entry-current-drift {
+  0%, 100% { opacity: 0.48; transform: translate3d(-3%, 0, 0); }
+  50%      { opacity: 0.86; transform: translate3d(3%, -3px, 0); }
+}
+
+@keyframes entry-whale-glide {
+  0%, 100% { transform: translate3d(-50%, 0, 0) rotate(-1deg); }
+  50%      { transform: translate3d(calc(-50% + 8px), -6px, 0) rotate(1.5deg); }
+}
+
+.entry-motion-bubble {
+  animation: entry-bubble-rise 5.8s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+.entry-current-ribbon {
+  animation: entry-current-drift 7.2s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+.entry-whale {
+  animation: entry-whale-glide 6.5s ease-in-out infinite;
+  will-change: transform;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .capy-wrapper,
   .capy-idle,
@@ -307,7 +338,10 @@
   .passive-dot-error,
   .screen-enter,
   .loading-dot,
-  .btn-mine-ready {
+  .btn-mine-ready,
+  .entry-motion-bubble,
+  .entry-current-ribbon,
+  .entry-whale {
     animation: none !important;
     transition: none !important;
   }


### PR DESCRIPTION
## 什麼改動
- 將 `EntryScene` 的水底主視覺補上 ambient motion layer。
- 新增 5 顆漂浮泡泡、水平水流 ribbon、鯨魚輕微 glide 動畫。
- 將 entry 動態元素納入 `prefers-reduced-motion: reduce` 關閉清單，並補 SceneRenderer 測試確認 press-to-enter 仍進 login。

## 為什麼
closes #748

#738 / PR #913 的靜態 entry 主視覺已合併；本 PR 只把 entry 首屏動態化，維持既有 press-to-enter 行為與 navigation flow。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#748
- Depends on PR：#913
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 navigation reducer / scene flow
  - 不改 login / loading / mining / HUD / onboarding / sound / auth
  - 不新增圖片資產、canvas、runtime interval/state loop
  - 不改 i18n 文案、backend、manifest、角色系統

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #748 did not define a separate worker plan.
- Actual worker profile(s)：
  - controller + AWP read-only explorer (`Plato`, session `019e5b06-cc41-71c0-8f18-4abeea02cdea`)
- Model strength：
  - controller = high；worker = medium
- Spawn directive(s)：
  - profile=read-only-explorer model=inherited reasoning=medium controller_fallback=not_used task=scan #748 EntryScene scope, minimal implementation, scope pollution risks, and validation commands
- Verification evidence：
  - `spec plan 748 --repo . --dry-run --format prompt --verbose`
  - RED: `pnpm --filter ./apps/extension test -- SceneRenderer.test.tsx` failed on missing `entry-motion-layer`
  - GREEN: `pnpm --filter ./apps/extension test -- SceneRenderer.test.tsx`
  - `pnpm --filter ./apps/extension test`
  - `pnpm --filter ./apps/extension build`
  - `pnpm --filter ./apps/extension lint`
  - `pnpm --filter ./apps/extension check:i18n`
  - `git diff --check`
  - `spec workflow-check --repo . --phase commit --format text` -> manual fallback, PR body pending at command time
- Self-review / exception reason：
  - Self-review completed; explorer was read-only and confirmed the safe two-surface slice.
- Worker session closeout：
  - Worker result read back and closed; recommendation adopted: only touch `EntryScene.tsx`, entry CSS, and focused navigation test.
- Workflow friction / follow-up split：
  - `spec plan` warned that the main checkout was dirty; implementation used a clean isolated worktree. #664 ledger comment pending merge.

## Review conversation closeout
- Unresolved threads：
  - pending initial review
- CodeRabbit：
  - pending
- chatgpt-codex-connector：
  - pending
- review_triage_ref：
  - this PR body / latest head
- root_cause_gate_ref：
  - n/a; no repeated finding yet
- finding_disposition_ref：
  - n/a; no findings yet
- Final reviewer action：
  - pending

## Final merge gate
- Ready-to-merge decision：
  - blocked by non-author review; GitHub checks passed on latest head
- Latest head SHA：
  - `e223adcbe4d85d10b699cc9f0b39786c8812d221`
- Required checks：
  - passed: Scope police / Frontend build / Backend CI gate / Cloudflare Pages / CodeRabbit / workflow metadata checks
- spec workflow-check evidence：
  - commit phase manual fallback: PR body was pending at command time; repo-local staged state clean
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/923

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 將 entry 靜態主視覺升級為低成本 ambient motion，並保持 press-to-enter 行為。
- Approx changed lines：~85
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #748 acceptance requires dynamic entry visual behavior plus coverage that press-to-enter still works.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] entry 主視覺動態化（動畫 / 動態元素）
- [x] 維持 press-to-enter 行為
- [x] 效能不影響 sidepanel 體驗（CSS transform / opacity only; no runtime loop）
- [x] 動態主視覺上線、互動正常；`pnpm test` 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm --filter ./apps/extension test -- SceneRenderer.test.tsx
Test Files 20 passed (20); Tests 72 passed (72)

pnpm --filter ./apps/extension test
Test Files 20 passed (20); Tests 72 passed (72)

pnpm --filter ./apps/extension build
built successfully; existing Vite chunk-size warning remains

pnpm --filter ./apps/extension lint
pass

pnpm --filter ./apps/extension check:i18n
i18n check passed: 21 locale mappings, 81 keys

git diff --check
pass
```

## 備註
- Dynamic layer uses CSS-only transform/opacity animation and respects reduced-motion.

## Notes for Claude Code Review
- Please focus on whether the motion stays small enough for sidepanel entry performance while satisfying #748 without adding assets or runtime loops.

