### PR TITLE
[infra] fix Dependabot pnpm lockfile repair scope

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -2500,7 +2500,17 @@ test('Dependabot pnpm lockfile repair is scoped to same-repo Dependabot PRs', as
     jobBlock,
     /working-directory: apps\/extension\n\s+run: pnpm install --lockfile-only --ignore-scripts --config\.shared-workspace-lockfile=false/,
   )
-  assert.match(jobBlock, /git add pnpm-lock\.yaml apps\/dashboard\/pnpm-lock\.yaml apps\/extension\/pnpm-lock\.yaml/)
+  const stripOverridesStep = workflowJobStep(
+    parsedWorkflow,
+    'repair-lockfiles',
+    'Strip root-only overrides from app lockfiles',
+  )
+  assert.match(stripOverridesStep.run, /apps\/dashboard\/package\.json/)
+  assert.match(stripOverridesStep.run, /apps\/extension\/package\.json/)
+  assert.match(stripOverridesStep.run, /packageJson\.pnpm\?\.overrides/)
+  assert.match(stripOverridesStep.run, /overrides:/)
+  assert.doesNotMatch(jobBlock, /git add pnpm-lock\.yaml\b/)
+  assert.match(jobBlock, /git add apps\/dashboard\/pnpm-lock\.yaml apps\/extension\/pnpm-lock\.yaml/)
   assert.match(jobBlock, /git commit -m "chore\(deps\): repair pnpm lockfiles"/)
   assert.match(jobBlock, /git push/)
 })

--- a/.github/workflows/dependabot-pnpm-lockfile.yml
+++ b/.github/workflows/dependabot-pnpm-lockfile.yml
@@ -55,12 +55,63 @@ jobs:
         working-directory: apps/extension
         run: pnpm install --lockfile-only --ignore-scripts --config.shared-workspace-lockfile=false
 
+      - name: Strip root-only overrides from app lockfiles
+        run: |
+          node <<'NODE'
+          const { existsSync, readFileSync, writeFileSync } = require('node:fs')
+
+          const appLockfiles = [
+            {
+              packagePath: 'apps/dashboard/package.json',
+              lockfilePath: 'apps/dashboard/pnpm-lock.yaml',
+            },
+            {
+              packagePath: 'apps/extension/package.json',
+              lockfilePath: 'apps/extension/pnpm-lock.yaml',
+            },
+          ]
+
+          const stripTopLevelOverrides = (lockfile) => {
+            const lines = lockfile.split(/\r?\n/)
+            const output = []
+
+            for (let index = 0; index < lines.length;) {
+              if (lines[index] === 'overrides:') {
+                index += 1
+                while (index < lines.length && (lines[index] === '' || lines[index].startsWith('  '))) {
+                  index += 1
+                }
+                continue
+              }
+
+              output.push(lines[index])
+              index += 1
+            }
+
+            return `${output.join('\n').replace(/\n*$/, '')}\n`
+          }
+
+          for (const { packagePath, lockfilePath } of appLockfiles) {
+            if (!existsSync(packagePath) || !existsSync(lockfilePath)) {
+              continue
+            }
+
+            const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'))
+            if (packageJson.pnpm?.overrides) {
+              continue
+            }
+
+            const lockfile = readFileSync(lockfilePath, 'utf8')
+            writeFileSync(lockfilePath, stripTopLevelOverrides(lockfile))
+          }
+          NODE
+
       - name: Commit repaired lockfiles
         id: commit-repair
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pnpm-lock.yaml apps/dashboard/pnpm-lock.yaml apps/extension/pnpm-lock.yaml
+          git add apps/dashboard/pnpm-lock.yaml apps/extension/pnpm-lock.yaml
           if git diff --cached --quiet; then
             echo "No pnpm lockfile repair needed."
             echo "repaired=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 什麼改動
- 修正 `Dependabot pnpm Lockfile Repair` workflow，只 stage app-local lockfiles。
- 新增 strip step：當 app package 沒有自己的 `pnpm.overrides` 時，移除 app-local `pnpm-lock.yaml` 裡被 root-only overrides 污染的 top-level `overrides:` block。
- 更新 workflow regression test，覆蓋「不 stage root lockfile」與「strip root-only overrides」兩個防線。

## 為什麼
Closes #925。#916-#921 的 app-local Dependabot PR 被 repair workflow 帶入 root `pnpm-lock.yaml` 與 root overrides metadata，導致 lockfile repair 反覆污染 PR branch。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#925
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 generated lockfiles
  - 不修改 Dependabot PR branches
  - 不調整 auto-merge / review policy

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #925
- Actual worker profile(s)：
  - controller-direct fallback
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=medium controller_fallback=allowed fallback_reason=AWP-worker-dispatch-unavailable-controller-direct-fallback
- Verification evidence：
  - `spec plan 925 --repo . --dry-run --format prompt --verbose`
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`
  - `git diff --check`
- Self-review / exception reason：
  - Completed self-review against #925 acceptance criteria.
- Worker session closeout：
  - controller-direct fallback completed and checked locally.
- Workflow friction / follow-up split：
  - n/a

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - no actionable comments on latest head
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - #925
- root_cause_gate_ref：
  - #925
- finding_disposition_ref：
  - adopted
- Final reviewer action：
  - pending reviewer approval

## Final merge gate
- Ready-to-merge decision：
  - blocked until CI and reviewer approval
- Latest head SHA：
  - e7a8a80c003d0f2d8ef21b2324bf1ba0b7f2f731
- Required checks：
  - pending PR Scope Police rerun and Cloudflare
- spec workflow-check evidence：
  - local-only spec plan dry-run completed for #925
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Keep Dependabot app-local lockfile repair from mutating root lockfiles or copying root-only overrides into app lockfiles.
- Approx changed lines：~65
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Repair workflow no longer stages or commits root `pnpm-lock.yaml` for app-local Dependabot PRs.
- [x] App-local lockfiles do not keep root-only `overrides:` metadata when the app package has no local `pnpm.overrides`.
- [x] Workflow regression test covers the lockfile staging boundary.
- [x] Workflow regression test covers the root-only overrides strip step.
- [x] Generated lockfile changes are not included.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
tests 99
pass 99
fail 0

git diff --check
pass
```

## 備註
此 PR 修改 workflow file，依 template 風險分類為 R4；需要 reviewer 明確 approve 後才能 merge。

## Notes for Claude Code Review
- 請特別看 `Strip root-only overrides from app lockfiles`：目前只在 app package 沒有自己的 `pnpm.overrides` 時移除 top-level `overrides:` block，避免未來 app 自己需要 overrides 時被誤刪。
