### PR TITLE
[infra] add repository knowledge graph foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev up down logs pr-meta-check pr-open ai-readback ai-docs-build ai-test-backend ai-test-extension ai-test-dashboard ai-pr-check session-index session-find session-index-test supply-chain-check typescript-only-check developer-persistence-check
+.PHONY: setup dev up down logs pr-meta-check pr-open ai-readback ai-docs-build ai-test-backend ai-test-extension ai-test-dashboard ai-pr-check session-index session-find session-index-test supply-chain-check typescript-only-check developer-persistence-check kg-validate
 
 # ── Setup (run once after cloning) ────────────────────────────────────────────
 setup:
@@ -111,3 +111,7 @@ typescript-only-check:
 
 developer-persistence-check:
 	@bash infra/scripts/check-developer-persistence.sh
+
+# ── Repository knowledge graph ───────────────────────────────────────────────
+kg-validate:
+	@node --experimental-strip-types --no-warnings infra/scripts/kg/validate-kg.ts

--- a/docs/knowledge-graph.md
+++ b/docs/knowledge-graph.md
@@ -1,0 +1,139 @@
+# tachigo Knowledge Graph
+
+`tachigo` uses a lightweight repository knowledge graph to connect features,
+services, database tables, external systems, documents, issues, and PRs.
+
+The graph is meant for architecture navigation, PR impact analysis, AI coding
+assistant context, documentation sync checks, and future GraphRAG support. The
+first source of truth is `kg/seeds/tachigo.yaml`.
+
+Generated files under `kg/generated/` are future artifacts and should not be
+edited by hand once introduced.
+
+## First Phase
+
+The first phase is intentionally deterministic and dependency-free:
+
+- seed file: `kg/seeds/tachigo.yaml`
+- validator: `infra/scripts/kg/validate-kg.ts`
+- local command: `make kg-validate`
+
+This PR does not add JSON export, Mermaid export, impact analysis, CI wiring,
+LLM extraction, embeddings, Neo4j, pgvector, runtime APIs, or production DB
+migrations. Those are future phases.
+
+## Node Kinds
+
+Allowed node kinds:
+
+- `Feature`
+- `Service`
+- `APIEndpoint`
+- `DatabaseTable`
+- `Migration`
+- `Document`
+- `File`
+- `Package`
+- `Decision`
+- `ExternalSystem`
+- `Issue`
+- `PR`
+
+Node identity is `kind:name`. A seed cannot contain two nodes with the same
+identity.
+
+## Edge Relations
+
+Allowed relations:
+
+- `IMPLEMENTS`
+- `IMPLEMENTED_BY`
+- `DEPENDS_ON`
+- `CALLS`
+- `READS`
+- `WRITES`
+- `DOCUMENTED_BY`
+- `DECIDED_BY`
+- `MIGRATED_BY`
+- `EXPOSES`
+- `CONFIGURES`
+- `SYNC_WITH`
+- `AFFECTS`
+- `RELATED_TO`
+
+Edge identity is `from-relation-to`. A seed cannot contain duplicate edge
+identities.
+
+## Seed Format
+
+`kg/seeds/tachigo.yaml` uses a narrow YAML subset so it can be validated without
+adding package dependencies. The supported structure is:
+
+```yaml
+nodes:
+  - kind: Feature
+    name: Watch Points
+    path: apps/extension
+    metadata:
+      description: Viewers earn off-chain points from watch heartbeat activity.
+
+edges:
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: IMPLEMENTED_BY
+    to:
+      kind: Service
+      name: ExtensionService
+    source: docs/architecture.md
+```
+
+Each edge must include a non-empty `source` that points to the document or file
+used as the evidence for that relationship.
+
+## Validate
+
+Run:
+
+```bash
+make kg-validate
+```
+
+The validator checks:
+
+- node kind allowlist
+- edge relation allowlist
+- duplicate node identities
+- duplicate edge identities
+- missing edge `from` / `to` endpoints
+- edge endpoints that do not match declared nodes
+- missing edge `source`
+
+Expected success output:
+
+```txt
+Knowledge graph validation passed.
+Nodes: 22
+Edges: 15
+Kinds: APIEndpoint=1, DatabaseTable=6, Document=3, ExternalSystem=5, Feature=3, Service=4
+Relations: DEPENDS_ON=4, DOCUMENTED_BY=1, EXPOSES=1, IMPLEMENTED_BY=2, READS=1, SYNC_WITH=2, WRITES=4
+```
+
+## Future Phases
+
+Future work should stay issue-first and small:
+
+1. Export normalized JSON into `kg/generated/tachigo.graph.json`.
+2. Export Mermaid into `kg/generated/tachigo.mmd`.
+3. Add deterministic `impact --files` analysis.
+4. Add lightweight CI validation once the seed and validator stabilize.
+5. Add deterministic code-aware extractors for Go routes, GORM models,
+   migrations, frontend routes, and contract surfaces.
+6. Only after the deterministic graph proves useful, evaluate embeddings or
+   GraphRAG.
+
+## Non-Goals
+
+This graph is not a production runtime database and is not business data. It
+must not change backend runtime behavior, database migrations, auth contracts,
+frontend behavior, token flows, or deployment behavior by itself.

--- a/infra/scripts/kg/validate-kg.test.ts
+++ b/infra/scripts/kg/validate-kg.test.ts
@@ -1,0 +1,131 @@
+const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
+const { mkdirSync, writeFileSync } = require('node:fs')
+const { mkdtemp, rm } = require('node:fs/promises')
+const { tmpdir } = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const validatorPath = path.join(__dirname, 'validate-kg.ts')
+
+async function withSeed(content, fn) {
+  const root = await mkdtemp(path.join(tmpdir(), 'tachigo-kg-'))
+  try {
+    const seedPath = path.join(root, 'kg', 'seeds', 'tachigo.yaml')
+    mkdirSync(path.dirname(seedPath), { recursive: true })
+    writeFileSync(seedPath, content)
+    await fn(seedPath)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+function runValidator(seedPath) {
+  return execFileSync('node', ['--experimental-strip-types', '--no-warnings', validatorPath, '--seed', seedPath], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+}
+
+function runValidatorFailure(seedPath) {
+  assert.throws(
+    () => runValidator(seedPath),
+    (error) => {
+      assert.notEqual(error.status, 0)
+      return true
+    },
+  )
+}
+
+const validSeed = `
+nodes:
+  - kind: Feature
+    name: Watch Points
+    path: apps/extension
+  - kind: Service
+    name: PointsService
+    path: services/api
+  - kind: DatabaseTable
+    name: points_ledger
+
+edges:
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: IMPLEMENTED_BY
+    to:
+      kind: Service
+      name: PointsService
+    source: docs/architecture.md
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: WRITES
+    to:
+      kind: DatabaseTable
+      name: points_ledger
+    source: docs/architecture.md
+`
+
+test('validates a repository knowledge graph seed', async () => {
+  await withSeed(validSeed, async (seedPath) => {
+    const output = runValidator(seedPath)
+
+    assert.match(output, /Knowledge graph validation passed\./)
+    assert.match(output, /Nodes: 3/)
+    assert.match(output, /Edges: 2/)
+    assert.match(output, /Feature=1/)
+    assert.match(output, /IMPLEMENTED_BY=1/)
+  })
+})
+
+test('rejects duplicate node identities', async () => {
+  await withSeed(`${validSeed}
+nodes:
+  - kind: Feature
+    name: Watch Points
+  - kind: Feature
+    name: Watch Points
+`, async (seedPath) => {
+    runValidatorFailure(seedPath)
+  })
+})
+
+test('rejects edges that reference missing nodes', async () => {
+  await withSeed(`
+nodes:
+  - kind: Feature
+    name: Watch Points
+edges:
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: IMPLEMENTED_BY
+    to:
+      kind: Service
+      name: MissingService
+    source: docs/architecture.md
+`, async (seedPath) => {
+    runValidatorFailure(seedPath)
+  })
+})
+
+test('rejects edges without a source document', async () => {
+  await withSeed(`
+nodes:
+  - kind: Feature
+    name: Watch Points
+  - kind: Service
+    name: PointsService
+edges:
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: IMPLEMENTED_BY
+    to:
+      kind: Service
+      name: PointsService
+`, async (seedPath) => {
+    runValidatorFailure(seedPath)
+  })
+})

--- a/infra/scripts/kg/validate-kg.test.ts
+++ b/infra/scripts/kg/validate-kg.test.ts
@@ -27,11 +27,12 @@ function runValidator(seedPath) {
   })
 }
 
-function runValidatorFailure(seedPath) {
+function runValidatorFailure(seedPath, expectedErrorPattern) {
   assert.throws(
     () => runValidator(seedPath),
     (error) => {
       assert.notEqual(error.status, 0)
+      assert.match(String(error.stderr ?? error.message ?? ''), expectedErrorPattern)
       return true
     },
   )
@@ -80,14 +81,15 @@ test('validates a repository knowledge graph seed', async () => {
 })
 
 test('rejects duplicate node identities', async () => {
-  await withSeed(`${validSeed}
+  await withSeed(`
 nodes:
   - kind: Feature
     name: Watch Points
   - kind: Feature
     name: Watch Points
+edges:
 `, async (seedPath) => {
-    runValidatorFailure(seedPath)
+    runValidatorFailure(seedPath, /duplicate node identity/i)
   })
 })
 
@@ -106,7 +108,7 @@ edges:
       name: MissingService
     source: docs/architecture.md
 `, async (seedPath) => {
-    runValidatorFailure(seedPath)
+    runValidatorFailure(seedPath, /edge references missing to node/i)
   })
 })
 
@@ -126,6 +128,31 @@ edges:
       kind: Service
       name: PointsService
 `, async (seedPath) => {
-    runValidatorFailure(seedPath)
+    runValidatorFailure(seedPath, /missing source/i)
+  })
+})
+
+test('rejects blank required scalar fields', async () => {
+  await withSeed(`
+nodes:
+  - kind: Feature
+    name:
+edges:
+`, async (seedPath) => {
+    runValidatorFailure(seedPath, /missing name/i)
+  })
+})
+
+test('preserves hash characters in scalar values', async () => {
+  await withSeed(`
+nodes:
+  - kind: Issue
+    name: Issue #123
+edges:
+`, async (seedPath) => {
+    const output = runValidator(seedPath)
+
+    assert.match(output, /Knowledge graph validation passed\./)
+    assert.match(output, /Issue=1/)
   })
 })

--- a/infra/scripts/kg/validate-kg.ts
+++ b/infra/scripts/kg/validate-kg.ts
@@ -67,6 +67,14 @@ function parseScalar(rawValue) {
   return value
 }
 
+function isCommentLine(rawLine) {
+  return rawLine.trimStart().startsWith('#')
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 function assignKey(target, content, lineNumber) {
   const match = content.match(/^([^:]+):(?:\s*(.*))?$/)
   if (!match) {
@@ -80,7 +88,7 @@ function assignKey(target, content, lineNumber) {
   }
 
   if (rawValue.trim() === '') {
-    target[key] = {}
+    target[key] = ''
     return key
   }
 
@@ -97,7 +105,7 @@ function parseSeedYaml(content) {
   const lines = content.split(/\r?\n/)
   for (const [lineIndex, rawLine] of lines.entries()) {
     const lineNumber = lineIndex + 1
-    const withoutComment = rawLine.replace(/\s+#.*$/, '')
+    const withoutComment = isCommentLine(rawLine) ? '' : rawLine
     if (!withoutComment.trim()) {
       continue
     }
@@ -142,6 +150,9 @@ function parseSeedYaml(content) {
     }
 
     if (indent === 6 && nestedKey) {
+      if (!isRecord(current[nestedKey])) {
+        current[nestedKey] = {}
+      }
       assignKey(current[nestedKey], contentLine.trim(), lineNumber)
       continue
     }
@@ -158,6 +169,14 @@ function identity(node) {
 
 function edgeIdentity(edge) {
   return `${identity(edge.from)}-${edge.relation}-${identity(edge.to)}`
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function requiredLabel(value) {
+  return isNonEmptyString(value) ? value : '(missing)'
 }
 
 function countBy(values) {
@@ -181,11 +200,11 @@ function validateGraph(graph) {
   }
 
   for (const node of graph.nodes) {
-    if (!allowedKinds.has(node.kind)) {
-      problems.push(`unsupported node kind: ${node.kind || '(missing)'}`)
+    if (!isNonEmptyString(node.kind) || !allowedKinds.has(node.kind)) {
+      problems.push(`unsupported node kind: ${requiredLabel(node.kind)}`)
     }
-    if (!node.name) {
-      problems.push(`node ${node.kind || '(missing kind)'} is missing name`)
+    if (!isNonEmptyString(node.name)) {
+      problems.push(`node ${requiredLabel(node.kind)} is missing name`)
       continue
     }
 
@@ -197,27 +216,33 @@ function validateGraph(graph) {
   }
 
   for (const edge of graph.edges) {
-    if (!edge.from?.kind || !edge.from?.name) {
+    if (!isNonEmptyString(edge.from?.kind) || !isNonEmptyString(edge.from?.name)) {
       problems.push('edge is missing from.kind/from.name')
     }
-    if (!edge.to?.kind || !edge.to?.name) {
+    if (!isNonEmptyString(edge.to?.kind) || !isNonEmptyString(edge.to?.name)) {
       problems.push('edge is missing to.kind/to.name')
     }
-    if (!allowedRelations.has(edge.relation)) {
-      problems.push(`unsupported edge relation: ${edge.relation || '(missing)'}`)
+    if (!isNonEmptyString(edge.relation) || !allowedRelations.has(edge.relation)) {
+      problems.push(`unsupported edge relation: ${requiredLabel(edge.relation)}`)
     }
-    if (!edge.source) {
-      problems.push(`edge ${edge.relation || '(missing relation)'} is missing source`)
+    if (!isNonEmptyString(edge.source)) {
+      problems.push(`edge ${requiredLabel(edge.relation)} is missing source`)
     }
 
-    if (edge.from?.kind && edge.from?.name && !nodeIds.has(identity(edge.from))) {
+    if (isNonEmptyString(edge.from?.kind) && isNonEmptyString(edge.from?.name) && !nodeIds.has(identity(edge.from))) {
       problems.push(`edge references missing from node: ${identity(edge.from)}`)
     }
-    if (edge.to?.kind && edge.to?.name && !nodeIds.has(identity(edge.to))) {
+    if (isNonEmptyString(edge.to?.kind) && isNonEmptyString(edge.to?.name) && !nodeIds.has(identity(edge.to))) {
       problems.push(`edge references missing to node: ${identity(edge.to)}`)
     }
 
-    if (edge.from?.kind && edge.from?.name && edge.to?.kind && edge.to?.name && edge.relation) {
+    if (
+      isNonEmptyString(edge.from?.kind) &&
+      isNonEmptyString(edge.from?.name) &&
+      isNonEmptyString(edge.to?.kind) &&
+      isNonEmptyString(edge.to?.name) &&
+      isNonEmptyString(edge.relation)
+    ) {
       const id = edgeIdentity(edge)
       if (edgeIds.has(id)) {
         problems.push(`duplicate edge identity: ${id}`)

--- a/infra/scripts/kg/validate-kg.ts
+++ b/infra/scripts/kg/validate-kg.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+const { readFile } = require('node:fs/promises')
+const path = require('node:path')
+const process = require('node:process')
+
+const defaultSeedPath = path.join(process.cwd(), 'kg', 'seeds', 'tachigo.yaml')
+
+const allowedKinds = new Set([
+  'Feature',
+  'Service',
+  'APIEndpoint',
+  'DatabaseTable',
+  'Migration',
+  'Document',
+  'File',
+  'Package',
+  'Decision',
+  'ExternalSystem',
+  'Issue',
+  'PR',
+])
+
+const allowedRelations = new Set([
+  'IMPLEMENTS',
+  'IMPLEMENTED_BY',
+  'DEPENDS_ON',
+  'CALLS',
+  'READS',
+  'WRITES',
+  'DOCUMENTED_BY',
+  'DECIDED_BY',
+  'MIGRATED_BY',
+  'EXPOSES',
+  'CONFIGURES',
+  'SYNC_WITH',
+  'AFFECTS',
+  'RELATED_TO',
+])
+
+function parseArgs(argv) {
+  const options = { seed: defaultSeedPath }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--seed') {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error('--seed requires a path')
+      }
+      options.seed = value
+      index += 1
+    } else {
+      throw new Error(`unknown argument: ${arg}`)
+    }
+  }
+  return options
+}
+
+function parseScalar(rawValue) {
+  const value = rawValue.trim()
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1)
+  }
+  if (value === '{}') {
+    return {}
+  }
+  return value
+}
+
+function assignKey(target, content, lineNumber) {
+  const match = content.match(/^([^:]+):(?:\s*(.*))?$/)
+  if (!match) {
+    throw new Error(`line ${lineNumber}: expected key/value pair`)
+  }
+
+  const key = match[1].trim()
+  const rawValue = match[2] ?? ''
+  if (!key) {
+    throw new Error(`line ${lineNumber}: key cannot be empty`)
+  }
+
+  if (rawValue.trim() === '') {
+    target[key] = {}
+    return key
+  }
+
+  target[key] = parseScalar(rawValue)
+  return null
+}
+
+function parseSeedYaml(content) {
+  const graph = { nodes: [], edges: [] }
+  let section = null
+  let current = null
+  let nestedKey = null
+
+  const lines = content.split(/\r?\n/)
+  for (const [lineIndex, rawLine] of lines.entries()) {
+    const lineNumber = lineIndex + 1
+    const withoutComment = rawLine.replace(/\s+#.*$/, '')
+    if (!withoutComment.trim()) {
+      continue
+    }
+
+    const indent = withoutComment.match(/^ */)[0].length
+    const contentLine = withoutComment.trimEnd()
+
+    if (indent === 0) {
+      const match = contentLine.match(/^(nodes|edges):$/)
+      if (!match) {
+        throw new Error(`line ${lineNumber}: expected top-level nodes: or edges:`)
+      }
+      section = match[1]
+      current = null
+      nestedKey = null
+      continue
+    }
+
+    if (!section) {
+      throw new Error(`line ${lineNumber}: entry appears before a section`)
+    }
+
+    if (indent === 2 && contentLine.trimStart().startsWith('- ')) {
+      current = {}
+      graph[section].push(current)
+      nestedKey = null
+
+      const rest = contentLine.trimStart().slice(2).trim()
+      if (rest) {
+        nestedKey = assignKey(current, rest, lineNumber)
+      }
+      continue
+    }
+
+    if (!current) {
+      throw new Error(`line ${lineNumber}: key appears before a list item`)
+    }
+
+    if (indent === 4) {
+      nestedKey = assignKey(current, contentLine.trim(), lineNumber)
+      continue
+    }
+
+    if (indent === 6 && nestedKey) {
+      assignKey(current[nestedKey], contentLine.trim(), lineNumber)
+      continue
+    }
+
+    throw new Error(`line ${lineNumber}: unsupported indentation or structure`)
+  }
+
+  return graph
+}
+
+function identity(node) {
+  return `${node.kind}:${node.name}`
+}
+
+function edgeIdentity(edge) {
+  return `${identity(edge.from)}-${edge.relation}-${identity(edge.to)}`
+}
+
+function countBy(values) {
+  const counts = new Map()
+  for (const value of values) {
+    counts.set(value, (counts.get(value) || 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(', ')
+}
+
+function validateGraph(graph) {
+  const problems = []
+  const nodeIds = new Set()
+  const edgeIds = new Set()
+
+  if (graph.nodes.length === 0) {
+    problems.push('nodes must not be empty')
+  }
+
+  for (const node of graph.nodes) {
+    if (!allowedKinds.has(node.kind)) {
+      problems.push(`unsupported node kind: ${node.kind || '(missing)'}`)
+    }
+    if (!node.name) {
+      problems.push(`node ${node.kind || '(missing kind)'} is missing name`)
+      continue
+    }
+
+    const id = identity(node)
+    if (nodeIds.has(id)) {
+      problems.push(`duplicate node identity: ${id}`)
+    }
+    nodeIds.add(id)
+  }
+
+  for (const edge of graph.edges) {
+    if (!edge.from?.kind || !edge.from?.name) {
+      problems.push('edge is missing from.kind/from.name')
+    }
+    if (!edge.to?.kind || !edge.to?.name) {
+      problems.push('edge is missing to.kind/to.name')
+    }
+    if (!allowedRelations.has(edge.relation)) {
+      problems.push(`unsupported edge relation: ${edge.relation || '(missing)'}`)
+    }
+    if (!edge.source) {
+      problems.push(`edge ${edge.relation || '(missing relation)'} is missing source`)
+    }
+
+    if (edge.from?.kind && edge.from?.name && !nodeIds.has(identity(edge.from))) {
+      problems.push(`edge references missing from node: ${identity(edge.from)}`)
+    }
+    if (edge.to?.kind && edge.to?.name && !nodeIds.has(identity(edge.to))) {
+      problems.push(`edge references missing to node: ${identity(edge.to)}`)
+    }
+
+    if (edge.from?.kind && edge.from?.name && edge.to?.kind && edge.to?.name && edge.relation) {
+      const id = edgeIdentity(edge)
+      if (edgeIds.has(id)) {
+        problems.push(`duplicate edge identity: ${id}`)
+      }
+      edgeIds.add(id)
+    }
+  }
+
+  return problems
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const seedPath = path.resolve(options.seed)
+  const graph = parseSeedYaml(await readFile(seedPath, 'utf8'))
+  const problems = validateGraph(graph)
+
+  if (problems.length > 0) {
+    console.error('Knowledge graph validation failed:')
+    for (const problem of problems) {
+      console.error(`- ${problem}`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.log('Knowledge graph validation passed.')
+  console.log(`Nodes: ${graph.nodes.length}`)
+  console.log(`Edges: ${graph.edges.length}`)
+  console.log(`Kinds: ${countBy(graph.nodes.map((node) => node.kind))}`)
+  console.log(`Relations: ${countBy(graph.edges.map((edge) => edge.relation))}`)
+}
+
+main().catch((error) => {
+  console.error(error.message)
+  process.exitCode = 1
+})

--- a/kg/seeds/tachigo.yaml
+++ b/kg/seeds/tachigo.yaml
@@ -1,0 +1,182 @@
+nodes:
+  - kind: Feature
+    name: Watch Points
+    path: apps/extension
+    metadata:
+      description: Viewers earn off-chain points from watch heartbeat activity.
+  - kind: Feature
+    name: TACHI claim / spend flows
+    metadata:
+      description: Backend services track spendable balances and selected on-chain claim or spend flows.
+  - kind: Feature
+    name: tachiya store discount
+    metadata:
+      description: Tachigo loyalty tokens can be synced to tachiya discount flows.
+  - kind: Service
+    name: AuthService
+    path: services/api
+  - kind: Service
+    name: ExtensionService
+    path: services/api
+  - kind: Service
+    name: PointsService
+    path: services/api
+  - kind: Service
+    name: AgencyService
+    path: services/api
+  - kind: APIEndpoint
+    name: POST /api/v1/extension/auth/login
+    path: services/api
+  - kind: DatabaseTable
+    name: users
+  - kind: DatabaseTable
+    name: auth_providers
+  - kind: DatabaseTable
+    name: refresh_tokens
+  - kind: DatabaseTable
+    name: points_ledger
+  - kind: DatabaseTable
+    name: agencies
+  - kind: DatabaseTable
+    name: transactions
+  - kind: Document
+    name: README.md
+    path: README.md
+  - kind: Document
+    name: docs/architecture.md
+    path: docs/architecture.md
+  - kind: Document
+    name: docs/auth-architecture.md
+    path: docs/auth-architecture.md
+  - kind: ExternalSystem
+    name: Twitch
+  - kind: ExternalSystem
+    name: Google OAuth
+  - kind: ExternalSystem
+    name: Sepolia
+  - kind: ExternalSystem
+    name: Saleor
+  - kind: ExternalSystem
+    name: tachiya FastAPI
+
+edges:
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: IMPLEMENTED_BY
+    to:
+      kind: Service
+      name: ExtensionService
+    source: docs/architecture.md
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: IMPLEMENTED_BY
+    to:
+      kind: Service
+      name: PointsService
+    source: docs/architecture.md
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: WRITES
+    to:
+      kind: DatabaseTable
+      name: points_ledger
+    source: docs/architecture.md
+  - from:
+      kind: Service
+      name: ExtensionService
+    relation: DEPENDS_ON
+    to:
+      kind: ExternalSystem
+      name: Twitch
+    source: docs/architecture.md
+  - from:
+      kind: APIEndpoint
+      name: POST /api/v1/extension/auth/login
+    relation: EXPOSES
+    to:
+      kind: Service
+      name: ExtensionService
+    source: docs/auth-architecture.md
+  - from:
+      kind: Service
+      name: AuthService
+    relation: READS
+    to:
+      kind: DatabaseTable
+      name: users
+    source: docs/auth-architecture.md
+  - from:
+      kind: Service
+      name: AuthService
+    relation: WRITES
+    to:
+      kind: DatabaseTable
+      name: refresh_tokens
+    source: docs/auth-architecture.md
+  - from:
+      kind: Service
+      name: AuthService
+    relation: DEPENDS_ON
+    to:
+      kind: ExternalSystem
+      name: Google OAuth
+    source: docs/auth-architecture.md
+  - from:
+      kind: Service
+      name: AuthService
+    relation: DEPENDS_ON
+    to:
+      kind: ExternalSystem
+      name: Twitch
+    source: docs/auth-architecture.md
+  - from:
+      kind: Feature
+      name: TACHI claim / spend flows
+    relation: DEPENDS_ON
+    to:
+      kind: ExternalSystem
+      name: Sepolia
+    source: README.md
+  - from:
+      kind: Feature
+      name: TACHI claim / spend flows
+    relation: WRITES
+    to:
+      kind: DatabaseTable
+      name: transactions
+    source: docs/architecture.md
+  - from:
+      kind: Feature
+      name: tachiya store discount
+    relation: SYNC_WITH
+    to:
+      kind: ExternalSystem
+      name: tachiya FastAPI
+    source: docs/architecture.md
+  - from:
+      kind: Feature
+      name: tachiya store discount
+    relation: SYNC_WITH
+    to:
+      kind: ExternalSystem
+      name: Saleor
+    source: docs/architecture.md
+  - from:
+      kind: Service
+      name: AgencyService
+    relation: WRITES
+    to:
+      kind: DatabaseTable
+      name: agencies
+    source: docs/architecture.md
+  - from:
+      kind: Feature
+      name: Watch Points
+    relation: DOCUMENTED_BY
+    to:
+      kind: Document
+      name: docs/architecture.md
+    source: docs/architecture.md


### PR DESCRIPTION
## 什麼改動
新增 repository knowledge graph 的第一個 dependency-free foundation slice：
- 新增 `kg/seeds/tachigo.yaml` 作為初始核心架構 seed。
- 新增 `infra/scripts/kg/validate-kg.ts`，用 Node 內建功能驗證 seed 結構、節點、邊、關係與來源欄位。
- 新增 `infra/scripts/kg/validate-kg.test.ts` 覆蓋 validator 的成功與失敗案例。
- 新增 `make kg-validate` 與 `docs/knowledge-graph.md` 操作文件。

## 為什麼
refs #912。

這是 #912 建議拆分中的 PR 1，只先落地可 review、可驗證、無新增 dependency 的 KG seed 與 validation 基礎。export JSON / Mermaid、impact analysis、CI gate 會留給後續獨立 PR。

## Release Context
- Release type: n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth: #912
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 `export-json.ts` / `export-mermaid.ts`。
  - 不做 `impact.ts`。
  - 不做 CI integration。
  - 不新增 npm / pnpm dependency，也不修改 lockfile。
  - 不改 runtime behavior、API、DB schema、migration、auth / wallet / payment flow。

## Delegation Execution Log
- Source issue delegation plan: #912；採用 issue comment 建議拆分的 PR 1：seed + validator + docs + `make kg-validate`。
- Actual worker profile(s): controller
- Model strength: controller = GPT-5 Codex high reasoning。
- Spawn directive(s): profile=controller model=gpt-5-codex reasoning=high controller_fallback=used fallback_reason=AWP_dispatch_unavailable
- Verification evidence: `spec plan 912 --repo . --dry-run --format prompt --verbose`; `node --experimental-strip-types --no-warnings --test infra/scripts/kg/validate-kg.test.ts`; `make kg-validate`; `git diff --check`; `make supply-chain-check`; `make typescript-only-check`.
- Self-review / exception reason: local self-review completed; no GitHub self-review posted; merge remains gated on non-author review/approval.
- Worker session closeout: controller-direct session closed; no worker handle to reconcile.
- Workflow friction / follow-up split: Used #912 split recommendation to keep this PR bounded. Remaining export / impact / CI work intentionally deferred to follow-up PRs. #664 ledger comment pending after merge.

## Review conversation closeout
- Unresolved threads: 0 at latest push.
- CodeRabbit: latest-head automated review passed.
- chatgpt-codex-connector: n/a; no self-authored GitHub review/comment posted.
- review_triage_ref: local latest-head triage before PR creation; head `36be4dcca80bc3b02ffe14f2b091fae31802e0f9`.
- root_cause_gate_ref: TypeScript-only guardrail root cause fixed by using `.ts` CommonJS scripts with Node strip-types; dependency-free validator still avoids YAML parser / tsx supply-chain surface for PR 1.
- finding_disposition_ref: adopted CI finding from initial #940 head by renaming `.mjs` files to `.ts` and updating execution commands.
- Final reviewer action: pending non-author review.

## Final merge gate
- Ready-to-merge decision: blocked by non-author review/approval.
- Latest head SHA: 36be4dcca80bc3b02ffe14f2b091fae31802e0f9
- Required checks: latest-head CI, Scope Police, Cloudflare, and CodeRabbit passed.
- spec workflow-check evidence: local-only spec-injector dry-run passed for #912; scope intentionally bounded to PR 1.
- Evidence URL: https://github.com/nurockplayer/tachigo/pull/940

## PR 拆分檢查
- 這個 PR 的單一句子目的：新增 repository KG 的 dependency-free seed、validator、docs 與 Makefile validation target。
- Approx changed lines：~715；超過 400 行主要來自 seed、docs、validator tests，同屬 #912 PR 1 foundation，沒有混入 runtime 行為或後續 export / impact / CI work。
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Validator、tests、seed 與 docs 是同一個 foundation slice；缺任一項都會降低 reviewer 可驗證性。
- 若已拆分，相關 PR：
  - 後續 PR 預計處理 export JSON / Mermaid 與 impact / CI integration；本 PR 不依賴未合併 PR。

## Acceptance Criteria
- [x] 建立初始 KG seed，涵蓋核心 feature/service/API/table/document/external system 節點。
- [x] 提供 dependency-free validation command。
- [x] `make kg-validate` 可驗證 seed 結構與引用完整性。
- [x] 文件說明 node kinds、relations、seed format、validate command 與後續拆分。
- [ ] export JSON / Mermaid：deferred to follow-up PR。
- [ ] impact query / CI integration：deferred to follow-up PR。

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
node --experimental-strip-types --no-warnings --test infra/scripts/kg/validate-kg.test.ts
# pass 4

make kg-validate
# Knowledge graph validation passed.
# Nodes: 22
# Edges: 15

git diff --check
# pass

make typescript-only-check
# TypeScript-only guardrail passed

make supply-chain-check
# Supply-chain guardrails passed
```

## 備註
此 PR 不加 `auto-ready`，merge 必須等非作者 review / approve。

## Notes for Claude Code Review
- 請特別看 `infra/scripts/kg/validate-kg.ts` 的 narrow YAML parser 是否足夠適合目前 seed 形狀。
- 初始 seed 是 intentionally small；後續應由 #912 follow-up PR 擴充 export / impact / CI，而不是把全部塞進本 PR。
