### PR TITLE
[discussion] Codify autonomous threshold policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ Autonomous workflow 的改善假設是「約 40% infra 本質複雜、約 60% �
 
 autonomous work 一開始就必須先分派 worker，再進入計劃、開 issue、讀資料或實作；只有 `trivial/self-only exception` 可以不分派，但必須明寫原因。0-3 分鐘的單一 read-only trivial check 可由 controller 直接做，但必須記錄 `controller_fallback_reason`。
 
-完整 worker profile、路由規則、review gate 與 PR Scope Police 合約見 [docs/ai/codex-autonomous-workflow.md](docs/ai/codex-autonomous-workflow.md)，Autonomous evidence gate、`spec workflow-check` start / commit / merge gate 與 local-only spec-injector 邊界見 [docs/ai/autonomous-pr-gates.md](docs/ai/autonomous-pr-gates.md)。
+完整 worker profile、路由規則、review gate 與 PR Scope Police 合約見 [docs/ai/codex-autonomous-workflow.md](docs/ai/codex-autonomous-workflow.md)，Autonomous evidence gate、`spec workflow-check` start / commit / merge gate 與 local-only spec-injector 邊界見 [docs/ai/autonomous-pr-gates.md](docs/ai/autonomous-pr-gates.md)。#664 收斂後的 controller-direct / worker-routing threshold policy 見 [docs/ai/autonomous-threshold-policy.md](docs/ai/autonomous-threshold-policy.md)。
 
 ## Gemini CLI Delegation
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -8,7 +8,8 @@ AI-facing collaboration guidance lives here unless a tool requires a specific pa
 - `claude-codex-cheatsheet.md` — quick reference for Claude Code and Codex collaboration.
 - `claude-codex-workflow.md` — full workflow guide for low-token Claude Code usage.
 - `codex-autonomous-workflow.md` — autonomous worker profiles, routing rules, review gates, and PR scope contract.
-- `autonomous-pr-gates.md` — autonomous evidence gates, review triage refs, spec workflow-check boundaries, and threshold ledger rules.
+- `autonomous-pr-gates.md` — autonomous evidence gates, review triage refs, and spec workflow-check boundaries.
+- `autonomous-threshold-policy.md` — #664 calibrated controller-direct / worker-routing threshold policy.
 - `code-review-refactor.md` — local Claude Code review workflow notes.
 - `github-ssh-443-push.md` — playbook for GitHub SSH over 443 when `git push` is unstable.
 - `github-actions-debugging.md` — playbook for PR, CI, CI scope router, and auto-ready debugging.

--- a/docs/ai/autonomous-pr-gates.md
+++ b/docs/ai/autonomous-pr-gates.md
@@ -107,9 +107,11 @@ PR body 只應留下 gate 狀態與可讀回的 evidence ref，例如本機 `spe
 
 ## Threshold Calibration Ledger
 
-Threshold 校正是暫時性的 autonomous workflow 分析資料，不是 tachigo product contract。校正紀錄集中留在 #664 的 long-lived issue comment，PR body 只需在 workflow friction / final closeout 裡放 #664 comment URL 或 `n/a`。
+Threshold 校正是暫時性的 autonomous workflow 分析資料，不是 tachigo product contract。#664 已累積足夠 datapoints，收斂後的規則見 [docs/ai/autonomous-threshold-policy.md](autonomous-threshold-policy.md)。
 
-不要把 `spawn_count`、CI rerun、review-thread count、threshold decision 等 metrics 加進 PR template，也不要讓 Scope Police 依賴這些 metrics。等 autonomous workflow 門檻穩定後，#664 可封存或停止新增紀錄，而不需要修改專案結構。
+本 policy landing 後，停止對一般 autonomous PR 追加 routine #664 threshold comment；只有新的 P0 workflow regression 才重新記錄。PR body 只需在 workflow friction / final closeout 裡放 `not_needed`、`#664 policy applied`，或實際 regression / follow-up URL。
+
+不要把 `spawn_count`、CI rerun、review-thread count、threshold decision 等 metrics 加進 PR template，也不要讓 Scope Police 依賴這些 metrics。
 
 ## Scope Police Contract
 

--- a/docs/ai/autonomous-threshold-policy.md
+++ b/docs/ai/autonomous-threshold-policy.md
@@ -1,0 +1,27 @@
+# Autonomous Threshold Policy
+
+本文件收斂 #664 autonomous threshold calibration ledger。#664 已累積足夠 dogfood datapoints；本 policy landing 後，停止對一般 autonomous PR 追加 routine threshold comment。只有出現新的 P0 workflow regression，例如錯誤 merge gate、遺漏 blocking review finding、或 Scope Police / spec-injector gate 明顯失效，才重新在 #664 或新 follow-up issue 留紀錄。
+
+## Calibrated Rule
+
+- Start gate 仍不可省略。Autonomous work 必須先讀 source issue、repo instructions、spec-injector start context，並做 routing decision；只有 routing decision 已判定符合 `trivial/self-only exception` 時，controller 才能不派 worker。
+- 小型、單一 surface 的 docs / tests / controller-direct 修補可以走 `trivial/self-only exception`，但必須留下明確 `controller_fallback_reason`。理由要說明為什麼不需要 worker，而不是只寫 `docs only` 或 `small task`。
+- Routine GitHub / CI / review / PR body readback 預設交給 `ops_spark` 或同級低成本 worker。包含 issue / PR metadata、status checks、CodeRabbit / connector 狀態、review-thread count、PR body 回填驗證與 post-push head SHA readback。
+- implementation slice 只要不是 trivial/self-only，預設交給 bounded worker；worker scope 要有明確檔案範圍、驗證方式與不得擴 scope 的限制。
+- controller 保留 final review、merge、scope、review finding disposition、scope-exception、schema / migration / auth / wallet / ledger / 金流 / 權限模型等高風險決策。
+
+## Evidence Shape
+
+- Routing evidence 必須包含 `routing_mode`、worker profile 或 `controller_fallback=true`、`controller_fallback_reason`、`delegation_outcome`、以及驗證/讀回 evidence ref。
+- 若 `controller_fallback=allowed`，spawn directive 或 PR log 同一段必須補 `fallback_reason=<category>: <reason>; impact=<decision-or-blocker>; evidence=<url|sha|command>`。
+- `fallback_reason` category 限定為 `trivial_self_only`、`worker_unavailable`、`tool_unavailable`、`rate_limited`、`conflicting_evidence`、`schema_or_data_risk`、`review_or_merge_decision`。
+- 若 `ops_spark` 不可用，先改用同級低成本 profile，例如 `repo_scout` 或 `docs_worker`。只有低成本 worker 都不可用或任務已進入 controller-only decision，才由 controller 補位，且必須明寫原因。
+- `threshold_ledger_ref` 可填 `not_needed`、`#664 policy applied`，或在 P0 workflow regression 時填實際 #664 / follow-up URL。
+- PR body 只保留 `status + ref`。不要貼完整 threshold matrix、spawn metrics、CI rerun count、review-thread count 或個人工作量敘述。
+- 不把 #664 metrics 加進 PR template、Scope Police、workflow schema、telemetry、daemon、dashboard 或任何 product runtime。
+
+## spec-injector Boundary
+
+- `spec plan <issue> --repo . --dry-run --format prompt --verbose` 與 `spec workflow-check` 是 local-only workflow evidence。
+- tachigo PR body / issue comment 只保存 status/ref 摘要；完整 prompt、task package、`.spec-injector/` output、private context 與 generated artifact 不進 repo。
+- `spec-injector` output 是 guardrail 與 context，不授權擴張 source issue scope。

--- a/docs/ai/codex-autonomous-workflow.md
+++ b/docs/ai/codex-autonomous-workflow.md
@@ -129,85 +129,16 @@ Autonomous Worker Profiles 的優化目標不是把所有工作都丟給低模�
 
 ### Threshold Calibration v2
 
-Threshold calibration v2 的目的不是永久蒐集個人工作量資料，而是暫時把「何時可 controller 直做、何時必須先走 Spark、何時需要 5.4 或 5.5」寫成可回看的 routing 決策。tachigo 的完整 metrics 集中留在 #664 long-lived ledger comment；PR body 只保留 `status + ref`，避免每張 PR 被 calibration 內容撐大。
+Threshold calibration v2 已由 #664 ledger 收斂成 [docs/ai/autonomous-threshold-policy.md](autonomous-threshold-policy.md)。後續不再要求每 3 張 autonomous PR 回寫 routine threshold comment；只有新的 P0 workflow regression 才重新記錄。
 
-#### 1. Controller direct / trivial / self-only allowed
+簡版規則：
 
-只有同時滿足下列條件，總控才可以不先派 worker，直接處理：
+- Start gate 與 routing decision 仍不可省略；只有 routing decision 已判定符合 `trivial/self-only exception` 時，小型、單一 surface 的 docs / tests / controller-direct 修補才可由 controller 直做。
+- Routine GitHub / CI / review / PR body readback 預設交給 `ops_spark` 或同級低成本 worker。
+- 非 trivial 的 implementation slice 預設交給 bounded worker。
+- controller 保留 final review、merge、scope、review finding disposition 與高風險技術決策。
 
-- 單檔或極小範圍修改，沒有跨檔共享狀態。
-- 不需要 CI/check readback、review thread readback、PR body/comment cleanup、或 closeout evidence 蒐集。
-- 不牽涉 schema、migration、ledger、auth、wallet、points、金流、跨 repo contract、merge gate、或 review disposition 決策。
-- 不需要額外 worker 才能把證據補齊。
-
-若走這條路，必須明寫 `Trivial/self-only exception reason` 或 `controller_fallback_reason`。不得只寫 `small task`、`quick fix`、`docs only` 這種空泛描述。
-
-#### 2. ops_spark required
-
-下列工作預設交給 `ops_spark` 或同級低成本替代 worker：
-
-- GitHub issue / PR / label / milestone / branch readback。
-- PR body、PR comment、issue comment、review closeout evidence 整理。
-- `gh pr checks`、status check rollup、CI log 初步摘要。
-- CodeRabbit / `chatgpt-codex-connector` review/comment/reaction 狀態讀回。
-- review thread list、resolved/unresolved count、thread URL 蒐集。
-- pre-commit checklist、post-push head SHA / branch / PR URL readback。
-
-同級低成本替代 worker 白名單為 `repo_scout`、`docs_worker`。若 `ops_spark` 不可用，PR log 必須寫明 fallback profile 與原因；若低成本 worker 都不可用，才可由 controller 補位，並把 `worker unavailable` 寫進 evidence。
-
-#### 3. 5.4 worker required
-
-任務超過 routine readback / docs / summary，但還沒進入 schema 或 merge decision 層級時，預設使用 GPT-5.4 或 GPT-5.4-mini worker：
-
-- 單檔或小範圍 workflow / unit test 補強。
-- API handler、service、CI 相關實作。
-- extension / dashboard 前端修補。
-- 跨 repo contract、Docker、build contract 驗證。
-
-這類工作不應直接吃 controller 的 GPT-5.5，除非低一階 worker 已經證明不足，且有明確 fallback reason。
-
-#### 4. 5.5 / controller decision
-
-下列情況才進入 GPT-5.5 或 controller decision 層級：
-
-- schema、migration、ledger、資料一致性、帳務、金流、權限模型。
-- merge 前風險掃描、review finding disposition、blocking technical decision。
-- scope-exception、merge method、guarded merge、branch protection、stale review、rebase / merge conflict 決策。
-- low-cost worker 或 5.4 worker 回報互相矛盾 evidence，需要總控做最後判斷。
-
-#### 5. Controller fallback reason format
-
-只要 `controller_fallback=allowed`，spawn directive 同一行必須補 `fallback_reason`，並在 PR log 的 `Self-review / exception reason` 或 `Worker session closeout` 展開。建議格式：
-
-```text
-fallback_reason=<category>: <why lower tier was insufficient>; impact=<decision or blocker>; evidence=<url|sha|command>
-```
-
-`category` 限定為：
-
-- `worker_unavailable`
-- `tool_unavailable`
-- `rate_limited`
-- `conflicting_evidence`
-- `schema_or_data_risk`
-- `review_or_merge_decision`
-
-#### 6. Calibration data fields
-
-新 autonomous PR 的 calibration evidence 保持精簡：
-
-- `threshold_ledger_ref`：#664 issue/comment URL、`#664`、或 `not_needed`。若 final merge gate 已 `ready_to_merge=true` / `ready`，不得再填 `pending`。
-- `status`：`logged`、`open_followup`、`not_needed`。
-
-完整 calibration metrics 以 #664 ledger comment 為主，不要求每張 PR 重複貼進 PR body。legacy metrics 只供舊 PR 或過渡期相容，不是新 PR 必填：`spawn_count`、`ci_rerun_count`、`review_thread_count`、`rework_reason`、`threshold_decision`、`threshold_followup_needed`。
-
-#### 7. Calibration review cadence
-
-至少每累積 3 張 autonomous PR，回看 #664 最近紀錄一次，決定 threshold 是否要調整。
-
-- 若連續出現 `spawn_count`、`ci_rerun_count` 或 `review_thread_count` 偏高，優先調整 routing 或拆 follow-up，不要只靠 controller 補洞。
-- 若連續出現 `threshold_followup_needed=yes`，必須開 follow-up issue 或更新 docs / PR template / routing policy。
-- 若資料顯示現有規則正常，回看紀錄仍要寫 `no threshold change`，避免規則默默漂移。
+完整 evidence shape、#664 停止條件、PR template / Scope Police 非目標、以及 spec-injector local-only 邊界，以 [autonomous-threshold-policy.md](autonomous-threshold-policy.md) 為準。
 
 ### ops_spark Routing Hardening
 


### PR DESCRIPTION
## 什麼改動
- 新增 `docs/ai/autonomous-threshold-policy.md`，把 #664 calibration ledger 收斂成 routing threshold policy。
- 更新 `AGENTS.md`、`docs/ai/README.md`、`docs/ai/autonomous-pr-gates.md`、`docs/ai/codex-autonomous-workflow.md` 指向新 policy，並移除重複的長篇 threshold v2 內文。

## 為什麼
closes #664

#664 已累積超過原本 3-5 筆門檻的 dogfood datapoints。這個 PR 把暫時 ledger 收斂成小型 repo policy，讓後續 autonomous PR 不必繼續 routine 回寫 threshold comments，也避免把 metrics 塞進 PR template / Scope Police / telemetry。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#664
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改產品 runtime / backend / frontend
  - 不改 PR template
  - 不改 Scope Police / CI workflow runtime
  - 不新增 telemetry / daemon / dashboard / schema
  - 不把 #664 metrics 加進 permanent gate

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#664 ledger closeout / policy consolidation plan in controller routing update
- Actual worker profile(s)：controller / docs_worker / spec_reviewer / quality_reviewer / quality_re-reviewer / spec_re-reviewer
- Model strength：controller = high；workers = medium
- Spawn directive(s)：profile=docs_worker model=inherited reasoning=medium controller_fallback=denied fallback_reason=n/a；profile=spec_reviewer model=inherited reasoning=medium controller_fallback=denied fallback_reason=n/a；profile=quality_reviewer model=inherited reasoning=medium controller_fallback=denied fallback_reason=n/a
- Verification evidence：spec plan 664 dry-run；node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts；make ai-docs-build；git diff --check
- Self-review / exception reason：quality reviewer findings adopted; controller rechecked docs scope and evidence boundaries
- Worker session closeout：all worker results read back; re-review PASS/APPROVED; no active worker follow-up needed
- Workflow friction / follow-up split：threshold_ledger_ref=#664 policy applied; status=logged; routine #664 comments stop after this policy unless P0 workflow regression appears

## Review conversation closeout
- Unresolved threads：0（GitHub reviewThreads readback at head db6708a89938549ec17c20f7766e4268b1147913）
- CodeRabbit：status context SUCCESS; review skipped / rate-limited, no actionable findings posted
- chatgpt-codex-connector：no remote review threads or latest review entries found
- review_triage_ref：GitHub reviewThreads readback + local AWP quality review adopted findings
- root_cause_gate_ref：local policy re-review confirmed start-gate/routing preservation
- finding_disposition_ref：workflow-check:finding:local-quality-review
- Final reviewer action：local spec re-review PASS; local quality re-review APPROVED; remote reviewDecision remains REVIEW_REQUIRED

## Final merge gate
- Ready-to-merge decision：manual with reason - all checks passed and no unresolved review threads; GitHub reviewDecision is still REVIEW_REQUIRED, so merge waits for valid approval / authorized merge path
- Latest head SHA：db6708a89938549ec17c20f7766e4268b1147913
- Required checks：pass - CI guardrails, Scope Police, Backend CI gate, CodeRabbit status, and Cloudflare Pages completed successfully; docs-only product jobs skipped as expected
- spec workflow-check evidence：merge gate pass, local-only, head db6708a89938549ec17c20f7766e4268b1147913; refs /tmp/tachigo-664-routing.json, /tmp/tachigo-664-finding-disposition.json, /tmp/tachigo-664-threshold.json
- Evidence URL：https://github.com/nurockplayer/tachigo/issues/664#issuecomment-4532352469

## PR 拆分檢查
- 這個 PR 的單一句子目的：把 #664 threshold calibration ledger 收斂成 repo-local autonomous threshold policy。
- Approx changed lines：~121
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] #664 ledger 收斂成小型 threshold policy
- [x] 停止 routine threshold comments，保留 P0 workflow regression 例外
- [x] 保留 AWP start gate / routing / fallback evidence 要求
- [x] 不把 metrics 加進 PR template / Scope Police / telemetry / runtime

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
spec plan 664 --repo . --dry-run --format prompt --verbose
node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts  # 99/99 pass
make ai-docs-build  # pass; static files generated
git diff --check  # pass
```

## 備註
`spec plan` 顯示既有 always_read missing `docs/claude-codex-workflow.md`，本 PR 不處理該 stale context，避免擴 scope。

## Notes for Claude Code Review
- 請特別檢查新 policy 是否維持 start gate / routing 不可省略。
- 請確認 #664 routine comment stop condition 是否足夠明確。

## Local workflow-check machine evidence
routing_evidence_status=pass
routing_evidence_ref=workflow-check:start:issue-664
routing_evidence_ref_match=yes
spark_readback_evidence=docs_worker/spec_reviewer/quality_reviewer/re-review sessions completed
finding_id=local-quality-review-1
finding_source=quality_reviewer
finding_status=adopted
finding_resolved=yes
task_size=small_docs_template_test
risk=workflow_policy
risk_class=R4
delegation_decision=hybrid_awp_docs_worker_plus_reviewers
expected_delegation_cost=medium
actual_friction=quality_review_found_start_gate_and_fallback_shape_gap_adopted_before_pr
threshold_ledger_ref=#664 policy applied
threshold_status=logged
delegation_outcome=completed

## Local workflow-check normalized fields
- spark_readback_evidence: workflow-check:spark:local-awp-readback
- finding_disposition_status: pass
- finding_disposition_ref: workflow-check:finding:local-quality-review
- threshold_evidence_status: pass
- threshold_ledger_ref: workflow-check:threshold:issue-664-policy

