### PR TITLE
[frontend] test: cover raffle prize tiers

### DIFF
--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -875,11 +875,12 @@ export default function RaffleDetailPage() {
 
       {/* Prize Tiers */}
       {effectiveStatus === 'active' && (
-        <div style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
+        <div data-testid="prize-tiers-section" style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
           <div style={{ ...glassStyle, padding: '16px 20px' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
               <span style={{ fontSize: 13, fontWeight: 700, color: '#e0f2fe', letterSpacing: '.04em' }}>🏆 獎項設定</span>
               <button
+                data-testid="prize-tier-toggle"
                 onClick={() => setShowAddTier(v => !v)}
                 style={{ background: 'rgba(56,189,248,.12)', border: '1px solid rgba(56,189,248,.3)', color: '#7dd3fc', borderRadius: 6, padding: '4px 12px', fontSize: 12, cursor: 'pointer' }}
               >
@@ -891,17 +892,17 @@ export default function RaffleDetailPage() {
               <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: 12, padding: '10px 12px', background: 'rgba(56,189,248,.06)', borderRadius: 8, border: '1px solid rgba(56,189,248,.15)' }}>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
                   <label style={{ fontSize: 10, color: 'rgba(148,210,255,.6)' }}>獎項名稱</label>
-                  <input value={newTier.name} onChange={e => setNewTier(p => ({ ...p, name: e.target.value }))} placeholder="例：一等獎" style={{ background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
+                  <input data-testid="prize-tier-name" value={newTier.name} onInput={e => setNewTier(p => ({ ...p, name: (e.target as HTMLInputElement).value }))} onChange={e => setNewTier(p => ({ ...p, name: e.target.value }))} placeholder="例：一等獎" style={{ background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
                   <label style={{ fontSize: 10, color: 'rgba(148,210,255,.6)' }}>獎品描述</label>
-                  <input value={newTier.prize_description} onChange={e => setNewTier(p => ({ ...p, prize_description: e.target.value }))} placeholder="例：Switch 主機" style={{ background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
+                  <input data-testid="prize-tier-description" value={newTier.prize_description} onInput={e => setNewTier(p => ({ ...p, prize_description: (e.target as HTMLInputElement).value }))} onChange={e => setNewTier(p => ({ ...p, prize_description: e.target.value }))} placeholder="例：Switch 主機" style={{ background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
                   <label style={{ fontSize: 10, color: 'rgba(148,210,255,.6)' }}>抽幾人</label>
-                  <input type="number" min={1} value={newTier.winner_count} onChange={e => setNewTier(p => ({ ...p, winner_count: Number(e.target.value) }))} style={{ width: 60, background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
+                  <input data-testid="prize-tier-winner-count" type="number" min={1} value={newTier.winner_count} onInput={e => setNewTier(p => ({ ...p, winner_count: Number((e.target as HTMLInputElement).value) }))} onChange={e => setNewTier(p => ({ ...p, winner_count: Number(e.target.value) }))} style={{ width: 60, background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
                 </div>
-                <button onClick={() => { void handleAddTier() }} disabled={addingTier || !newTier.name.trim()} style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 6, padding: '6px 14px', fontSize: 12, cursor: 'pointer', opacity: (addingTier || !newTier.name.trim()) ? .5 : 1 }}>
+                <button data-testid="prize-tier-add" onClick={() => { void handleAddTier() }} disabled={addingTier || !newTier.name.trim()} style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 6, padding: '6px 14px', fontSize: 12, cursor: 'pointer', opacity: (addingTier || !newTier.name.trim()) ? .5 : 1 }}>
                   {addingTier ? '新增中...' : '確認新增'}
                 </button>
                 {addTierError && (
@@ -919,18 +920,18 @@ export default function RaffleDetailPage() {
               const isDrawing = tierDrawing[tier.id] ?? false
               const isExhausted = tierExhausted[tier.id] ?? false
               return (
-                <div key={tier.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px', borderRadius: 8, marginBottom: 6, background: isDone ? 'rgba(255,255,255,.03)' : 'rgba(56,189,248,.05)', border: `1px solid ${isDone ? 'rgba(255,255,255,.08)' : 'rgba(56,189,248,.18)'}` }}>
+                <div key={tier.id} data-testid={`prize-tier-row-${tier.id}`} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px', borderRadius: 8, marginBottom: 6, background: isDone ? 'rgba(255,255,255,.03)' : 'rgba(56,189,248,.05)', border: `1px solid ${isDone ? 'rgba(255,255,255,.08)' : 'rgba(56,189,248,.18)'}` }}>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                     <span style={{ fontSize: 13, fontWeight: 600, color: isDone ? 'rgba(148,210,255,.5)' : '#e0f2fe' }}>{tier.name}</span>
                     {tier.prize_description && <span style={{ fontSize: 11, color: 'rgba(148,210,255,.5)' }}>{tier.prize_description}</span>}
                     <span style={{ fontSize: 10, color: isDone ? '#4ade80' : 'rgba(148,210,255,.4)' }}>{tier.drawn_count} / {tier.winner_count} 人已抽出</span>
                   </div>
                   <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-                    <button onClick={() => { void handleDrawFromTier(tier.id) }} disabled={isDone || isDrawing || isExhausted} style={{ background: 'rgba(14,165,233,.15)', border: '1px solid rgba(14,165,233,.3)', color: '#38bdf8', borderRadius: 6, padding: '5px 12px', fontSize: 11, cursor: 'pointer', opacity: (isDone || isDrawing || isExhausted) ? .4 : 1 }}>
+                    <button data-testid={`prize-tier-draw-${tier.id}`} onClick={() => { void handleDrawFromTier(tier.id) }} disabled={isDone || isDrawing || isExhausted} style={{ background: 'rgba(14,165,233,.15)', border: '1px solid rgba(14,165,233,.3)', color: '#38bdf8', borderRadius: 6, padding: '5px 12px', fontSize: 11, cursor: 'pointer', opacity: (isDone || isDrawing || isExhausted) ? .4 : 1 }}>
                       {isDrawing ? '抽中...' : isExhausted ? '已抽完' : '抽一人'}
                     </button>
                     {tier.drawn_count === 0 && (
-                      <button onClick={() => { void handleDeleteTier(tier.id) }} style={{ background: 'rgba(239,68,68,.1)', border: '1px solid rgba(239,68,68,.25)', color: '#f87171', borderRadius: 6, padding: '5px 10px', fontSize: 11, cursor: 'pointer' }}>✕</button>
+                      <button data-testid={`prize-tier-delete-${tier.id}`} onClick={() => { void handleDeleteTier(tier.id) }} style={{ background: 'rgba(239,68,68,.1)', border: '1px solid rgba(239,68,68,.25)', color: '#f87171', borderRadius: 6, padding: '5px 10px', fontSize: 11, cursor: 'pointer' }}>✕</button>
                     )}
                   </div>
                 </div>

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -76,6 +76,10 @@ const statusLabel: Record<RaffleStatus, string> = {
   completed: '已完成',
 }
 
+function isValidPrizeTierWinnerCount(value: number): boolean {
+  return Number.isInteger(value) && value >= 1
+}
+
 function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr)
   if (Number.isNaN(date.getTime())) return ''
@@ -688,7 +692,7 @@ export default function RaffleDetailPage() {
   }
 
   async function handleAddTier() {
-    if (!raffleId || addingTier || !newTier.name.trim() || newTier.winner_count < 1) return
+    if (!raffleId || addingTier || !newTier.name.trim() || !isValidPrizeTierWinnerCount(newTier.winner_count)) return
     setAddingTier(true)
     setAddTierError(null)
     try {
@@ -900,9 +904,9 @@ export default function RaffleDetailPage() {
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
                   <label style={{ fontSize: 10, color: 'rgba(148,210,255,.6)' }}>抽幾人</label>
-                  <input data-testid="prize-tier-winner-count" type="number" min={1} value={newTier.winner_count} onInput={e => setNewTier(p => ({ ...p, winner_count: Number((e.target as HTMLInputElement).value) }))} onChange={e => setNewTier(p => ({ ...p, winner_count: Number(e.target.value) }))} style={{ width: 60, background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
+                  <input data-testid="prize-tier-winner-count" type="number" min={1} value={Number.isFinite(newTier.winner_count) ? newTier.winner_count : ''} onInput={e => setNewTier(p => ({ ...p, winner_count: (e.target as HTMLInputElement).valueAsNumber }))} onChange={e => setNewTier(p => ({ ...p, winner_count: e.target.valueAsNumber }))} style={{ width: 60, background: 'rgba(255,255,255,.07)', border: '1px solid rgba(80,160,255,.25)', borderRadius: 5, color: '#e0f2fe', fontSize: 12, padding: '5px 8px' }} />
                 </div>
-                <button data-testid="prize-tier-add" onClick={() => { void handleAddTier() }} disabled={addingTier || !newTier.name.trim()} style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 6, padding: '6px 14px', fontSize: 12, cursor: 'pointer', opacity: (addingTier || !newTier.name.trim()) ? .5 : 1 }}>
+                <button data-testid="prize-tier-add" onClick={() => { void handleAddTier() }} disabled={addingTier || !newTier.name.trim() || !isValidPrizeTierWinnerCount(newTier.winner_count)} style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 6, padding: '6px 14px', fontSize: 12, cursor: 'pointer', opacity: (addingTier || !newTier.name.trim() || !isValidPrizeTierWinnerCount(newTier.winner_count)) ? .5 : 1 }}>
                   {addingTier ? '新增中...' : '確認新增'}
                 </button>
                 {addTierError && (

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -17,6 +17,10 @@ vi.mock('@/services/raffles', async (importOriginal) => {
     completeRaffle: vi.fn().mockResolvedValue(undefined),
     setDiscordWebhook: vi.fn().mockResolvedValue(true),
     activateRaffle: vi.fn().mockResolvedValue({ id: 'r1', status: 'active' }),
+    listPrizeTiers: vi.fn().mockResolvedValue([]),
+    createPrizeTier: vi.fn().mockResolvedValue({}),
+    deletePrizeTier: vi.fn().mockResolvedValue(undefined),
+    drawFromTier: vi.fn().mockResolvedValue({}),
   }
 })
 
@@ -42,6 +46,15 @@ const mockDraw: rafflesService.RaffleDraw = {
     display_name: 'Viewer One',
     created_at: '',
   },
+}
+const mockPrizeTier: rafflesService.RafflePrizeTier = {
+  id: 't1',
+  raffle_id: 'r1',
+  name: '一等獎',
+  prize_description: 'Switch 主機',
+  winner_count: 2,
+  drawn_count: 0,
+  created_at: '2026-01-01T00:00:00Z',
 }
 async function renderAt(raffleId: string, dp: ReturnType<typeof createMockDataProvider>) {
   const container = document.createElement('div')
@@ -74,6 +87,10 @@ beforeEach(() => {
   vi.mocked(rafflesService.completeRaffle).mockResolvedValue(undefined)
   vi.mocked(rafflesService.setDiscordWebhook).mockResolvedValue(true)
   vi.mocked(rafflesService.activateRaffle).mockResolvedValue({ ...mockRaffle, status: 'active' as const })
+  vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([])
+  vi.mocked(rafflesService.createPrizeTier).mockResolvedValue(mockPrizeTier)
+  vi.mocked(rafflesService.deletePrizeTier).mockResolvedValue(undefined)
+  vi.mocked(rafflesService.drawFromTier).mockResolvedValue(mockDraw)
 })
 afterEach(() => {
   vi.restoreAllMocks()
@@ -138,6 +155,104 @@ describe('RaffleDetailPage — winner list', () => {
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.textContent).toContain('viewer1'))
+    cleanup(root, container)
+  })
+
+  it('renders prize tier badge for tier-specific draws', async () => {
+    vi.mocked(rafflesService.listDraws).mockResolvedValue([
+      { ...mockDraw, prize_tier_id: 't1', prize_tier: mockPrizeTier },
+    ])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('Viewer One'))
+    expect(container.textContent).toContain('一等獎')
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — prize tiers', () => {
+  it('hides prize tiers while raffle is still draft', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
+    expect(container.querySelector('[data-testid="prize-tiers-section"]')).toBeFalsy()
+    cleanup(root, container)
+  })
+
+  it('shows active raffle prize tiers and disables completed tiers', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([
+      mockPrizeTier,
+      { ...mockPrizeTier, id: 't2', name: '二等獎', winner_count: 1, drawn_count: 1 },
+    ])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-row-t1"]')).toBeTruthy())
+    expect(container.textContent).toContain('Switch 主機')
+    expect(container.querySelector('[data-testid="prize-tier-draw-t1"]')).toBeTruthy()
+    expect((container.querySelector('[data-testid="prize-tier-draw-t2"]') as HTMLButtonElement).disabled).toBe(true)
+    cleanup(root, container)
+  })
+
+  it('creates a prize tier from the active raffle panel', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-toggle"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="prize-tier-toggle"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    const name = container.querySelector('[data-testid="prize-tier-name"]') as HTMLInputElement
+    const description = container.querySelector('[data-testid="prize-tier-description"]') as HTMLInputElement
+    const count = container.querySelector('[data-testid="prize-tier-winner-count"]') as HTMLInputElement
+    await act(async () => {
+      name.value = '一等獎'
+      name.dispatchEvent(new Event('input', { bubbles: true }))
+      description.value = 'Switch 主機'
+      description.dispatchEvent(new Event('input', { bubbles: true }))
+      count.value = '2'
+      count.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      container.querySelector('[data-testid="prize-tier-add"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    await waitFor(() => expect(rafflesService.createPrizeTier).toHaveBeenCalledWith('r1', {
+      name: '一等獎',
+      prize_description: 'Switch 主機',
+      winner_count: 2,
+    }))
+    cleanup(root, container)
+  })
+
+  it('draws and deletes prize tiers through tier actions', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([mockPrizeTier])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-draw-t1"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="prize-tier-draw-t1"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(rafflesService.drawFromTier).toHaveBeenCalledWith('r1', 't1'))
+
+    await act(async () => {
+      container.querySelector('[data-testid="prize-tier-delete-t1"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(rafflesService.deletePrizeTier).toHaveBeenCalledWith('r1', 't1'))
     cleanup(root, container)
   })
 })

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -234,6 +234,38 @@ describe('RaffleDetailPage — prize tiers', () => {
     cleanup(root, container)
   })
 
+  it('does not create a prize tier when winner count is empty', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-toggle"]')).toBeTruthy())
+
+    await act(async () => {
+      container.querySelector('[data-testid="prize-tier-toggle"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const name = container.querySelector('[data-testid="prize-tier-name"]') as HTMLInputElement
+    const count = container.querySelector('[data-testid="prize-tier-winner-count"]') as HTMLInputElement
+    vi.mocked(rafflesService.createPrizeTier).mockClear()
+    await act(async () => {
+      name.value = '一等獎'
+      name.dispatchEvent(new Event('input', { bubbles: true }))
+      count.value = ''
+      count.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    const add = container.querySelector('[data-testid="prize-tier-add"]') as HTMLButtonElement
+    expect(add.disabled).toBe(true)
+
+    await act(async () => {
+      add.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(rafflesService.createPrizeTier).not.toHaveBeenCalled()
+    cleanup(root, container)
+  })
+
   it('draws and deletes prize tiers through tier actions', async () => {
     vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([mockPrizeTier])
     const dp = createMockDataProvider({

--- a/apps/dashboard/src/services/__tests__/raffles.test.ts
+++ b/apps/dashboard/src/services/__tests__/raffles.test.ts
@@ -1,20 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listRaffles, createRaffle, listDraws, drawNext, importCSV, completeRaffle, setDiscordWebhook, activateRaffle } from '@/services/raffles'
+import { listRaffles, createRaffle, listDraws, drawNext, importCSV, completeRaffle, setDiscordWebhook, activateRaffle, listPrizeTiers, createPrizeTier, deletePrizeTier, drawFromTier } from '@/services/raffles'
 
 const getMock = vi.fn()
 const postMock = vi.fn()
 const patchMock = vi.fn()
+const deleteMock = vi.fn()
 
 vi.mock('@/services/api', () => ({
   default: {
     get: (...a: unknown[]) => getMock(...a),
     post: (...a: unknown[]) => postMock(...a),
     patch: (...a: unknown[]) => patchMock(...a),
+    delete: (...a: unknown[]) => deleteMock(...a),
   },
 }))
 
 const mockRaffle = { id: 'r1', user_id: 'u1', title: 'Test', status: 'draft' as const, created_at: '', updated_at: '' }
-beforeEach(() => { getMock.mockReset(); postMock.mockReset(); patchMock.mockReset() })
+beforeEach(() => { getMock.mockReset(); postMock.mockReset(); patchMock.mockReset(); deleteMock.mockReset() })
 
 describe('listRaffles', () => {
   it('returns raffles array', async () => {
@@ -106,5 +108,46 @@ describe('setDiscordWebhook', () => {
       '/api/v1/dashboard/raffles/r1/discord-webhook',
       { discord_webhook_url: '' },
     )
+  })
+})
+
+const mockPrizeTier = {
+  id: 't1',
+  raffle_id: 'r1',
+  name: '一等獎',
+  prize_description: 'Switch 主機',
+  winner_count: 2,
+  drawn_count: 0,
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+describe('prize tiers', () => {
+  it('lists prize tiers for a raffle', async () => {
+    getMock.mockResolvedValue({ data: { success: true, data: { tiers: [mockPrizeTier] } } })
+    const result = await listPrizeTiers('r1')
+    expect(result).toEqual([mockPrizeTier])
+    expect(getMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/prize-tiers')
+  })
+
+  it('creates a prize tier and returns the created tier', async () => {
+    const payload = { name: '一等獎', prize_description: 'Switch 主機', winner_count: 2 }
+    postMock.mockResolvedValue({ data: { success: true, data: { tier: mockPrizeTier } } })
+    const result = await createPrizeTier('r1', payload)
+    expect(result).toEqual(mockPrizeTier)
+    expect(postMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/prize-tiers', payload)
+  })
+
+  it('deletes an empty prize tier', async () => {
+    deleteMock.mockResolvedValue({ data: { success: true, data: {} } })
+    await deletePrizeTier('r1', 't1')
+    expect(deleteMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/prize-tiers/t1')
+  })
+
+  it('draws one winner from a prize tier', async () => {
+    const tierDraw = { ...mockDraw, prize_tier_id: 't1', prize_tier: mockPrizeTier }
+    postMock.mockResolvedValue({ data: { success: true, data: { draw: tierDraw } } })
+    const result = await drawFromTier('r1', 't1')
+    expect(result).toEqual(tierDraw)
+    expect(postMock).toHaveBeenCalledWith('/api/v1/dashboard/raffles/r1/prize-tiers/t1/draws', undefined)
   })
 })


### PR DESCRIPTION
## 什麼改動
補上 dashboard 抽獎獎項分層的前端測試覆蓋，並為既有獎項區塊加入穩定的 `data-testid` 測試標記。後續依 CodeRabbit thread 補強新增獎項人數驗證，避免 `winner_count` 空值 / `NaN` 被送進 API。

## 為什麼
closes #907

#907 的 dashboard 獎項分層功能主體已在 `develop`，本 PR 補齊前端 API 與 UI 驗收測試，確認 active raffle 顯示獎項區、draft 隱藏、已抽滿獎項停用、建立 / 抽出 / 刪除動作與中獎名單 badge。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#907
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 backend route / service
  - 不改 extension / Discord per-tier 顯示
  - 不新增 campaign / coupon / claim flow
  - 不新增資料庫 schema 或 migration

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #907
- Actual worker profile(s)：
  - controller + read-only explorer
- Model strength：
  - controller = gpt-5.5 xhigh；read-only explorer = gpt-5.3-codex-spark high
- Spawn directive(s)：
  - profile=read-only-explorer model=gpt-5.3-codex-spark reasoning=high controller_fallback=controller verified current-sprint PR metadata, issue scope, and review capacity directly during closeout because the only remaining task was a narrow self-authored PR thread fix.
- Verification evidence：
  - `rtk pnpm --dir apps/dashboard test -- src/services/__tests__/raffles.test.ts src/pages/__tests__/RaffleDetailPage.test.tsx`
  - `rtk pnpm --dir apps/dashboard build`
- Self-review / exception reason：
  - 已檢查 diff 僅限 dashboard raffle prize tiers 測試、測試標記與 `winner_count` 前端驗證；不改 backend contract / schema / auth。
- Worker session closeout：
  - worker 結果已讀回；不需追加任務。
- Workflow friction / follow-up split：
  - 本輪 infra 複雜主要在乾淨 worktree 缺 `node_modules` 與 sandbox native binding；以臨時 symlink + escalated test/build 收斂，無需 follow-up split。

## Review conversation closeout
- Unresolved threads：
  - 0；CodeRabbit thread `PRRT_kwDORtUM5M6EzT22` 已回覆並 resolve。
- CodeRabbit：
  - addressed；`winner_count` 空值 / `NaN` thread 已由 commit `3c635bff` 修正，CodeRabbit 已回覆 confirmed as addressed。
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - `PRRT_kwDORtUM5M6EzT22` / `https://github.com/nurockplayer/tachigo/pull/942#discussion_r3303995635`
- root_cause_gate_ref：
  - `apps/dashboard/src/pages/RaffleDetailPage.tsx` 原本以 `Number(...)` 解析空值會得到 `NaN`，且 Add button 只檢查名稱；已確認是仍有效且可窄修的前端 validation bug。
- finding_disposition_ref：
  - fixed in `3c635bff`；改用 `valueAsNumber`、`isValidPrizeTierWinnerCount`，並補測空白人數不會呼叫 `createPrizeTier`。
- Final reviewer action：
  - 等待外部 reviewer；本 automation 不 self-approve / merge。

## Final merge gate
- Ready-to-merge decision：
  - pending external review / GitHub CI
- Latest head SHA：
  - `3c635bff`
- Required checks：
  - pending GitHub CI；local test/build pass
- spec workflow-check evidence：
  - n/a；`spec` CLI not available in automation memory
- Evidence URL：
  - `https://github.com/nurockplayer/tachigo/pull/942#discussion_r3305636297`

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 補齊 dashboard 抽獎獎項分層的前端 API / UI 驗收測試，並補上同區塊新增獎項人數驗證。
- Approx changed lines：~217
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試標記、UI 驗收測試與 CodeRabbit 指出的 `winner_count` validation 都在同一個 dashboard raffle prize tier 表單行為內；未跨 backend / schema / auth。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Dashboard API client tests cover `listPrizeTiers`, `createPrizeTier`, `deletePrizeTier`, and `drawFromTier`
- [x] Active raffle shows prize tier panel; draft raffle hides prize tier panel
- [x] Tier draw button is disabled once `drawn_count >= winner_count`
- [x] Winner list renders prize tier badge when draw includes `prize_tier`
- [x] Add prize tier blocks empty / invalid `winner_count` before calling `createPrizeTier`
- [x] Dashboard TypeScript build passes

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk pnpm --dir apps/dashboard test -- src/services/__tests__/raffles.test.ts src/pages/__tests__/RaffleDetailPage.test.tsx
Test Files 14 passed (14)
Tests 119 passed (119)

rtk pnpm --dir apps/dashboard build
tsc -b && vite build
✓ built in 974ms
```

## 備註
本輪 audit 發現 #907 issue 文字列出的 tier draw endpoint 是 `/draw`，但目前 `develop` 的 backend router / handler test / frontend service 一致使用 `/draws`；本 PR 不更動已存在 contract，僅記錄 reviewer 注意。

## Notes for Claude Code Review
- 請特別看 `apps/dashboard/src/pages/RaffleDetailPage.tsx` 的新增獎項表單：`winner_count` 現在以 `valueAsNumber` 解析，並由 `isValidPrizeTierWinnerCount` 同時保護按鈕 disabled 與 submit handler。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 發布說明

* **新增功能**
  * 增強奖項設定 UI，改進奖品分組管理和互動流程。

* **測試**
  * 新增奖項相關功能的綜合測試覆蓋，包括奖項建立、刪除和抽獎操作。
  * 擴展服務層測試，驗證奖品分組 API 呼叫行為。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
