### PR TITLE
[frontend] Dashboard Streamer UX — Twitch OAuth 登入、首頁統計與角色感知導覽

### DIFF
--- a/apps/dashboard/src/components/Layout.tsx
+++ b/apps/dashboard/src/components/Layout.tsx
@@ -3,14 +3,14 @@ import { NavLink, Outlet, useNavigate } from 'react-router'
 import { LayoutDashboard, Users, ArrowLeftRight, Settings, Ticket } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { logout } from '@/services/auth'
+import { logout, getUserRole } from '@/services/auth'
 
 const navItems = [
   { to: '/', label: '總覽', icon: LayoutDashboard, end: true },
-  { to: '/streamers', label: '實況主管理', icon: Users, end: false },
+  { to: '/streamers', label: '實況主管理', icon: Users, end: false, roles: ['admin'] },
   { to: '/raffles', label: '抽獎管理', icon: Ticket, end: false },
   { to: '/transactions', label: '交易紀錄', icon: ArrowLeftRight, end: false },
-  { to: '/settings', label: '設定', icon: Settings, end: false },
+  { to: '/settings', label: '設定', icon: Settings, end: false, roles: ['admin'] },
 ]
 
 export default function Layout() {
@@ -28,6 +28,9 @@ export default function Layout() {
     }
   }
 
+  const role = getUserRole()
+  const visibleItems = navItems.filter(item => !item.roles || item.roles.includes(role ?? ''))
+
   return (
     <div className="flex h-screen bg-background">
       {/* Sidebar */}
@@ -36,7 +39,7 @@ export default function Layout() {
           <span className="text-lg font-bold text-foreground">Tachigo</span>
         </div>
         <nav className="flex-1 px-3 py-4 space-y-1">
-          {navItems.map(({ to, label, icon: Icon, end }) => (
+          {visibleItems.map(({ to, label, icon: Icon, end }) => (
             <NavLink
               key={to}
               to={to}

--- a/apps/dashboard/src/components/__tests__/Layout.nav.test.tsx
+++ b/apps/dashboard/src/components/__tests__/Layout.nav.test.tsx
@@ -1,0 +1,62 @@
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/services/auth', () => ({
+  logout: vi.fn().mockResolvedValue(undefined),
+  getUserRole: vi.fn(),
+}))
+
+import { getUserRole } from '@/services/auth'
+import Layout from '@/components/Layout'
+
+function render(role: string | null) {
+  const mockGetUserRole = vi.mocked(getUserRole)
+  mockGetUserRole.mockReturnValue(role)
+
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(
+      <MemoryRouter initialEntries={['/']}>
+        <Layout />
+      </MemoryRouter>,
+    )
+  })
+  return { container, root }
+}
+
+describe('Layout nav role filtering', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('streamer 看不到實況主管理與設定', () => {
+    const { container } = render('streamer')
+    const nav = container.querySelector('nav')!
+    expect(nav.textContent).toContain('總覽')
+    expect(nav.textContent).toContain('抽獎管理')
+    expect(nav.textContent).toContain('交易紀錄')
+    expect(nav.textContent).not.toContain('實況主管理')
+    expect(nav.textContent).not.toContain('設定')
+  })
+
+  it('admin 看到所有導航項目', () => {
+    const { container } = render('admin')
+    const nav = container.querySelector('nav')!
+    expect(nav.textContent).toContain('總覽')
+    expect(nav.textContent).toContain('實況主管理')
+    expect(nav.textContent).toContain('抽獎管理')
+    expect(nav.textContent).toContain('交易紀錄')
+    expect(nav.textContent).toContain('設定')
+  })
+
+  it('未登入（role null）只看到無限制項目', () => {
+    const { container } = render(null)
+    const nav = container.querySelector('nav')!
+    expect(nav.textContent).not.toContain('實況主管理')
+    expect(nav.textContent).not.toContain('設定')
+  })
+})

--- a/apps/dashboard/src/components/__tests__/Layout.nav.test.tsx
+++ b/apps/dashboard/src/components/__tests__/Layout.nav.test.tsx
@@ -1,5 +1,5 @@
 import { act } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -10,6 +10,8 @@ vi.mock('@/services/auth', () => ({
 
 import { getUserRole } from '@/services/auth'
 import Layout from '@/components/Layout'
+
+let currentRoot: Root | null = null
 
 function render(role: string | null) {
   const mockGetUserRole = vi.mocked(getUserRole)
@@ -25,11 +27,16 @@ function render(role: string | null) {
       </MemoryRouter>,
     )
   })
+  currentRoot = root
   return { container, root }
 }
 
 describe('Layout nav role filtering', () => {
   afterEach(() => {
+    if (currentRoot) {
+      act(() => { currentRoot!.unmount() })
+      currentRoot = null
+    }
     document.body.innerHTML = ''
   })
 

--- a/apps/dashboard/src/pages/DashboardPage.tsx
+++ b/apps/dashboard/src/pages/DashboardPage.tsx
@@ -68,6 +68,7 @@ export default function DashboardPage() {
 
   const statsLoading = channelsQuery.isLoading || (Boolean(channelId) && statsQuery.isLoading)
   const rafflesLoading = rafflesQuery.isLoading
+  const rafflesError = rafflesQuery.isError
 
   return (
     <div className="space-y-8">
@@ -111,6 +112,12 @@ export default function DashboardPage() {
                 ))}
               </div>
             )
+          : rafflesError
+            ? (
+                <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-8 text-center text-sm text-destructive">
+                  無法載入最近抽獎。
+                </div>
+              )
           : recentRaffles.length === 0
             ? (
                 <div className="rounded-lg border border-border bg-secondary/20 px-4 py-8 text-center text-sm text-muted-foreground">

--- a/apps/dashboard/src/pages/DashboardPage.tsx
+++ b/apps/dashboard/src/pages/DashboardPage.tsx
@@ -1,3 +1,145 @@
+import { useList, useOne } from '@refinedev/core'
+import { useNavigate } from 'react-router'
+import { Skeleton } from '@/components/ui/skeleton'
+import type { Streamer } from '@/services/channels'
+import type { Raffle, RaffleStatus } from '@/services/raffles'
+
+type StreamerStats = {
+  monthly_seconds?: number
+  unique_miners?: number
+  total_token_minted?: number
+}
+
+const statusLabel: Record<RaffleStatus, string> = {
+  draft: '草稿',
+  active: '進行中',
+  completed: '已結束',
+}
+
+const statusClass: Record<RaffleStatus, string> = {
+  draft: 'bg-secondary text-muted-foreground',
+  active: 'bg-green-500/10 text-green-700',
+  completed: 'bg-destructive/10 text-destructive',
+}
+
+function fmtHours(seconds?: number) {
+  if (seconds === undefined) return undefined
+  return `${(seconds / 3600).toFixed(1)} 小時`
+}
+
+function fmtNumber(value?: number) {
+  if (value === undefined) return undefined
+  return value.toLocaleString()
+}
+
+function StatCard({ label, value }: { label: string; value?: string }) {
+  return (
+    <div className="flex-1 rounded-lg border border-border bg-secondary/30 p-5">
+      <p className="mb-1 text-xs text-muted-foreground">{label}</p>
+      {value !== undefined
+        ? <p className="text-2xl font-bold text-foreground">{value}</p>
+        : <p className="text-2xl font-bold text-muted-foreground" data-testid="stat-empty">—</p>
+      }
+    </div>
+  )
+}
+
 export default function DashboardPage() {
-  return <h1 className="text-2xl font-bold text-foreground">總覽</h1>
+  const navigate = useNavigate()
+
+  const { query: channelsQuery } = useList<Streamer>({
+    resource: 'streamer-channels',
+    queryOptions: { retry: false },
+  })
+  const channelId = channelsQuery.data?.data[0]?.id
+
+  const { query: statsQuery } = useOne<StreamerStats>({
+    resource: 'streamer-stats',
+    id: channelId ?? '',
+    queryOptions: { enabled: Boolean(channelId), retry: false },
+  })
+  const stats = statsQuery.data?.data
+
+  const { query: rafflesQuery } = useList<Raffle>({
+    resource: 'raffles',
+    queryOptions: { retry: false },
+  })
+  const recentRaffles = (rafflesQuery.data?.data ?? []).slice(0, 3)
+
+  const statsLoading = channelsQuery.isLoading || (Boolean(channelId) && statsQuery.isLoading)
+  const rafflesLoading = rafflesQuery.isLoading
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold text-foreground">總覽</h1>
+
+      {/* Stats */}
+      {statsLoading
+        ? (
+            <div className="flex gap-4" data-testid="stats-skeleton">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-24 flex-1 rounded-lg" />
+              ))}
+            </div>
+          )
+        : (
+            <div className="flex gap-4">
+              <StatCard label="本月開台" value={fmtHours(stats?.monthly_seconds)} />
+              <StatCard label="挖礦觀眾" value={stats?.unique_miners !== undefined ? `${fmtNumber(stats.unique_miners)} 人` : undefined} />
+              <StatCard label="總產出點數" value={stats?.total_token_minted !== undefined ? `${fmtNumber(stats.total_token_minted)} 點` : undefined} />
+            </div>
+          )
+      }
+
+      {/* Recent Raffles */}
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-foreground">最近抽獎</h2>
+          <button
+            onClick={() => navigate('/raffles')}
+            className="text-xs text-primary hover:underline"
+          >
+            查看全部 →
+          </button>
+        </div>
+
+        {rafflesLoading
+          ? (
+              <div className="space-y-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-11 w-full rounded-lg" />
+                ))}
+              </div>
+            )
+          : recentRaffles.length === 0
+            ? (
+                <div className="rounded-lg border border-border bg-secondary/20 px-4 py-8 text-center text-sm text-muted-foreground">
+                  尚無抽獎活動。
+                </div>
+              )
+            : (
+                <div className="overflow-hidden rounded-lg border border-border">
+                  {recentRaffles.map((raffle, i) => (
+                    <button
+                      key={raffle.id}
+                      onClick={() => navigate(`/raffles/${raffle.id}`)}
+                      className={`flex w-full items-center justify-between border-b border-border px-4 py-3 text-left text-sm last:border-0 hover:bg-accent/30 ${i % 2 !== 0 ? 'bg-secondary/20' : ''}`}
+                    >
+                      <span className="font-medium text-foreground">{raffle.title}</span>
+                      <span className="flex items-center gap-3">
+                        <span className={`rounded-full px-2 py-0.5 text-xs ${statusClass[raffle.status]}`}>
+                          {statusLabel[raffle.status]}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {new Date(raffle.created_at).toLocaleDateString('zh-TW')}
+                        </span>
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )
+        }
+      </div>
+    </div>
+  )
 }

--- a/apps/dashboard/src/pages/LoginPage.tsx
+++ b/apps/dashboard/src/pages/LoginPage.tsx
@@ -4,6 +4,7 @@ import { isAxiosError } from 'axios'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { apiBaseURL } from '@/services/api'
 
 const messages = {
   'zh-TW': {
@@ -119,11 +120,32 @@ export default function LoginPage() {
     }
   }
 
+  function handleTwitchLogin() {
+    window.location.href = `${apiBaseURL}/api/v1/auth/twitch?redirect_to=%2F`
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="w-full max-w-sm rounded-lg border border-border bg-background p-8 shadow-sm">
         <h1 className="mb-6 text-2xl font-bold text-foreground">{t.title}</h1>
         {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
+        <button
+          type="button"
+          data-testid="twitch-login-btn"
+          onClick={handleTwitchLogin}
+          className="mb-4 w-full rounded-lg border border-purple-500/40 bg-purple-500/10 py-2.5 text-sm font-semibold text-purple-400 transition-colors hover:bg-purple-500/20"
+        >
+          🎮 用 Twitch 帳號登入
+          <span className="ml-2 text-xs font-normal opacity-60">主播推薦使用</span>
+        </button>
+        <div className="relative mb-4">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center text-xs text-muted-foreground">
+            <span className="bg-background px-2">或</span>
+          </div>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1">
             <Label htmlFor="email">Email</Label>

--- a/apps/dashboard/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/DashboardPage.test.tsx
@@ -105,4 +105,34 @@ describe('DashboardPage', () => {
     })
     cleanup(root, container)
   })
+
+  it('抽獎列表為空時顯示「尚無抽獎活動」', async () => {
+    const dp = createMockDataProvider({
+      getList: {
+        'streamer-channels': async () => [mockChannel],
+        raffles: async () => [],
+      },
+      getOne: { 'streamer-stats': async () => mockStats },
+    })
+    const { container, root } = await renderDashboard(dp)
+    await waitFor(() => {
+      expect(container.textContent).toContain('尚無抽獎活動')
+    })
+    cleanup(root, container)
+  })
+
+  it('抽獎 API 錯誤時顯示錯誤訊息', async () => {
+    const dp = createMockDataProvider({
+      getList: {
+        'streamer-channels': async () => [mockChannel],
+        raffles: async () => { throw new Error('network error') },
+      },
+      getOne: { 'streamer-stats': async () => mockStats },
+    })
+    const { container, root } = await renderDashboard(dp)
+    await waitFor(() => {
+      expect(container.textContent).toContain('無法載入最近抽獎')
+    })
+    cleanup(root, container)
+  })
 })

--- a/apps/dashboard/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,108 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMockDataProvider, RefineWrapper, waitFor } from '@/test/refine-wrapper'
+import DashboardPage from '@/pages/DashboardPage'
+
+async function renderDashboard(dataProvider: ReturnType<typeof createMockDataProvider>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(
+      <RefineWrapper dataProvider={dataProvider}>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </RefineWrapper>,
+    )
+  })
+  return { container, root }
+}
+
+function cleanup(root: Root, container: HTMLDivElement) {
+  act(() => { root.unmount() })
+  container.remove()
+}
+
+const mockChannel = { id: 'ch1', channel_id: 'ch1', display_name: '測試主播' }
+const mockStats = {
+  id: 'ch1',
+  channel_id: 'ch1',
+  monthly_seconds: 153000,   // 42.5 hr
+  unique_miners: 1284,
+  total_token_minted: 98320,
+}
+const mockRaffles = [
+  { id: 'r1', title: '五月抽獎', status: 'active',    created_at: '2026-05-20T00:00:00Z' },
+  { id: 'r2', title: '四月抽獎', status: 'draft',     created_at: '2026-05-15T00:00:00Z' },
+  { id: 'r3', title: '三月抽獎', status: 'completed', created_at: '2026-04-30T00:00:00Z' },
+]
+
+describe('DashboardPage', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  it('顯示載入中 skeleton', async () => {
+    const dp = createMockDataProvider({
+      getList: {
+        'streamer-channels': async () => new Promise(() => {}),
+        raffles: async () => new Promise(() => {}),
+      },
+    })
+    const { container, root } = await renderDashboard(dp)
+    expect(container.querySelector('[data-testid="stats-skeleton"]')).not.toBeNull()
+    cleanup(root, container)
+  })
+
+  it('載入完成後顯示統計卡片', async () => {
+    const dp = createMockDataProvider({
+      getList: {
+        'streamer-channels': async () => [mockChannel],
+        raffles: async () => mockRaffles,
+      },
+      getOne: {
+        'streamer-stats': async () => mockStats,
+      },
+    })
+    const { container, root } = await renderDashboard(dp)
+    await waitFor(() => {
+      expect(container.textContent).toContain('42.5')
+      expect(container.textContent).toContain('1,284')
+      expect(container.textContent).toContain('98,320')
+    })
+    cleanup(root, container)
+  })
+
+  it('顯示最近 3 筆抽獎', async () => {
+    const dp = createMockDataProvider({
+      getList: {
+        'streamer-channels': async () => [mockChannel],
+        raffles: async () => mockRaffles,
+      },
+      getOne: { 'streamer-stats': async () => mockStats },
+    })
+    const { container, root } = await renderDashboard(dp)
+    await waitFor(() => {
+      expect(container.textContent).toContain('五月抽獎')
+      expect(container.textContent).toContain('四月抽獎')
+      expect(container.textContent).toContain('三月抽獎')
+    })
+    cleanup(root, container)
+  })
+
+  it('無 channel 時統計顯示「—」不報錯', async () => {
+    const dp = createMockDataProvider({
+      getList: {
+        'streamer-channels': async () => [],
+        raffles: async () => [],
+      },
+    })
+    const { container, root } = await renderDashboard(dp)
+    await waitFor(() => {
+      const dashes = container.querySelectorAll('[data-testid="stat-empty"]')
+      expect(dashes.length).toBeGreaterThanOrEqual(3)
+    })
+    cleanup(root, container)
+  })
+})

--- a/apps/dashboard/src/pages/__tests__/LoginPage.twitch.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/LoginPage.twitch.test.tsx
@@ -1,0 +1,44 @@
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@refinedev/core', () => ({
+  useLogin: () => ({ mutateAsync: vi.fn() }),
+}))
+
+vi.mock('@/services/api', () => ({
+  apiBaseURL: 'http://localhost:8080',
+}))
+
+import LoginPage from '@/pages/LoginPage'
+
+describe('LoginPage Twitch OAuth button', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  it('顯示 Twitch 登入按鈕', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    await act(async () => {
+      createRoot(container).render(<LoginPage />)
+    })
+    const btn = container.querySelector('[data-testid="twitch-login-btn"]')
+    expect(btn).not.toBeNull()
+    expect(btn!.textContent).toContain('Twitch')
+  })
+
+  it('點擊 Twitch 按鈕觸發正確 redirect', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    let assignedHref = ''
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, set href(v: string) { assignedHref = v } },
+      writable: true,
+    })
+    await act(async () => {
+      createRoot(container).render(<LoginPage />)
+    })
+    const btn = container.querySelector<HTMLButtonElement>('[data-testid="twitch-login-btn"]')!
+    await act(async () => { btn.click() })
+    expect(assignedHref).toBe('http://localhost:8080/api/v1/auth/twitch?redirect_to=%2F')
+  })
+})


### PR DESCRIPTION
## 什麼改動

為主播角色實作 Dashboard 三項 UX 改善：

1. **LoginPage** — 加入 Twitch OAuth 登入按鈕（紫色，主播推薦），保留原有 email/密碼表單
2. **DashboardPage** — 從空殼改為實際內容：本月開台時數、挖礦觀眾數、總產出點數三張統計卡片，加上最近 3 筆抽獎列表（含狀態 badge 與日期）
3. **Layout** — `navItems` 加入 `roles?: string[]` 欄位，主播登入後只看到「總覽、抽獎管理、交易紀錄」三項；管理員仍看到全部五項

## 為什麼

主播目前需要記住額外帳密才能登入 Dashboard，登入後看到的是空白首頁與過多的導覽項目，體驗不佳。本次改動讓主播能一鍵 Twitch 登入並立刻看到自己頻道的關鍵資訊。

closes #763

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：docs/superpowers/specs/2026-05-26-dashboard-streamer-ux-design.md / #763
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Route-level RBAC guard（後端 ownership check 已足夠保護）
  - Settings 頁面改動
  - 管理員專屬功能新增
  - Twitch 帳號連結 / 解除連結

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：docs/superpowers/plans/2026-05-26-dashboard-streamer-ux.md
- Actual worker profile(s)：frontend_worker (haiku × 3 implementers, sonnet reviewers)
- Model strength：haiku for Layout/LoginPage tasks; sonnet for DashboardPage + all spec/quality reviewers
- Spawn directive(s)：profile=frontend_worker model=claude-haiku-4-5-20251001 reasoning=3-isolated-frontend-tasks-with-spec controller_fallback=claude-sonnet-4-6
- Verification evidence：120/120 tests pass；pnpm build pass；pnpm exec tsc --noEmit pass
- Self-review / exception reason：spec reviewer + code quality reviewer passed per task; CodeRabbit findings (root.unmount, rafflesError, empty-raffle test) addressed in follow-up commits
- Worker session closeout：3 implementer + 6 reviewer subagents closed; 3 follow-up fix commits pushed post-review
- Workflow friction / follow-up split：n/a

## Review conversation closeout
- Unresolved threads：0
- CodeRabbit：addressed — root.unmount (53f7483), rafflesError state (f21ce48), empty+error raffle tests (cca9c24)
- chatgpt-codex-connector：n/a
- review_triage_ref：CodeRabbit inline comments at Layout.nav.test.tsx:34 and DashboardPage.tsx:67 — both fixed
- root_cause_gate_ref：afterEach missing unmount (test pollution risk); missing isError branch (API failure shown as empty state) — both root causes addressed
- finding_disposition_ref：all CodeRabbit findings fixed in commits 53f7483, f21ce48, cca9c24; no remaining open issues
- Final reviewer action：approved — all findings resolved, 120/120 tests pass

## Final merge gate
- Ready-to-merge decision：ready
- Latest head SHA：cca9c24
- Required checks：CI pass pending re-run (GitHub CDN transient issue on prior run); Scope Police addressed
- spec workflow-check evidence：120/120 vitest pass; pnpm build success; tsc --noEmit 0 errors
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：為主播角色實作 Dashboard 登入（Twitch OAuth）、首頁統計卡片與最近抽獎、及角色感知導覽列
- Approx changed lines：~200 行（3 個 source files + 3 個 test files）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 三個 source file 改動均為同一使用者旅程（主播登入 → 首頁 → 導覽），拆開會讓每個 PR 都無法獨立驗收
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] 登入頁顯示 Twitch 登入按鈕，點擊正確跳轉 Twitch OAuth 流程
- [x] email/密碼登入路徑維持正常運作
- [x] 首頁顯示三張統計卡片（本月開台、挖礦觀眾、總產出點數）
- [x] 首頁顯示最近 3 筆抽獎，含狀態 badge 與日期
- [x] 「查看全部」連結跳轉到 /raffles
- [x] 主播角色（role: streamer）導航只顯示：總覽、抽獎管理、交易紀錄
- [x] 管理員角色（role: admin）導航顯示全部項目
- [x] TypeScript 零錯誤
- [x] Dashboard build 通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
Test Files  17 passed (17)
     Tests  120 passed (120)
  Duration  7.29s

pnpm build: 成功，零 TypeScript 錯誤
```

## 備註
- 後端 Twitch OAuth 路由已存在（GET /api/v1/auth/twitch、GET /api/v1/auth/twitch/callback），本 PR 不需後端改動
- 本機測試需在 services/api/.env 設定 FRONTEND_URL=http://localhost:5174

## Notes for Claude Code Review
- useOne 呼叫 streamer-stats 時以 id: channelId ?? '' 搭配 enabled: Boolean(channelId) 避免空 id 請求，符合 Refine v4 conditional query 慣例
- 後端 ListByStreamerContext 已確認有 .Order("created_at DESC")，前端取前 3 筆無需額外 sort
- Twitch redirect URL 硬編碼 %2F（非 user input），無 open-redirect / XSS 風險