### PR TITLE
[infra] Guard app-scoped CI routing policy

### DIFF
--- a/.github/workflows/ci-app-scope-regression.yml
+++ b/.github/workflows/ci-app-scope-regression.yml
@@ -1,0 +1,43 @@
+name: CI app scope regression
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - .github/workflows/ci.yml
+      - .github/workflows/ci-app-scope-regression.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  app-scope-regression:
+    timeout-minutes: 5
+    name: CI app scope regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Verify extension and dashboard routing stay separate
+        run: |
+          set -eu
+
+          workflow=.github/workflows/ci.yml
+
+          grep -q "extension: allFilePaths.some" "$workflow"
+          grep -q "dashboard: allFilePaths.some" "$workflow"
+          grep -q "runFrontend = runFullCi || (runCi && (touches.extension" "$workflow"
+          grep -q "runDashboard = runFullCi || (runCi && (touches.dashboard" "$workflow"
+          grep -q "run: docker compose run --no-deps --rm frontend pnpm test" "$workflow"
+          grep -q "run: docker compose run --no-deps --rm dashboard pnpm test" "$workflow"
+
+          if grep -q "runDashboard = runFullCi || (runCi && (touches.frontend" "$workflow"; then
+            echo "Dashboard routing must not depend on the generic frontend surface."
+            exit 1
+          fi
+
+          if grep -q "runFrontend = runFullCi || (runCi && (touches.dashboard" "$workflow"; then
+            echo "Extension/frontend routing must not depend on dashboard-only changes."
+            exit 1
+          fi

--- a/docs/ci-app-scope-policy.md
+++ b/docs/ci-app-scope-policy.md
@@ -1,0 +1,26 @@
+# App-scoped CI policy
+
+Tachigo is a monorepo. CI routing should follow the app boundary instead of a coarse frontend/backend split.
+
+## App scopes
+
+| Scope | Paths | Expected validation |
+| --- | --- | --- |
+| Extension | `apps/extension/**`, legacy `tachimint/**` | Extension build, lint, test, and i18n checks. |
+| Dashboard | `apps/dashboard/**`, legacy `dashboard/**` | Dashboard build, lint, and test checks. |
+| Backend | `services/api/**`, legacy `backend/**` | Backend build, Go checks, migration checks, and integration checks. |
+| Contracts | `contracts/**` | Contract build, test, format, and report checks. |
+| Shared frontend workspace | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` | Extension and Dashboard checks. |
+| API contract surfaces | API client, shared API types, backend router, OpenAPI docs | API contract drift checks. |
+| CI routing files | CI workflow and workflow regression files | Full CI, because routing changes affect the router itself. |
+| Docs and templates | `docs/**`, `plans/**`, root Markdown, PR/issue templates | No heavy product CI for metadata-only changes. |
+
+## Rules
+
+- Treat Extension and Dashboard as separate app scopes.
+- Do not force extension checks for dashboard-only changes.
+- Do not force dashboard checks for extension-only changes.
+- Run both Extension and Dashboard checks for shared frontend workspace changes.
+- Keep the existing required-check names stable unless branch protection is updated in the same change.
+
+The current `frontend` CI job name maps to the Extension app scope. New documentation should use `Extension` for that app while preserving the existing check name.


### PR DESCRIPTION
refs #947

Source of truth: https://github.com/nurockplayer/tachigo/issues/947

Depends on PR: none

Backend contract already in develop:
- [x] yes
- [ ] no

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Summary

- Documents the intended app-scoped CI routing policy for tachigo.
- Adds `.github/workflows/ci-app-scope-regression.yml` to guard the CI router against collapsing Dashboard and Extension back into one generic frontend bucket.
- Verifies Dashboard routing is driven by `touches.dashboard` and Extension routing is driven by `touches.extension`.
- Keeps existing required-check names stable; this PR does not rename the existing `Frontend build` check.

## Validation

- Added a dedicated CI app-scope regression workflow.
- Compared branch diff against `develop`: only CI/documentation files are changed.

本 PR 明確不做
- Does not change product code.
- Does not rename existing required checks.
- Does not change branch protection or auto-merge rules.