### PR TITLE
[backend] raffle scheduler — 改為每 5 分鐘掃描並補抓逾期排程

### DIFF
--- a/services/api/internal/services/raffle_scheduler.go
+++ b/services/api/internal/services/raffle_scheduler.go
@@ -6,7 +6,16 @@ import (
 	"time"
 )
 
-// RaffleScheduler fires RunScheduledSnapshots at 23:55 UTC every day.
+// snapshotCheckInterval is how often the scheduler scans for raffles whose
+// scheduled_at has arrived (or is within the look-ahead window). It must be
+// <= the look-ahead window in RunScheduledSnapshots so every scheduled raffle is
+// covered by at least one scan.
+const snapshotCheckInterval = 5 * time.Minute
+
+// RaffleScheduler periodically triggers snapshots for raffles whose scheduled_at
+// has arrived. It scans every snapshotCheckInterval rather than once a day, so a
+// raffle scheduled for any time of day is picked up — not only those near a
+// single daily run.
 type RaffleScheduler struct {
 	svc *RaffleService
 }
@@ -15,34 +24,31 @@ func NewRaffleScheduler(svc *RaffleService) *RaffleScheduler {
 	return &RaffleScheduler{svc: svc}
 }
 
-// Start launches the background goroutine. Stops when ctx is cancelled.
+// Start launches the background goroutine. It runs an initial scan immediately —
+// so raffles whose scheduled time elapsed while the server was down are caught on
+// restart — and then re-scans every snapshotCheckInterval until ctx is cancelled.
 func (rs *RaffleScheduler) Start(ctx context.Context) {
 	go func() {
+		ticker := time.NewTicker(snapshotCheckInterval)
+		defer ticker.Stop()
+
+		rs.runOnce(ctx)
 		for {
-			now := time.Now().UTC()
-			next := nextSchedulerRun(now)
-			log.Printf("event=raffle_scheduler_wait job=raffle_scheduled_snapshots next_run=%s", next.Format(time.RFC3339))
 			select {
 			case <-ctx.Done():
 				log.Printf("event=raffle_scheduler_stop job=raffle_scheduled_snapshots")
 				return
-			case <-time.After(next.Sub(now)):
-				runCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-				if err := rs.svc.RunScheduledSnapshots(runCtx, time.Now().UTC()); err != nil {
-					log.Printf("event=raffle_scheduler_batch_error job=raffle_scheduled_snapshots err=%q", err)
-				}
-				cancel()
+			case <-ticker.C:
+				rs.runOnce(ctx)
 			}
 		}
 	}()
 }
 
-// nextSchedulerRun returns the next 23:55 UTC after now.
-func nextSchedulerRun(now time.Time) time.Time {
-	today := time.Date(now.Year(), now.Month(), now.Day(), 23, 55, 0, 0, time.UTC)
-	if now.Before(today) {
-		return today
+func (rs *RaffleScheduler) runOnce(ctx context.Context) {
+	runCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	if err := rs.svc.RunScheduledSnapshots(runCtx, time.Now().UTC()); err != nil {
+		log.Printf("event=raffle_scheduler_batch_error job=raffle_scheduled_snapshots err=%q", err)
 	}
-	tomorrow := now.AddDate(0, 0, 1)
-	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 23, 55, 0, 0, time.UTC)
 }

--- a/services/api/internal/services/raffle_scheduler_test.go
+++ b/services/api/internal/services/raffle_scheduler_test.go
@@ -17,49 +17,12 @@ import (
 	"github.com/tachigo/tachigo/internal/testutil"
 )
 
-func TestNextSchedulerRun(t *testing.T) {
-	utc := time.UTC
-	cases := []struct {
-		name string
-		now  time.Time
-		want time.Time
-	}{
-		{
-			name: "before 23:55 same day",
-			now:  time.Date(2025, 1, 1, 12, 0, 0, 0, utc),
-			want: time.Date(2025, 1, 1, 23, 55, 0, 0, utc),
-		},
-		{
-			name: "one second before 23:55",
-			now:  time.Date(2025, 1, 1, 23, 54, 59, 0, utc),
-			want: time.Date(2025, 1, 1, 23, 55, 0, 0, utc),
-		},
-		{
-			name: "exactly at 23:55 → tomorrow",
-			now:  time.Date(2025, 1, 1, 23, 55, 0, 0, utc),
-			want: time.Date(2025, 1, 2, 23, 55, 0, 0, utc),
-		},
-		{
-			name: "after 23:55 → tomorrow",
-			now:  time.Date(2025, 1, 1, 23, 56, 0, 0, utc),
-			want: time.Date(2025, 1, 2, 23, 55, 0, 0, utc),
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := nextSchedulerRun(tc.now)
-			if !got.Equal(tc.want) {
-				t.Errorf("got %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
 func TestRunScheduledSnapshots_SkipsOutOfWindow(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewRaffleService(db, "", "", nil)
 
 	user := insertRaffleTestUser(t, db)
+	// Scheduled well beyond the look-ahead window: must not be snapshotted yet.
 	scheduledAt := time.Now().UTC().Add(2 * time.Hour)
 	raffle := insertScheduledRaffle(t, db, user.ID, scheduledAt, models.RaffleSourceTwitchAPI)
 
@@ -71,6 +34,38 @@ func TestRunScheduledSnapshots_SkipsOutOfWindow(t *testing.T) {
 	db.First(&r, "id = ?", raffle.ID)
 	if r.Status != models.RaffleStatusDraft {
 		t.Errorf("expected draft, got %s", r.Status)
+	}
+}
+
+// TestRunScheduledSnapshots_CatchesOverdue verifies the catch-up behaviour: a
+// raffle whose scheduled_at already elapsed (e.g. missed while the server was
+// down) is still snapshotted on the next scan, not skipped forever.
+func TestRunScheduledSnapshots_CatchesOverdue(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewRaffleService(db, "test-client-id", "", nil)
+	svc.SetTwitchBaseURL("https://twitch.test")
+	svc.httpClient = testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			return testutil.NewStringResponse(http.StatusOK, `{"data":[],"pagination":{}}`), nil
+		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
+	})
+
+	user := insertRaffleTestUser(t, db)
+	insertRaffleTwitchProvider(t, db, user.ID, "broadcaster123", "streamer_token")
+
+	// scheduled_at already 1h in the past — e.g. missed while the server was down.
+	scheduledAt := time.Now().UTC().Add(-1 * time.Hour)
+	raffle := insertScheduledRaffle(t, db, user.ID, scheduledAt, models.RaffleSourceTwitchAPI)
+
+	if err := svc.RunScheduledSnapshots(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var r models.Raffle
+	db.First(&r, "id = ?", raffle.ID)
+	if r.Status != models.RaffleStatusActive {
+		t.Errorf("expected active after catch-up snapshot, got %s", r.Status)
 	}
 }
 

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -798,9 +798,12 @@ func (s *RaffleService) clearProviderTokensContext(ctx context.Context, provider
 
 // ── Scheduled snapshot (cron) ─────────────────────────────────────────────────
 
-// RunScheduledSnapshots finds draft raffles with scheduled_at in [now, now+10min]
-// and triggers their snapshot. Per-raffle errors are logged and do not abort the batch.
-// CSV raffles are excluded: they are uploaded manually and have no remote source to sync from.
+// RunScheduledSnapshots finds draft raffles whose scheduled_at is due — already
+// elapsed or within the next 10 minutes — and triggers their snapshot. There is
+// intentionally no lower bound, so a raffle whose scheduled_at passed while the
+// server was down is caught up on the next scan rather than skipped forever.
+// Per-raffle errors are logged and do not abort the batch. CSV raffles are
+// excluded: they are uploaded manually and have no remote source to sync from.
 func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time) error {
 	start := time.Now()
 	result := "success"
@@ -813,8 +816,8 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 	window := now.Add(10 * time.Minute)
 	var raffles []models.Raffle
 	if err := s.db.WithContext(ctx).Where(
-		"status = ? AND source != ? AND scheduled_at IS NOT NULL AND scheduled_at >= ? AND scheduled_at <= ?",
-		models.RaffleStatusDraft, models.RaffleSourceCSV, now, window,
+		"status = ? AND source != ? AND scheduled_at IS NOT NULL AND scheduled_at <= ?",
+		models.RaffleStatusDraft, models.RaffleSourceCSV, window,
 	).Find(&raffles).Error; err != nil {
 		log.Printf(
 			"event=raffle_scheduled_snapshots_query_error job=raffle_scheduled_snapshots run_at=%s window_end=%s err=%q",

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -798,6 +798,8 @@ func (s *RaffleService) clearProviderTokensContext(ctx context.Context, provider
 
 // ── Scheduled snapshot (cron) ─────────────────────────────────────────────────
 
+const scheduledSnapshotBatchLimit = 500
+
 // RunScheduledSnapshots finds draft raffles whose scheduled_at is due — already
 // elapsed or within the next 10 minutes — and triggers their snapshot. There is
 // intentionally no lower bound, so a raffle whose scheduled_at passed while the
@@ -818,7 +820,7 @@ func (s *RaffleService) RunScheduledSnapshots(ctx context.Context, now time.Time
 	if err := s.db.WithContext(ctx).Where(
 		"status = ? AND source != ? AND scheduled_at IS NOT NULL AND scheduled_at <= ?",
 		models.RaffleStatusDraft, models.RaffleSourceCSV, window,
-	).Find(&raffles).Error; err != nil {
+	).Order("scheduled_at ASC, id ASC").Limit(scheduledSnapshotBatchLimit).Find(&raffles).Error; err != nil {
 		log.Printf(
 			"event=raffle_scheduled_snapshots_query_error job=raffle_scheduled_snapshots run_at=%s window_end=%s err=%q",
 			now.Format(time.RFC3339),


### PR DESCRIPTION
## 什麼改動
- `RaffleScheduler` 從「每天只在 23:55 UTC 掃一次」改成「每 5 分鐘掃一次」(`time.NewTicker`),並在啟動時先掃一次。
- `RunScheduledSnapshots` 拿掉視窗下界 `scheduled_at >= now`,改成只看上界 `scheduled_at <= now+10min`,因此也會補抓「停機期間錯過、scheduled_at 已過去」的 draft raffle。
- 移除已不需要的 `nextSchedulerRun`(23:55 計算)及其測試;新增 `TestRunScheduledSnapshots_CatchesOverdue` 涵蓋逾期補抓。

## 為什麼
原本排程器整天只在 23:55 觸發一次,而 `RunScheduledSnapshots` 只挑 `[now, now+10min]` 的 raffle,導致**排在 23:55 以外時段的 raffle 永遠不會自動 snapshot/轉 Active**。同時也修正 closes #955 的「23:55 後重啟漏跑當日 snapshot」——啟動即掃 + 無下界補抓,重啟會自動補上。

closes #955

> 註:本 PR 範圍略大於 #955 字面(重啟補跑),因為兩者是同一個排程機制的同一個根因;完整修法必然同時涵蓋「掃描頻率」與「逾期補抓」,故一併處理而非拆成會互相依賴的兩個半成品 PR。

## Release Context
- Release type：n/a

## Workflow Type
- n/a(非 Codex task,由 Claude Code 直接實作)

## PR Risk Class
- [x] R3 backend / API behavior

## Scope 對齊
- Source of truth：#955
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是(見上方「為什麼」對範圍略大於 #955 字面的說明)
- 本 PR 明確不做：
  - 不為「永久同步失敗的 raffle」加 backoff / max-attempts(目前仍每輪重試,僅 log 噪音;若需要另開票)
  - 不改抽選 / 領獎 / Twitch 同步邏輯
  - 不動 channel config multiplier 上限等其他 follow-up

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- n/a — 非 autonomous / 非 Codex task,Claude Code 直接於 develop-based worktree 實作與驗證。

## Review conversation closeout
- Unresolved threads：0
- CodeRabbit：n/a(尚未審)
- chatgpt-codex-connector：n/a
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：n/a
- Final reviewer action：pending human review

## Final merge gate
- Ready-to-merge decision：pending

## 驗證
- `go vet ./internal/services/` → No issues found
- `go test ./internal/services/`(完整包)→ 368 passed,含新增 `TestRunScheduledSnapshots_CatchesOverdue`
- `go build ./cmd/...` → OK(scheduler 介面未變,main.go 不需改)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 彩券调度频率优化为每 5 分钟检查一次，提高定时任务响应速度

* **Bug Fixes**
  * 系统停机期间错过的定时彩券现将在下次扫描时自动补充触发

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->