### PR TITLE
[backend] channel config — multiplier/seconds_per_point 加上限

### DIFF
--- a/services/api/internal/handlers/channel_config_handler.go
+++ b/services/api/internal/handlers/channel_config_handler.go
@@ -43,9 +43,12 @@ func (h *ChannelConfigHandler) GetChannelConfig(c *gin.Context) {
 }
 
 func (h *ChannelConfigHandler) UpdateChannelConfig(c *gin.Context) {
+	// Upper bounds cap the earning rate a channel owner can configure. multiplier
+	// is the main inflation lever (points → claimable $TACHI), so it is capped at
+	// 10x; seconds_per_point has a generous sanity ceiling. 0 still means "unset".
 	var body struct {
-		SecondsPerPoint int64 `json:"seconds_per_point" binding:"min=0"`
-		Multiplier      int64 `json:"multiplier" binding:"min=0"`
+		SecondsPerPoint int64 `json:"seconds_per_point" binding:"min=0,max=86400"`
+		Multiplier      int64 `json:"multiplier" binding:"min=0,max=10"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		badRequest(c, err.Error())

--- a/services/api/internal/handlers/channel_config_handler_test.go
+++ b/services/api/internal/handlers/channel_config_handler_test.go
@@ -313,6 +313,28 @@ func TestUpdateChannelConfig_RejectsInvalidBody(t *testing.T) {
 	}
 }
 
+func TestUpdateChannelConfig_RejectsOutOfRange(t *testing.T) {
+	env := newDashboardTestEnv(t)
+	token := env.tokenForRole(t, models.RoleAdmin)
+
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{name: "multiplier above cap", body: `{"multiplier":11}`},
+		{name: "seconds_per_point above cap", body: `{"seconds_per_point":86401}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := updateChannelConfig(t, env.router, token, "channel_123", tc.body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestUpdateChannelConfig_RejectsEmptyValues(t *testing.T) {
 	env := newDashboardTestEnv(t)
 	token := env.tokenForRole(t, models.RoleAdmin)


### PR DESCRIPTION
## 什麼改動
- `UpdateChannelConfig` 的 binding 加上界:`multiplier` `max=10`、`seconds_per_point` `max=86400`(1 天)。
- 維持 `min=0`(0 = 未設,沿用既有「至少一個正值」語意)。

## 為什麼
原本兩個欄位只驗 `min=0`、無上界。因為 claim 是 1 點 = 1 顆可兌折價券的 $TACHI,無上限的 `multiplier` 是潛在的 mint 通膨槓桿(`int64` 無上限也會引發溢位/誇張顯示)。streamer 為 admin 審核夥伴制,風險低、不急,本 PR 屬便宜止血。對應 #761 的 channel config 上下限 checklist 項。

refs #761

> 註:本 PR 只完成 #761 其中一個 checklist 項,**不 close** 整張 tracking issue。

## Release Context
- Release type：n/a

## Workflow Type
- n/a(非 Codex task,由 Claude Code 直接實作)

## PR Risk Class
- [x] R3 backend / API behavior

## Scope 對齊
- Source of truth：#761
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不設「下限 floor」防快速 farming(1 sec/point 是否該允許屬產品經濟決策,不擅自定)
  - 不改 watch 計點邏輯 / claim / mint 流程
  - cap 數值(10 / 86400)為保守預設,可由 reviewer 依經濟模型調整

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- n/a — 非 autonomous / 非 Codex task,Claude Code 直接於 develop-based worktree 實作與驗證。

## Review conversation closeout
- Unresolved threads：0
- CodeRabbit：n/a(尚未審)
- chatgpt-codex-connector：n/a
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：n/a
- Final reviewer action：pending human review

## Final merge gate
- Ready-to-merge decision：pending

## 驗證
- `go vet ./internal/handlers/` → No issues found
- `go test ./internal/handlers/`(完整包)→ 通過
- 新測試:`TestUpdateChannelConfig_RejectsOutOfRange`(multiplier=11、seconds_per_point=86401 → 400)
- 既有測試(multiplier 1–3、seconds_per_point 45–90)全在界內,未受影響
- binding tag 改動不涉及 swagger annotation / route,無需 swag init
