### PR TITLE
[chore] Gate CodeRabbit behind draft PR flow

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -31,6 +31,7 @@ const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-
 const dependencyInventoryWorkflowPath = path.join(currentDir, 'dependency-inventory.yml')
 const notifyRebaseNeededWorkflowPath = path.join(currentDir, 'notify-rebase-needed.yml')
 const releasePrWorkflowPath = path.join(currentDir, 'release-pr.yml')
+const codeRabbitConfigPath = path.join(repoRoot, '.coderabbit.yaml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 const claudeConventionsPath = path.join(repoRoot, '.claude', 'rules', 'conventions.md')
 const prScopePolicyPath = path.join(repoRoot, 'docs', 'pr-scope-policy.md')
@@ -1229,6 +1230,20 @@ test('autonomous work entrypoints require start-of-work delegation and point to 
   assert.match(workflow, /stale handle/)
   assert.match(workflow, /CodeRabbit rate limit/)
   assert.match(workflow, /chatgpt-codex-connector/)
+})
+
+test('CodeRabbit auto review stays behind the draft PR gate', async () => {
+  const config = parseYaml(codeRabbitConfigPath)
+  const draftAutoReadyDocs = await readFile(path.join(repoRoot, 'docs', 'draft-pr-auto-ready.md'), 'utf8')
+  const prScopePolicy = await readFile(prScopePolicyPath, 'utf8')
+
+  assert.equal(config.reviews.auto_review.enabled, true)
+  assert.equal(config.reviews.auto_review.drafts, false)
+  assert.deepEqual(config.reviews.auto_review.base_branches, ['.*'])
+  assert.match(draftAutoReadyDocs, /CodeRabbit auto review/)
+  assert.match(draftAutoReadyDocs, /Scope Police/)
+  assert.match(prScopePolicy, /READY=1/)
+  assert.match(prScopePolicy, /CodeRabbit/)
 })
 
 test('Codex issue template requires an autonomous worker delegation plan textarea', async () => {

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ pr-meta-check:
 pr-open:
 	@test -n "$(TITLE)" || (echo "TITLE is required"; exit 2)
 	@test -n "$(BODY_FILE)" || (echo "BODY_FILE is required"; exit 2)
-	@./infra/scripts/pr-open.sh --title "$(TITLE)" --body-file "$(BODY_FILE)" --base "$(or $(BASE),develop)" $(if $(HEAD),--head "$(HEAD)",) $(if $(filter 1,$(DRAFT)),--draft,) $(if $(filter 1,$(AUTO_READY)),--auto-ready,)
+	@./infra/scripts/pr-open.sh --title "$(TITLE)" --body-file "$(BODY_FILE)" --base "$(or $(BASE),develop)" $(if $(HEAD),--head "$(HEAD)",) $(if $(filter 1,$(DRAFT)),--draft,) $(if $(filter 1,$(READY)),--ready,) $(if $(filter 1,$(AUTO_READY)),--auto-ready,)
 
 # ── AI-safe command surface ─────────────────────────────────────────────────
 ai-readback:

--- a/docs/draft-pr-auto-ready.md
+++ b/docs/draft-pr-auto-ready.md
@@ -157,7 +157,15 @@ their PR Risk Class is `R0` through `R3`:
 make pr-open TITLE="[type] ..." BODY_FILE=/tmp/pr_body.md AUTO_READY=1
 ```
 
-If opening a PR directly with `gh pr create`, use `--draft --label auto-ready`.
+`make pr-open` creates a draft PR by default. Use `READY=1` only when a human
+intentionally wants the PR to enter review immediately.
+
+If opening a PR directly with `gh pr create`, use `--draft --label auto-ready`
+for Codex task PRs.
+
+CodeRabbit auto review is configured with `reviews.auto_review.drafts: false`.
+Keeping Codex task PRs draft until Scope Police and required CI pass prevents
+review work from starting on PRs that the scope gate may close or block.
 
 Non-Codex tasks, human WIP drafts, `R4` PRs, and PRs that should not enter the
 review queue automatically should not use the `auto-ready` label.

--- a/docs/pr-scope-policy.md
+++ b/docs/pr-scope-policy.md
@@ -268,6 +268,10 @@ make pr-meta-check TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md
 make pr-open TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md
 ```
 
+`make pr-open` 預設建立 draft PR。若 reviewer 已準備好立即看、且接受
+CodeRabbit 可能會在 Scope Police 完成前開始 review，才使用 `READY=1` 建立
+ready PR。
+
 Codex task PR 預設應使用 auto-ready 流程：
 
 ```bash
@@ -279,6 +283,7 @@ make pr-open TITLE="[chore] Example title" BODY_FILE=/tmp/pr-body.md AUTO_READY=
 - `BASE`：預設 `develop`
 - `HEAD`：預設目前 branch
 - `DRAFT=1`：建立 draft PR
+- `READY=1`：建立 ready PR，會立即進入一般 review queue
 - `AUTO_READY=1`：建立 draft PR 並加上 `auto-ready` label，等 required
   checks 通過後由 workflow 自動轉成 Ready for review
 

--- a/infra/scripts/pr-open.sh
+++ b/infra/scripts/pr-open.sh
@@ -5,9 +5,10 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  infra/scripts/pr-open.sh --title "<pr title>" --body-file <path> [--base develop] [--head <branch>] [--draft] [--auto-ready]
+  infra/scripts/pr-open.sh --title "<pr title>" --body-file <path> [--base develop] [--head <branch>] [--draft] [--ready] [--auto-ready]
 
-Runs local PR metadata checks, then opens a PR with gh.
+Runs local PR metadata checks, then opens a draft PR with gh.
+Use --ready only when the PR should enter review immediately.
 EOF
 }
 
@@ -49,6 +50,7 @@ main() {
   local base_branch="develop"
   local head_branch=""
   local draft=0
+  local ready=0
   local auto_ready=0
   local pr_output=""
   local pr_number=""
@@ -76,6 +78,10 @@ main() {
         draft=1
         shift
         ;;
+      --ready)
+        ready=1
+        shift
+        ;;
       --auto-ready)
         auto_ready=1
         shift
@@ -95,6 +101,14 @@ main() {
   [ -n "$title" ] || { echo "--title 為必填" >&2; exit 2; }
   [ -n "$body_file" ] || { echo "--body-file 為必填" >&2; exit 2; }
   [ -f "$body_file" ] || { echo "找不到 body file：$body_file" >&2; exit 2; }
+  if [ "$draft" -eq 1 ] && [ "$ready" -eq 1 ]; then
+    echo "--draft 與 --ready 不可同時使用" >&2
+    exit 2
+  fi
+  if [ "$auto_ready" -eq 1 ] && [ "$ready" -eq 1 ]; then
+    echo "--auto-ready 會建立 draft PR；不可搭配 --ready" >&2
+    exit 2
+  fi
 
   if [ -z "$head_branch" ]; then
     head_branch=$(git branch --show-current)
@@ -120,7 +134,7 @@ main() {
   "${metadata_cmd[@]}"
 
   local cmd=(gh pr create --base "$base_branch" --head "$head_branch" --title "$title" --body-file "$body_file")
-  if [ "$draft" -eq 1 ] || [ "$auto_ready" -eq 1 ]; then
+  if [ "$ready" -eq 0 ] || [ "$draft" -eq 1 ] || [ "$auto_ready" -eq 1 ]; then
     cmd+=(--draft)
   fi
   if [ "$auto_ready" -eq 1 ]; then

--- a/infra/scripts/pr-open.test.sh
+++ b/infra/scripts/pr-open.test.sh
@@ -79,13 +79,46 @@ grep -q -- '--worktree '"$tmp_dir" "$tmp_dir/session-index.log"
       --body-file body.md
 )
 
-! grep -q -- '--draft' "$tmp_dir/gh-pr-create-default.log"
+grep -q -- '--draft' "$tmp_dir/gh-pr-create-default.log"
 ! grep -q -- '--label auto-ready' "$tmp_dir/gh-pr-create-default.log"
 grep -q -- '--title \[chore\] Test default PR' "$tmp_dir/pr-metadata-check-default.log"
 ! grep -q -- '--auto-ready' "$tmp_dir/pr-metadata-check-default.log"
 grep -q -- 'add --pr 566' "$tmp_dir/session-index-default.log"
 grep -q -- '--issue 420' "$tmp_dir/session-index-default.log"
 grep -q -- '--worktree '"$tmp_dir" "$tmp_dir/session-index-default.log"
+
+(
+  cd "$tmp_dir"
+
+  PATH="$tmp_dir/fakebin:$PATH" \
+    GH_PR_CREATE_LOG="$tmp_dir/gh-pr-create-ready.log" \
+    PR_METADATA_CHECK_LOG="$tmp_dir/pr-metadata-check-ready.log" \
+    SESSION_INDEX_LOG="$tmp_dir/session-index-ready.log" \
+    "$tmp_dir/infra/scripts/pr-open.sh" \
+      --title "[chore] Test explicit ready PR" \
+      --body-file body.md \
+      --ready
+)
+
+! grep -q -- '--draft' "$tmp_dir/gh-pr-create-ready.log"
+! grep -q -- '--label auto-ready' "$tmp_dir/gh-pr-create-ready.log"
+grep -q -- '--title \[chore\] Test explicit ready PR' "$tmp_dir/pr-metadata-check-ready.log"
+
+(
+  cd "$tmp_dir"
+
+  PATH="$tmp_dir/fakebin:$PATH" \
+    GH_PR_CREATE_LOG="$tmp_dir/gh-pr-create-conflict.log" \
+    PR_METADATA_CHECK_LOG="$tmp_dir/pr-metadata-check-conflict.log" \
+    SESSION_INDEX_LOG="$tmp_dir/session-index-conflict.log" \
+    "$tmp_dir/infra/scripts/pr-open.sh" \
+      --title "[chore] Test conflicting ready PR" \
+      --body-file body.md \
+      --auto-ready \
+      --ready \
+      2>"$tmp_dir/conflict.stderr" && exit 1
+  grep -q -- '--auto-ready 會建立 draft PR；不可搭配 --ready' "$tmp_dir/conflict.stderr"
+)
 
 (
   cd "$tmp_dir"


### PR DESCRIPTION
## 什麼改動
- 讓 `make pr-open` / `infra/scripts/pr-open.sh` 預設建立 draft PR。
- 新增 `READY=1` / `--ready` 作為立即進 review queue 的明確 opt-in。
- 擋下 `--auto-ready --ready` 的互斥組合，避免 auto-ready PR 繞過 draft gate。
- 補文件與 workflow regression，鎖住 CodeRabbit `drafts: false` 的 Scope Police-first 流程。

## 為什麼
closes #963

CodeRabbit auto review 不應該在 Scope Police / required CI gate 前先消耗 review work；draft PR gate 可以讓可能被 Scope Police 關閉或擋下的 PR 不先觸發 CodeRabbit。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#963
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 CodeRabbit provider 設定以外的 review policy；不改 auto-ready / auto-merge workflow 行為；不調整 branch protection。

## Delegation Execution Log
- Source issue delegation plan：
  - #963 scope and acceptance criteria only; no separate worker routing plan was present.
- Actual worker profile(s)：
  - controller only under self-only exception
- Model strength：
  - controller = high
- Spawn directive(s)：
  - self-only exception; no worker spawned
- Verification evidence：
  - `bash infra/scripts/pr-open.test.sh`；`node --test .github/workflows/ci.test.ts`；`rtk git diff --check -- Makefile infra/scripts/pr-open.sh infra/scripts/pr-open.test.sh .github/workflows/ci.test.ts docs/draft-pr-auto-ready.md docs/pr-scope-policy.md`
- Self-review / exception reason：
  - trivial/self-only exception for a bounded workflow/tooling PR tied directly to #963 acceptance criteria
- Worker session closeout：
  - No worker session was spawned under the self-only exception; controller completed readback and no worker handles remain open.
- Workflow friction / follow-up split：
  - No follow-up split required; PR remains a single workflow guardrail change with tests and docs.

## Review conversation closeout
- Unresolved threads：
  - 0 thread-aware review threads found in PR metadata at initial closeout.
- CodeRabbit：
  - intentionally gated behind draft until Scope Police / required CI pass
- chatgpt-codex-connector：
  - n/a; no connector review comments present
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/965#issuecomment-4556098688
- root_cause_gate_ref：
  - https://github.com/nurockplayer/tachigo/pull/965#issuecomment-4556098688
- finding_disposition_ref：
  - https://github.com/nurockplayer/tachigo/pull/965#issuecomment-4556098688
- Final reviewer action：
  - Scope Police metadata finding adopted by updating this PR body; no code review findings were present.

## Final merge gate
- Ready-to-merge decision：
  - blocked until updated Scope Police rerun passes and a human reviewer approves; R4 remains non-auto-ready
- Latest head SHA：
  - 2ef83dfc76353c5c2758a5f1c93e6cd93cae190f
- Required checks：
  - non-Scope-Police checks passed on 2ef83df; Scope Police rerun required after this PR body update
- spec workflow-check evidence：
  - n/a; manual checklist and local commands recorded in Verification evidence
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/965#issuecomment-4556098688

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓本地 PR wrapper 預設用 draft gate 保護 CodeRabbit review work。
- Approx changed lines：~87
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 行為變更、文件與 regression test 是同一個 PR creation guardrail 的最小可驗證單位。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `make pr-open` creates draft PRs by default.
- [x] `READY=1` is the explicit opt-in path for immediate ready PRs.
- [x] `AUTO_READY=1` remains draft and cannot be combined with ready mode.
- [x] Docs explain that CodeRabbit auto review stays behind the draft gate.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
bash infra/scripts/pr-open.test.sh
=> pr-open regression tests passed

node --test .github/workflows/ci.test.ts
=> tests 100, pass 100, fail 0

rtk git diff --check -- Makefile infra/scripts/pr-open.sh infra/scripts/pr-open.test.sh .github/workflows/ci.test.ts docs/draft-pr-auto-ready.md docs/pr-scope-policy.md
=> pass
```
