### PR TITLE
[frontend] add Chrome extension prototype icon assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,14 +4,19 @@ apps/extension/src/assets/**/*.jpg filter=lfs diff=lfs merge=lfs -text
 apps/extension/src/assets/**/*.jpeg filter=lfs diff=lfs merge=lfs -text
 apps/extension/src/assets/**/*.webp filter=lfs diff=lfs merge=lfs -text
 apps/extension/src/assets/**/*.gif filter=lfs diff=lfs merge=lfs -text
-
 # Tachimint fonts
 apps/extension/src/assets/**/*.ttf filter=lfs diff=lfs merge=lfs -text
 apps/extension/src/assets/**/*.otf filter=lfs diff=lfs merge=lfs -text
 apps/extension/src/assets/**/*.woff filter=lfs diff=lfs merge=lfs -text
 apps/extension/src/assets/**/*.woff2 filter=lfs diff=lfs merge=lfs -text
-
 # Atlas migration SQL files and checksums must stay LF on all platforms
 # to ensure consistent atlas checksum computation
 services/api/migrations/*.sql text eol=lf
 services/api/migrations/atlas.sum text eol=lf
+design/prototypes/chrome-extension/**/*.mp4 filter=lfs diff=lfs merge=lfs -text
+design/prototypes/chrome-extension/**/*.png filter=lfs diff=lfs merge=lfs -text
+design/prototypes/chrome-extension/**/*.jpg filter=lfs diff=lfs merge=lfs -text
+design/prototypes/chrome-extension/**/*.jpeg filter=lfs diff=lfs merge=lfs -text
+design/prototypes/chrome-extension/**/*.webp filter=lfs diff=lfs merge=lfs -text
+design/prototypes/chrome-extension/**/*.gif filter=lfs diff=lfs merge=lfs -text
+design/prototypes/chrome-extension/**/*.svg filter=lfs diff=lfs merge=lfs -text

--- a/design/prototypes/chrome-extension/public/assets/icons/icon128.png
+++ b/design/prototypes/chrome-extension/public/assets/icons/icon128.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83904a931f36cfd8380ebcff1b928b10fe4b088025e25f1a5185395076aefeb6
-size 1251009
+oid sha256:6a1b8fefb319f5ea453f0eea140005800516bde7e3d162dfe7685d406ab990c6
+size 24444

--- a/design/prototypes/chrome-extension/public/assets/icons/icon128.png
+++ b/design/prototypes/chrome-extension/public/assets/icons/icon128.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83904a931f36cfd8380ebcff1b928b10fe4b088025e25f1a5185395076aefeb6
+size 1251009

--- a/design/prototypes/chrome-extension/public/assets/icons/icon16.png
+++ b/design/prototypes/chrome-extension/public/assets/icons/icon16.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83904a931f36cfd8380ebcff1b928b10fe4b088025e25f1a5185395076aefeb6
-size 1251009
+oid sha256:19aebfef592a0a718c3822b5d35762bfcdc985af50bef0adecbec6aaca218a0a
+size 1254

--- a/design/prototypes/chrome-extension/public/assets/icons/icon16.png
+++ b/design/prototypes/chrome-extension/public/assets/icons/icon16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83904a931f36cfd8380ebcff1b928b10fe4b088025e25f1a5185395076aefeb6
+size 1251009

--- a/design/prototypes/chrome-extension/public/assets/icons/icon32.png
+++ b/design/prototypes/chrome-extension/public/assets/icons/icon32.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83904a931f36cfd8380ebcff1b928b10fe4b088025e25f1a5185395076aefeb6
-size 1251009
+oid sha256:667653ab94b856e6fc70973fd2e3cad4b4c0d9b85ec63419338716204be1141f
+size 2549

--- a/design/prototypes/chrome-extension/public/assets/icons/icon32.png
+++ b/design/prototypes/chrome-extension/public/assets/icons/icon32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83904a931f36cfd8380ebcff1b928b10fe4b088025e25f1a5185395076aefeb6
+size 1251009

--- a/design/prototypes/chrome-extension/public/assets/icons/icon48.png
+++ b/design/prototypes/chrome-extension/public/assets/icons/icon48.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83904a931f36cfd8380ebcff1b928b10fe4b088025e25f1a5185395076aefeb6
-size 1251009
+oid sha256:5b0acc28d86c672b1da4d93f65f87355743f16b83d63b9fdba03dcf1adda3266
+size 4990

--- a/design/prototypes/chrome-extension/public/assets/icons/icon48.png
+++ b/design/prototypes/chrome-extension/public/assets/icons/icon48.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83904a931f36cfd8380ebcff1b928b10fe4b088025e25f1a5185395076aefeb6
+size 1251009


### PR DESCRIPTION
## 什麼改動
新增/修正 Chrome extension prototype 的 PNG icon assets：`icon16.png`、`icon32.png`、`icon48.png`、`icon128.png` 現在分別是實際 16x16、32x32、48x48、128x128 PNG，並透過 Git LFS 儲存。

## 為什麼
Closed PR #962 一次加入整包 prototype，diff 過大不利 review。#967 要求拆成較小、可審查的 PR，且圖檔必須推 LFS。

refs #967

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#967
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不改 `apps/extension/` production code
  - 不改 backend / API / schema / migration
  - 不加入 scaffold / stylesheet / runtime logic

## PR 拆分檢查
- 相關 PR：#969 scaffold + static assets；#970 stylesheet；#971 runtime logic；#972 PNG icon assets

## 驗證
- `sips -g pixelWidth -g pixelHeight design/prototypes/chrome-extension/public/assets/icons/icon*.png` → 16/32/48/128 square sizes confirmed
- `sha256sum design/prototypes/chrome-extension/public/assets/icons/icon*.png` → four distinct icon files confirmed
- `git check-attr filter diff merge -- design/prototypes/chrome-extension/public/assets/icons/icon*.png` → Git LFS attrs confirmed
- push output：`Uploading LFS objects: 100% (4/4)`

## Final merge gate
- Ready-to-merge decision：pending human re-review
- Latest head SHA：eb0b68c889510cf91143ec310ca32a998f5b12af
- Required checks：pending GitHub CI rerun after latest push
