### PR TITLE
[infra] avoid required LFS fetch in frontend CI checkout

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -782,6 +782,13 @@ async function runNotifyRebaseNeededWorkflow({
 
 test('frontend CI job runs the frontend test command', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
+  const frontendCheckout = parsedWorkflow.jobs.frontend.steps.find((step) =>
+    typeof step.uses === 'string' && step.uses.startsWith('actions/checkout@')
+  )
+
+  assert.ok(frontendCheckout, 'expected frontend job to checkout the repository')
+  assert.notEqual(frontendCheckout.with?.lfs, true)
 
   assert.match(
     workflow,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,8 +675,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          lfs: true
 
       - name: Build image
         run: docker compose build frontend


### PR DESCRIPTION
## 什麼改動

讓 `Frontend build` GitHub Actions job 在 checkout 時不再強制 fetch Git LFS blobs，避免 repo/account LFS 額度超限時，CI 還沒跑到 frontend lint/test/build 就失敗。

## 為什麼

PR #976 的 `Frontend build` 曾失敗在 checkout 階段：

- Failure URL：https://github.com/nurockplayer/tachigo/actions/runs/26564315534/job/78254945021
- Root cause：frontend job 的 `actions/checkout` 設定 `lfs: true`，觸發 `git lfs fetch`，GitHub 回報 repository exceeded its LFS budget。

這張 PR 把該 infra/CI 修正從 prototype runtime PR 分離，避免 #976 scope 變寬。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#977
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 production frontend code。
  - 不調整 backend/dashboard/contracts CI 行為。
  - 不處理 GitHub LFS billing / quota。
  - 不移除或改寫既有 LFS assets。

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：#977
- Actual worker profile(s)：controller-direct
- Model strength：current Codex session
- Spawn directive(s)：profile=controller-direct model=current-codex reasoning=medium controller_fallback=used fallback_reason=small two-file CI fix after direct user authorization
- Verification evidence：local validation listed below
- Self-review / exception reason：self-review completed; no exception requested
- Worker session closeout：controller-direct completed the bounded two-file CI workflow fix, local workflow regression test, diff hygiene check, commit, push, and PR publication
- Workflow friction / follow-up split：#976 had an out-of-scope frontend CI workaround commit; it was removed from #976 and split here as #977.

## Review conversation closeout

- Unresolved threads：0 known
- CodeRabbit：pending first review for this PR
- chatgpt-codex-connector：n/a
- review_triage_ref：#977 and PR #976 frontend checkout failure log
- root_cause_gate_ref：`actions/checkout` with `lfs: true` fails before frontend validation when GitHub reports repository LFS budget exceeded
- finding_disposition_ref：frontend checkout no longer opts into LFS fetch; workflow regression asserts it does not regress to `lfs: true`
- Final reviewer action：n/a pending GitHub checks

## Final merge gate

- Ready-to-merge decision：blocked pending GitHub checks and review
- Latest head SHA：be2d781
- Required checks：pending after PR creation
- spec workflow-check evidence：`spec plan 977 --repo . --dry-run --format prompt --verbose` failed in the isolated worktree because `.spec-injector/` is not tracked there; reran read-only from `/Users/erickwang/Desktop/tachigo`, which succeeded but warned that the desktop checkout is dirty. Implementation stayed limited to `.github/workflows/ci.yml` and `.github/workflows/ci.test.ts`.
- Evidence URL：n/a pending GitHub checks

## PR 拆分檢查

- 這個 PR 的單一句子目的：避免 frontend CI 在 checkout 階段因不必要的 LFS fetch 被 repo LFS 額度擋住。
- Approx changed lines：9。
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #976 removed the out-of-scope frontend CI workaround commit; this PR carries that infra-only fix.

## Acceptance Criteria

- [x] `Frontend build` job 不再於 checkout 階段強制 `git lfs fetch`。
- [x] Workflow regression test 覆蓋 frontend checkout 不使用 `lfs: true`。
- [x] CI workflow tests 通過。
- [x] PR body 說明這是 infra/CI-only 修正，與 prototype runtime PR 分離。

## 超出範圍內容

無。

## Validation

- `spec plan 977 --repo . --dry-run --format prompt --verbose`（isolated worktree failed: missing `.spec-injector/`; desktop read-only rerun succeeded with dirty checkout warning）
- `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`（99 tests passed）
- `git diff --check`

closes #977

