### PR TITLE
[infra] skip LFS smudge in PR metadata regression tests

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -808,6 +808,13 @@ test('CI workflow uses infra script entrypoints', async () => {
   assert.doesNotMatch(workflow, /run: bash scripts\//)
 })
 
+test('PR metadata regression skips Git LFS smudge during test worktree checkouts', () => {
+  const parsedWorkflow = parseYaml(workflowPath)
+  const job = parsedWorkflow.jobs['pr-metadata-regression']
+
+  assert.equal(job.env.GIT_LFS_SKIP_SMUDGE, '1')
+})
+
 test('frontend Dockerfiles install dependencies with lifecycle scripts disabled', async () => {
   const extensionDockerfile = await readFile(extensionDockerfilePath, 'utf8')
   const dashboardDockerfile = await readFile(dashboardDockerfilePath, 'utf8')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,8 @@ jobs:
     timeout-minutes: 5
     name: PR metadata check regression tests
     runs-on: ubuntu-latest
+    env:
+      GIT_LFS_SKIP_SMUDGE: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## 什麼改動

讓 `PR metadata check regression tests` job 設定 `GIT_LFS_SKIP_SMUDGE=1`，避免 metadata-only regression test 建立測試 worktree 時觸發 Git LFS smudge。

## 為什麼

PR #978 的 `PR metadata check regression tests` 失敗在 `infra/scripts/pr-metadata-check.test.sh` 建立測試 worktree 階段，尚未完成 metadata regression 驗證。

- Failure URL：https://github.com/nurockplayer/tachigo/actions/runs/26564952181/job/78257109169
- Root cause：測試 worktree materialization 觸發既有 LFS png smudge；GitHub 回報 repository exceeded its LFS budget。

這張 PR 把 metadata regression 的 LFS smudge 修正從 #977 / #978 的 frontend checkout 修正分離。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#979
- Depends on PR：#978
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 frontend build job；frontend checkout LFS fetch 由 #977 / #978 處理。
  - 不處理 GitHub LFS billing / quota。
  - 不修改 production app code。
  - 不移除或改寫既有 LFS assets。

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：#979
- Actual worker profile(s)：controller-direct
- Model strength：current Codex session
- Spawn directive(s)：profile=controller-direct model=current-codex reasoning=medium controller_fallback=used fallback_reason=small two-file CI metadata regression fix after direct user authorization
- Verification evidence：local validation listed below
- Self-review / exception reason：self-review completed; no exception requested
- Worker session closeout：controller-direct completed the bounded two-file metadata regression CI fix, local workflow regression test, metadata regression test, PR open regression test, diff hygiene check, commit, push, and PR publication
- Workflow friction / follow-up split：#978 exposed a separate metadata regression LFS smudge blocker; this PR carries that metadata-regression-only fix separately from #978.

## Review conversation closeout

- Unresolved threads：0 known
- CodeRabbit：pending first review for this PR
- chatgpt-codex-connector：n/a
- review_triage_ref：#979 and PR #978 metadata regression failure log
- root_cause_gate_ref：`infra/scripts/pr-metadata-check.test.sh` creates test worktrees that can trigger LFS smudge, while the metadata regression does not need LFS blob contents
- finding_disposition_ref：`pr-metadata-regression` now exports `GIT_LFS_SKIP_SMUDGE=1`; workflow regression asserts the setting remains present
- Final reviewer action：n/a pending GitHub checks

## Final merge gate

- Ready-to-merge decision：blocked until GitHub checks complete; full CI may remain blocked by #978 until frontend checkout no longer forces LFS fetch on develop-based workflow PRs
- Latest head SHA：6d9b755
- Required checks：pending after PR creation
- spec workflow-check evidence：`spec plan 979 --repo . --dry-run --format prompt --verbose` completed read-only from `/Users/erickwang/Desktop/tachigo`, but warned the desktop checkout is dirty and reported a false missing-file signal due `.worktrees` same-basename ambiguity; implementation verified the target file exists in the clean isolated worktree and stayed limited to `.github/workflows/ci.yml` plus `.github/workflows/ci.test.ts`.
- Evidence URL：n/a pending GitHub checks

## PR 拆分檢查

- 這個 PR 的單一句子目的：避免 metadata regression test worktrees 因不必要的 LFS smudge 被 repo LFS 額度擋住。
- Approx changed lines：9。
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #978 handles frontend checkout LFS fetch only; this PR handles metadata regression test worktree LFS smudge only.

## Acceptance Criteria

- [x] `PR metadata check regression tests` 不再因測試 worktree 的 LFS smudge 被 LFS budget exceeded 擋住。
- [x] Workflow regression test 覆蓋 `pr-metadata-regression` job 設定 `GIT_LFS_SKIP_SMUDGE=1`。
- [x] CI workflow tests 通過。
- [x] PR body 說明這是 metadata-regression-only 修正，與 #977 / #978 的 frontend checkout 修正分離。

## 超出範圍內容

無。

## Validation

- `spec plan 979 --repo . --dry-run --format prompt --verbose`（desktop read-only; dirty checkout warning; false missing-file signal from `.worktrees` same-basename ambiguity）
- `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`（100 tests passed）
- `GIT_LFS_SKIP_SMUDGE=1 bash infra/scripts/pr-metadata-check.test.sh`
- `GIT_LFS_SKIP_SMUDGE=1 bash infra/scripts/pr-open.test.sh`
- `git diff --check`

closes #979

