### PR TITLE
[infra] skip LFS smudge in PR metadata regression tests

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -782,6 +782,13 @@ async function runNotifyRebaseNeededWorkflow({
 
 test('frontend CI job runs the frontend test command', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(workflowPath)
+  const frontendCheckout = parsedWorkflow.jobs.frontend.steps.find((step) =>
+    typeof step.uses === 'string' && step.uses.startsWith('actions/checkout@')
+  )
+
+  assert.ok(frontendCheckout, 'expected frontend job to checkout the repository')
+  assert.notEqual(frontendCheckout.with?.lfs, true)
 
   assert.match(
     workflow,
@@ -806,6 +813,13 @@ test('CI workflow uses infra script entrypoints', async () => {
   assert.match(workflow, /run: bash infra\/scripts\/pr-open\.test\.sh/)
   assert.match(workflow, /run: bash infra\/scripts\/check-pr-commit-messages\.sh/)
   assert.doesNotMatch(workflow, /run: bash scripts\//)
+})
+
+test('PR metadata regression skips Git LFS smudge during test worktree checkouts', () => {
+  const parsedWorkflow = parseYaml(workflowPath)
+  const job = parsedWorkflow.jobs['pr-metadata-regression']
+
+  assert.equal(job.env.GIT_LFS_SKIP_SMUDGE, '1')
 })
 
 test('frontend Dockerfiles install dependencies with lifecycle scripts disabled', async () => {

--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -788,7 +788,7 @@ test('frontend CI job runs the frontend test command', async () => {
   )
 
   assert.ok(frontendCheckout, 'expected frontend job to checkout the repository')
-  assert.notEqual(frontendCheckout.with?.lfs, true)
+  assert.equal(frontendCheckout.with?.lfs, true)
 
   assert.match(
     workflow,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,6 +677,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          lfs: true
 
       - name: Build image
         run: docker compose build frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,8 @@ jobs:
     timeout-minutes: 5
     name: PR metadata check regression tests
     runs-on: ubuntu-latest
+    env:
+      GIT_LFS_SKIP_SMUDGE: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -675,8 +677,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          lfs: true
 
       - name: Build image
         run: docker compose build frontend


### PR DESCRIPTION
## 什麼改動

這張 PR 是 #968 的 narrow follow-up，只針對 metadata-only regression job：

- `pr-metadata-regression` job 設定 `GIT_LFS_SKIP_SMUDGE=1`，避免測試 worktree materialization 時觸發 LFS smudge。
- Workflow regression tests 覆蓋 `pr-metadata-regression` job 必須保留 `GIT_LFS_SKIP_SMUDGE=1`。
- 不修改 `Frontend build` 的 LFS asset 策略；frontend 需要的真實 LFS assets 由 #968 的 path-aware restore step 管理。

## 為什麼

#968 已合併並成為 repo/frontend LFS bandwidth mitigation 的主線：

- repo-level `.lfsconfig` 預設 `fetchexclude = *`，避免一般 checkout / CI 無差別下載全部 LFS objects。
- frontend CI 只顯式 restore `apps/extension/src/assets` 需要的 image/font LFS assets。

#982 保留更窄的保險：metadata regression test 會建立臨時 worktree，但它只驗證 PR metadata / workflow behavior，不需要 LFS blob，因此明確設定 no-smudge，避免 metadata-only 測試意外消耗或卡在 LFS smudge。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#979
- Primary LFS bandwidth mitigation：#966 / #968
- Related investigation：#981
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是，僅限 metadata-regression-only LFS smudge hardening
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不取代 #968。
  - 不讓 `Frontend build` 跳過真實 Git LFS assets。
  - 不處理 GitHub LFS billing / quota。
  - 不修改 production frontend/backend/dashboard/contracts code。
  - 不移除或改寫既有 LFS assets。
  - 不調整其他 CI job 的 LFS 行為。

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：#979
- Actual worker profile(s)：controller-direct
- Model strength：current Codex session
- Spawn directive(s)：profile=controller-direct model=current-codex reasoning=medium controller_fallback=used fallback_reason=small CI workflow follow-up after direct user authorization
- Verification evidence：local and GitHub validation listed below
- Self-review / exception reason：self-review completed; no exception requested
- Worker session closeout：controller-direct merged #982 onto latest `develop`, preserved #968 frontend restore-assets behavior, and retained only metadata-regression no-smudge hardening
- Workflow friction / follow-up split：#968 owns repo/frontend LFS bandwidth mitigation; #982 only addresses metadata-regression worktree smudge risk

## Review conversation closeout

- Unresolved threads：older frontend LFS findings are not applicable after #968; this PR no longer changes frontend LFS policy
- CodeRabbit：previous false-positive frontend finding acknowledged as not applicable; latest checks pending after merge refresh
- chatgpt-codex-connector：older automated review was for pre-fix head `cc4a5c6716`; latest scope no longer removes frontend LFS validation
- review_triage_ref：#979, #981, #968, #982 owner review
- root_cause_gate_ref：metadata-regression test worktrees can trigger unnecessary Git LFS smudge; #968 addresses repo-level default LFS fetches
- finding_disposition_ref：metadata regression exports `GIT_LFS_SKIP_SMUDGE=1`; frontend LFS policy remains owned by #968 restore-assets path
- Final reviewer action：pending latest CI / automated checks / reviewer recheck

## Final merge gate

- Ready-to-merge decision：pending latest GitHub checks and reviewer recheck after head refresh
- Latest head SHA：feb14e1c918bb40176a2a4935e64f0d7128ed426
- Required checks：pending latest GitHub run on refreshed head
- Evidence URL：https://github.com/nurockplayer/tachigo/pull/982

## PR 拆分檢查

- 這個 PR 的單一句子目的：在 #968 主方案之外，為 metadata regression job 加一層 explicit no-smudge regression guard。
- Approx changed lines：9。
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是，#968 已在 `develop`，本 PR diff 只剩 metadata-regression follow-up
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #968 is the primary LFS bandwidth mitigation PR and is already merged.

## Acceptance Criteria

- [x] `PR metadata check regression tests` 不再因測試 worktree LFS smudge 被 LFS budget exceeded 擋住。
- [x] Workflow regression tests 覆蓋 `pr-metadata-regression` job 設定 `GIT_LFS_SKIP_SMUDGE=1`。
- [x] `Frontend build` job 不被本 PR 改成跳過真實 LFS assets。
- [x] #968 合併後重新評估本 PR：仍有價值作為 metadata-regression-only no-smudge guard，且不與 #968 frontend restore-assets 策略衝突。

## 超出範圍內容

- #968 是 repo/frontend LFS bandwidth mitigation 的主方案。
- #977 / #976 的 frontend LFS budget exceeded 問題應由 #968 或等效策略解決；本 PR 不繞過 frontend asset validation。

## Validation

- `spec plan 979 --repo . --dry-run --format prompt --verbose`：pass with dirty-worktree warning in main checkout; used only as bounded context
- `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`：101 tests passed
- `GIT_LFS_SKIP_SMUDGE=1 bash infra/scripts/pr-metadata-check.test.sh`：pass
- `GIT_LFS_SKIP_SMUDGE=1 bash infra/scripts/pr-open.test.sh`：pass
- `git diff --check`：pass
- `git diff --stat refs/remotes/origin/develop..HEAD`：2 files changed, 9 insertions
- GitHub checks：pending latest run on refreshed head

closes #979
