### PR TITLE
[frontend] #957 dedupe extension token recovery

### DIFF
--- a/apps/extension/src/services/api.test.ts
+++ b/apps/extension/src/services/api.test.ts
@@ -449,3 +449,279 @@ test('sendHeartbeat re-authenticates after 401 and falls back to previous balanc
     },
   )
 })
+
+test('concurrent 401 responses share one extension JWT refresh', async () => {
+  let expiredPointReads = 0
+  let loginAttempts = 0
+
+  async function waitForConcurrent401s(timeoutMs = 1000) {
+    const deadline = Date.now() + timeoutMs
+
+    while (expiredPointReads < 2) {
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for concurrent 401s; expiredPointReads=${expiredPointReads}`)
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+  }
+
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/auth/login') {
+        loginAttempts += 1
+        await waitForConcurrent401s()
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { tokens: { access_token: 'refreshed-access-token' } } }))
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/users/me/points?channel_id=channel-123') {
+        if (req.headers.authorization === 'Bearer expired-access-token') {
+          expiredPointReads += 1
+          res.writeHead(401, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: false, error: 'expired' }))
+          return
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            success: true,
+            data: { spendable_balance: 42, cumulative_total: 77 },
+          }),
+        )
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+
+      try {
+        vi.resetModules()
+        const api = await import('./api.ts')
+
+        api.setExtensionJwtForRecovery('extension-jwt')
+        api.setAuthToken('expired-access-token')
+
+        const [firstResult, secondResult] = await Promise.all([
+          api.getPointBalance('channel-123'),
+          api.getPointBalance('channel-123'),
+        ])
+
+        assert.deepEqual(firstResult, { spendableBalance: 42, cumulativeTotal: 77 })
+        assert.deepEqual(secondResult, { spendableBalance: 42, cumulativeTotal: 77 })
+        assert.equal(expiredPointReads, 2)
+        assert.equal(loginAttempts, 1)
+        const pointReads = requests.filter(
+          ({ method, url }) =>
+            method === 'GET' && url === '/api/v1/users/me/points?channel_id=channel-123',
+        )
+        const loginRequests = requests.filter(
+          ({ method, url }) =>
+            method === 'POST' && url === '/api/v1/extension/auth/login',
+        )
+
+        assert.equal(loginRequests.length, 1)
+        assert.deepEqual(loginRequests[0]?.body, { extension_jwt: 'extension-jwt' })
+        assert.equal(
+          pointReads.filter(({ authorization }) => authorization === 'Bearer expired-access-token').length,
+          2,
+        )
+        assert.equal(
+          pointReads.filter(({ authorization }) => authorization === 'Bearer refreshed-access-token').length,
+          2,
+        )
+      } finally {
+        if (originalBaseUrl === undefined) {
+          delete process.env.VITE_TACHIGO_API_URL
+        } else {
+          process.env.VITE_TACHIGO_API_URL = originalBaseUrl
+        }
+      }
+    },
+  )
+})
+
+test('401 recovery starts a new refresh when the extension JWT changes while an old refresh is in flight', async () => {
+  let oldLoginStartedResolve!: () => void
+  let releaseOldLogin!: () => void
+  const oldLoginStarted = new Promise<void>((resolve) => {
+    oldLoginStartedResolve = resolve
+  })
+  const oldLoginRelease = new Promise<void>((resolve) => {
+    releaseOldLogin = resolve
+  })
+
+  async function waitForNewJwtLogin(requests: RecordedRequest[], timeoutMs = 1000) {
+    const deadline = Date.now() + timeoutMs
+
+    while (
+      !requests.some(
+        ({ method, url, body }) =>
+          method === 'POST' &&
+          url === '/api/v1/extension/auth/login' &&
+          JSON.stringify(body) === JSON.stringify({ extension_jwt: 'new-extension-jwt' }),
+      )
+    ) {
+      if (Date.now() > deadline) {
+        throw new Error('Timed out waiting for new-extension-jwt login')
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+  }
+
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/auth/login') {
+        if (JSON.stringify(body) === JSON.stringify({ extension_jwt: 'old-extension-jwt' })) {
+          oldLoginStartedResolve()
+          await oldLoginRelease
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: true, data: { tokens: { access_token: 'old-refreshed-token' } } }))
+          return
+        }
+
+        if (JSON.stringify(body) === JSON.stringify({ extension_jwt: 'new-extension-jwt' })) {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: true, data: { tokens: { access_token: 'new-refreshed-token' } } }))
+          return
+        }
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/users/me/points?channel_id=old-channel') {
+        if (req.headers.authorization === 'Bearer expired-old-token') {
+          res.writeHead(401, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: false, error: 'expired' }))
+          return
+        }
+
+        if (req.headers.authorization === 'Bearer old-refreshed-token') {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: true, data: { spendable_balance: 10, cumulative_total: 11 } }))
+          return
+        }
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/users/me/points?channel_id=new-channel') {
+        if (req.headers.authorization === 'Bearer expired-new-token') {
+          res.writeHead(401, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: false, error: 'expired' }))
+          return
+        }
+
+        if (req.headers.authorization === 'Bearer new-refreshed-token') {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: true, data: { spendable_balance: 20, cumulative_total: 21 } }))
+          return
+        }
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/users/me/points?channel_id=default-channel') {
+        if (req.headers.authorization === 'Bearer new-refreshed-token') {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: true, data: { spendable_balance: 30, cumulative_total: 31 } }))
+          return
+        }
+
+        res.writeHead(401, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: false, error: 'stale token' }))
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+
+      try {
+        vi.resetModules()
+        const api = await import('./api.ts')
+
+        api.setExtensionJwtForRecovery('old-extension-jwt')
+        api.setAuthToken('expired-old-token')
+        const oldRequest = api.getPointBalance('old-channel')
+
+        await oldLoginStarted
+        api.setExtensionJwtForRecovery('new-extension-jwt')
+        api.setAuthToken('expired-new-token')
+        const newRequest = api.getPointBalance('new-channel')
+
+        let newJwtLoginError: unknown
+        try {
+          await waitForNewJwtLogin(requests)
+        } catch (error) {
+          newJwtLoginError = error
+        } finally {
+          releaseOldLogin()
+        }
+
+        const [oldResult, newResult] = await Promise.allSettled([oldRequest, newRequest])
+        if (newJwtLoginError) {
+          throw newJwtLoginError
+        }
+
+        assert.deepEqual(oldResult, {
+          status: 'fulfilled',
+          value: { spendableBalance: 10, cumulativeTotal: 11 },
+        })
+        assert.deepEqual(newResult, {
+          status: 'fulfilled',
+          value: { spendableBalance: 20, cumulativeTotal: 21 },
+        })
+        assert.deepEqual(await api.getPointBalance('default-channel'), {
+          spendableBalance: 30,
+          cumulativeTotal: 31,
+        })
+
+        const loginRequests = requests.filter(
+          ({ method, url }) =>
+            method === 'POST' && url === '/api/v1/extension/auth/login',
+        )
+        assert.deepEqual(
+          loginRequests.map(({ body }) => body),
+          [{ extension_jwt: 'old-extension-jwt' }, { extension_jwt: 'new-extension-jwt' }],
+        )
+        assert.equal(
+          requests.some(
+            ({ method, url, authorization }) =>
+              method === 'GET' &&
+              url === '/api/v1/users/me/points?channel_id=new-channel' &&
+              authorization === 'Bearer new-refreshed-token',
+          ),
+          true,
+        )
+      } finally {
+        releaseOldLogin()
+        if (originalBaseUrl === undefined) {
+          delete process.env.VITE_TACHIGO_API_URL
+        } else {
+          process.env.VITE_TACHIGO_API_URL = originalBaseUrl
+        }
+      }
+    },
+  )
+})

--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -28,6 +28,7 @@ const client = axios.create({
 })
 
 let extensionJwtForRecovery: string | null = null
+const authRecoveryRefreshes = new Map<string, Promise<string | null>>()
 
 function extractAccessToken(payload: unknown): string | null {
   if (!payload || typeof payload !== 'object') {
@@ -79,20 +80,39 @@ export async function loginWithTwitchExtension(extensionJwt: string): Promise<Ta
   return data
 }
 
-async function refreshAuthTokenFromExtensionJwt(): Promise<boolean> {
-  if (!extensionJwtForRecovery) {
-    return false
-  }
-
-  const loginResult = await loginWithTwitchExtension(extensionJwtForRecovery)
+async function performAuthTokenRefreshFromExtensionJwt(extensionJwt: string): Promise<string | null> {
+  const loginResult = await loginWithTwitchExtension(extensionJwt)
   const accessToken = extractAccessToken(loginResult)
   if (!accessToken) {
-    clearAuthToken()
-    return false
+    if (extensionJwtForRecovery === extensionJwt) {
+      clearAuthToken()
+    }
+    return null
   }
 
-  setAuthToken(accessToken)
-  return true
+  if (extensionJwtForRecovery === extensionJwt) {
+    setAuthToken(accessToken)
+  }
+  return accessToken
+}
+
+async function refreshAuthTokenFromExtensionJwt(): Promise<string | null> {
+  const extensionJwt = extensionJwtForRecovery
+  if (!extensionJwt) {
+    return null
+  }
+
+  let refresh = authRecoveryRefreshes.get(extensionJwt)
+  if (!refresh) {
+    refresh = performAuthTokenRefreshFromExtensionJwt(extensionJwt).finally(() => {
+      if (authRecoveryRefreshes.get(extensionJwt) === refresh) {
+        authRecoveryRefreshes.delete(extensionJwt)
+      }
+    })
+    authRecoveryRefreshes.set(extensionJwt, refresh)
+  }
+
+  return refresh
 }
 
 async function runWithAuthRecovery<T>(
@@ -107,12 +127,18 @@ async function runWithAuthRecovery<T>(
       throw error
     }
 
-    const recovered = await refreshAuthTokenFromExtensionJwt()
-    if (!recovered) {
+    const recoveredToken = await refreshAuthTokenFromExtensionJwt()
+    if (!recoveredToken) {
       throw error
     }
 
-    return execute(config)
+    return execute({
+      ...config,
+      headers: {
+        ...config?.headers,
+        Authorization: `Bearer ${recoveredToken}`,
+      },
+    })
   }
 }
 


### PR DESCRIPTION
## 什麼改動
為 Extension API client 的 401 token recovery 加入 single-flight 去重，避免多個並發 401 各自觸發一次 Twitch Extension JWT login；新增並發 401 回歸測試。

## 為什麼
closes #957

多個 API request 同時拿到 401 時，應共用同一個 refresh promise，refresh 完成後再各自用新 token 重試原請求，避免重複登入與 token 覆蓋風險。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#957
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改後端認證流程
  - 不改非 401 錯誤處理
  - 不改 UI 或其他 API surface

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #957 無獨立 delegation plan；本輪依 sprint audit 選為低風險 frontend-only scoped fix。
- Actual worker profile(s)：
  - controller only
- Model strength：
  - controller = gpt-5.5 xhigh
- Spawn directive(s)：
  - profile=controller model=gpt-5.5-xhigh reasoning=xhigh controller_fallback=allowed fallback_reason=本輪 scope 僅 2 個 frontend client/test 檔案，先前 audit 已收斂，沒有需要 batch 掃描的低風險 sidecar 工作。
- Verification evidence：
  - `rtk pnpm --dir apps/extension test src/services/api.test.ts`
  - `rtk pnpm --dir apps/extension exec eslint src/services/api.ts src/services/api.test.ts`
  - `rtk git --no-optional-locks diff --check -- apps/extension/src/services/api.ts apps/extension/src/services/api.test.ts`
- Self-review / exception reason：
  - 已完成 self-review；變更限於 in-flight promise lifecycle 與並發 401 回歸測試。
- Worker session closeout：
  - n/a，未分派 worker。
- Workflow friction / follow-up split：
  - 使用獨立 worktree 避開主 worktree 既有髒檔；未新增 follow-up。

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - success; review threads resolved
- chatgpt-codex-connector：
  - resolved
- review_triage_ref：
  - https://github.com/nurockplayer/tachigo/pull/993#discussion_r3323253116
  - https://github.com/nurockplayer/tachigo/pull/993#discussion_r3323268104
  - https://github.com/nurockplayer/tachigo/pull/993#discussion_r3323268116
- root_cause_gate_ref：
  - JWT-keyed refresh promise and stale default-token overwrite race fixed in latest head
- finding_disposition_ref：
  - all still-valid product findings fixed and locally/GitHub verified
- Final reviewer action：
  - pending human re-review to clear prior Changes Requested

## Final merge gate
- Ready-to-merge decision：
  - implementation ready; pending human re-review because an earlier Changes Requested review remains active
- Latest head SHA：
  - e8656630ccbc8b796fd38709d31d0d504ac91062
- Required checks：
  - GitHub Actions current-head checks pass; `PR commit messages` pass; `Frontend build` pass
  - CodeRabbit success; no unresolved CodeRabbit review threads
- spec workflow-check evidence：
  - manual AWP checklist fallback；bounded two-file product fix, no spec-injector gate used
- Evidence URL：
  - CI run: https://github.com/nurockplayer/tachigo/actions/runs/26639479843
  - Frontend build job: https://github.com/nurockplayer/tachigo/actions/runs/26639479843/job/78508357067

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 Extension API client 的並發 401 共用同一個 token refresh。
- Approx changed lines：~130
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試直接覆蓋本 PR 的 single-flight 行為，與 frontend client 變更不可分割。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 並發 401 只觸發一次重新登入
- [x] 既有單一請求的 recovery 行為不變
- [x] 有測試覆蓋並發 401 情境

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk pnpm --dir apps/extension test src/services/api.test.ts
Test Files  1 passed (1)
Tests  7 passed (7)

rtk pnpm --dir apps/extension exec eslint src/services/api.ts src/services/api.test.ts
pass

rtk git --no-optional-locks diff --check -- apps/extension/src/services/api.ts apps/extension/src/services/api.test.ts
pass
```

## 備註
本 PR 未修改 CI/LFS workflow、package 或 lockfile。

## Notes for Claude Code Review
- 請特別看 `authRecoveryRefresh` 的清理時機：refresh resolve/reject 後都會在 `finally` 清掉，下一批 401 可重新 refresh。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化认证令牌刷新：并发认证失败时同一凭证只触发一次刷新，且重试请求会使用恢复到的访问令牌，减少重复刷新和授权不一致的情况。
  * 增强在刷新进行中凭证变更时的恢复逻辑，确保不同凭证来源的请求各自获得正确的令牌与响应。

* **Tests**
  * 新增并发与竞态场景测试，验证刷新去重及凭证变更时的正确恢复行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

