### PR TITLE
[infra] avoid automatic LFS fetch in frontend CI checkout

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -784,8 +784,15 @@ async function runNotifyRebaseNeededWorkflow({
 test('frontend CI job runs the frontend test command', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
   const parsedWorkflow = parseYaml(workflowPath)
+  const frontendCheckoutStep = parsedWorkflow.jobs.frontend.steps[0]
   const restoreAssetsStep = workflowJobStep(parsedWorkflow, 'frontend', 'Restore frontend LFS assets')
 
+  assert.equal(frontendCheckoutStep.uses, 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5')
+  assert.notEqual(
+    frontendCheckoutStep.with?.lfs,
+    true,
+    'frontend checkout must not fetch all LFS objects before the scoped restore step',
+  )
   assert.match(
     workflow,
     /frontend:\n[\s\S]*?- name: Test\n\s+run: docker compose run --no-deps --rm frontend pnpm test/,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,8 +675,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          lfs: true
 
       - name: Restore frontend LFS assets
         run: |


### PR DESCRIPTION
## 什麼改動

讓 `Frontend build` job 的 checkout 不再自動抓取全部 Git LFS objects，保留後續 scoped `Restore frontend LFS assets` 步驟，只取 extension frontend 實際需要的資產。

## 為什麼

PR #993 的 `Frontend build` 在進入 frontend lint/test/build 前，就因 `actions/checkout` 的 `lfs: true` 觸發 broad `git lfs fetch` 而失敗：

`batch response: This repository exceeded its LFS budget`

這是 CI/workflow 層問題，不屬於 #957 frontend token recovery 的產品行為範圍，因此拆成獨立 infra PR。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：PR #993 Frontend build LFS budget checkout failure
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 frontend product behavior。
  - 不改 extension API client logic。
  - 不處理 GitHub LFS billing / quota 本身。
  - 不移除既有 LFS assets。
  - 不停用 scoped frontend LFS asset restore。

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：
  - n/a；本 PR source of truth 是 #993 的 CI checkout failure，非 product issue。
- Actual worker profile(s)：
  - controller/direct
- Model strength：
  - controller = current Codex session
- Spawn directive(s)：
  - profile=controller model=current-codex reasoning=medium controller_fallback=allowed fallback_reason=tool_unavailable: no separate low-cost worker was needed after prior readback; impact=bounded two-file workflow patch; evidence=local commands in Verification evidence
- Verification evidence：
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`
  - `rtk git diff --check -- .github/workflows/ci.yml .github/workflows/ci.test.ts`
- Self-review / exception reason：
  - self-review completed; change is limited to frontend CI checkout LFS behavior and workflow regression coverage.
- Worker session closeout：
  - controller verified prior readback, implemented the bounded two-file patch, and closed the earlier read-only worker session.
- Workflow friction / follow-up split：
  - Split from #993 to avoid mixing R4 workflow CI behavior into R2 frontend token recovery.

## Review conversation closeout

- Unresolved threads：
  - n/a at PR creation
- CodeRabbit：
  - pending after PR creation
- chatgpt-codex-connector：
  - n/a at PR creation
- review_triage_ref：
  - PR #993 CI failure readback
- root_cause_gate_ref：
  - `Frontend build` checkout still used `lfs: true`; this runs broad `git lfs fetch` before the scoped restore step.
- finding_disposition_ref：
  - adopted: remove automatic checkout LFS fetch; preserved scoped `Restore frontend LFS assets`.
- Final reviewer action：
  - pending reviewer feedback

## Final merge gate

- Ready-to-merge decision：
  - blocked pending GitHub checks and human review; R4 workflow PR must not use auto-ready.
- Latest head SHA：
  - 3a07f9bd99ef83c63c106b04115477d8e2335f8e
- Required checks：
  - pending after PR creation
- spec workflow-check evidence：
  - local runner capability check passed; start gate failed because repo has no `.spec-injector/` config, using manual AWP checklist fallback.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/994

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - Avoid automatic broad Git LFS fetch during frontend CI checkout while preserving scoped frontend LFS asset restore.
- Approx changed lines：9
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #993 retains only the frontend token recovery behavior/test scope.

## Acceptance Criteria

- [x] `Frontend build` checkout no longer opts into automatic broad LFS fetching.
- [x] Scoped `Restore frontend LFS assets` remains in place.
- [x] Workflow regression test covers the checkout behavior.

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
tests 100
pass 100
fail 0

rtk git diff --check -- .github/workflows/ci.yml .github/workflows/ci.test.ts
pass
```

## 備註

R4 workflow PR，不加 `auto-ready`，也不自動轉 ready。

## Notes for Claude Code Review

- 請確認移除 checkout `lfs: true` 不會跳過必要 assets；本 PR 保留 explicit scoped restore step。
