### PR TITLE
[infra] split frontend real asset validation from normal PR CI

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -784,21 +784,77 @@ async function runNotifyRebaseNeededWorkflow({
 test('frontend CI job runs the frontend test command', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
   const parsedWorkflow = parseYaml(workflowPath)
-  const restoreAssetsStep = workflowJobStep(parsedWorkflow, 'frontend', 'Restore frontend LFS assets')
+  const frontendJob = parsedWorkflow.jobs.frontend
+  const frontendCheckoutStep = frontendJob.steps[0]
+  const frontendJobBlock = workflowJobBlock(workflow, 'frontend')
 
+  assert.equal(frontendCheckoutStep.uses, 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5')
+  assert.notEqual(
+    frontendCheckoutStep.with?.lfs,
+    true,
+    'normal frontend PR CI must not fetch Git LFS objects during checkout',
+  )
+  assert.doesNotMatch(frontendJobBlock, /git lfs fetch/)
+  assert.doesNotMatch(frontendJobBlock, /Restore frontend LFS assets/)
+  assert.match(
+    workflow,
+    /frontend:\n[\s\S]*?- name: Build image\n\s+run: docker compose build frontend/,
+  )
+  assert.match(
+    workflow,
+    /frontend:\n[\s\S]*?- name: Lint\n\s+run: docker compose run --no-deps --rm frontend pnpm lint/,
+  )
   assert.match(
     workflow,
     /frontend:\n[\s\S]*?- name: Test\n\s+run: docker compose run --no-deps --rm frontend pnpm test/,
   )
-  assert.equal(
-    restoreAssetsStep.run.trimEnd(),
-    'git lfs fetch --exclude="" --include="apps/extension/src/assets/**/*.png,apps/extension/src/assets/**/*.jpg,apps/extension/src/assets/**/*.jpeg,apps/extension/src/assets/**/*.webp,apps/extension/src/assets/**/*.gif,apps/extension/src/assets/**/*.ttf,apps/extension/src/assets/**/*.otf,apps/extension/src/assets/**/*.woff,apps/extension/src/assets/**/*.woff2"\ngit lfs checkout apps/extension/src/assets',
+  assert.match(
+    workflow,
+    /frontend:\n[\s\S]*?- name: Build\n\s+run: docker compose run --no-deps --rm frontend pnpm build/,
+  )
+  assert.match(
+    workflow,
+    /frontend:\n[\s\S]*?- name: i18n check\n\s+run: docker compose run --no-deps --rm frontend pnpm check:i18n/,
   )
 
   assert.match(
     workflow,
     /workflow-regression:\n[\s\S]*?- name: Verify CI workflow assertions\n\s+run: node --experimental-strip-types --no-warnings --test \.github\/workflows\/ci\.test\.ts/,
   )
+})
+
+test('frontend LFS asset validation is release or manual opt-in only', async () => {
+  const parsedWorkflow = parseYaml(workflowPath)
+  const workflow = await readFile(workflowPath, 'utf8')
+  const workflowDispatchInput = parsedWorkflow.on.workflow_dispatch.inputs.validate_frontend_lfs_assets
+  const job = parsedWorkflow.jobs['frontend-lfs-assets']
+  const jobBlock = workflowJobBlock(workflow, 'frontend-lfs-assets')
+  const restoreAssetsStep = workflowJobStep(parsedWorkflow, 'frontend-lfs-assets', 'Restore frontend LFS assets')
+
+  assert.equal(workflowDispatchInput.type, 'boolean')
+  assert.equal(workflowDispatchInput.default, false)
+  assert.equal(job.name, 'Frontend LFS assets')
+  assert.equal(
+    job.if,
+    "(github.event_name == 'workflow_dispatch' && inputs.validate_frontend_lfs_assets == true) || (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop')",
+  )
+  assert.equal(job.needs, undefined)
+  assert.equal(
+    developRequiredCheckRuns.some((run) => run.name === 'Frontend LFS assets'),
+    false,
+    'Frontend LFS assets must not be part of the normal PR required check path',
+  )
+  assert.match(jobBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.equal(restoreAssetsStep.run.trimEnd(), [
+    'git lfs fetch --exclude="" --include="apps/extension/src/assets/**/*.png,apps/extension/src/assets/**/*.jpg,apps/extension/src/assets/**/*.jpeg,apps/extension/src/assets/**/*.webp,apps/extension/src/assets/**/*.gif,apps/extension/src/assets/**/*.ttf,apps/extension/src/assets/**/*.otf,apps/extension/src/assets/**/*.woff,apps/extension/src/assets/**/*.woff2"',
+    'git lfs checkout apps/extension/src/assets',
+    "git lfs ls-files --long | awk '$3 ~ /^apps\\/extension\\/src\\/assets\\//' | while read -r oid _ path; do",
+    '  object=".git/lfs/objects/${oid:0:2}/${oid:2:2}/${oid}"',
+    '  test -f "$object" || { echo "Missing LFS object for $path ($oid)" >&2; exit 1; }',
+    '  actual="$(sha256sum "$object" | awk \'{print $1}\')"',
+    '  test "$actual" = "$oid" || { echo "Corrupt LFS object for $path ($oid)" >&2; exit 1; }',
+    'done',
+  ].join('\n'))
 })
 
 test('CI workflow uses infra script entrypoints', async () => {
@@ -1170,26 +1226,38 @@ test('backend Docker runtime applies Atlas migrations before starting the API', 
 test('CI scope router backend contract regex accepts full-width and half-width colons', async () => {
   const workflow = await readFile(workflowPath, 'utf8')
   const scopePolice = await readFile(scopePolicePath, 'utf8')
-  const backendContractYesPattern =
-    String.raw`Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] yes`
-  const backendContractNoPattern =
-    String.raw`Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] no`
 
   assert.ok(
-    workflow.includes(backendContractYesPattern),
-    'ci.yml Backend contract regex must accept full-width and half-width colons',
+    workflow.includes("const backendContractSection = extractPrBodySection('Backend contract already in develop')"),
+    'ci.yml Backend contract parser must inspect only the backend contract section',
   )
   assert.ok(
-    workflow.includes(backendContractNoPattern),
-    'ci.yml Backend contract regex must accept full-width and half-width colons',
+    workflow.includes('[：:]'),
+    'ci.yml Backend contract section parser must accept full-width and half-width colons',
   )
   assert.ok(
-    scopePolice.includes(backendContractYesPattern),
-    'pr-scope-police.yml Backend contract regex must accept full-width and half-width colons',
+    workflow.includes(String.raw`\s*yes\s*(?:\n|$)`),
+    'ci.yml Backend contract yes parser must match the exact checkbox value',
   )
   assert.ok(
-    scopePolice.includes(backendContractNoPattern),
-    'pr-scope-police.yml Backend contract regex must accept full-width and half-width colons',
+    workflow.includes(String.raw`\s*no\s*(?:\n|$)`),
+    'ci.yml Backend contract no parser must match the exact checkbox value',
+  )
+  assert.ok(
+    scopePolice.includes("const backendContractSection = extractPrBodySection('Backend contract already in develop')"),
+    'pr-scope-police.yml Backend contract parser must inspect only the backend contract section',
+  )
+  assert.ok(
+    scopePolice.includes('[：:]'),
+    'pr-scope-police.yml Backend contract section parser must accept full-width and half-width colons',
+  )
+  assert.ok(
+    scopePolice.includes(String.raw`\s*yes\s*(?:\n|$)`),
+    'pr-scope-police.yml Backend contract yes parser must match the exact checkbox value',
+  )
+  assert.ok(
+    scopePolice.includes(String.raw`\s*no\s*(?:\n|$)`),
+    'pr-scope-police.yml Backend contract no parser must match the exact checkbox value',
   )
 })
 
@@ -2202,6 +2270,32 @@ test('CI scope router emits full CI outputs for workflow file PRs', async () => 
   assert.deepEqual(ciRegression.outputs, fullOutputs)
   assert.equal(ciRuntime.notices.some((notice) => notice.includes('Skipping heavy')), false)
   assert.equal(ciRegression.notices.some((notice) => notice.includes('Skipping heavy')), false)
+})
+
+test('CI scope router keeps workflow PRs in full CI when later checked acceptance criteria start with Normal', async () => {
+  const body = selectRiskClass(`${validStandardPrBody}
+
+## Acceptance Criteria
+
+- [x] Normal frontend PR CI still runs frontend image build, lint, test, build, and i18n checks.
+- [x] Normal frontend PR CI does not run mandatory Git LFS fetch.
+`, 'R4')
+  const result = await runCiScopeGateWorkflow({
+    prOverrides: {
+      title: '[infra] split frontend real asset validation from normal PR CI',
+      body,
+    },
+    files: [
+      { filename: '.github/workflows/ci.yml', additions: 27, deletions: 7, status: 'modified' },
+      { filename: '.github/workflows/ci.test.ts', additions: 60, deletions: 4, status: 'modified' },
+    ],
+  })
+
+  assert.equal(result.outputs.run_ci, 'true')
+  assert.equal(result.outputs.run_frontend, 'true')
+  assert.equal(result.outputs.run_backend, 'true')
+  assert.equal(result.outputs.run_dashboard, 'true')
+  assert.equal(result.notices.some((notice) => notice.includes('Skipping heavy')), false)
 })
 
 test('CI scope router emits dependency review output only for dependency file PRs', async () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: "17 2 * * 1"
   workflow_dispatch:
+    inputs:
+      validate_frontend_lfs_assets:
+        description: "Fetch and validate real frontend Git LFS assets"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -195,8 +201,17 @@ jobs:
             const dependsOnRaw = dependsOnMatch?.[1]?.trim()
             const dependsOnNone = dependsOnRaw?.toLowerCase() === 'none'
             const dependsOnPrMatch = dependsOnRaw?.match(/^#(\d+)$/)
-            const backendContractYes = /Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] yes/i.test(body)
-            const backendContractNo = /Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] no/i.test(body)
+            const extractPrBodySection = (heading) => {
+              const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+              const match = body.match(new RegExp(
+                `(?:^|\\n)\\s*-?\\s*${escapedHeading}\\s*[：:]\\s*\\n([\\s\\S]*?)(?=\\n\\s*-?\\s*(?:[A-Z][A-Za-z ]+|[\\u4e00-\\u9fff][^\\n]*|##\\s+)|\\n*$)`,
+                'i',
+              ))
+              return match?.[1] || ''
+            }
+            const backendContractSection = extractPrBodySection('Backend contract already in develop')
+            const backendContractYes = /(?:^|\n)\s*-\s*\[[xX]\]\s*yes\s*(?:\n|$)/i.test(backendContractSection)
+            const backendContractNo = /(?:^|\n)\s*-\s*\[[xX]\]\s*no\s*(?:\n|$)/i.test(backendContractSection)
             const dependencyBlocked =
               titlePrefix === '[frontend]' &&
               Boolean(dependsOnPrMatch) &&
@@ -675,13 +690,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          lfs: true
-
-      - name: Restore frontend LFS assets
-        run: |
-          git lfs fetch --exclude="" --include="apps/extension/src/assets/**/*.png,apps/extension/src/assets/**/*.jpg,apps/extension/src/assets/**/*.jpeg,apps/extension/src/assets/**/*.webp,apps/extension/src/assets/**/*.gif,apps/extension/src/assets/**/*.ttf,apps/extension/src/assets/**/*.otf,apps/extension/src/assets/**/*.woff,apps/extension/src/assets/**/*.woff2"
-          git lfs checkout apps/extension/src/assets
 
       - name: Build image
         run: docker compose build frontend
@@ -697,6 +705,27 @@ jobs:
 
       - name: i18n check
         run: docker compose run --no-deps --rm frontend pnpm check:i18n
+
+  frontend-lfs-assets:
+    timeout-minutes: 10
+    name: Frontend LFS assets
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.validate_frontend_lfs_assets == true) ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Restore frontend LFS assets
+        run: |
+          git lfs fetch --exclude="" --include="apps/extension/src/assets/**/*.png,apps/extension/src/assets/**/*.jpg,apps/extension/src/assets/**/*.jpeg,apps/extension/src/assets/**/*.webp,apps/extension/src/assets/**/*.gif,apps/extension/src/assets/**/*.ttf,apps/extension/src/assets/**/*.otf,apps/extension/src/assets/**/*.woff,apps/extension/src/assets/**/*.woff2"
+          git lfs checkout apps/extension/src/assets
+          git lfs ls-files --long | awk '$3 ~ /^apps\/extension\/src\/assets\//' | while read -r oid _ path; do
+            object=".git/lfs/objects/${oid:0:2}/${oid:2:2}/${oid}"
+            test -f "$object" || { echo "Missing LFS object for $path ($oid)" >&2; exit 1; }
+            actual="$(sha256sum "$object" | awk '{print $1}')"
+            test "$actual" = "$oid" || { echo "Corrupt LFS object for $path ($oid)" >&2; exit 1; }
+          done
 
   dashboard:
     timeout-minutes: 15

--- a/.github/workflows/pr-scope-police.yml
+++ b/.github/workflows/pr-scope-police.yml
@@ -520,8 +520,17 @@ jobs:
             const dependsOnRaw = dependsOnMatch?.[1]?.trim()
             const dependsOnNone = dependsOnRaw?.toLowerCase() === 'none'
             const dependsOnPrMatch = dependsOnRaw?.match(/^#(\d+)$/)
-            const backendContractYes = /Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] yes/i.test(body)
-            const backendContractNo = /Backend contract already in develop\s*[：:][\s\S]*?- \[[xX]\] no/i.test(body)
+            const extractPrBodySection = (heading) => {
+              const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+              const match = body.match(new RegExp(
+                `(?:^|\\n)\\s*-?\\s*${escapedHeading}\\s*[：:]\\s*\\n([\\s\\S]*?)(?=\\n\\s*-?\\s*(?:[A-Z][A-Za-z ]+|[\\u4e00-\\u9fff][^\\n]*|##\\s+)|\\n*$)`,
+                'i',
+              ))
+              return match?.[1] || ''
+            }
+            const backendContractSection = extractPrBodySection('Backend contract already in develop')
+            const backendContractYes = /(?:^|\n)\s*-\s*\[[xX]\]\s*yes\s*(?:\n|$)/i.test(backendContractSection)
+            const backendContractNo = /(?:^|\n)\s*-\s*\[[xX]\]\s*no\s*(?:\n|$)/i.test(backendContractSection)
             const stackedOnDependency = /If no, this PR is:[\s\S]*?- \[[xX]\] stacked on dependency branch/i.test(body)
             const intentionallyBlocked = /If no, this PR is:[\s\S]*?- \[[xX]\] intentionally blocked until dependency merges/i.test(body)
 


### PR DESCRIPTION
## 什麼改動

把 normal `Frontend build` job 從 mandatory Git LFS asset restore 中拆出來：一般 PR frontend CI 不再在 lint/test/build/i18n 前跑 `git lfs fetch`，並新增獨立的 conditional `Frontend LFS assets` job 供 manual / release validation 使用。

## 為什麼

closes #995

#994 只移除 broad checkout LFS fetch；但實際觀察到的 CI failure 發生在後續 scoped `Restore frontend LFS assets` step。當 GitHub LFS quota exhausted 時，normal frontend PR CI 仍會在 lint/test/build/i18n 前被擋住。

Root cause：normal frontend PR CI 仍要求先下載真實 Git LFS image/font assets，才會執行 frontend validation。

Solution：normal frontend PR CI 不再執行 mandatory LFS fetch；真實 frontend image/font asset validation 保留在 `Frontend LFS assets` conditional job：manual `workflow_dispatch` input `validate_frontend_lfs_assets=true`，或 `develop -> main` release promotion PR。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#995
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 frontend product behavior。
  - 不改 extension API client logic。
  - 不處理 GitHub LFS billing / quota 本身。
  - 不移動 assets 到 CDN。
  - 不移除或改寫既有 LFS assets。
  - 不用 `continue-on-error` 隱藏 LFS failure。
  - 不弱化 backend / dashboard / contracts / API contract / scope-router checks。

## Delegation Execution Log（非 Codex autonomous PR 可略過）

- Source issue delegation plan：
  - #995；issue 由 controller 建立，列出 normal PR CI 與 real asset validation split policy、scope、non-goals、AC。
- Actual worker profile(s)：
  - attempted `repo_scout/ops_spark` read-only worker for GitHub / workflow / asset readback；worker stream disconnected before completion。
  - controller fallback completed bounded readback and implementation.
- Model strength：
  - controller = current Codex session；worker attempted with inherited model.
- Spawn directive(s)：
  - profile=repo_scout model=inherited reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=controller model=current-codex reasoning=high controller_fallback=allowed fallback_reason=worker_unavailable: subagent stream disconnected before completion; impact=metadata/readback only; evidence=local gh/git readback plus workflow tests
- Verification evidence：
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`
  - `rtk git diff --check -- .github/workflows/ci.yml .github/workflows/ci.test.ts`
  - `pnpm --dir apps/extension build`
  - `pnpm --dir apps/extension lint`
  - `pnpm --dir apps/extension test`
  - `pnpm --dir apps/extension check:i18n`
- Self-review / exception reason：
  - self-review completed; implementation is limited to `.github/workflows/ci.yml` and `.github/workflows/ci.test.ts`.
- Worker session closeout：
  - worker session errored before completion (`stream disconnected before completion`); controller recorded fallback evidence and completed readback manually.
- Workflow friction / follow-up split：
  - #994 remains the narrow checkout broad-LFS-fetch fix; #995 owns the explicit policy split for normal PR CI vs real asset validation.

## Review conversation closeout

- Unresolved threads：
  - none; previous outdated fsck-scope thread resolved after fix.
- CodeRabbit：
  - success in latest GitHub status readback.
- chatgpt-codex-connector：
  - addressed P1 fsck scope finding by replacing broad `git lfs fsck` with frontend-only LFS object hash validation.
- review_triage_ref：
  - fixed reviewer finding discussion_r3323741998; self-review checked job condition readability, normal PR required path, #994 independence, and workflow regression coverage.
- root_cause_gate_ref：
  - #995 documents the root cause and policy decision; local TDD RED run reproduced existing workflow behavior.
- finding_disposition_ref：
  - local-only `/tmp/finding-disposition-995.json` status=not_applicable until review findings exist.
- Final reviewer action：
  - pending with reason: awaiting reviewer feedback.

## Final merge gate

- Ready-to-merge decision：
  - ready for human reviewer final decision; R4 workflow PR must not use auto-ready.
- Latest head SHA：
  - ba1b34b7a296826471f17268768a92b2c605306a
- Required checks：
  - Current-head GitHub Actions run https://github.com/nurockplayer/tachigo/actions/runs/26637522998 passed. `Frontend build` actually ran on head `ba1b34b7a296826471f17268768a92b2c605306a` and passed build image, lint, test, build, and i18n steps. `Frontend LFS assets` is skipped on normal PR and is not part of the normal required path. CodeRabbit status is success.
- spec workflow-check evidence：
  - local runner capability check passed; start gate failed because repo has no `.spec-injector/` config; commit gate uses manual AWP checklist fallback plus local evidence JSON.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/actions/runs/26637522998

## PR 拆分檢查

- 這個 PR 的單一句子目的：
  - Split real frontend LFS asset validation from normal frontend PR CI while preserving frontend lint/test/build/i18n coverage.
- Approx changed lines：~160
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a；workflow behavior and workflow regression tests are one reviewable CI policy change.
- 若已拆分，相關 PR：
  - #994 is the narrow checkout LFS fetch mitigation; #995 is this follow-up policy split.

## Acceptance Criteria

- [x] Normal frontend PR CI does not run a mandatory `git lfs fetch` before lint/test/build/i18n.
- [x] Normal frontend PR CI still runs frontend image build, lint, test, build, and i18n checks.
- [x] Real frontend image/font LFS asset validation remains available through a conditional manual/release/full-validation path.
- [x] Workflow regression tests assert normal frontend PR CI is independent from mandatory LFS downloads.
- [x] Workflow regression tests assert frontend lint/test/build/i18n commands remain present.
- [x] Separate LFS asset validation job is not required for normal PR CI.

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```text
node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
tests 102
pass 102
fail 0

rtk git diff --check -- .github/workflows/ci.yml .github/workflows/ci.test.ts .github/workflows/pr-scope-police.yml
pass

pnpm --dir apps/extension build
pass (with LFS pointer files; no placeholder script needed)

pnpm --dir apps/extension lint
pass

pnpm --dir apps/extension test
Test Files 22 passed (22)
Tests 78 passed (78)

pnpm --dir apps/extension check:i18n
i18n check passed: 21 locale mappings, 81 keys
```


Current-head GitHub Actions evidence:
- Run: https://github.com/nurockplayer/tachigo/actions/runs/26637522998
- Head SHA: ba1b34b7a296826471f17268768a92b2c605306a
- Frontend build: success
- Frontend build steps passed: `docker compose build frontend`, `pnpm lint`, `pnpm test`, `pnpm build`, `pnpm check:i18n`
- Frontend LFS assets: skipped on normal PR path as expected and not required
- CodeRabbit: success
- Review threads: none unresolved

## 備註

R4 workflow PR，不加 `auto-ready`，也不自動轉 ready。

## Notes for Claude Code Review

- Normal frontend PR CI can still build against LFS pointer files; this keeps TypeScript/Vite/lint/test/i18n signal but does not validate real binary assets.
- Real image/font validation is preserved in the separate conditional `Frontend LFS assets` job; the validation is scoped to fetched frontend asset OIDs so it does not scan unrelated design/prototype LFS objects.
- This PR is self-contained and does not require #994 to merge first, but it intentionally leaves #994 narrow rather than expanding it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 增强并新增前端 CI 流程相关的测试，覆盖 LFS 资源校验触发条件与校验逻辑的多种情况

* **Chores**
  * 调整前端持续集成工作流，移除原内联恢复步骤并拆分为独立作业
  * 新增手动触发输入选项，用于显式控制前端 LFS 资源验证的执行条件

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


