### PR TITLE
[backend] #986 Twitch OAuth scope 擴充與 re-auth 403 回應

### DIFF
--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1378,6 +1378,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
+                    },
+                    "403": {
+                        "description": "Twitch token lacks required scopes; streamer must re-authorize",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1372,6 +1372,12 @@
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
+                    },
+                    "403": {
+                        "description": "Twitch token lacks required scopes; streamer must re-authorize",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -1170,6 +1170,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Twitch token lacks required scopes; streamer must re-authorize
+          schema:
+            $ref: '#/definitions/handlers.Response'
       security:
       - BearerAuth: []
       summary: Sync raffle entries from Twitch subscriber list

--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -533,6 +533,7 @@ type publicDrawView struct {
 // @Param        body body object{source=string} true "source must be twitch_api"
 // @Success      200  {object}  Response
 // @Failure      400  {object}  Response
+// @Failure      403  {object}  Response "Twitch token lacks required scopes; streamer must re-authorize"
 // @Router       /dashboard/raffles/{id}/snapshot [post]
 func (h *RaffleHandler) Snapshot(c *gin.Context) {
 	claims := middleware.MustClaims(c)

--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -570,7 +570,11 @@ func (h *RaffleHandler) Snapshot(c *gin.Context) {
 		case errors.Is(err, services.ErrTwitchTokenMissing):
 			badRequest(c, "no twitch access token: streamer must log in via twitch")
 		case errors.Is(err, services.ErrTwitchInsufficientScope):
-			badRequest(c, "insufficient twitch scope: requires channel:read:subscriptions")
+			c.JSON(http.StatusForbidden, gin.H{
+				"success": false,
+				"code":    "twitch_reauth_required",
+				"error":   "twitch token lacks required scopes; streamer must re-authorize",
+			})
 		case errors.Is(err, services.ErrUnsupportedRaffleSource):
 			badRequest(c, "raffle source must be twitch_api to use snapshot sync")
 		default:

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -1218,12 +1218,12 @@ func TestRaffle_Snapshot_TwitchScopeError(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", bearer(token))
 	env.router.ServeHTTP(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("want 400 (scope error), got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403 (scope error), got %d: %s", w.Code, w.Body.String())
 	}
 	resp := parseBody(t, w.Body.Bytes())
-	if msg, _ := resp["error"].(string); !strings.Contains(msg, "scope") {
-		t.Errorf("expected scope error message, got: %v", msg)
+	if code, _ := resp["code"].(string); code != "twitch_reauth_required" {
+		t.Errorf("expected code twitch_reauth_required, got: %v", code)
 	}
 }
 

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -59,7 +59,7 @@ func NewAuthService(db *gorm.DB, cfg *config.Config) *AuthService {
 		ClientID:     cfg.OAuth.Twitch.ClientID,
 		ClientSecret: cfg.OAuth.Twitch.ClientSecret,
 		RedirectURL:  cfg.OAuth.Twitch.RedirectURL,
-		Scopes:       []string{"user:read:email"},
+		Scopes:       []string{"user:read:email", "channel:read:subscriptions"},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  "https://id.twitch.tv/oauth2/authorize",
 			TokenURL: "https://id.twitch.tv/oauth2/token",

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -1361,3 +1361,16 @@ func TestLogin_RefreshTokensTableGone_ReturnsError(t *testing.T) {
 		t.Fatal("want error when refresh_tokens table is gone, got nil")
 	}
 }
+
+// ─── OAuth config scopes ─────────────────────────────────────────────────────
+
+func TestTwitchOAuthConfig_ContainsChannelReadSubscriptions(t *testing.T) {
+	svc := NewAuthService(newTestDB(t), testConfig())
+	target := "channel:read:subscriptions"
+	for _, s := range svc.twitchOAuth.Scopes {
+		if s == target {
+			return
+		}
+	}
+	t.Errorf("twitchOAuth.Scopes does not contain %q; got: %v", target, svc.twitchOAuth.Scopes)
+}


### PR DESCRIPTION
## 什麼改動
新增 `channel:read:subscriptions` 至 Twitch OAuth scope；將 `ErrTwitchInsufficientScope` 的錯誤回應從 HTTP 400 改為 403，並加入結構化 `code: twitch_reauth_required` 欄位，讓前端可偵測並引導 re-auth。

## 為什麼
closes #986 — 抽獎模式 Mode 2（訂閱者專屬）需呼叫 `/helix/subscriptions`，現有 OAuth 缺少 `channel:read:subscriptions`；且前端需要機器可讀的錯誤 code 來判斷是否觸發 re-auth redirect。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#986
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做前端 re-auth redirect UI（屬前端 issue）
  - 不新增其他 Twitch scope
  - 不修改其他 handler 的 scope 錯誤處理

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- n/a（self-only exception — Claude Code direct session，非 Codex autonomous PR）

## Review conversation closeout
- Unresolved threads：0
- CodeRabbit：n/a
- chatgpt-codex-connector：n/a
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：n/a
- Final reviewer action：n/a

## Final merge gate
- Ready-to-merge decision：pending CI
- Latest head SHA：9436d5c
- Required checks：PR Scope Police pass；CI pass
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：擴充 Twitch OAuth scope 並將 scope 錯誤由 400 改為 403 帶機器可讀 code
- Approx changed lines：~23
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？：handler 改動與對應測試必須原子性提交
- 若已拆分，相關 PR：#992 (schema migration)

## Acceptance Criteria
- [x] `go test ./internal/services/... ./internal/handlers/...` 全過
- [x] TestRaffle_Snapshot_TwitchScopeError 更新為期望 403 + `twitch_reauth_required`
- [x] OAuth config 包含 `channel:read:subscriptions`（TestTwitchOAuthConfig_ContainsChannelReadSubscriptions）

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
\`\`\`
=== RUN   TestTwitchOAuthConfig_ContainsChannelReadSubscriptions
--- PASS  (0.00s)

=== RUN   TestRaffle_Snapshot_TwitchScopeError
--- PASS  (0.09s)

ok  github.com/tachigo/tachigo/internal/services   0.021s
ok  github.com/tachigo/tachigo/internal/handlers   0.109s
\`\`\`

## 備註
- R4 class：純屬 OAuth scope string 新增 + error code 欄位，不涉及 auth 邏輯重寫，但仍標 R4 需人工 review
- Swagger：Snapshot handler 可補 `@Failure 403` annotation，已記錄為 follow-up nit

## Notes for Claude Code Review
- `ErrTwitchInsufficientScope` 回應改用 `gin.H` 而非 `Response` struct，原因是需要額外的 `code` 欄位，`Response` struct 不含此欄位
- `twitchOAuth.Scopes` 為 private field，新測試在 `package services` 內直接存取，合法

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **New Features**
  * 扩展 Twitch OAuth 认证权限范围，新增频道订阅信息权限。

* **Bug Fixes**
  * 改进权限不足错误处理，返回更明确的错误消息和状态码，引导用户重新授权所需权限。

* **Tests**
  * 新增权限范围验证测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/tachigo/pull/997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->