### PR TITLE
[infra] temporarily skip release frontend LFS asset check

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -823,7 +823,7 @@ test('frontend CI job runs the frontend test command', async () => {
   )
 })
 
-test('frontend LFS asset validation is release or manual opt-in only', async () => {
+test('frontend LFS asset validation skips only the authorized #974 release exception', async () => {
   const parsedWorkflow = parseYaml(workflowPath)
   const workflow = await readFile(workflowPath, 'utf8')
   const workflowDispatchInput = parsedWorkflow.on.workflow_dispatch.inputs.validate_frontend_lfs_assets
@@ -836,7 +836,7 @@ test('frontend LFS asset validation is release or manual opt-in only', async () 
   assert.equal(job.name, 'Frontend LFS assets')
   assert.equal(
     job.if,
-    "(github.event_name == 'workflow_dispatch' && inputs.validate_frontend_lfs_assets == true) || (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop')",
+    "(github.event_name == 'workflow_dispatch' && inputs.validate_frontend_lfs_assets == true) || (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop' && github.event.pull_request.number != 974)",
   )
   assert.equal(job.needs, undefined)
   assert.equal(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,7 +713,7 @@ jobs:
     name: Frontend LFS assets
     if: >-
       (github.event_name == 'workflow_dispatch' && inputs.validate_frontend_lfs_assets == true) ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop')
+      (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop' && github.event.pull_request.number != 974)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## 什麼改動
- Add a one-time exception so `Frontend LFS assets` does **not** run for release PR #974 only.
- Keep future `develop` -> `main` release PRs covered by `Frontend LFS assets`.
- Keep manual validation available through `workflow_dispatch` with `validate_frontend_lfs_assets=true`.
- Update the CI workflow regression test to lock the #974-only condition.

## 為什麼
- Release PR #974 is blocked by `Frontend LFS assets` because GitHub LFS reports that the repository exceeded its LFS budget.
- This temporary skip is authorized by the team lead for this release PR only; future release PRs should still follow the normal LFS asset validation rule.

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#974 release unblock with team-lead-authorized one-time LFS asset check exception
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改任何 frontend asset。
  - 不移除手動 LFS asset validation。
  - 不讓未來 release PR 永久跳過 LFS asset validation。
  - 不修改 #974 的 release contents。

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add a one-time #974 exception for frontend LFS asset validation while LFS budget is unavailable.
- Approx changed lines：8
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #974

## Acceptance Criteria
- [x] `Frontend LFS assets` skips only PR #974 among release PRs.
- [x] Future `develop` -> `main` release PRs still run `Frontend LFS assets`.
- [x] Workflow regression test covers the #974-only exception.
- [ ] Required checks pass.
- [ ] After merge, #974 reruns with `Frontend LFS assets` skipped for this PR only.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
rtk node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts — pass, 103 tests
rtk git diff --check -- .github/workflows/ci.yml .github/workflows/ci.test.ts — pass
```

## 備註
- refs #974
- This exception must be removed or left inactive after #974; the condition is intentionally tied to `github.event.pull_request.number != 974` so later release PRs keep the normal LFS validation path.
