### PR TITLE
[infra] restore release LFS asset validation

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -823,7 +823,7 @@ test('frontend CI job runs the frontend test command', async () => {
   )
 })
 
-test('frontend LFS asset validation skips only the authorized #974 release exception', async () => {
+test('frontend LFS asset validation is release or manual opt-in only', async () => {
   const parsedWorkflow = parseYaml(workflowPath)
   const workflow = await readFile(workflowPath, 'utf8')
   const workflowDispatchInput = parsedWorkflow.on.workflow_dispatch.inputs.validate_frontend_lfs_assets
@@ -836,7 +836,7 @@ test('frontend LFS asset validation skips only the authorized #974 release excep
   assert.equal(job.name, 'Frontend LFS assets')
   assert.equal(
     job.if,
-    "(github.event_name == 'workflow_dispatch' && inputs.validate_frontend_lfs_assets == true) || (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop' && github.event.pull_request.number != 974)",
+    "(github.event_name == 'workflow_dispatch' && inputs.validate_frontend_lfs_assets == true) || (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop')",
   )
   assert.equal(job.needs, undefined)
   assert.equal(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,7 +713,7 @@ jobs:
     name: Frontend LFS assets
     if: >-
       (github.event_name == 'workflow_dispatch' && inputs.validate_frontend_lfs_assets == true) ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop' && github.event.pull_request.number != 974)
+      (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'develop')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- restore Frontend LFS assets so develop -> main release PRs run normally again
- remove the hardcoded PR #974 exception introduced by #999
- update the workflow regression assertion to cover the normal release/manual opt-in rule

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Validation
- rtk node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
- rtk git diff --check -- .github/workflows/ci.yml .github/workflows/ci.test.ts

refs #974