### PR TITLE
[backend] return heartbeat balance

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -67,6 +67,17 @@ export interface HandlersWalletResponse {
   address?: string;
 }
 
+export interface HandlersWatchHeartbeatResponse {
+  cumulative_total?: number;
+  points_earned?: number;
+  session?: ModelsWatchSession;
+  spendable_balance?: number;
+}
+
+export interface HandlersWatchRequest {
+  channel_id?: string;
+}
+
 export interface HandlersClaimRequest {
   amount?: number;
 }
@@ -128,6 +139,19 @@ export interface ModelsUser {
 }
 
 export type ModelsUserRole = "viewer" | "streamer" | "agency" | "admin";
+
+export interface ModelsWatchSession {
+  accumulated_seconds?: number;
+  channel_id?: string;
+  created_at?: string;
+  ended_at?: string;
+  id?: string;
+  is_active?: boolean;
+  last_heartbeat_at?: string;
+  rewarded_seconds?: number;
+  updated_at?: string;
+  user_id?: string;
+}
 
 export interface ServicesAddressInput {
   address_line1: string;
@@ -395,6 +419,12 @@ export interface ApiOperations {
     };
     response: HandlersResponse & {
       data?: HandlersAuthResponse;
+    };
+  };
+  "POST /extension/watch/heartbeat": {
+    requestBody: HandlersWatchRequest;
+    response: HandlersResponse & {
+      data?: HandlersWatchHeartbeatResponse;
     };
   };
   "GET /metrics": {

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1635,6 +1635,74 @@ const docTemplate = `{
                 }
             }
         },
+        "/extension/watch/heartbeat": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "extension-watch"
+                ],
+                "summary": "Record extension watch heartbeat",
+                "parameters": [
+                    {
+                        "description": "Watch heartbeat request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.WatchRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.WatchHeartbeatResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/metrics": {
             "get": {
                 "description": "Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer \u003cMETRICS_BEARER_TOKEN\u003e when METRICS_BEARER_TOKEN is set.",
@@ -2613,6 +2681,31 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.WatchHeartbeatResponse": {
+            "type": "object",
+            "properties": {
+                "cumulative_total": {
+                    "type": "integer"
+                },
+                "points_earned": {
+                    "type": "integer"
+                },
+                "session": {
+                    "$ref": "#/definitions/models.WatchSession"
+                },
+                "spendable_balance": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.WatchRequest": {
+            "type": "object",
+            "properties": {
+                "channel_id": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.claimRequest": {
             "type": "object",
             "properties": {
@@ -2800,6 +2893,41 @@ const docTemplate = `{
                 "RoleAgency",
                 "RoleAdmin"
             ]
+        },
+        "models.WatchSession": {
+            "type": "object",
+            "properties": {
+                "accumulated_seconds": {
+                    "type": "integer"
+                },
+                "channel_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "ended_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "last_heartbeat_at": {
+                    "type": "string"
+                },
+                "rewarded_seconds": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
         },
         "services.AddressInput": {
             "type": "object",

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1629,6 +1629,74 @@
                 }
             }
         },
+        "/extension/watch/heartbeat": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "extension-watch"
+                ],
+                "summary": "Record extension watch heartbeat",
+                "parameters": [
+                    {
+                        "description": "Watch heartbeat request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.WatchRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handlers.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.WatchHeartbeatResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/metrics": {
             "get": {
                 "description": "Operational endpoint exposed at root /metrics when ENABLE_METRICS=true. Requires Authorization: Bearer \u003cMETRICS_BEARER_TOKEN\u003e when METRICS_BEARER_TOKEN is set.",
@@ -2607,6 +2675,31 @@
                 }
             }
         },
+        "handlers.WatchHeartbeatResponse": {
+            "type": "object",
+            "properties": {
+                "cumulative_total": {
+                    "type": "integer"
+                },
+                "points_earned": {
+                    "type": "integer"
+                },
+                "session": {
+                    "$ref": "#/definitions/models.WatchSession"
+                },
+                "spendable_balance": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.WatchRequest": {
+            "type": "object",
+            "properties": {
+                "channel_id": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.claimRequest": {
             "type": "object",
             "properties": {
@@ -2794,6 +2887,41 @@
                 "RoleAgency",
                 "RoleAdmin"
             ]
+        },
+        "models.WatchSession": {
+            "type": "object",
+            "properties": {
+                "accumulated_seconds": {
+                    "type": "integer"
+                },
+                "channel_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "ended_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "last_heartbeat_at": {
+                    "type": "string"
+                },
+                "rewarded_seconds": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
         },
         "services.AddressInput": {
             "type": "object",

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -102,6 +102,22 @@ definitions:
       address:
         type: string
     type: object
+  handlers.WatchHeartbeatResponse:
+    properties:
+      cumulative_total:
+        type: integer
+      points_earned:
+        type: integer
+      session:
+        $ref: '#/definitions/models.WatchSession'
+      spendable_balance:
+        type: integer
+    type: object
+  handlers.WatchRequest:
+    properties:
+      channel_id:
+        type: string
+    type: object
   handlers.claimRequest:
     properties:
       amount:
@@ -230,6 +246,29 @@ definitions:
     - RoleStreamer
     - RoleAgency
     - RoleAdmin
+  models.WatchSession:
+    properties:
+      accumulated_seconds:
+        type: integer
+      channel_id:
+        type: string
+      created_at:
+        type: string
+      ended_at:
+        type: string
+      id:
+        type: string
+      is_active:
+        type: boolean
+      last_heartbeat_at:
+        type: string
+      rewarded_seconds:
+        type: integer
+      updated_at:
+        type: string
+      user_id:
+        type: string
+    type: object
   services.AddressInput:
     properties:
       address_line1:
@@ -1333,6 +1372,46 @@ paths:
       summary: Complete a T-point transaction
       tags:
       - extension
+  /extension/watch/heartbeat:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Watch heartbeat request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.WatchRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/handlers.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.WatchHeartbeatResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Record extension watch heartbeat
+      tags:
+      - extension-watch
   /metrics:
     get:
       description: 'Operational endpoint exposed at root /metrics when ENABLE_METRICS=true.

--- a/services/api/internal/handlers/swagger_types.go
+++ b/services/api/internal/handlers/swagger_types.go
@@ -69,3 +69,14 @@ type PointsHistoryItem struct {
 type PointsHistoryResponse struct {
 	Transactions []PointsHistoryItem `json:"transactions"`
 }
+
+type WatchRequest struct {
+	ChannelID string `json:"channel_id"`
+}
+
+type WatchHeartbeatResponse struct {
+	Session          *models.WatchSession `json:"session"`
+	PointsEarned     int64                `json:"points_earned"`
+	SpendableBalance int64                `json:"spendable_balance"`
+	CumulativeTotal  int64                `json:"cumulative_total"`
+}

--- a/services/api/internal/handlers/watch_handler.go
+++ b/services/api/internal/handlers/watch_handler.go
@@ -51,7 +51,18 @@ func (h *WatchHandler) StartSession(c *gin.Context) {
 	ok(c, session)
 }
 
-// Heartbeat handles POST /extension/watch/heartbeat
+// Heartbeat godoc
+// @Summary      Record extension watch heartbeat
+// @Tags         extension-watch
+// @Accept       json
+// @Produce      json
+// @Param        request body WatchRequest true "Watch heartbeat request"
+// @Success      200 {object} Response{data=WatchHeartbeatResponse}
+// @Failure      400 {object} Response
+// @Failure      401 {object} Response
+// @Failure      500 {object} Response
+// @Security     BearerAuth
+// @Router       /extension/watch/heartbeat [post]
 func (h *WatchHandler) Heartbeat(c *gin.Context) {
 	claims := middleware.MustClaims(c)
 	var body watchBody
@@ -88,11 +99,11 @@ func (h *WatchHandler) Heartbeat(c *gin.Context) {
 		return
 	}
 
-	ok(c, gin.H{
-		"session":           result.Session,
-		"points_earned":     result.PointsEarned,
-		"spendable_balance": spendable,
-		"cumulative_total":  cumulative,
+	ok(c, WatchHeartbeatResponse{
+		Session:          result.Session,
+		PointsEarned:     result.PointsEarned,
+		SpendableBalance: spendable,
+		CumulativeTotal:  cumulative,
 	})
 }
 

--- a/services/api/internal/handlers/watch_handler.go
+++ b/services/api/internal/handlers/watch_handler.go
@@ -82,9 +82,17 @@ func (h *WatchHandler) Heartbeat(c *gin.Context) {
 		}
 	}
 
+	spendable, cumulative, err := h.watchSvc.GetBalanceContext(c.Request.Context(), userID, body.ChannelID)
+	if err != nil {
+		internal(c)
+		return
+	}
+
 	ok(c, gin.H{
-		"session":       result.Session,
-		"points_earned": result.PointsEarned,
+		"session":           result.Session,
+		"points_earned":     result.PointsEarned,
+		"spendable_balance": spendable,
+		"cumulative_total":  cumulative,
 	})
 }
 

--- a/services/api/internal/handlers/watch_handler_test.go
+++ b/services/api/internal/handlers/watch_handler_test.go
@@ -104,6 +104,21 @@ func (e *watchEnv) watchTimeSeconds(t *testing.T, userID uuid.UUID, channelID st
 	return total
 }
 
+func (e *watchEnv) setActiveSessionCounters(t *testing.T, userID uuid.UUID, channelID string, accumulated, rewarded int64) {
+	t.Helper()
+	if err := e.db.Exec(
+		`UPDATE watch_sessions
+		 SET accumulated_seconds = ?, rewarded_seconds = ?
+		 WHERE user_id = ? AND channel_id = ? AND is_active = 1`,
+		accumulated,
+		rewarded,
+		userID,
+		channelID,
+	).Error; err != nil {
+		t.Fatalf("set active session counters: %v", err)
+	}
+}
+
 // heartbeatRequest sends POST /api/v1/extension/watch/heartbeat with the given token and channel.
 func heartbeatRequest(t *testing.T, router http.Handler, token, channelID string) *httptest.ResponseRecorder {
 	t.Helper()
@@ -136,6 +151,41 @@ func TestWatchHandler_Heartbeat_AccumulatesWatchTime(t *testing.T) {
 	secs := e.watchTimeSeconds(t, userID, channelID)
 	if secs <= 0 {
 		t.Fatalf("expected watch_time_stats to be > 0, got %d", secs)
+	}
+}
+
+func TestWatchHandler_Heartbeat_ReturnsLatestBalance(t *testing.T) {
+	e := newWatchTestEnv(t)
+	channelID := "ch_test_balance"
+
+	userID, token := e.registerViewer(t, "balance")
+	e.seedActiveSession(t, userID, channelID, 30)
+	e.setActiveSessionCounters(t, userID, channelID, 45, 0)
+
+	w := heartbeatRequest(t, e.router, token, channelID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			PointsEarned     int64 `json:"points_earned"`
+			SpendableBalance int64 `json:"spendable_balance"`
+			CumulativeTotal  int64 `json:"cumulative_total"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success=true, got false")
+	}
+	if resp.Data.PointsEarned != 1 {
+		t.Fatalf("expected points_earned=1, got %d", resp.Data.PointsEarned)
+	}
+	if resp.Data.SpendableBalance != 1 || resp.Data.CumulativeTotal != 1 {
+		t.Fatalf("expected latest balance 1/1, got spendable=%d cumulative=%d", resp.Data.SpendableBalance, resp.Data.CumulativeTotal)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
- 讓 watch heartbeat response 在 `data` 內回傳 `spendable_balance` 與 `cumulative_total`。
- 新增 handler focused test，驗證 heartbeat 發點後 response 帶回最新 balance。
- 補上 `/extension/watch/heartbeat` Swagger annotation 與 generated docs，讓 `spendable_balance` / `cumulative_total` 出現在 API contract。

## 為什麼
refs #958

前端每 30 秒 heartbeat 後目前還要額外 GET points balance；先落地 backend contract，讓後續 frontend consumer PR 可以省掉這個 round trip。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#958
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改點數計算規則
  - 不改 ensureWatchSession / watch session 建立邏輯
  - 不改 frontend `sendHeartbeat` consumer；frontend 另開 stacked PR，避免 backend/frontend product surface 混在同一 PR

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #958 issue-first AWP implementation
- Actual worker profile(s)：
  - controller / explorer
- Model strength：
  - controller = high；explorer = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=denied fallback_reason=n/a read-only contract/test surface scan
- Verification evidence：
  - `spec plan 958 --repo . --dry-run --format prompt --verbose` failed because `.spec-injector/` config is missing in the clean worktree
  - `spec workflow-check --repo . --phase start --issue 958 --format text` failed with `missing_fields=config`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestWatchHandler_Heartbeat'`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers`
  - `go run github.com/swaggo/swag/cmd/swag@v1.16.6 init -g cmd/server/main.go --output docs --quiet`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestWatchHandler_Heartbeat|TestPointsHandler_GetBalance'`
  - `GOCACHE=/tmp/tachigo-go-build-cache go test ./docs ./cmd/server`
  - `pnpm api:types:generate`
  - `pnpm api:types:check`
  - `pnpm api:client:test`
  - `pnpm smoke:contracts`
  - `rtk git --no-optional-locks diff --check`
  - `bash infra/scripts/check-typescript-only.sh --root .`
- Self-review / exception reason：
  - Self-review completed; backend/frontend split chosen to avoid product-surface scope violation.
- Worker session closeout：
  - Explorer readback reviewed; no open worker task remains.
- Workflow friction / follow-up split：
  - Split frontend consumer into a separate stacked PR because #958 needs both backend contract and frontend consumption, while Scope Police treats those as separate product surfaces.

## Review conversation closeout
- Unresolved threads：
  - none; CodeRabbit Swagger docs thread addressed in head `a733ffe`
- CodeRabbit：
  - success on latest head `a733ffe`; Swagger thread auto-marked addressed
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - CodeRabbit finding PRRT_kwDORtUM5M6F76QI verified as valid and fixed by adding Heartbeat Swagger annotation, typed response DTO, and regenerated docs
- root_cause_gate_ref：
  - CodeRabbit Swagger drift root-caused to generated API docs lagging behind the heartbeat response DTO and fixed in head `a733ffe`
- finding_disposition_ref：
  - CodeRabbit Swagger finding adopted and fixed; no unresolved review threads remain on latest head
- Final reviewer action：
  - pending human review; latest automated checks are complete and passing

## Final merge gate
- Ready-to-merge decision：
  - blocked only by human approval; latest automated checks are complete and passing
- Latest head SHA：
  - a733ffe
- Required checks：
  - pass: Scope police, Backend CI gate, backend tests, backend integration, API contract drift, TypeScript-only guardrail, workflow regression, CodeRabbit status success
- spec workflow-check evidence：
  - start and commit gates unavailable: `.spec-injector/` config missing in clean worktree; manual checklist plus local-only evidence files under `/tmp/tachigo-958/` used instead
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/1003

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 backend heartbeat API 回傳最新 points balance。
- Approx changed lines：~453 including generated Swagger docs and shared-types contract output
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [x] API handler / router
    - [x] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Focused handler test and generated Swagger docs verify the API contract added in this PR.
- 若已拆分，相關 PR：
  - Frontend consumer stacked PR to follow after this backend contract PR.

## Acceptance Criteria
- [x] AC 1：heartbeat handler 回傳最新 balance
- [ ] AC 2：frontend `sendHeartbeat` 移除額外 balance GET（stacked frontend PR）
- [x] AC 3：未改點數計算與 session 建立邏輯

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers -run 'TestWatchHandler_Heartbeat|TestPointsHandler_GetBalance'
ok github.com/tachigo/tachigo/internal/handlers 0.938s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/handlers
ok github.com/tachigo/tachigo/internal/handlers 21.455s

rtk git --no-optional-locks diff --check
pass

go run github.com/swaggo/swag/cmd/swag@v1.16.6 init -g cmd/server/main.go --output docs --quiet
pass

GOCACHE=/tmp/tachigo-go-build-cache go test ./docs ./cmd/server
ok github.com/tachigo/tachigo/docs 0.384s
ok github.com/tachigo/tachigo/cmd/server 0.498s

pnpm api:types:generate
pass

pnpm api:types:check
pass

pnpm api:client:test
9 tests passed

pnpm smoke:contracts
Cross-surface API contract smoke passed: 9 checks.

bash infra/scripts/check-typescript-only.sh --root .
TypeScript-only guardrail passed
```

## 備註
CodeRabbit 指出的 Swagger drift 已修正：本 PR 現在包含 Heartbeat Swagger annotation、`services/api/docs/` generated output，以及 `packages/shared-types` API contract 同步。

## Notes for Claude Code Review
- 請特別確認 response shape 是否符合 frontend parser 預期：`data.spendable_balance` / `data.cumulative_total`。
- #958 的 frontend consumer 已在本地另行修改，會拆成 stacked PR，避免 backend/frontend 混 surface。




