### PR TITLE
[frontend] consume heartbeat balance

### DIFF
--- a/apps/extension/src/services/api.test.ts
+++ b/apps/extension/src/services/api.test.ts
@@ -52,7 +52,7 @@ async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
   return JSON.parse(Buffer.concat(chunks).toString('utf8'))
 }
 
-test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes point balance', async () => {
+test('sendHeartbeat returns heartbeat balance without refreshing point balance', async () => {
   await withApiServer(
     (requests) => async (req, res) => {
       const body = await readJsonBody(req)
@@ -71,16 +71,14 @@ test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes poin
 
       if (req.method === 'POST' && req.url === '/api/v1/extension/watch/heartbeat') {
         res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ success: true, data: { points_earned: 2 } }))
-        return
-      }
-
-      if (req.method === 'GET' && req.url === '/api/v1/users/me/points?channel_id=channel-123') {
-        res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(
           JSON.stringify({
             success: true,
-            data: { spendable_balance: 42, cumulative_total: 77 },
+            data: {
+              points_earned: 2,
+              spendable_balance: 42,
+              cumulative_total: 77,
+            },
           }),
         )
         return
@@ -121,12 +119,6 @@ test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes poin
               authorization: 'Bearer tachigo-access-token',
               body: { channel_id: 'channel-123' },
             },
-            {
-              method: 'GET',
-              url: '/api/v1/users/me/points?channel_id=channel-123',
-              authorization: 'Bearer tachigo-access-token',
-              body: null,
-            },
           ],
         )
       } finally {
@@ -140,7 +132,7 @@ test('sendHeartbeat starts a watch session, sends heartbeat, then refreshes poin
   )
 })
 
-test('sendHeartbeat falls back when point balance response is missing cumulative total', async () => {
+test('sendHeartbeat falls back when heartbeat and point balance responses miss cumulative total', async () => {
   await withApiServer(
     (requests) => async (req, res) => {
       const body = await readJsonBody(req)
@@ -172,7 +164,7 @@ test('sendHeartbeat falls back when point balance response is missing cumulative
       res.writeHead(404, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ success: false, error: 'not found' }))
     },
-    async (baseUrl) => {
+    async (baseUrl, requests) => {
       const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
       process.env.VITE_TACHIGO_API_URL = baseUrl
 
@@ -184,6 +176,14 @@ test('sendHeartbeat falls back when point balance response is missing cumulative
         const result = await api.sendHeartbeat('channel-123', 40)
 
         assert.deepEqual(result, { balance: 42, cumulativeTotal: null })
+        assert.deepEqual(
+          requests.map(({ method, url }) => ({ method, url })),
+          [
+            { method: 'POST', url: '/api/v1/extension/watch/start' },
+            { method: 'POST', url: '/api/v1/extension/watch/heartbeat' },
+            { method: 'GET', url: '/api/v1/users/me/points?channel_id=channel-123' },
+          ],
+        )
       } finally {
         if (originalBaseUrl === undefined) {
           delete process.env.VITE_TACHIGO_API_URL

--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -200,6 +200,14 @@ function parsePointBalanceFromPayload(payload: unknown): PointBalanceResponse {
   return { spendableBalance, cumulativeTotal }
 }
 
+function parseOptionalPointBalanceFromPayload(payload: unknown): PointBalanceResponse | null {
+  try {
+    return parsePointBalanceFromPayload(payload)
+  } catch {
+    return null
+  }
+}
+
 function parseTachiBalanceFromPayload(payload: unknown): number {
   if (!payload || typeof payload !== 'object') {
     throw new Error('Invalid tachi balance response')
@@ -307,6 +315,14 @@ export async function sendHeartbeat(
     client.post('/api/v1/extension/watch/heartbeat', {
       channel_id: channelId,
     }, config))
+
+  const heartbeatBalance = parseOptionalPointBalanceFromPayload(heartbeatResponse.data)
+  if (heartbeatBalance) {
+    return {
+      balance: heartbeatBalance.spendableBalance,
+      cumulativeTotal: heartbeatBalance.cumulativeTotal,
+    }
+  }
 
   try {
     const pointBalance = await getPointBalance(channelId)


### PR DESCRIPTION
## 什麼改動
- `sendHeartbeat` 優先使用 heartbeat response 內的 `spendable_balance` / `cumulative_total`。
- heartbeat response 已含完整 balance 時，不再額外 GET `/api/v1/users/me/points`。
- 保留舊 fallback：heartbeat response 缺 balance 時仍會嘗試 GET；GET 回應不完整時仍用 `previousBalance + points_earned`。

## 為什麼
refs #958

#1003 已 merge 至 develop；本 PR 消費該 heartbeat balance contract，完成每次 heartbeat 減少一個 API round trip 的 frontend 行為。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#958
- Depends on PR：none
- Prior dependency：#1003 已 merge 至 develop
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 backend heartbeat handler；backend contract 在 #1003
  - 不改點數計算規則
  - 不改 ensureWatchSession 的 session 建立邏輯
  - 不改 UI 顯示或動畫

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #958 issue-first AWP implementation
- Actual worker profile(s)：
  - controller / explorer
- Model strength：
  - controller = high；explorer = inherited medium
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=denied fallback_reason=n/a read-only contract/test surface scan
- Verification evidence：
  - `spec plan 958 --repo . --dry-run --format prompt --verbose` failed because `.spec-injector/` config is missing in the clean worktree
  - `spec workflow-check --repo . --phase start --issue 958 --format text` failed with `missing_fields=config`
  - `pnpm exec vitest run src/services/api.test.ts`
  - `pnpm exec tsc -b --pretty false`
  - `rtk git --no-optional-locks diff --check feat/heartbeat-balance-response...HEAD`
  - `bash infra/scripts/check-typescript-only.sh --root .`
- Self-review / exception reason：
  - Self-review completed; frontend PR was originally stacked on #1003 and is now retargeted to develop after #1003 merged.
- Worker session closeout：
  - Explorer readback reviewed; no open worker task remains.
- Workflow friction / follow-up split：
  - Backend contract and frontend consumer were split into #1003 plus this PR because Scope Police treats `services/api` and `apps/extension` as separate product surfaces; #1003 is now merged.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR open
- CodeRabbit：
  - completed on retargeted head; no actionable inline comments observed
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - CodeRabbit completed on retargeted head; no actionable inline comments observed
- root_cause_gate_ref：
  - no repeated automated finding on retargeted head; no root-cause follow-up required
- finding_disposition_ref：
  - no actionable CodeRabbit or chatgpt-codex-connector finding on retargeted head
- Final reviewer action：
  - awaiting human review

## Final merge gate
- Ready-to-merge decision：
  - ready for human review; GitHub CI passed after retargeting to develop
- Latest head SHA：
  - 7feb5a4b3d90
- Required checks：
  - GitHub CI pass: Frontend build, CI scope router, Scope police, PR metadata, supply-chain, TypeScript-only, workflow regression, commit message checks
- spec workflow-check evidence：
  - start and commit gates unavailable: `.spec-injector/` config missing in clean worktree; manual checklist plus local-only evidence files under `/tmp/tachigo-958/` used instead
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/1004

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 讓 frontend heartbeat client 使用 heartbeat response 的 balance 以省去額外 GET。
- Approx changed lines：~48
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [ ] 是
  - [x] 否，原因：依賴 #1003 的 heartbeat balance response contract
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Focused API client tests verify the frontend integration behavior changed in this PR.
- 若已拆分，相關 PR：
  - #1003 backend heartbeat balance contract

## Acceptance Criteria
- [x] AC 1：每次心跳的 API round trip 減少（在 #1003 contract 可用時，frontend 不再 GET points balance）
- [x] AC 2：balance 顯示資料 shape 維持 `{ balance, cumulativeTotal }`
- [x] AC 3：保留 backend 未回 balance / GET 不完整時的 fallback 行為

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm exec vitest run src/services/api.test.ts
Test Files 1 passed (1)
Tests 7 passed (7)

pnpm exec tsc -b --pretty false
pass

rtk git --no-optional-locks diff --check feat/heartbeat-balance-response...HEAD
pass

bash infra/scripts/check-typescript-only.sh --root .
TypeScript-only guardrail passed
```

## 備註
本 PR 已在 #1003 merge 後 retarget 回 `develop`；review diff 只包含 frontend consumer 變更。

## Notes for Claude Code Review
- 請確認 fallback 行為仍符合 #958：heartbeat response 缺完整 balance 時，前端仍走既有 GET / previousBalance fallback。




