### PR TITLE
[chore] document app-scoped CI routing policy

### DIFF
--- a/docs/ci-app-scope-policy.md
+++ b/docs/ci-app-scope-policy.md
@@ -2,6 +2,8 @@
 
 Tachigo is a monorepo. CI routing should follow the app boundary instead of a coarse frontend/backend split.
 
+This document describes the intended policy boundary for `.github/workflows/ci.yml`. It is not a request to rename existing required checks.
+
 ## App scopes
 
 | Scope | Paths | Expected validation |
@@ -15,12 +17,27 @@ Tachigo is a monorepo. CI routing should follow the app boundary instead of a co
 | CI routing files | CI workflow and workflow regression files | Full CI, because routing changes affect the router itself. |
 | Docs and templates | `docs/**`, `plans/**`, root Markdown, PR/issue templates | No heavy product CI for metadata-only changes. |
 
-## Rules
+## Routing rules
 
 - Treat Extension and Dashboard as separate app scopes.
-- Do not force extension checks for dashboard-only changes.
-- Do not force dashboard checks for extension-only changes.
-- Run both Extension and Dashboard checks for shared frontend workspace changes.
+- Do not force Extension checks for Dashboard-only changes.
+- Do not force Dashboard checks for Extension-only changes.
+- Run both Extension and Dashboard checks for shared frontend workspace changes, because root package metadata can affect either app.
+- Run API contract drift checks for backend router/OpenAPI changes, app API client/service changes, shared API packages, and root workspace package metadata.
+- Run full CI for CI workflow or workflow regression changes, because the router itself is part of the change.
+- Keep docs/template/metadata-only PRs out of heavy product CI unless their paths also affect workflow behavior.
 - Keep the existing required-check names stable unless branch protection is updated in the same change.
 
+## Required check names
+
 The current `frontend` CI job name maps to the Extension app scope. New documentation should use `Extension` for that app while preserving the existing check name.
+
+This naming distinction matters because branch protection and auto-ready logic may depend on check names. A policy or documentation PR may clarify that `frontend` means Extension, but it must not rename the required check without a separate branch-protection-aware workflow change.
+
+## Reviewer checklist
+
+- If a PR touches only `apps/extension/**`, expect Extension/frontend checks without Dashboard checks.
+- If a PR touches only `apps/dashboard/**`, expect Dashboard checks without Extension/frontend checks.
+- If a PR touches root frontend workspace files, expect both Extension and Dashboard checks.
+- If a PR touches `.github/workflows/ci.yml` or `.github/workflows/ci.test.ts`, expect full CI and workflow regression coverage.
+- If a PR changes only docs/templates/metadata, heavy product CI may be skipped by design.

--- a/docs/dev-portal/source-index.md
+++ b/docs/dev-portal/source-index.md
@@ -39,6 +39,7 @@ related_repos:
 | [auth-architecture.md](/tachigo/auth-architecture) | Auth 現況與 migration guardrails |
 | [backend-permissions.md](/tachigo/backend-permissions) | Backend role / permission 現況與變更 guardrails |
 | [auto-merge-policy.md](/tachigo/auto-merge-policy) | Auto-merge 與 approve 語義 |
+| [ci-app-scope-policy.md](/tachigo/ci-app-scope-policy) | Extension / Dashboard / Backend / Contracts 的 CI app-scope routing policy |
 | [dependabot-update-policy.md](/tachigo/dependabot-update-policy) | Dependabot 更新政策 |
 | [draft-pr-auto-ready.md](/tachigo/draft-pr-auto-ready) | Draft PR auto-ready 現行流程 |
 | [pr-scope-policy.md](/tachigo/pr-scope-policy) | PR scope 與 required checks policy |


### PR DESCRIPTION
## 什麼改動
Clarifies the existing app-scoped CI routing policy and adds it to the Dev Portal source index.

## 為什麼
closes #947

The repo already routes CI by application surface, but future CI changes need a visible policy boundary that distinguishes Extension, Dashboard, Backend, Contracts, shared workspace, API contract, workflow-file, and docs/template routing behavior.

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [x] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#947
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 `.github/workflows/**`
  - 不變更 required check 名稱
  - 不變更 branch protection / auto-ready / Scope Police runtime behavior
  - 不修改 product source code

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #947 has no issue-level delegation plan; AWP controller used repo policy fallback.
- Actual worker profile(s)：
  - explorer: read-only issue triage
  - controller: docs implementation, verification, PR packaging
- Model strength：
  - controller = high
  - explorer = low
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=low controller_fallback=denied task=open-issue-triage-for-safe-next-awp-candidate
- Verification evidence：
  - `spec plan 947 --repo . --dry-run --format prompt --verbose` failed with missing `.spec-injector/` config after fetching issue metadata.
  - `spec workflow-check --repo . --phase start --issue 947 --format text` failed with `missing_fields=config`.
  - `rtk git --no-optional-locks diff --check`
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`
- Self-review / exception reason：
  - Self-review complete; controller-direct edit after explorer triage because this is a two-file docs-only R0 change.
- Worker session closeout：
  - Explorer result read back and session closed; no outstanding worker tasks.
- Workflow friction / follow-up split：
  - tool_gap=spec-injector config missing; used manual AWP checklist fallback. No follow-up split needed for this docs-only policy clarification.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - rate_limited before review; no actionable findings reported
- chatgpt-codex-connector：
  - n/a before first review
- review_triage_ref：
  - n/a; no review findings yet
- root_cause_gate_ref：
  - n/a; no repeated finding state
- finding_disposition_ref：
  - n/a; no findings yet
- Final reviewer action：
  - n/a before human review

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review; local verification and GitHub checks passed
- Latest head SHA：
  - 8c354f176b66b4fbfb5df3ab27027551a0337b61
- Required checks：
  - pass: Scope Police pass; CI docs-only checks passed or skipped as expected; CodeRabbit status success with review skipped due usage limit
- spec workflow-check evidence：
  - tool_gap=config missing; start gate failed locally with `missing_fields=config`; manual checklist fallback used
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/actions/runs/26712159941

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Document how app-scoped CI routing should map product surfaces to existing validation jobs.
- Approx changed lines：~26
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Clarify that Dashboard is its own app scope.
- [x] Clarify that the existing frontend CI job maps to the Extension app scope.
- [x] Preserve existing required check names unless branch protection is updated separately.

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
rtk git --no-optional-locks diff --check
pass

node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
tests 103 / pass 103 / fail 0
```

## 備註
Docs-only PR. It documents the intended app-scope routing policy but does not change CI runtime behavior.

## Notes for Claude Code Review
- Please verify the policy wording matches the current CI router intent, especially the distinction between the existing `frontend` check name and the Extension app scope.
