### PR TITLE
[backend] fix OAuth username collision fallback

### DIFF
--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -532,7 +532,11 @@ func (s *AuthService) upsertOAuthUser(
 		return nil, nil, recoverErr
 	}
 
-	return nil, nil, s.mapOAuthUserUniqueError(ctx, username, email, err)
+	mappedErr := s.mapOAuthUserUniqueError(ctx, username, email, err)
+	if username != "" && errors.Is(mappedErr, ErrUsernameExists) {
+		return s.upsertOAuthUser(ctx, provider, providerID, "", email, avatarURL, token)
+	}
+	return nil, nil, mappedErr
 }
 
 func (s *AuthService) upsertOAuthUserInTransaction(

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -227,17 +227,18 @@ func TestRecoverOAuthProviderConflictReturnsExistingAccount(t *testing.T) {
 	}
 }
 
-func TestUpsertOAuthUser_DuplicateUsernameCreateReturnsStableError(t *testing.T) {
+func TestUpsertOAuthUser_DuplicateUsernameCreatesUserWithoutUsername(t *testing.T) {
 	db := newTestDB(t)
 	svc := NewAuthService(db, testConfig())
 
 	takenUsername := "oauth-taken"
 	existingEmail := "oauth-taken@example.com"
-	if err := db.Create(&models.User{
+	seededUser := models.User{
 		Username: &takenUsername,
 		Email:    &existingEmail,
 		Role:     models.RoleViewer,
-	}).Error; err != nil {
+	}
+	if err := db.Create(&seededUser).Error; err != nil {
 		t.Fatalf("seed user: %v", err)
 	}
 
@@ -250,14 +251,28 @@ func TestUpsertOAuthUser_DuplicateUsernameCreateReturnsStableError(t *testing.T)
 		nil,
 		&oauth2.Token{AccessToken: "google-access-token"},
 	)
-	if !errors.Is(err, ErrUsernameExists) {
-		t.Fatalf("want ErrUsernameExists, got %v (user=%#v tokens=%#v)", err, user, tokens)
+	if err != nil {
+		t.Fatalf("upsertOAuthUser: %v", err)
+	}
+	if user == nil || tokens == nil || tokens.RefreshToken == "" {
+		t.Fatalf("expected user and tokens, got user=%#v tokens=%#v", user, tokens)
+	}
+	if user.Username != nil {
+		t.Fatalf("expected OAuth-created user to leave colliding username unset, got %q", *user.Username)
 	}
 
 	var providerCount int64
 	db.Model(&models.AuthProvider{}).Where("provider_id = ?", "google-duplicate-username").Count(&providerCount)
-	if providerCount != 0 {
-		t.Fatalf("auth provider should not be created after username conflict, got %d rows", providerCount)
+	if providerCount != 1 {
+		t.Fatalf("expected auth provider to be created with nil username user, got %d rows", providerCount)
+	}
+
+	var provider models.AuthProvider
+	if err := db.Where("provider_id = ?", "google-duplicate-username").First(&provider).Error; err != nil {
+		t.Fatalf("load auth provider: %v", err)
+	}
+	if provider.UserID == uuid.Nil || provider.UserID == seededUser.ID {
+		t.Fatalf("expected provider to link a new user, got user_id=%s seeded_user_id=%s", provider.UserID, seededUser.ID)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
修正 OAuth 建帳時的 username collision：當 provider username 已被其他 tachigo user 使用，`upsertOAuthUser()` 會以 `username = nil` 重跑建立流程，而不是回 `ErrUsernameExists` 阻斷 OAuth 登入。

## 為什麼
refs #814

#814 的 `POST /auth/twitch/exchange` 需要先修掉 `upsertOAuthUser()` username collision bug。這個 PR 只做該前置修正，讓後續 Twitch exchange endpoint 可以在 username 撞名時仍建立 OAuth user。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#814
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增 `POST /api/v1/auth/twitch/exchange`
  - 不修改 handler / router / swagger docs
  - 不修改 email 命中既有 user 的 OAuth auto-link 行為（#951 另行追蹤）
  - 不做 redirect_uri allowlist
  - 不 close #814；本 PR 只完成其中一個前置 checklist

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #814；heartbeat AWP issue-scoped implementation slice
- Actual worker profile(s)：
  - controller：candidate selection, TDD patch, validation, PR publish
  - Plato `019e7e3d-74dd-7af0-88b9-a3ff4cfb1f21`：read-only scan of `upsertOAuthUser()` username collision behavior and #951 risk boundary
- Model strength：
  - controller = current session; Plato = inherited
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=medium controller_fallback=allowed fallback_reason=controller_handles_minimal_auth_patch_and_pr_publish
- Verification evidence：
  - `spec plan 814 --repo . --dry-run --format prompt --verbose` fetched issue but stopped at missing `.spec-injector/` config
  - RED: `GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestUpsertOAuthUser_DuplicateUsernameCreatesUserWithoutUsername -count=1` failed with `username already taken`
  - GREEN targeted services tests
  - full backend: `GOCACHE=/tmp/tachigo-go-build-cache go test ./...`
  - `git diff --check`
- Self-review / exception reason：
  - Controller reviewed the diff against #814 and Plato's read-only scan; patch only changes username-collision fallback and does not touch #951 email auto-link behavior
- Worker session closeout：
  - Plato completed read-only scan; no further worker action required
- Workflow friction / follow-up split：
  - Tool gap recorded: `.spec-injector/` config missing, so no spec config was initialized or committed. New Twitch exchange endpoint remains a follow-up #814 slice.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - pass; Review skipped
- chatgpt-codex-connector：
  - not requested for self-authored PR; no self-review per automation policy
- review_triage_ref：
  - no review findings at PR creation
- root_cause_gate_ref：
  - no repeated finding at PR creation
- finding_disposition_ref：
  - no finding disposition at PR creation
- Final reviewer action：
  - waiting for human review; self-authored PR is not self-reviewed

## Final merge gate
- Ready-to-merge decision：
  - blocked only by required human review
- Latest head SHA：
  - 9134c6ec214c979606e9b29fc9643d60643e5004
- Required checks：
  - Scope police pass; Backend tests pass; Backend integration tests pass; Backend security scanners pass; Atlas migration tooling pass; Backend CI gate pass; CodeRabbit pass
- spec workflow-check evidence：
  - tool_gap=config missing; `spec plan 814 --repo . --dry-run --format prompt --verbose` fetched issue then stopped because `.spec-injector/` config is absent
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/1009

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Let OAuth user creation continue with `username = nil` when provider username collides.
- Approx changed lines：~35
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - The service fallback and regression test are one behavior change and need to land together.
- 若已拆分，相關 PR：
  - This is a split prerequisite from #814; the endpoint/handler/router/swagger work remains separate.

## Acceptance Criteria
- [x] `upsertOAuthUser()` username collision bug is fixed for new OAuth users
- [x] Colliding provider username no longer blocks OAuth account creation
- [x] Regression test proves the new provider links to a new user with nil username, not the existing username owner
- [x] Email auto-link behavior is unchanged and remains tracked separately by #951

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
RED:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run TestUpsertOAuthUser_DuplicateUsernameCreatesUserWithoutUsername -count=1
failed: username already taken

GREEN:
GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -run 'TestUpsertOAuthUser_DuplicateUsernameCreatesUserWithoutUsername|TestMapOAuthUserUniqueErrorReturnsStableEmailError|TestOAuthUser|TestRecoverOAuthProviderConflictReturnsExistingAccount' -count=1
ok github.com/tachigo/tachigo/internal/services 0.396s

GOCACHE=/tmp/tachigo-go-build-cache go test ./internal/services -count=1
ok github.com/tachigo/tachigo/internal/services 3.224s

GOCACHE=/tmp/tachigo-go-build-cache go test ./...
ok all services/api packages

git diff --check
pass
```

## 備註
First verification attempt from repo root failed with `go: go.mod file not found`; reran from `services/api`, where the module lives. No repo changes came from that failed command.

## Notes for Claude Code Review
- Please check that the retry path only handles `ErrUsernameExists`; email collision / #951 auto-link behavior is intentionally unchanged.
