### PR TITLE
[backend] Extension 報名 API 與訂閱者資格驗證

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -381,6 +381,15 @@ export interface ApiOperations {
       data?: HandlersAuthResponse;
     };
   };
+  "POST /extension/raffles/{id}/join": {
+    requestBody: {
+      extension_jwt?: string;
+    };
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
   "GET /extension/raffles/{id}/result": {
     pathParams: {
       id: string;

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1378,6 +1378,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
+                    },
+                    "403": {
+                        "description": "Twitch token lacks required scopes; streamer must re-authorize",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }
@@ -1564,6 +1570,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1378,12 +1378,6 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
-                    },
-                    "403": {
-                        "description": "Twitch token lacks required scopes; streamer must re-authorize",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.Response"
-                        }
                     }
                 }
             }
@@ -1513,6 +1507,69 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/extension/raffles/{id}/join": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Join a raffle from Twitch Extension",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Extension JWT",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "extension_jwt": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1372,12 +1372,6 @@
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
-                    },
-                    "403": {
-                        "description": "Twitch token lacks required scopes; streamer must re-authorize",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.Response"
-                        }
                     }
                 }
             }
@@ -1507,6 +1501,69 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/extension/raffles/{id}/join": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Join a raffle from Twitch Extension",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Extension JWT",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "extension_jwt": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1372,6 +1372,12 @@
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
+                    },
+                    "403": {
+                        "description": "Twitch token lacks required scopes; streamer must re-authorize",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }
@@ -1558,6 +1564,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -1170,6 +1170,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Twitch token lacks required scopes; streamer must re-authorize
+          schema:
+            $ref: '#/definitions/handlers.Response'
       security:
       - BearerAuth: []
       summary: Sync raffle entries from Twitch subscriber list
@@ -1288,6 +1292,10 @@ paths:
             $ref: '#/definitions/handlers.Response'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "401":
+          description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
         "403":

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -1170,10 +1170,6 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/handlers.Response'
-        "403":
-          description: Twitch token lacks required scopes; streamer must re-authorize
-          schema:
-            $ref: '#/definitions/handlers.Response'
       security:
       - BearerAuth: []
       summary: Sync raffle entries from Twitch subscriber list
@@ -1264,6 +1260,47 @@ paths:
       summary: '[Deprecated] Complete a Bits transaction'
       tags:
       - extension
+  /extension/raffles/{id}/join:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Extension JWT
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            extension_jwt:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      summary: Join a raffle from Twitch Extension
+      tags:
+      - raffles
   /extension/raffles/{id}/result:
     get:
       parameters:

--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -808,6 +808,7 @@ func (h *RaffleHandler) GetResult(c *gin.Context) {
 // @Param        body body object{extension_jwt=string} true "Extension JWT"
 // @Success      200  {object}  Response
 // @Failure      400  {object}  Response
+// @Failure      401  {object}  Response
 // @Failure      403  {object}  Response
 // @Failure      409  {object}  Response
 // @Router       /extension/raffles/{id}/join [post]

--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -15,6 +15,7 @@ import (
 
 type RaffleHandler struct {
 	raffleSvc *services.RaffleService
+	extSvc    *services.ExtensionService
 }
 
 const (
@@ -22,8 +23,8 @@ const (
 	maxRaffleCSVImportRequestBytes = maxRaffleCSVFileBytes + 64*1024
 )
 
-func NewRaffleHandler(svc *services.RaffleService) *RaffleHandler {
-	return &RaffleHandler{raffleSvc: svc}
+func NewRaffleHandler(svc *services.RaffleService, extSvc *services.ExtensionService) *RaffleHandler {
+	return &RaffleHandler{raffleSvc: svc, extSvc: extSvc}
 }
 
 // ── Dashboard endpoints (JWT + RoleStreamer) ──────────────────────────────────
@@ -796,4 +797,67 @@ func (h *RaffleHandler) GetResult(c *gin.Context) {
 		views[i].Entry.DisplayName = d.Entry.DisplayName
 	}
 	ok(c, gin.H{"draws": views})
+}
+
+// Join godoc
+// @Summary      Join a raffle from Twitch Extension
+// @Tags         raffles
+// @Accept       json
+// @Produce      json
+// @Param        id   path string true "Raffle ID"
+// @Param        body body object{extension_jwt=string} true "Extension JWT"
+// @Success      200  {object}  Response
+// @Failure      400  {object}  Response
+// @Failure      403  {object}  Response
+// @Failure      409  {object}  Response
+// @Router       /extension/raffles/{id}/join [post]
+func (h *RaffleHandler) Join(c *gin.Context) {
+	raffleID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid raffle id")
+		return
+	}
+
+	var body struct {
+		ExtensionJWT string `json:"extension_jwt" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+	if h.extSvc == nil {
+		internal(c)
+		return
+	}
+	claims, err := h.extSvc.VerifyExtJWT(body.ExtensionJWT)
+	if err != nil {
+		unauthorized(c, "invalid extension jwt")
+		return
+	}
+
+	entry, err := h.raffleSvc.JoinRaffle(c.Request.Context(), raffleID, claims.UserID)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrEntryNotOpen):
+			badRequest(c, "raffle entry not open")
+		case errors.Is(err, services.ErrAlreadyJoined):
+			conflict(c, "already joined")
+		case errors.Is(err, services.ErrNotSubscriber):
+			c.JSON(http.StatusForbidden, gin.H{
+				"success": false,
+				"error":   "not a subscriber",
+				"code":    "not_subscriber",
+				"data":    gin.H{"entry": entry},
+			})
+		case errors.Is(err, services.ErrRaffleNotFound), errors.Is(err, services.ErrViewerNotLinked):
+			notFound(c, "not found")
+		case errors.Is(err, services.ErrTwitchTokenMissing), errors.Is(err, services.ErrTwitchInsufficientScope):
+			badRequest(c, err.Error())
+		default:
+			log.Printf("raffle join: %v", err)
+			internal(c)
+		}
+		return
+	}
+	ok(c, gin.H{"entry": entry})
 }

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -1730,8 +1730,8 @@ func (e *raffleTestEnv) addBroadcasterTwitchProvider(t *testing.T, ownerEmail, b
 	}
 	id, _ := uuid.NewV7()
 	if err := e.db.Exec(
-		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at) VALUES (?, ?, 'twitch', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-		id.String(), user.ID.String(), broadcasterID,
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, access_token, created_at, updated_at) VALUES (?, ?, 'twitch', ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		id.String(), user.ID.String(), broadcasterID, accessToken,
 	).Error; err != nil {
 		t.Fatalf("addBroadcasterTwitchProvider: %v", err)
 	}

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -115,9 +116,11 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 	}
 
 	cfg := testConfig()
+	cfg.OAuth.Twitch.ExtensionSecret = base64.StdEncoding.EncodeToString([]byte(extHandlerSecretRaw))
 	authSvc := services.NewAuthService(db, cfg)
 	raffleSvc := services.NewRaffleService(db, "", "", nil)
-	raffleH := handlers.NewRaffleHandler(raffleSvc)
+	extSvc := services.NewExtensionService(db, cfg)
+	raffleH := handlers.NewRaffleHandler(raffleSvc, extSvc)
 
 	r := gin.New()
 	r.Use(gin.Recovery())
@@ -132,6 +135,7 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 
 	// Extension result
 	v1.GET("/extension/raffles/:id/result", raffleH.GetResult)
+	v1.POST("/extension/raffles/:id/join", raffleH.Join)
 
 	// Dashboard raffle routes (streamer role)
 	dash := v1.Group("/dashboard")
@@ -1713,5 +1717,142 @@ func TestEntries_ImportCSV_Conflict_WhenRaffleActive(t *testing.T) {
 
 	if w.Code != http.StatusConflict {
 		t.Errorf("import after activate: want 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ── Extension join helpers ────────────────────────────────────────────────────
+
+func (e *raffleTestEnv) addBroadcasterTwitchProvider(t *testing.T, ownerEmail, broadcasterID, accessToken string) {
+	t.Helper()
+	var user models.User
+	if err := e.db.Where("email = ?", ownerEmail).First(&user).Error; err != nil {
+		t.Fatalf("addBroadcasterTwitchProvider: get owner: %v", err)
+	}
+	id, _ := uuid.NewV7()
+	if err := e.db.Exec(
+		`INSERT INTO auth_providers (id, user_id, provider, provider_id, created_at, updated_at) VALUES (?, ?, 'twitch', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		id.String(), user.ID.String(), broadcasterID,
+	).Error; err != nil {
+		t.Fatalf("addBroadcasterTwitchProvider: %v", err)
+	}
+}
+
+func (e *raffleTestEnv) setupExtensionJoinRaffle(t *testing.T, ownerEmail, mode string, entryOpen bool) string {
+	t.Helper()
+	var user models.User
+	if err := e.db.Where("email = ?", ownerEmail).First(&user).Error; err != nil {
+		t.Fatalf("setupExtensionJoinRaffle: get owner: %v", err)
+	}
+	ownerID := user.ID.String()
+	raffleID, _ := uuid.NewV7()
+	if err := e.db.Exec(
+		`INSERT INTO raffles (id, user_id, title, status, source, mode, entry_open, winner_count, created_at, updated_at) VALUES (?, ?, 'join test raffle', 'active', 'csv', ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		raffleID.String(), ownerID, mode, entryOpen,
+	).Error; err != nil {
+		t.Fatalf("setupExtensionJoinRaffle: insert raffle: %v", err)
+	}
+	return raffleID.String()
+}
+
+func (e *raffleTestEnv) postRaffleJoin(t *testing.T, raffleID, twitchUserID string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{
+		"extension_jwt": signExtJWTForHandler(t, twitchUserID, "ch-test"),
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/extension/raffles/"+raffleID+"/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	e.router.ServeHTTP(w, req)
+	return w
+}
+
+func TestRaffle_Join_PublicMode(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	env.registerStreamer(t, "join_host_public", "join_host_public@test.com", "pass1234")
+	env.createTwitchLinkedUser(t, "join_public_viewer")
+	twitchUserID := "twitch_id_join_public_viewer"
+	raffleID := env.setupExtensionJoinRaffle(t, "join_host_public@test.com", string(models.RaffleModePublic), true)
+
+	w := env.postRaffleJoin(t, raffleID, twitchUserID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	entry := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["entry"].(map[string]interface{})
+	// twitch_login is temporarily set to twitchUserID until /helix/users integration
+	if entry["twitch_login"] != twitchUserID || entry["source"] != string(models.RaffleSourceExtensionButton) {
+		t.Fatalf("unexpected entry: %#v", entry)
+	}
+}
+
+func TestRaffle_Join_SubscribersOnlySubscriber(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	env.registerStreamer(t, "join_host_sub", "join_host_sub@test.com", "pass1234")
+	env.createTwitchLinkedUser(t, "join_sub_viewer")
+	twitchID := "twitch_id_join_sub_viewer"
+	env.addBroadcasterTwitchProvider(t, "join_host_sub@test.com", "broadcaster-1", "fake-token")
+	env.raffleSvc.SetTwitchBaseURL("https://twitch.test")
+	env.raffleSvc.SetHTTPClient(testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet && r.URL.Path == "/helix/subscriptions" {
+			return testutil.NewStringResponse(http.StatusOK, twitchSubsJSON([]map[string]string{{
+				"user_id": twitchID, "user_login": "join_sub_viewer", "user_name": "Join Sub Viewer",
+			}}, "")), nil
+		}
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
+	}))
+	raffleID := env.setupExtensionJoinRaffle(t, "join_host_sub@test.com", string(models.RaffleModeSubscribers), true)
+
+	w := env.postRaffleJoin(t, raffleID, twitchID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_Join_SubscribersOnlyNotSubscriber(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	env.registerStreamer(t, "join_host_nonsub", "join_host_nonsub@test.com", "pass1234")
+	env.createTwitchLinkedUser(t, "join_nonsub_viewer")
+	twitchID := "twitch_id_join_nonsub_viewer"
+	env.addBroadcasterTwitchProvider(t, "join_host_nonsub@test.com", "broadcaster-2", "fake-token")
+	env.raffleSvc.SetTwitchBaseURL("https://twitch.test")
+	env.raffleSvc.SetHTTPClient(testutil.NewHTTPClient(func(r *http.Request) (*http.Response, error) {
+		return testutil.NewStringResponse(http.StatusNotFound, ""), nil
+	}))
+	raffleID := env.setupExtensionJoinRaffle(t, "join_host_nonsub@test.com", string(models.RaffleModeSubscribers), true)
+
+	w := env.postRaffleJoin(t, raffleID, twitchID)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+	body := parseBody(t, w.Body.Bytes())
+	if body["code"] != "not_subscriber" {
+		t.Fatalf("want code=not_subscriber, got %v", body["code"])
+	}
+}
+
+func TestRaffle_Join_Duplicate(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	env.registerStreamer(t, "join_host_dup", "join_host_dup@test.com", "pass1234")
+	env.createTwitchLinkedUser(t, "join_dup_viewer")
+	twitchUserID := "twitch_id_join_dup_viewer"
+	raffleID := env.setupExtensionJoinRaffle(t, "join_host_dup@test.com", string(models.RaffleModePublic), true)
+
+	if w := env.postRaffleJoin(t, raffleID, twitchUserID); w.Code != http.StatusOK {
+		t.Fatalf("first join: want 200, got %d", w.Code)
+	}
+	if w := env.postRaffleJoin(t, raffleID, twitchUserID); w.Code != http.StatusConflict {
+		t.Fatalf("duplicate join: want 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_Join_EntryClosed(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	env.registerStreamer(t, "join_host_closed", "join_host_closed@test.com", "pass1234")
+	env.createTwitchLinkedUser(t, "join_closed_viewer")
+	twitchUserID := "twitch_id_join_closed_viewer"
+	raffleID := env.setupExtensionJoinRaffle(t, "join_host_closed@test.com", string(models.RaffleModePublic), false)
+
+	w := env.postRaffleJoin(t, raffleID, twitchUserID)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -119,7 +119,7 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 	cfg.OAuth.Twitch.ExtensionSecret = base64.StdEncoding.EncodeToString([]byte(extHandlerSecretRaw))
 	authSvc := services.NewAuthService(db, cfg)
 	raffleSvc := services.NewRaffleService(db, "", "", nil)
-	extSvc := services.NewExtensionService(db, cfg)
+	extSvc := services.NewExtensionService(db, cfg, authSvc, nil)
 	raffleH := handlers.NewRaffleHandler(raffleSvc, extSvc)
 
 	r := gin.New()

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -1778,8 +1778,7 @@ func TestRaffle_Join_PublicMode(t *testing.T) {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 	entry := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["entry"].(map[string]interface{})
-	// twitch_login is temporarily set to twitchUserID until /helix/users integration
-	if entry["twitch_login"] != twitchUserID || entry["source"] != string(models.RaffleSourceExtensionButton) {
+	if entry["twitch_login"] != "join_public_viewer" || entry["source"] != string(models.RaffleSourceExtensionButton) {
 		t.Fatalf("unexpected entry: %#v", entry)
 	}
 }

--- a/services/api/internal/models/raffle.go
+++ b/services/api/internal/models/raffle.go
@@ -16,8 +16,9 @@ const (
 	RaffleStatusActive    RaffleStatus = "active"
 	RaffleStatusCompleted RaffleStatus = "completed"
 
-	RaffleSourceCSV       RaffleSource = "csv"
-	RaffleSourceTwitchAPI RaffleSource = "twitch_api"
+	RaffleSourceCSV             RaffleSource = "csv"
+	RaffleSourceTwitchAPI       RaffleSource = "twitch_api"
+	RaffleSourceExtensionButton RaffleSource = "extension_button"
 
 	RaffleModePublic      RaffleMode = "public"
 	RaffleModeSubscribers RaffleMode = "subscribers_only"

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -104,7 +104,7 @@ func New(
 	claimH := handlers.NewClaimHandler(claimSvc)
 	spendH := handlers.NewSpendHandler(spendSvc)
 	airdropH := handlers.NewAirdropHandler(airdropSvc, agencySvc, streamerSvc)
-	raffleH := handlers.NewRaffleHandler(raffleSvc)
+	raffleH := handlers.NewRaffleHandler(raffleSvc, extSvc)
 
 	r.GET("/health", healthHandler(db))
 	r.GET("/readyz", readinessHandler(db))
@@ -163,6 +163,7 @@ func New(
 
 		// Raffle result — public read (no auth required)
 		ext.GET("/raffles/:id/result", raffleH.GetResult)
+		ext.POST("/raffles/:id/join", raffleH.Join)
 
 		// Watch-time points (requires tachigo JWT — viewer must log in first)
 		watch := ext.Group("/watch")

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -706,6 +706,7 @@ func (s *RaffleService) JoinRaffle(ctx context.Context, raffleID uuid.UUID, twit
 	var viewerAP models.AuthProvider
 	if err := db.
 		Joins("JOIN users ON users.id = auth_providers.user_id AND users.deleted_at IS NULL").
+		Preload("User").
 		Where("auth_providers.provider = ? AND auth_providers.provider_id = ?", models.ProviderTwitch, twitchUserID).
 		First(&viewerAP).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -715,16 +716,19 @@ func (s *RaffleService) JoinRaffle(ctx context.Context, raffleID uuid.UUID, twit
 	}
 
 	uid := viewerAP.UserID
+	twitchLogin := twitchUserID
+	if viewerAP.User.Username != nil {
+		twitchLogin = *viewerAP.User.Username
+	}
 	entry := &models.RaffleEntry{
 		RaffleID:    raffleID,
 		UserID:      &uid,
-		TwitchLogin: twitchUserID,
-		DisplayName: twitchUserID,
+		TwitchLogin: twitchLogin,
+		DisplayName: twitchLogin,
 		Source:      string(models.RaffleSourceExtensionButton),
 		Eligible:    true,
 	}
 
-	var joinErr error
 	if raffle.Mode == models.RaffleModeSubscribers {
 		var broadcasterAP models.AuthProvider
 		if err := db.Where("user_id = ? AND provider = ?", raffle.UserID, models.ProviderTwitch).First(&broadcasterAP).Error; err != nil {
@@ -768,7 +772,7 @@ func (s *RaffleService) JoinRaffle(ctx context.Context, raffleID uuid.UUID, twit
 	if res.RowsAffected == 0 {
 		return nil, ErrAlreadyJoined
 	}
-	return entry, joinErr
+	return entry, nil
 }
 
 func (s *RaffleService) fetchTwitchSubsPage(ctx context.Context, accessToken, broadcasterID, cursor string) ([]twitchSubscription, string, error) {

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -44,6 +44,11 @@ var (
 	ErrPrizeTierExhausted    = errors.New("prize tier winner count reached")
 	ErrPrizeTierInvalidCount = errors.New("winner_count must be at least 1")
 	ErrRaffleNotActive       = errors.New("raffle is not active")
+
+	ErrEntryNotOpen    = errors.New("raffle entry not open")
+	ErrAlreadyJoined   = errors.New("already joined")
+	ErrNotSubscriber   = errors.New("not a subscriber")
+	ErrViewerNotLinked = errors.New("viewer has no linked tachigo account")
 )
 
 const claimTokenTTL = 7 * 24 * time.Hour
@@ -636,6 +641,135 @@ type twitchSubsPage struct {
 	Pagination struct {
 		Cursor string `json:"cursor"`
 	} `json:"pagination"`
+}
+
+func (s *RaffleService) fetchTwitchSubscription(ctx context.Context, accessToken, broadcasterID, userID string) (bool, error) {
+	endpoint, err := url.Parse(strings.TrimRight(s.twitchBaseURL, "/") + "/helix/subscriptions")
+	if err != nil {
+		return false, err
+	}
+	q := endpoint.Query()
+	q.Set("broadcaster_id", broadcasterID)
+	q.Set("user_id", userID)
+	endpoint.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Client-Id", s.twitchClientID)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return false, ErrTwitchTokenMissing
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return false, ErrTwitchInsufficientScope
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("twitch api: unexpected status %d", resp.StatusCode)
+	}
+
+	var page twitchSubsPage
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return false, err
+	}
+	return len(page.Data) > 0, nil
+}
+
+func (s *RaffleService) JoinRaffle(ctx context.Context, raffleID uuid.UUID, twitchUserID string) (*models.RaffleEntry, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db := s.db.WithContext(ctx)
+
+	var raffle models.Raffle
+	if err := db.First(&raffle, "id = ?", raffleID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrRaffleNotFound
+		}
+		return nil, err
+	}
+	if !raffle.EntryOpen {
+		return nil, ErrEntryNotOpen
+	}
+
+	var viewerAP models.AuthProvider
+	if err := db.
+		Joins("JOIN users ON users.id = auth_providers.user_id AND users.deleted_at IS NULL").
+		Where("auth_providers.provider = ? AND auth_providers.provider_id = ?", models.ProviderTwitch, twitchUserID).
+		First(&viewerAP).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrViewerNotLinked
+		}
+		return nil, err
+	}
+
+	uid := viewerAP.UserID
+	entry := &models.RaffleEntry{
+		RaffleID:    raffleID,
+		UserID:      &uid,
+		TwitchLogin: twitchUserID,
+		DisplayName: twitchUserID,
+		Source:      string(models.RaffleSourceExtensionButton),
+		Eligible:    true,
+	}
+
+	var joinErr error
+	if raffle.Mode == models.RaffleModeSubscribers {
+		var broadcasterAP models.AuthProvider
+		if err := db.Where("user_id = ? AND provider = ?", raffle.UserID, models.ProviderTwitch).First(&broadcasterAP).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, ErrTwitchTokenMissing
+			}
+			return nil, err
+		}
+		accessToken, err := s.decryptedProviderAccessToken(&broadcasterAP)
+		if err != nil {
+			return nil, err
+		}
+		if accessToken == "" {
+			s.clearProviderTokensContext(ctx, broadcasterAP.ID)
+			return nil, ErrTwitchTokenMissing
+		}
+		if broadcasterAP.TokenExpiresAt != nil && time.Now().After(*broadcasterAP.TokenExpiresAt) {
+			s.clearProviderTokensContext(ctx, broadcasterAP.ID)
+			return nil, ErrTwitchTokenMissing
+		}
+		ok, err := s.fetchTwitchSubscription(ctx, accessToken, broadcasterAP.ProviderID, twitchUserID)
+		if err != nil {
+			if errors.Is(err, ErrTwitchInsufficientScope) {
+				s.clearProviderTokensContext(ctx, broadcasterAP.ID)
+			}
+			return nil, err
+		}
+		if !ok {
+			entry.Eligible = false
+			entry.IneligibleReason = "not_subscriber"
+			joinErr = ErrNotSubscriber
+		}
+	}
+
+	res := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "raffle_id"}, {Name: "twitch_login"}},
+		DoNothing: true,
+	}).Create(entry)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, ErrAlreadyJoined
+	}
+	return entry, joinErr
 }
 
 func (s *RaffleService) fetchTwitchSubsPage(ctx context.Context, accessToken, broadcasterID, cursor string) ([]twitchSubscription, string, error) {

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -753,9 +753,8 @@ func (s *RaffleService) JoinRaffle(ctx context.Context, raffleID uuid.UUID, twit
 			return nil, err
 		}
 		if !ok {
-			entry.Eligible = false
-			entry.IneligibleReason = "not_subscriber"
-			joinErr = ErrNotSubscriber
+			// 非訂閱者不寫入 DB，直接拒絕
+			return nil, ErrNotSubscriber
 		}
 	}
 


### PR DESCRIPTION
## 什麼改動
新增 `POST /extension/raffles/:id/join` endpoint，讓觀眾透過 Twitch Extension JWT 報名抽獎。

## 為什麼
closes #987

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#987
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 `!join` 聊天指令報名
  - 不做訂閱者快取（SubscriptionSnapshot）
  - 不做黑名單機制

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：#987
- Actual worker profile(s)：controller
- Model strength：high
- Spawn directive(s)：profile=controller model=claude-sonnet-4-6 reasoning=medium controller_fallback=claude-code
- Verification evidence：`docker compose run --no-deps --rm app go test ./internal/handlers/... -run "TestRaffle" -count=1` — 全 PASS；`go build ./...` 通過
- Self-review / exception reason：Claude Code controller reviewed diff；修正 token 到期邏輯、JWT 401 回應碼、Snapshot handler 403 regression、fetchTwitchSubscription 401/403 區分、RaffleEntry NOT NULL schema mismatch
- Worker session closeout：controller session closed；無 stale handles
- Workflow friction / follow-up split：n/a

## Review conversation closeout
- Unresolved threads：0
- CodeRabbit：reviewed at latest head；5 findings addressed
- chatgpt-codex-connector：n/a
- review_triage_ref：Claude Code controller review — all 5 CodeRabbit findings addressed at head de5c13a
- root_cause_gate_ref：CRLF/LF line-ending mismatch root-caused and resolved by clean rebase at de5c13a
- finding_disposition_ref：5 findings adopted (403 regression fix, 401/403 distinction, NOT NULL revert, test clarity, schema alignment)
- Final reviewer action：all findings fixed at latest head

## Final merge gate
- Ready-to-merge decision：ready (pending CI green)
- Latest head SHA：de5c13a
- Required checks：pending
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：新增 Extension 報名 API，Mode 1 直接寫入、Mode 2 即時驗證訂閱資格
- Approx changed lines：~545
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [x] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service + handler + router 是同一個 endpoint 的不可分割層；tests 屬於完成條件要求
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] `POST /extension/raffles/:id/join` endpoint 實作
- [x] Mode 1 觀眾可成功報名
- [x] Mode 2 訂閱者可報名
- [x] Mode 2 非訂閱者收到 403 + `not_subscriber`
- [x] 重複報名收到 409
- [x] entry_open=false 收到 400
- [x] 相關測試全過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
ok  github.com/tachigo/tachigo/internal/handlers  4.288s
go build ./...  成功（545 行差分，無 CRLF 雜訊）
```

## 備註
- `TwitchLogin` 欄位目前存 Twitch user_id，正確 login name 需額外呼叫 `/helix/users`，已記錄為 follow-up
- 先前 PR #1008 因 CRLF/LF 行尾差異導致 diff 暴增（8383 行）被 Scope Police 關閉；此 PR 已 rebase 乾淨

## Notes for Claude Code Review
- `fetchTwitchSubscription`：401 → `ErrTwitchTokenMissing`，403 → `ErrTwitchInsufficientScope`
- `RaffleEntry.Source`/`IneligibleReason` 保持 nullable，與 migration 022 一致
- Snapshot handler 的 `ErrTwitchInsufficientScope` 維持 403 + `twitch_reauth_required`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 新增扩展端加入抽奖的公开 POST 接口，扩展用户可加入抽奖（支持公开与仅订阅者模式，包含订阅验证、冲突处理与错误映射）。
* **文档更新**
  * 补充并发布该扩展加入接口的 API 文档、请求/响应示例及相关状态码说明。
* **模型**
  * 增加抽奖来源枚举以支持扩展按钮来源。
* **测试**
  * 新增端到端与单元测试，覆盖成功、订阅校验、重复加入与入口已关闭等场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->