### PR TITLE
[backend] gate OAuth email auto-link

### DIFF
--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -143,6 +143,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }
@@ -584,6 +590,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -137,6 +137,12 @@
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
                     }
                 }
             }
@@ -578,6 +584,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/handlers.Response"
                         }

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -458,6 +458,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.Response'
       summary: Google OAuth callback
       tags:
       - auth
@@ -722,6 +726,10 @@ paths:
             $ref: '#/definitions/handlers.Response'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/handlers.Response'
       summary: Twitch OAuth callback

--- a/services/api/internal/handlers/auth_handler.go
+++ b/services/api/internal/handlers/auth_handler.go
@@ -211,6 +211,7 @@ func (h *AuthHandler) TwitchLogin(c *gin.Context) {
 // @Success      302
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
+// @Failure      409  {object}  Response
 // @Router       /auth/twitch/callback [get]
 func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 	if err := validateOAuthState(c); err != nil {
@@ -226,7 +227,7 @@ func (h *AuthHandler) TwitchCallback(c *gin.Context) {
 	code := c.Query("code")
 	user, tokens, err := h.auth.TwitchCallback(c.Request.Context(), code)
 	if err != nil {
-		internal(c)
+		h.handleOAuthCallbackError(c, err)
 		return
 	}
 
@@ -259,6 +260,7 @@ func (h *AuthHandler) GoogleLogin(c *gin.Context) {
 // @Success      200  {object}  Response{data=AuthResponse}
 // @Failure      400  {object}  Response
 // @Failure      401  {object}  Response
+// @Failure      409  {object}  Response
 // @Router       /auth/google/callback [get]
 func (h *AuthHandler) GoogleCallback(c *gin.Context) {
 	if err := validateOAuthState(c); err != nil {
@@ -271,7 +273,7 @@ func (h *AuthHandler) GoogleCallback(c *gin.Context) {
 	code := c.Query("code")
 	user, tokens, err := h.auth.GoogleCallback(c.Request.Context(), code)
 	if err != nil {
-		internal(c)
+		h.handleOAuthCallbackError(c, err)
 		return
 	}
 
@@ -488,6 +490,14 @@ func (h *AuthHandler) refreshTokenFromRequest(c *gin.Context) (string, error) {
 		return "", errors.New("refresh token is required")
 	}
 	return body.RefreshToken, nil
+}
+
+func (h *AuthHandler) handleOAuthCallbackError(c *gin.Context, err error) {
+	if errors.Is(err, services.ErrEmailExists) {
+		conflict(c, "email already registered")
+		return
+	}
+	internal(c)
 }
 
 func (h *AuthHandler) setRefreshCookie(c *gin.Context, refreshToken string) {

--- a/services/api/internal/handlers/auth_handler_test.go
+++ b/services/api/internal/handlers/auth_handler_test.go
@@ -865,6 +865,25 @@ func (mockTwitchRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}, nil
 }
 
+type mockGoogleRoundTripper struct{}
+
+func (mockGoogleRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+	switch {
+	case strings.Contains(req.URL.Host, "oauth2.googleapis.com"):
+		body = `{"access_token":"mock-google-token","token_type":"Bearer","expires_in":3600}`
+	case strings.Contains(req.URL.Host, "www.googleapis.com"):
+		body = `{"sub":"google-user-1","name":"Mock Google User","email":"mock@example.com","email_verified":false,"picture":"https://example.com/avatar.png"}`
+	default:
+		return nil, fmt.Errorf("unexpected Google OAuth request: %s", req.URL)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
 // ─── TwitchCallback redirect ─────────────────────────────────────────────────
 
 func TestTwitchCallback_WithRedirectCookie_Redirects(t *testing.T) {
@@ -938,6 +957,48 @@ func TestTwitchCallback_WithoutRedirectCookie_ReturnsJSON(t *testing.T) {
 	resp := parseBody(t, w.Body.Bytes())
 	if resp["success"] != true {
 		t.Errorf("want success: true")
+	}
+}
+
+func TestTwitchCallback_UnverifiedProviderEmailMatchingExistingUser_ReturnsConflict(t *testing.T) {
+	env := newTestEnv(t)
+	env.registerUser(t, "existing-oauth", "mock@example.com", "password123")
+	httpClient := &http.Client{Transport: mockTwitchRoundTripper{}}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+
+	state := "twitch-conflict-state"
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/twitch/callback?code=mockcode&state="+state, nil).WithContext(ctx)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: state, Path: "/"})
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if resp["error"] != "email already registered" {
+		t.Fatalf("want email already registered, got %#v", resp["error"])
+	}
+}
+
+func TestGoogleCallback_UnverifiedProviderEmailMatchingExistingUser_ReturnsConflict(t *testing.T) {
+	env := newTestEnv(t)
+	env.registerUser(t, "existing-google", "mock@example.com", "password123")
+	httpClient := &http.Client{Transport: mockGoogleRoundTripper{}}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+
+	state := "google-conflict-state"
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/google/callback?code=mockcode&state="+state, nil).WithContext(ctx)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: state, Path: "/"})
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w.Body.Bytes())
+	if resp["error"] != "email already registered" {
+		t.Fatalf("want email already registered, got %#v", resp["error"])
 	}
 }
 

--- a/services/api/internal/services/auth_service.go
+++ b/services/api/internal/services/auth_service.go
@@ -283,7 +283,7 @@ func (s *AuthService) TwitchCallback(ctx context.Context, code string) (*models.
 		return nil, nil, err
 	}
 
-	return s.upsertOAuthUser(ctx, models.ProviderTwitch, info.ID, info.Login, info.Email, info.ProfileURL, token)
+	return s.upsertOAuthUser(ctx, models.ProviderTwitch, info.ID, info.Login, info.Email, false, info.ProfileURL, token)
 }
 
 // ─── Google OAuth ────────────────────────────────────────────────────────────
@@ -303,7 +303,7 @@ func (s *AuthService) GoogleCallback(ctx context.Context, code string) (*models.
 		return nil, nil, err
 	}
 
-	return s.upsertOAuthUser(ctx, models.ProviderGoogle, info.Sub, info.Name, info.Email, &info.Picture, token)
+	return s.upsertOAuthUser(ctx, models.ProviderGoogle, info.Sub, info.Name, info.Email, info.EmailVerified, &info.Picture, token)
 }
 
 // ─── Web3 / SIWE ─────────────────────────────────────────────────────────────
@@ -393,7 +393,7 @@ func (s *AuthService) Web3VerifyContext(ctx context.Context, input Web3VerifyInp
 		txSvc := *s
 		txSvc.db = tx
 		var err error
-		user, tokens, err = txSvc.upsertOAuthUser(ctx, models.ProviderWeb3, checksumAddr, "", "", nil, nil)
+		user, tokens, err = txSvc.upsertOAuthUser(ctx, models.ProviderWeb3, checksumAddr, "", "", false, nil, nil)
 		return err
 	}); err != nil {
 		return nil, nil, err
@@ -499,16 +499,18 @@ func (s *AuthService) issueTokenPairContext(ctx context.Context, user *models.Us
 // ─── OAuth upsert helper ─────────────────────────────────────────────────────
 
 type googleUserInfo struct {
-	Sub     string `json:"sub"`
-	Name    string `json:"name"`
-	Email   string `json:"email"`
-	Picture string `json:"picture"`
+	Sub           string `json:"sub"`
+	Name          string `json:"name"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Picture       string `json:"picture"`
 }
 
 func (s *AuthService) upsertOAuthUser(
 	ctx context.Context,
 	provider models.ProviderType,
 	providerID, username, email string,
+	providerEmailVerified bool,
 	avatarURL *string,
 	token *oauth2.Token,
 ) (*models.User, *TokenPair, error) {
@@ -516,7 +518,7 @@ func (s *AuthService) upsertOAuthUser(
 		ctx = context.Background()
 	}
 
-	user, tokens, err := s.upsertOAuthUserInTransaction(s.db.WithContext(ctx), provider, providerID, username, email, avatarURL, token)
+	user, tokens, err := s.upsertOAuthUserInTransaction(s.db.WithContext(ctx), provider, providerID, username, email, providerEmailVerified, avatarURL, token)
 	if err == nil {
 		return user, tokens, nil
 	}
@@ -534,7 +536,7 @@ func (s *AuthService) upsertOAuthUser(
 
 	mappedErr := s.mapOAuthUserUniqueError(ctx, username, email, err)
 	if username != "" && errors.Is(mappedErr, ErrUsernameExists) {
-		return s.upsertOAuthUser(ctx, provider, providerID, "", email, avatarURL, token)
+		return s.upsertOAuthUser(ctx, provider, providerID, "", email, providerEmailVerified, avatarURL, token)
 	}
 	return nil, nil, mappedErr
 }
@@ -543,13 +545,14 @@ func (s *AuthService) upsertOAuthUserInTransaction(
 	db *gorm.DB,
 	provider models.ProviderType,
 	providerID, username, email string,
+	providerEmailVerified bool,
 	avatarURL *string,
 	token *oauth2.Token,
 ) (*models.User, *TokenPair, error) {
 	var user *models.User
 	var tokens *TokenPair
 	err := db.Transaction(func(tx *gorm.DB) error {
-		txUser, txTokens, err := s.upsertOAuthUserTx(tx, provider, providerID, username, email, avatarURL, token)
+		txUser, txTokens, err := s.upsertOAuthUserTx(tx, provider, providerID, username, email, providerEmailVerified, avatarURL, token)
 		if err != nil {
 			return err
 		}
@@ -564,6 +567,7 @@ func (s *AuthService) upsertOAuthUserTx(
 	tx *gorm.DB,
 	provider models.ProviderType,
 	providerID, username, email string,
+	providerEmailVerified bool,
 	avatarURL *string,
 	token *oauth2.Token,
 ) (*models.User, *TokenPair, error) {
@@ -582,11 +586,15 @@ func (s *AuthService) upsertOAuthUserTx(
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil, err
 		}
+		if err == nil && !providerEmailVerified {
+			return nil, nil, ErrEmailExists
+		}
 	}
 
 	if user.ID == uuid.Nil {
 		if email != "" {
 			user.Email = &email
+			user.EmailVerified = providerEmailVerified
 		}
 		if username != "" {
 			user.Username = &username

--- a/services/api/internal/services/auth_service_test.go
+++ b/services/api/internal/services/auth_service_test.go
@@ -85,6 +85,7 @@ func TestOAuthUser_PersistsOnlyEncryptedTwitchAccessToken(t *testing.T) {
 		"twitch-broadcaster-1",
 		"twitch-user",
 		"twitch-user@example.com",
+		false,
 		nil,
 		&oauth2.Token{
 			AccessToken:  "plain-access-token",
@@ -142,6 +143,7 @@ func TestOAuthUser_DoesNotPersistUnusedGoogleTokens(t *testing.T) {
 		"google-user-1",
 		"google-user",
 		"google-user@example.com",
+		true,
 		nil,
 		&oauth2.Token{
 			AccessToken:  "google-access-token",
@@ -165,6 +167,182 @@ func TestOAuthUser_DoesNotPersistUnusedGoogleTokens(t *testing.T) {
 	}
 	if ap.TokenExpiresAt != nil {
 		t.Fatalf("google token expiry should not be persisted, got %v", ap.TokenExpiresAt)
+	}
+}
+
+func TestUpsertOAuthUser_UnverifiedProviderEmailMatchingExistingUserDoesNotLinkOrIssueTokens(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	email := "existing-oauth@example.com"
+	username := "existing-oauth"
+	if err := db.Create(&models.User{
+		Email:    &email,
+		Username: &username,
+		Role:     models.RoleViewer,
+	}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	user, tokens, err := svc.upsertOAuthUser(
+		context.Background(),
+		models.ProviderGoogle,
+		"google-unverified-existing",
+		"google-user",
+		email,
+		false,
+		nil,
+		&oauth2.Token{AccessToken: "google-access-token"},
+	)
+	if !errors.Is(err, ErrEmailExists) {
+		t.Fatalf("want ErrEmailExists, got %v (user=%#v tokens=%#v)", err, user, tokens)
+	}
+
+	var providerCount int64
+	if err := db.Model(&models.AuthProvider{}).
+		Where("provider = ? AND provider_id = ?", models.ProviderGoogle, "google-unverified-existing").
+		Count(&providerCount).Error; err != nil {
+		t.Fatalf("count auth providers: %v", err)
+	}
+	if providerCount != 0 {
+		t.Fatalf("auth provider should not be created, got %d rows", providerCount)
+	}
+
+	var tokenCount int64
+	if err := db.Model(&models.RefreshToken{}).Count(&tokenCount).Error; err != nil {
+		t.Fatalf("count refresh tokens: %v", err)
+	}
+	if tokenCount != 0 {
+		t.Fatalf("refresh token should not be created, got %d rows", tokenCount)
+	}
+}
+
+func TestUpsertOAuthUser_VerifiedProviderEmailMatchingExistingUserLinksAccount(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	email := "verified-existing@example.com"
+	username := "verified-existing"
+	existingUser := models.User{
+		Email:    &email,
+		Username: &username,
+		Role:     models.RoleViewer,
+	}
+	if err := db.Create(&existingUser).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	user, tokens, err := svc.upsertOAuthUser(
+		context.Background(),
+		models.ProviderGoogle,
+		"google-verified-existing",
+		"google-user",
+		email,
+		true,
+		nil,
+		&oauth2.Token{AccessToken: "google-access-token"},
+	)
+	if err != nil {
+		t.Fatalf("upsertOAuthUser: %v", err)
+	}
+	if user == nil || user.ID != existingUser.ID {
+		t.Fatalf("expected existing user %s, got %#v", existingUser.ID, user)
+	}
+	if tokens == nil || tokens.AccessToken == "" || tokens.RefreshToken == "" {
+		t.Fatalf("expected token pair, got %#v", tokens)
+	}
+
+	var providerCount int64
+	if err := db.Model(&models.AuthProvider{}).
+		Where("user_id = ? AND provider = ? AND provider_id = ?", existingUser.ID, models.ProviderGoogle, "google-verified-existing").
+		Count(&providerCount).Error; err != nil {
+		t.Fatalf("count auth providers: %v", err)
+	}
+	if providerCount != 1 {
+		t.Fatalf("expected linked auth provider, got %d rows", providerCount)
+	}
+}
+
+func TestUpsertOAuthUser_LocalVerifiedEmailStillRejectsUnverifiedProviderLink(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	email := "local-verified@example.com"
+	username := "local-verified"
+	existingUser := models.User{
+		Email:         &email,
+		Username:      &username,
+		Role:          models.RoleViewer,
+		EmailVerified: true,
+	}
+	if err := db.Create(&existingUser).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	user, tokens, err := svc.upsertOAuthUser(
+		context.Background(),
+		models.ProviderTwitch,
+		"twitch-local-verified",
+		"twitch-user",
+		email,
+		false,
+		nil,
+		&oauth2.Token{AccessToken: "twitch-access-token"},
+	)
+	if !errors.Is(err, ErrEmailExists) {
+		t.Fatalf("want ErrEmailExists, got %v (user=%#v tokens=%#v)", err, user, tokens)
+	}
+
+	var providerCount int64
+	if err := db.Model(&models.AuthProvider{}).
+		Where("user_id = ? AND provider = ? AND provider_id = ?", existingUser.ID, models.ProviderTwitch, "twitch-local-verified").
+		Count(&providerCount).Error; err != nil {
+		t.Fatalf("count auth providers: %v", err)
+	}
+	if providerCount != 0 {
+		t.Fatalf("auth provider should not be created, got %d rows", providerCount)
+	}
+
+	var tokenCount int64
+	if err := db.Model(&models.RefreshToken{}).Count(&tokenCount).Error; err != nil {
+		t.Fatalf("count refresh tokens: %v", err)
+	}
+	if tokenCount != 0 {
+		t.Fatalf("refresh token should not be created, got %d rows", tokenCount)
+	}
+}
+
+func TestUpsertOAuthUser_NewVerifiedGoogleUserPersistsEmailVerifiedTrue(t *testing.T) {
+	db := newTestDB(t)
+	svc := NewAuthService(db, testConfig())
+
+	email := "new-verified-google@example.com"
+	user, tokens, err := svc.upsertOAuthUser(
+		context.Background(),
+		models.ProviderGoogle,
+		"google-new-verified",
+		"new-verified-google",
+		email,
+		true,
+		nil,
+		&oauth2.Token{AccessToken: "google-access-token"},
+	)
+	if err != nil {
+		t.Fatalf("upsertOAuthUser: %v", err)
+	}
+	if user == nil || tokens == nil {
+		t.Fatalf("expected user and tokens, got user=%#v tokens=%#v", user, tokens)
+	}
+	if !user.EmailVerified {
+		t.Fatalf("returned user should be email verified")
+	}
+
+	var persisted models.User
+	if err := db.First(&persisted, "id = ?", user.ID).Error; err != nil {
+		t.Fatalf("load user: %v", err)
+	}
+	if !persisted.EmailVerified {
+		t.Fatalf("persisted user should be email verified")
 	}
 }
 
@@ -248,6 +426,7 @@ func TestUpsertOAuthUser_DuplicateUsernameCreatesUserWithoutUsername(t *testing.
 		"google-duplicate-username",
 		takenUsername,
 		"oauth-new@example.com",
+		true,
 		nil,
 		&oauth2.Token{AccessToken: "google-access-token"},
 	)
@@ -1076,6 +1255,7 @@ func TestUpsertOAuthUser_ExistingProviderSaveFailureReturnsError(t *testing.T) {
 		"google-existing-provider",
 		"existing-user",
 		"existing@example.com",
+		true,
 		nil,
 		&oauth2.Token{
 			AccessToken:  "new-access-token",

--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -142,7 +142,7 @@ func (s *ExtensionService) loginOrCreateExtensionUserContext(ctx context.Context
 		return nil, nil, ErrInvalidExtJWT
 	}
 
-	return s.authSvc.upsertOAuthUser(ctx, models.ProviderTwitch, claims.UserID, "", "", nil, nil)
+	return s.authSvc.upsertOAuthUser(ctx, models.ProviderTwitch, claims.UserID, "", "", false, nil, nil)
 }
 
 func (s *ExtensionService) LoginWithExtension(extJWT string) (*models.User, *TokenPair, error) {


### PR DESCRIPTION
## 什麼改動

在 OAuth email auto-link 路徑加入 email ownership gate：只有 provider 明確回傳 verified email 時，才允許用 email 命中既有帳號並自動連結；未驗證 provider email 命中既有帳號時穩定回 `ErrEmailExists`，不建立 `AuthProvider`、不發 token。

Google userinfo 現在會解析 `email_verified` 並傳入 upsert；Twitch / Web3 沒有 provider email verified 訊號，因此不會靠 email 自動連結既有帳號。新建 OAuth user 時會依 provider verified 訊號設定 `EmailVerified`。

## 為什麼

closes #951

避免 OAuth provider 回傳未驗證 email 時，被用來自動連結到同 email 的既有 tachigo 帳號，造成 pre-account-takeover 風險。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#951
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不實作手動連結帳號 UI / flow
  - 不做 Twitch OIDC migration
  - 不改其他 provider 的整體登入流程
  - 不處理 auth_service 的其他 DB error / refactor
  - 不新增 DB schema 或 migration

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #951 Issue Delegation Plan 已補入 issue body：https://github.com/nurockplayer/tachigo/issues/951
- Actual worker profile(s)：
  - ops_spark readback：open PR / issue metadata scan
  - backend_worker：bounded patch in `services/api/internal/services/auth_service.go` and focused tests
  - controller：auth/security decision, scope, diff review, validation, PR body, merge gate
- Model strength：
  - ops_spark = medium；backend_worker = high；controller = high
- Spawn directive(s)：
  - profile=ops_spark model=gpt-5.3-codex-spark reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=backend_worker model=gpt-5.4 reasoning=high controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `go test ./internal/services -run 'TestOAuthUser|TestUpsertOAuthUser'` pass
  - `go test ./...` pass from `services/api`
  - `git diff --check` pass
  - `docker compose run --no-deps --rm app go test ./...` not run: Docker / OrbStack socket unavailable locally
- Self-review / exception reason：
  - Controller reviewed worker patch and tightened the security gate so local `EmailVerified` alone does not authorize an unverified provider email auto-link.
- Worker session closeout：
  - ops_spark and backend_worker results were read back; no further worker task is needed and sessions were closed.
- Workflow friction / follow-up split：
  - `spec workflow-check` was attempted but tachigo repo lacks `.spec-injector/` config; used manual AWP checklist fallback. No #664 threshold ledger comment needed because routine threshold calibration has converged.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - not_run_at_creation; await automated review on PR head
- chatgpt-codex-connector：
  - not_run_at_creation; await automated review on PR head
- review_triage_ref：
  - not_applicable_at_creation_no_review_findings
- root_cause_gate_ref：
  - local_controller_security_readback: provider verified signal is required for existing-email auto-link; local EmailVerified alone is insufficient
- finding_disposition_ref：
  - local:/tmp/tachigo-951-finding-disposition.json status=not_applicable_at_creation
- Final reviewer action：
  - human security review required; R4 PR intentionally does not use auto-ready

## Final merge gate
- Ready-to-merge decision：
  - not ready: waiting for GitHub checks, automated review, and human security review
- Latest head SHA：
  - n/a before first push
- Required checks：
  - local tests pass; GitHub checks not run until PR opens
- spec workflow-check evidence：
  - start gate attempted; status=tool_gap_config_missing (`.spec-injector/` absent). Manual checklist fallback used; no `.spec-injector/` artifacts committed.
- Evidence URL：
  - n/a before first PR checks

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 防止未驗證 OAuth provider email 自動連結到既有 tachigo 帳號。
- Approx changed lines：~200
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 安全 gate 與 regression tests 必須同 PR 才能證明 #951 行為。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 未驗證 email 不會觸發自動帳號連結
- [x] 連結策略在 PR body 說明清楚
- [x] 有測試覆蓋接管情境
- [ ] `docker compose run --no-deps --rm app go test ./...` 通過（local Docker / OrbStack socket unavailable；已執行 `go test ./...`）

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
go test ./internal/services -run 'TestOAuthUser|TestUpsertOAuthUser'
ok  github.com/tachigo/tachigo/internal/services  0.438s

go test ./...
ok  github.com/tachigo/tachigo/cmd/loader
ok  github.com/tachigo/tachigo/cmd/server
ok  github.com/tachigo/tachigo/docs
ok  github.com/tachigo/tachigo/internal/config
ok  github.com/tachigo/tachigo/internal/contract
ok  github.com/tachigo/tachigo/internal/handlers
ok  github.com/tachigo/tachigo/internal/metrics
ok  github.com/tachigo/tachigo/internal/middleware
ok  github.com/tachigo/tachigo/internal/models
ok  github.com/tachigo/tachigo/internal/router
ok  github.com/tachigo/tachigo/internal/services
ok  github.com/tachigo/tachigo/internal/tracing

git diff --check
pass

docker compose run --no-deps --rm app go test ./...
not run: failed to connect to Docker / OrbStack socket at /Users/erickwang/.orbstack/run/docker.sock
```

## 備註
本 PR 採較保守策略：本地 `EmailVerified=true` 不能單獨證明 incoming provider email ownership；provider 必須明確回傳 verified email，才可用 email 自動 link 既有帳號。

## Notes for Claude Code Review
- 請特別看 `upsertOAuthUserTx` 對既有 email 的 gate：Twitch Helix 沒有 `email_verified`，因此同 email 既有帳號會回 `ErrEmailExists` 而不是自動 link。
- `ErrEmailExists` 是刻意沿用既有穩定錯誤，不新增 public error surface。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了第三方账号关联时的邮箱验证逻辑。未验证的第三方邮箱将不再与现有账户关联；已验证的第三方邮箱可正常关联现有账户。
  * 优化了新账户创建时的邮箱验证状态处理，确保从第三方提供商获取的验证信息被正确保存。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->