### PR TITLE
[frontend] add account panel

### DIFF
--- a/apps/extension/src/app/components/AccountPanel.tsx
+++ b/apps/extension/src/app/components/AccountPanel.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react'
+
+import { getCurrentAccount, type CurrentAccount } from '../../services/api'
+
+interface AccountPanelProps {
+  onBack: () => void
+}
+
+type AccountState =
+  | { status: 'loading'; account?: undefined; error?: undefined }
+  | { status: 'success'; account: CurrentAccount; error?: undefined }
+  | { status: 'error'; account?: undefined; error: string }
+
+const panelStyle = {
+  width: 320,
+  height: 600,
+  display: 'flex',
+  flexDirection: 'column',
+  color: '#e0f2fe',
+  background: '#08111f',
+  fontFamily: 'var(--pixel-font-family)',
+  overflow: 'hidden',
+  position: 'relative',
+} as const
+
+const backButtonStyle = {
+  background: 'none',
+  border: 'none',
+  color: '#38bdf8',
+  cursor: 'pointer',
+  fontSize: 8,
+  letterSpacing: 0,
+  padding: 0,
+  fontFamily: 'var(--pixel-font-family)',
+} as const
+
+const detailCardStyle = {
+  border: '1px solid rgba(56,189,248,0.24)',
+  borderRadius: 8,
+  padding: '12px 14px',
+  background: 'rgba(15,23,42,0.72)',
+  display: 'grid',
+  gap: 6,
+} as const
+
+function formatAccountName(account: CurrentAccount) {
+  return account.username ?? account.email ?? account.id
+}
+
+function formatActiveStatus(account: CurrentAccount) {
+  if (account.isActive === null) {
+    return null
+  }
+
+  return account.isActive ? 'Active' : 'Inactive'
+}
+
+function formatEmailVerified(account: CurrentAccount) {
+  if (account.emailVerified === null) {
+    return null
+  }
+
+  return account.emailVerified ? 'Email verified' : 'Email not verified'
+}
+
+export function AccountPanel({ onBack }: AccountPanelProps) {
+  const [state, setState] = useState<AccountState>({ status: 'loading' })
+
+  useEffect(() => {
+    let isMounted = true
+
+    getCurrentAccount()
+      .then((account) => {
+        if (isMounted) {
+          setState({ status: 'success', account })
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setState({ status: 'error', error: 'Could not load account' })
+        }
+      })
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return (
+    <div style={panelStyle}>
+      <div
+        style={{
+          padding: '14px 16px 12px',
+          borderBottom: '1px solid rgba(56,189,248,0.18)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <button type="button" onClick={onBack} style={backButtonStyle}>
+          Back
+        </button>
+        <div style={{ fontSize: 8, color: '#7dd3fc', letterSpacing: 0 }}>ACCOUNT</div>
+      </div>
+
+      <div style={{ padding: 16, display: 'grid', gap: 12 }}>
+        {state.status === 'loading' ? (
+          <div role="status" aria-live="polite" style={detailCardStyle}>
+            Loading account
+          </div>
+        ) : state.status === 'error' ? (
+          <div style={{ display: 'grid', gap: 12 }}>
+            <div role="alert" style={detailCardStyle}>
+              {state.error}
+            </div>
+            <button type="button" onClick={onBack} style={{ ...backButtonStyle, justifySelf: 'start' }}>
+              Close
+            </button>
+          </div>
+        ) : (
+          <>
+            <section style={{ ...detailCardStyle, gap: 10 }}>
+              <div style={{ fontSize: 7, color: '#7dd3fc', letterSpacing: 0 }}>PROFILE</div>
+              <div style={{ color: '#f8fafc', fontSize: 18, lineHeight: 1.2 }}>{formatAccountName(state.account)}</div>
+              {state.account.email && (
+                <div style={{ color: '#bae6fd', fontSize: 8, lineHeight: 1.5 }}>{state.account.email}</div>
+              )}
+            </section>
+
+            <section style={detailCardStyle}>
+              <div style={{ fontSize: 7, color: '#7dd3fc', letterSpacing: 0 }}>ACCOUNT ROLE</div>
+              <div style={{ color: '#f8fafc', fontSize: 14 }}>{state.account.role}</div>
+            </section>
+
+            {(formatActiveStatus(state.account) || formatEmailVerified(state.account)) && (
+              <section style={detailCardStyle}>
+                <div style={{ fontSize: 7, color: '#7dd3fc', letterSpacing: 0 }}>STATUS</div>
+                {formatActiveStatus(state.account) && (
+                  <div style={{ color: '#f8fafc', fontSize: 10 }}>{formatActiveStatus(state.account)}</div>
+                )}
+                {formatEmailVerified(state.account) && (
+                  <div style={{ color: '#f8fafc', fontSize: 10 }}>{formatEmailVerified(state.account)}</div>
+                )}
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/extension/src/app/navigation/OverlayHost.test.tsx
+++ b/apps/extension/src/app/navigation/OverlayHost.test.tsx
@@ -1,10 +1,17 @@
 // @vitest-environment jsdom
-import { afterEach, expect, test } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { NavigationProvider } from './NavigationProvider'
 import { OverlayHost } from './OverlayHost'
 import { useNavigation } from './useNavigation'
+import { getCurrentAccount } from '../../services/api'
+
+vi.mock('../../services/api', () => ({
+  getCurrentAccount: vi.fn(),
+}))
+
+const getCurrentAccountMock = vi.mocked(getCurrentAccount)
 
 function Harness() {
   const { state, pushOverlay } = useNavigation()
@@ -30,6 +37,7 @@ function Harness() {
 
 afterEach(() => {
   cleanup()
+  getCurrentAccountMock.mockReset()
 })
 
 test('menu hub exposes all MVP destination buttons and opens a panel', () => {
@@ -48,4 +56,53 @@ test('menu hub exposes all MVP destination buttons and opens a panel', () => {
   fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
 
   expect(screen.getByLabelText('top overlay').textContent).toBe('settings')
+})
+
+test('account overlay renders current account details and closes with back', async () => {
+  getCurrentAccountMock.mockResolvedValue({
+    id: 'user-1',
+    username: 'mika',
+    email: 'mika@example.com',
+    role: 'streamer',
+    isActive: true,
+    emailVerified: false,
+  })
+
+  render(
+    <NavigationProvider>
+      <Harness />
+    </NavigationProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'open menu' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Account' }))
+
+  expect(screen.getAllByRole('status').some((node) => node.textContent?.includes('Loading account'))).toBe(true)
+  expect(await screen.findByText('mika')).toBeTruthy()
+  expect(screen.getByText('mika@example.com')).toBeTruthy()
+  expect(screen.getByText('streamer')).toBeTruthy()
+  expect(screen.getByText('Active')).toBeTruthy()
+  expect(screen.getByText('Email not verified')).toBeTruthy()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('top overlay').textContent).toBe('menu')
+  })
+})
+
+test('account overlay renders an error state when the current account fetch fails', async () => {
+  getCurrentAccountMock.mockRejectedValue(new Error('network down'))
+
+  render(
+    <NavigationProvider>
+      <Harness />
+    </NavigationProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'open menu' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Account' }))
+
+  expect((await screen.findByRole('alert')).textContent).toContain('Could not load account')
+  expect(screen.getAllByRole('button', { name: 'Close' }).length).toBeGreaterThan(0)
 })

--- a/apps/extension/src/app/navigation/OverlayHost.tsx
+++ b/apps/extension/src/app/navigation/OverlayHost.tsx
@@ -1,3 +1,4 @@
+import { AccountPanel } from '../components/AccountPanel'
 import { ClaimPanel } from '../components/ClaimPanel'
 import { CouponShopPanel } from '../components/CouponShopPanel'
 import { RaffleResultPanel } from '../components/RaffleResultPanel'
@@ -212,6 +213,8 @@ export function OverlayHost({
             )
           ) : entry.kind === 'menu' ? (
             <MenuOverlay />
+          ) : entry.kind === 'account' ? (
+            <AccountPanel onBack={popOverlay} />
           ) : (
             <PlaceholderSurface
               eyebrow="Dev-only"

--- a/apps/extension/src/services/api.test.ts
+++ b/apps/extension/src/services/api.test.ts
@@ -339,6 +339,113 @@ test('claimPoints claims viewer points then refreshes tachi balance', async () =
   )
 })
 
+test('getCurrentAccount fetches the current account profile through auth recovery', async () => {
+  let accountReads = 0
+
+  await withApiServer(
+    (requests) => async (req, res) => {
+      const body = await readJsonBody(req)
+      requests.push({
+        method: req.method ?? 'GET',
+        url: req.url ?? '/',
+        authorization: req.headers.authorization,
+        body,
+      })
+
+      if (req.method === 'POST' && req.url === '/api/v1/extension/auth/login') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true, data: { tokens: { access_token: 'refreshed-access-token' } } }))
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/api/v1/users/me') {
+        accountReads += 1
+        if (accountReads === 1) {
+          res.writeHead(401, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ success: false, error: 'expired' }))
+          return
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            success: true,
+            data: {
+              user: {
+                id: 'user-1',
+                username: 'mika',
+                email: 'mika@example.com',
+                role: 'streamer',
+                is_active: true,
+                email_verified: false,
+              },
+            },
+          }),
+        )
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ success: false, error: 'not found' }))
+    },
+    async (baseUrl, requests) => {
+      const originalBaseUrl = process.env.VITE_TACHIGO_API_URL
+      process.env.VITE_TACHIGO_API_URL = baseUrl
+
+      try {
+        vi.resetModules()
+        const api = await import('./api.ts')
+
+        api.setExtensionJwtForRecovery('extension-jwt')
+        api.setAuthToken('expired-access-token')
+
+        assert.deepEqual(await api.getCurrentAccount(), {
+          id: 'user-1',
+          username: 'mika',
+          email: 'mika@example.com',
+          role: 'streamer',
+          isActive: true,
+          emailVerified: false,
+        })
+        assert.deepEqual(
+          requests.map(({ method, url, authorization, body }) => ({
+            method,
+            url,
+            authorization,
+            body,
+          })),
+          [
+            {
+              method: 'GET',
+              url: '/api/v1/users/me',
+              authorization: 'Bearer expired-access-token',
+              body: null,
+            },
+            {
+              method: 'POST',
+              url: '/api/v1/extension/auth/login',
+              authorization: 'Bearer expired-access-token',
+              body: { extension_jwt: 'extension-jwt' },
+            },
+            {
+              method: 'GET',
+              url: '/api/v1/users/me',
+              authorization: 'Bearer refreshed-access-token',
+              body: null,
+            },
+          ],
+        )
+      } finally {
+        if (originalBaseUrl === undefined) {
+          delete process.env.VITE_TACHIGO_API_URL
+        } else {
+          process.env.VITE_TACHIGO_API_URL = originalBaseUrl
+        }
+      }
+    },
+  )
+})
+
 test('sendHeartbeat re-authenticates after 401 and falls back to previous balance when balance read fails', async () => {
   let heartbeatAttempts = 0
 

--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -156,6 +156,15 @@ interface PointBalanceResponse {
   cumulativeTotal: number
 }
 
+export interface CurrentAccount {
+  id: string
+  username: string | null
+  email: string | null
+  role: string
+  isActive: boolean | null
+  emailVerified: boolean | null
+}
+
 export interface RedeemCouponResponse {
   balance: number
   voucher_code: string
@@ -217,6 +226,34 @@ function parseTachiBalanceFromPayload(payload: unknown): number {
   return value
 }
 
+function parseCurrentAccountFromPayload(payload: unknown): CurrentAccount {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid account response')
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = payload as any
+  const user = raw.data?.user ?? raw.user ?? raw.data
+  if (!user || typeof user !== 'object') {
+    throw new Error('Account response missing user')
+  }
+
+  const id = user.id
+  const role = user.role
+  if (typeof id !== 'string' || typeof role !== 'string') {
+    throw new Error('Account response missing id or role')
+  }
+
+  return {
+    id,
+    username: typeof user.username === 'string' ? user.username : null,
+    email: typeof user.email === 'string' ? user.email : null,
+    role,
+    isActive: typeof user.is_active === 'boolean' ? user.is_active : null,
+    emailVerified: typeof user.email_verified === 'boolean' ? user.email_verified : null,
+  }
+}
+
 interface ClickResponse {
   balance: number
   delta: number
@@ -233,6 +270,12 @@ export async function getPointBalance(channelId: string): Promise<PointBalanceRe
   }))
 
   return parsePointBalanceFromPayload(data)
+}
+
+export async function getCurrentAccount(): Promise<CurrentAccount> {
+  const { data } = await runWithAuthRecovery((config) => client.get('/api/v1/users/me', config))
+
+  return parseCurrentAccountFromPayload(data)
 }
 
 export async function sendClick(channelId: string): Promise<ClickResponse> {


### PR DESCRIPTION
## 什麼改動
- 在 Twitch extension 前端新增 AccountPanel overlay，用來顯示目前登入帳號的基本資料與 account role。
- 新增 `/api/v1/users/me` 前端 client 與 auth recovery 測試。
- 將 `account` overlay route 接到 OverlayHost，補上 loading / success / error / back 行為測試。

## 為什麼
refs #747

#747 需要 account 帳號角色資訊面板。本 PR 只使用目前 develop 已存在的 `/api/v1/users/me` account contract 顯示帳號層級角色，不引入 ocean character / active character backend contract。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#747
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 ocean / character active character API 整合
  - 不做 character switch / settings panel
  - 不做 backend / schema / API contract 變更
  - 不新增圖片、影片、LFS asset 或相依套件

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #747 Issue Delegation Plan：https://github.com/nurockplayer/tachigo/issues/747#issuecomment-4587127354
- Actual worker profile(s)：
  - controller：scope 決策、spec gate、worker review、驗證、PR 發布
  - explorer worker：比較 #746 / #747 / #758 / #759，建議選 #747 作為安全小 PR
  - frontend worker：實作 AccountPanel、API client、OverlayHost wiring 與 focused tests
- Model strength：
  - controller = high；explorer / frontend worker = medium-high
- Spawn directive(s)：
  - profile=explorer model=gpt-5.3-codex-spark reasoning=medium controller_fallback=denied fallback_reason=n/a task=select-safe-frontend-issue issue_candidates=#746,#747,#758,#759
  - profile=frontend_worker model=gpt-5.3-codex reasoning=medium controller_fallback=denied fallback_reason=n/a task=implement-account-panel issue=#747 scope=apps/extension only
- Verification evidence：
  - `pnpm --dir apps/extension exec vitest run src/services/api.test.ts src/app/navigation/OverlayHost.test.tsx`
  - `pnpm --dir apps/extension exec tsc -b --pretty false`
  - `bash infra/scripts/check-typescript-only.sh --root .`
  - `rtk git --no-optional-locks diff --check`
  - `pnpm --dir apps/extension lint`
  - `pnpm --dir apps/extension test`
  - `pnpm --dir apps/extension build`
- Self-review / exception reason：
  - Controller reviewed the worker patch and tightened UI styling to keep `letterSpacing: 0`. RED phase was imperfect: initial local run was blocked by missing installed frontend deps, and the first executable test failure was a query ambiguity rather than the feature missing.
- Worker session closeout：
  - Explorer and frontend worker returned results; no additional worker task is needed for this head.
- Workflow friction / follow-up split：
  - spec-injector is present but this checkout has no `.spec-injector/` config, so `spec plan --dry-run` and `spec workflow-check` returned `missing_fields=config`. Manual delegation plan and local verification evidence were used for this small R2 PR. Threshold calibration ledger remains #664.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR open
- CodeRabbit：
  - Not reviewed yet at PR open
- chatgpt-codex-connector：
  - Not reviewed yet at PR open
- review_triage_ref：
  - Initial scope and worker triage recorded in #747 Issue Delegation Plan：https://github.com/nurockplayer/tachigo/issues/747#issuecomment-4587127354
- root_cause_gate_ref：
  - Latest-head rationale: scope intentionally uses existing account role from `/api/v1/users/me`; no ocean character contract is available in develop for this PR.
- finding_disposition_ref：
  - Initial disposition: no automated-review finding exists yet; local validation completed for latest head.
- Final reviewer action：
  - Awaiting GitHub CI and human / automated review.

## Final merge gate
- Ready-to-merge decision：
  - Blocked until GitHub CI and human / automated review complete.
- Latest head SHA：
  - `72f95811d0473c00b62a81290df524100b4e6858`
- Required checks：
  - Local extension lint / tests / typecheck / build pass; GitHub CI will run after PR open.
- spec workflow-check evidence：
  - `spec workflow-check --phase start --issue 747` and `--phase commit --issue 747` failed locally with `missing_fields=config`; manual checklist used.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/747#issuecomment-4587127354

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 extension account 帳號角色資訊 overlay。
- Approx changed lines：~365
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - AccountPanel 需要 API client 與 OverlayHost 測試一起驗證，否則無法證明 account overlay 會正確載入、顯示錯誤並返回上一層。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] AC 1：account overlay 顯示目前帳號基本資訊。
- [x] AC 2：account overlay 顯示目前帳號 role。
- [x] AC 3：loading / error / back 行為有 focused tests 覆蓋。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm --dir apps/extension exec vitest run src/services/api.test.ts src/app/navigation/OverlayHost.test.tsx
PASS  2 files, 11 tests

pnpm --dir apps/extension exec tsc -b --pretty false
PASS

bash infra/scripts/check-typescript-only.sh --root .
PASS

rtk git --no-optional-locks diff --check
PASS

pnpm --dir apps/extension lint
PASS

pnpm --dir apps/extension test
PASS  22 files, 83 tests

pnpm --dir apps/extension build
PASS  existing Vite warning: main chunk exceeds 350 kB
```

## 備註
此 PR 不新增或修改任何 LFS asset。`/api/v1/users/me` 是 develop 既有 backend contract。

## Notes for Claude Code Review
- 本 PR 將 #747 的「角色資訊」解讀為 account role；不是 ocean active character role。
- spec-injector local config 缺失，相關 gate 以 `missing_fields=config` 失敗；本 PR 以 issue delegation comment 與 local verification evidence 補足。
- RED phase 不完美：一開始本機缺 frontend deps，第一次可執行測試失敗是 selector ambiguity，而非 feature missing。
- build 通過，但 Vite 仍有既有 main chunk size warning。
