### PR TITLE
[frontend] add settings panel

### DIFF
--- a/apps/extension/src/app/App.tsx
+++ b/apps/extension/src/app/App.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { loadDemoState, saveDemoState } from '../extension/storage'
 import {
   defaultDemoState,
+  defaultSettingsState,
   normalizeAppLanguage,
   type HudDemoState,
+  type SettingsState,
 } from '../extension/types'
 import type { NavigationFlags } from './navigation/types'
 import type { AppLanguage } from '../i18n'
@@ -40,6 +42,7 @@ export default function App() {
   const [hudState, setHudState] = useState<HudDemoState>(defaultDemoState.hud)
   const [tcgBalance, setTcgBalance] = useState(defaultDemoState.tcgBalance)
   const [redeemedCouponIds, setRedeemedCouponIds] = useState<string[]>(defaultDemoState.redeemedCouponIds)
+  const [settings, setSettings] = useState<SettingsState>(defaultSettingsState)
   const [voucherCodes, setVoucherCodes] = useState<Record<string, string>>({})
   const [currentRaffleId, setCurrentRaffleId] = useState('')
   const tcgBalanceRef = useRef(defaultDemoState.tcgBalance)
@@ -60,6 +63,7 @@ export default function App() {
         tcgBalanceRef.current = storedState.tcgBalance
         setRedeemedCouponIds(storedState.redeemedCouponIds)
         redeemedCouponIdsRef.current = [...storedState.redeemedCouponIds]
+        setSettings(storedState.settings)
 
         const targetLanguage = normalizeAppLanguage(storedState.language)
         setCurrentLanguage(targetLanguage)
@@ -97,13 +101,14 @@ export default function App() {
         hud: hudState,
         tcgBalance,
         redeemedCouponIds,
+        settings,
       }).catch((error: unknown) => {
         console.warn('Failed to persist extension demo state', error)
       })
     }, 120)
 
     return () => window.clearTimeout(persistTimer)
-  }, [currentLanguage, flags, hudState, isHydrated, redeemedCouponIds, tcgBalance])
+  }, [currentLanguage, flags, hudState, isHydrated, redeemedCouponIds, settings, tcgBalance])
 
   useEffect(() => {
     if (!isHydrated) {
@@ -181,6 +186,7 @@ export default function App() {
         hudState={hudState}
         isPopupMode={isPopupMode}
         redeemedCouponIds={redeemedCouponIds}
+        settings={settings}
         tcgBalance={tcgBalance}
         voucherCodes={voucherCodes}
         onChangeLanguage={handleLanguageChange}
@@ -190,6 +196,7 @@ export default function App() {
         onFlagsChange={setFlags}
         onHudStateChange={setHudState}
         onOpenPopupMode={openPopupMode}
+        onSettingsChange={setSettings}
       />
     </NavigationProvider>
   )
@@ -202,6 +209,7 @@ interface AppShellProps {
   hudState: HudDemoState
   isPopupMode: boolean
   redeemedCouponIds: string[]
+  settings: SettingsState
   tcgBalance: number
   voucherCodes: Record<string, string>
   onChangeLanguage: (language: AppLanguage) => void
@@ -211,6 +219,7 @@ interface AppShellProps {
   onFlagsChange: Dispatch<SetStateAction<NavigationFlags>>
   onHudStateChange: Dispatch<SetStateAction<HudDemoState>>
   onOpenPopupMode: () => void
+  onSettingsChange: Dispatch<SetStateAction<SettingsState>>
 }
 
 function AppShell({
@@ -220,6 +229,7 @@ function AppShell({
   hudState,
   isPopupMode,
   redeemedCouponIds,
+  settings,
   tcgBalance,
   voucherCodes,
   onChangeLanguage,
@@ -229,6 +239,7 @@ function AppShell({
   onFlagsChange,
   onHudStateChange,
   onOpenPopupMode,
+  onSettingsChange,
 }: AppShellProps) {
   const { state, setFlag } = useNavigation()
   const showOnboarding = shouldShowOnboarding(state.scene, state.flags)
@@ -263,7 +274,10 @@ function AppShell({
           width: 'min(100%, 430px)',
           minWidth: 320,
           minHeight: 600,
-          height: 'min(720px, calc(100vh - 104px))',
+          height:
+            settings.screenMode === 'focus'
+              ? 'min(820px, calc(100vh - 40px))'
+              : 'min(720px, calc(100vh - 104px))',
           borderRadius: 12,
           overflow: 'hidden',
           border: '1px solid rgba(255,255,255,0.07)',
@@ -272,14 +286,18 @@ function AppShell({
           position: 'relative',
         }}
       >
-        <SceneRenderer hudState={hudState} onHudStateChange={onHudStateChange} />
+        <SceneRenderer hudState={hudState} settings={settings} onHudStateChange={onHudStateChange} />
         <OverlayHost
           cpcBalance={hudState.points}
+          currentLanguage={currentLanguage}
           tcgBalance={tcgBalance}
           redeemedCouponIds={redeemedCouponIds}
+          settings={settings}
           voucherCodes={voucherCodes}
+          onChangeLanguage={onChangeLanguage}
           onClaim={onClaim}
           onCouponRedeem={onCouponRedeem}
+          onSettingsChange={onSettingsChange}
         />
         {showOnboarding ? <OnboardingOverlay onComplete={completeOnboarding} /> : null}
       </div>

--- a/apps/extension/src/app/components/MarioHUD.tsx
+++ b/apps/extension/src/app/components/MarioHUD.tsx
@@ -320,11 +320,13 @@ function SpinningCoin({ onClick, ariaLabel }: { onClick: () => void; ariaLabel: 
 // ─── Main HUD Component ───────────────────────────────────────
 interface MarioHUDProps {
   state?: HudDemoState
+  soundEnabled?: boolean
+  effectsEnabled?: boolean
   onStateChange?: (state: HudDemoState) => void
   onNavigate?: (screen: 'claim' | 'coupon') => void
 }
 
-export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
+export function MarioHUD({ state, soundEnabled = true, effectsEnabled = true, onStateChange, onNavigate }: MarioHUDProps) {
   const { t } = useTranslation()
   const { playMiningClick, playRewardComplete, playMaxClicks, playToggleWatch, startBgMusic, stopBgMusic, bridgeStatus } = useSound()
   const [points, setPoints]               = useState(state?.points ?? 0);
@@ -353,15 +355,23 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
     n >= 10000 ? (n / 1000).toFixed(1) + 'K' : n.toLocaleString();
 
   const triggerBalancePop = useCallback(() => {
+    if (!effectsEnabled) {
+      return
+    }
+
     setBalanceBump(true);
     const id = setTimeout(() => {
       setBalanceBump(false);
       timeoutRefs.current = timeoutRefs.current.filter(t => t !== id);
     }, 420);
     timeoutRefs.current.push(id);
-  }, []);
+  }, [effectsEnabled]);
 
   const spawnFloat = useCallback((amount: number) => {
+    if (!effectsEnabled) {
+      return
+    }
+
     const floatItemId = ++floatId.current;
     const offsetX = (Math.random() - 0.5) * 40;
     setFloats(f => [...f, { id: floatItemId, amount, offsetX }]);
@@ -370,7 +380,7 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
       timeoutRefs.current = timeoutRefs.current.filter(t => t !== id);
     }, 1600);
     timeoutRefs.current.push(id);
-  }, []);
+  }, [effectsEnabled]);
 
   const awardPoints = useCallback(
     (amount: number) => {
@@ -378,6 +388,10 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
       setTotalPoints(p => p + amount);
       triggerBalancePop();
       spawnFloat(amount);
+
+      if (!effectsEnabled) {
+        return
+      }
 
       // Success animation
       setShowSuccess(true);
@@ -404,7 +418,7 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
         timeoutRefs.current.push(capyId);
       }
     },
-    [triggerBalancePop, spawnFloat]
+    [effectsEnabled, triggerBalancePop, spawnFloat]
   );
 
   // ── Passive countdown (60s cycle, awards +100 when complete) ────
@@ -414,7 +428,7 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
       setCountdown(c => {
         if (c <= 1) {
           awardPoints(100);
-          playRewardComplete();
+          if (soundEnabled) playRewardComplete();
           setClickCount(0);
           return CYCLE;
         }
@@ -422,13 +436,13 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
       });
     }, 1000);
     return () => clearInterval(tick);
-  }, [isWatching, awardPoints, playRewardComplete]);
+  }, [isWatching, awardPoints, playRewardComplete, soundEnabled]);
 
   // ── 背景音樂：watching 且 bgMusicOn 時才播放 ─────────────
   useEffect(() => {
-    if (isWatching && bgMusicOn) startBgMusic();
+    if (soundEnabled && isWatching && bgMusicOn) startBgMusic();
     else stopBgMusic();
-  }, [isWatching, bgMusicOn, startBgMusic, stopBgMusic]);
+  }, [isWatching, bgMusicOn, soundEnabled, startBgMusic, stopBgMusic]);
 
   useEffect(() => {
     onStateChange?.({
@@ -445,15 +459,16 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
   const handleCapybaraClick = useCallback(() => {
     if (!isWatching) return;
     if (clickCount >= MAX_CLICKS_PER_CYCLE) {
-      playMaxClicks();
+      if (soundEnabled) playMaxClicks();
       return;
     }
-    playMiningClick();
+    if (soundEnabled) playMiningClick();
     awardPoints(1);
     setClickCount(c => c + 1);
-  }, [isWatching, clickCount, awardPoints, playMiningClick, playMaxClicks]);
+  }, [isWatching, clickCount, awardPoints, playMiningClick, playMaxClicks, soundEnabled]);
 
   const progress = (CYCLE - countdown) / CYCLE;
+  const bgMusicActive = soundEnabled && bgMusicOn;
 
   // ─────────────────────────────────────────────────────────
   return (
@@ -471,7 +486,7 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
       }}
     >
       {/* ── Float layer ── */}
-      {floats.map(f => (
+      {effectsEnabled && floats.map(f => (
         <div
           key={f.id}
           style={{
@@ -538,7 +553,10 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
 
         {/* Demo toggle */}
         <button
-          onClick={() => { playToggleWatch(); setIsWatching(w => !w); }}
+          onClick={() => {
+            if (soundEnabled) playToggleWatch();
+            setIsWatching(w => !w);
+          }}
           style={{
             padding: '2px 6px',
             borderRadius: 2,
@@ -639,8 +657,8 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
         <ClickableCapybara
           onClick={handleCapybaraClick}
           isIdle={!isWatching}
-          isSuccess={showSuccess}
-          animState={capyState}
+          isSuccess={effectsEnabled && showSuccess}
+          animState={effectsEnabled ? capyState : 'idle'}
           size={180}
         />
 
@@ -746,20 +764,21 @@ export function MarioHUD({ state, onStateChange, onNavigate }: MarioHUDProps) {
             {t('hud.bgmLabel')}
           </span>
           <button
+            disabled={!soundEnabled}
             onClick={() => setBgMusicOn(v => !v)}
             style={{
               padding: '3px 8px',
               borderRadius: 2,
-              border: `1px solid ${bgMusicOn ? '#9146FF' : 'rgba(145,70,255,0.2)'}`,
-              background: bgMusicOn ? 'rgba(145,70,255,0.15)' : 'transparent',
-              color: bgMusicOn ? '#9146FF' : '#444',
+              border: `1px solid ${bgMusicActive ? '#9146FF' : 'rgba(145,70,255,0.2)'}`,
+              background: bgMusicActive ? 'rgba(145,70,255,0.15)' : 'transparent',
+              color: bgMusicActive ? '#9146FF' : '#444',
               fontSize: 7,
-              cursor: 'pointer',
+              cursor: soundEnabled ? 'pointer' : 'default',
               fontFamily: 'var(--pixel-font-family)',
               letterSpacing: '0.08em',
             }}
           >
-            {bgMusicOn ? t('hud.bgmOn') : t('hud.bgmOff')}
+            {bgMusicActive ? t('hud.bgmOn') : t('hud.bgmOff')}
           </button>
         </div>
       </div>

--- a/apps/extension/src/app/components/SettingsPanel.tsx
+++ b/apps/extension/src/app/components/SettingsPanel.tsx
@@ -1,0 +1,212 @@
+import type { SettingsState } from '../../extension/types'
+import type { AppLanguage } from '../../i18n'
+
+interface SettingsPanelProps {
+  currentLanguage: AppLanguage
+  settings: SettingsState
+  onBack: () => void
+  onChangeLanguage: (language: AppLanguage) => void
+  onChange: (settings: SettingsState) => void
+}
+
+const languageOptions: Array<{ code: AppLanguage; label: string }> = [
+  { code: 'en', label: 'English' },
+  { code: 'zh-TW', label: '繁體中文' },
+  { code: 'zh-CN', label: '简体中文' },
+]
+
+const panelButtonStyle = {
+  minHeight: 36,
+  border: '1px solid rgba(148, 163, 184, 0.22)',
+  borderRadius: 8,
+  background: 'rgba(15, 23, 42, 0.58)',
+  color: '#e2e8f0',
+  cursor: 'pointer',
+  fontFamily: 'var(--pixel-font-family)',
+  fontSize: 9,
+} as const
+
+const toggleRowStyle = {
+  minHeight: 58,
+  border: '1px solid rgba(226, 232, 240, 0.12)',
+  borderRadius: 8,
+  padding: '12px 14px',
+  background: 'rgba(15, 23, 42, 0.72)',
+  color: '#f8fafc',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 16,
+} as const
+
+function updateSetting<K extends keyof SettingsState>(
+  settings: SettingsState,
+  key: K,
+  value: SettingsState[K],
+): SettingsState {
+  return {
+    ...settings,
+    [key]: value,
+  }
+}
+
+export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLanguage, onChange }: SettingsPanelProps) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        minHeight: 600,
+        overflow: 'hidden',
+        padding: '28px 22px 24px',
+        boxSizing: 'border-box',
+        background:
+          'linear-gradient(180deg, rgba(12, 18, 32, 0.98), rgba(24, 36, 48, 0.97) 54%, rgba(8, 13, 24, 0.99))',
+        color: '#f8fafc',
+        fontFamily: 'var(--ui-font-family)',
+      }}
+    >
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background:
+            'linear-gradient(90deg, rgba(250,204,21,0.08) 1px, transparent 1px), linear-gradient(180deg, rgba(56,189,248,0.05) 1px, transparent 1px)',
+          backgroundSize: '28px 28px',
+          opacity: 0.72,
+        }}
+      />
+      <div style={{ position: 'relative', zIndex: 1, display: 'grid', height: '100%', gap: 18 }}>
+        <header style={{ display: 'grid', gap: 8 }}>
+          <div
+            style={{
+              color: '#facc15',
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 9,
+              letterSpacing: 0,
+              textTransform: 'uppercase',
+            }}
+          >
+            Control Deck
+          </div>
+          <h1 style={{ margin: 0, fontFamily: 'var(--pixel-font-family)', fontSize: 28, lineHeight: 1 }}>
+            Settings
+          </h1>
+        </header>
+
+        <fieldset
+          style={{
+            border: '1px solid rgba(226, 232, 240, 0.12)',
+            borderRadius: 8,
+            padding: 14,
+            margin: 0,
+            background: 'rgba(15, 23, 42, 0.72)',
+            display: 'grid',
+            gap: 12,
+          }}
+        >
+          <legend
+            style={{
+              padding: '0 8px',
+              color: '#facc15',
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 8,
+              letterSpacing: 0,
+            }}
+          >
+            Language
+          </legend>
+          {languageOptions.map((language) => (
+            <label
+              key={language.code}
+              style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, fontWeight: 800 }}
+            >
+              <input
+                type="radio"
+                name="language"
+                checked={currentLanguage === language.code}
+                onChange={() => onChangeLanguage(language.code)}
+              />
+              {language.label}
+            </label>
+          ))}
+        </fieldset>
+
+        <section style={{ display: 'grid', alignContent: 'start', gap: 10 }}>
+          <label style={toggleRowStyle}>
+            <span style={{ fontWeight: 800, fontSize: 13 }}>Sound</span>
+            <input
+              type="checkbox"
+              checked={settings.soundEnabled}
+              onChange={(event) => onChange(updateSetting(settings, 'soundEnabled', event.currentTarget.checked))}
+            />
+          </label>
+          <label style={toggleRowStyle}>
+            <span style={{ fontWeight: 800, fontSize: 13 }}>Effects</span>
+            <input
+              type="checkbox"
+              checked={settings.effectsEnabled}
+              onChange={(event) => onChange(updateSetting(settings, 'effectsEnabled', event.currentTarget.checked))}
+            />
+          </label>
+          <label style={toggleRowStyle}>
+            <span style={{ fontWeight: 800, fontSize: 13 }}>HUD</span>
+            <input
+              type="checkbox"
+              checked={settings.hudVisible}
+              onChange={(event) => onChange(updateSetting(settings, 'hudVisible', event.currentTarget.checked))}
+            />
+          </label>
+        </section>
+
+        <fieldset
+          style={{
+            border: '1px solid rgba(226, 232, 240, 0.12)',
+            borderRadius: 8,
+            padding: 14,
+            margin: 0,
+            background: 'rgba(15, 23, 42, 0.72)',
+            display: 'grid',
+            gap: 12,
+          }}
+        >
+          <legend
+            style={{
+              padding: '0 8px',
+              color: '#facc15',
+              fontFamily: 'var(--pixel-font-family)',
+              fontSize: 8,
+              letterSpacing: 0,
+            }}
+          >
+            Screen
+          </legend>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, fontWeight: 800 }}>
+            <input
+              type="radio"
+              name="screenMode"
+              checked={settings.screenMode === 'compact'}
+              onChange={() => onChange(updateSetting(settings, 'screenMode', 'compact'))}
+            />
+            Compact
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, fontWeight: 800 }}>
+            <input
+              type="radio"
+              name="screenMode"
+              checked={settings.screenMode === 'focus'}
+              onChange={() => onChange(updateSetting(settings, 'screenMode', 'focus'))}
+            />
+            Focus
+          </label>
+        </fieldset>
+
+        <button type="button" onClick={onBack} style={{ ...panelButtonStyle, alignSelf: 'end' }}>
+          Back
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/extension/src/app/components/SettingsPanel.tsx
+++ b/apps/extension/src/app/components/SettingsPanel.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 import type { SettingsState } from '../../extension/types'
 import type { AppLanguage } from '../../i18n'
 
@@ -51,6 +53,8 @@ function updateSetting<K extends keyof SettingsState>(
 }
 
 export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLanguage, onChange }: SettingsPanelProps) {
+  const { t } = useTranslation()
+
   return (
     <div
       style={{
@@ -89,10 +93,10 @@ export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLangu
               textTransform: 'uppercase',
             }}
           >
-            Control Deck
+            {t('settings.eyebrow')}
           </div>
           <h1 style={{ margin: 0, fontFamily: 'var(--pixel-font-family)', fontSize: 28, lineHeight: 1 }}>
-            Settings
+            {t('settings.title')}
           </h1>
         </header>
 
@@ -116,7 +120,7 @@ export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLangu
               letterSpacing: 0,
             }}
           >
-            Language
+            {t('settings.language')}
           </legend>
           {languageOptions.map((language) => (
             <label
@@ -136,7 +140,7 @@ export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLangu
 
         <section style={{ display: 'grid', alignContent: 'start', gap: 10 }}>
           <label style={toggleRowStyle}>
-            <span style={{ fontWeight: 800, fontSize: 13 }}>Sound</span>
+            <span style={{ fontWeight: 800, fontSize: 13 }}>{t('settings.sound')}</span>
             <input
               type="checkbox"
               checked={settings.soundEnabled}
@@ -144,7 +148,7 @@ export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLangu
             />
           </label>
           <label style={toggleRowStyle}>
-            <span style={{ fontWeight: 800, fontSize: 13 }}>Effects</span>
+            <span style={{ fontWeight: 800, fontSize: 13 }}>{t('settings.effects')}</span>
             <input
               type="checkbox"
               checked={settings.effectsEnabled}
@@ -152,7 +156,7 @@ export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLangu
             />
           </label>
           <label style={toggleRowStyle}>
-            <span style={{ fontWeight: 800, fontSize: 13 }}>HUD</span>
+            <span style={{ fontWeight: 800, fontSize: 13 }}>{t('settings.hud')}</span>
             <input
               type="checkbox"
               checked={settings.hudVisible}
@@ -181,7 +185,7 @@ export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLangu
               letterSpacing: 0,
             }}
           >
-            Screen
+            {t('settings.screen')}
           </legend>
           <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, fontWeight: 800 }}>
             <input
@@ -190,7 +194,7 @@ export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLangu
               checked={settings.screenMode === 'compact'}
               onChange={() => onChange(updateSetting(settings, 'screenMode', 'compact'))}
             />
-            Compact
+            {t('settings.screenModes.compact')}
           </label>
           <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, fontWeight: 800 }}>
             <input
@@ -199,12 +203,12 @@ export function SettingsPanel({ currentLanguage, settings, onBack, onChangeLangu
               checked={settings.screenMode === 'focus'}
               onChange={() => onChange(updateSetting(settings, 'screenMode', 'focus'))}
             />
-            Focus
+            {t('settings.screenModes.focus')}
           </label>
         </fieldset>
 
         <button type="button" onClick={onBack} style={{ ...panelButtonStyle, alignSelf: 'end' }}>
-          Back
+          {t('settings.back')}
         </button>
       </div>
     </div>

--- a/apps/extension/src/app/navigation/OverlayHost.test.tsx
+++ b/apps/extension/src/app/navigation/OverlayHost.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import '../../i18n'
+
 import { useState } from 'react'
 import { afterEach, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'

--- a/apps/extension/src/app/navigation/OverlayHost.test.tsx
+++ b/apps/extension/src/app/navigation/OverlayHost.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { useState } from 'react'
 import { afterEach, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
@@ -6,6 +7,8 @@ import { NavigationProvider } from './NavigationProvider'
 import { OverlayHost } from './OverlayHost'
 import { useNavigation } from './useNavigation'
 import { getCurrentAccount } from '../../services/api'
+import type { SettingsState } from '../../extension/types'
+import type { AppLanguage } from '../../i18n'
 
 vi.mock('../../services/api', () => ({
   getCurrentAccount: vi.fn(),
@@ -13,9 +16,38 @@ vi.mock('../../services/api', () => ({
 
 const getCurrentAccountMock = vi.mocked(getCurrentAccount)
 
-function Harness() {
+const defaultSettings: SettingsState = {
+  soundEnabled: true,
+  effectsEnabled: true,
+  hudVisible: true,
+  screenMode: 'compact',
+}
+
+interface HarnessProps {
+  currentLanguage?: AppLanguage
+  onChangeLanguage?: (language: AppLanguage) => void
+  settings?: SettingsState
+  onSettingsChange?: (settings: SettingsState) => void
+}
+
+function Harness({
+  currentLanguage = 'en',
+  onChangeLanguage = () => undefined,
+  settings = defaultSettings,
+  onSettingsChange = () => undefined,
+}: HarnessProps) {
   const { state, pushOverlay } = useNavigation()
+  const [language, setLanguage] = useState<AppLanguage>(currentLanguage)
+  const [currentSettings, setCurrentSettings] = useState(settings)
   const topOverlay = state.overlayStack.at(-1)?.kind ?? 'none'
+  const handleLanguageChange = (nextLanguage: AppLanguage) => {
+    setLanguage(nextLanguage)
+    onChangeLanguage(nextLanguage)
+  }
+  const handleSettingsChange = (nextSettings: SettingsState) => {
+    setCurrentSettings(nextSettings)
+    onSettingsChange(nextSettings)
+  }
 
   return (
     <>
@@ -25,11 +57,15 @@ function Harness() {
       <output aria-label="top overlay">{topOverlay}</output>
       <OverlayHost
         cpcBalance={0}
+        currentLanguage={language}
         tcgBalance={0}
         redeemedCouponIds={[]}
         voucherCodes={{}}
+        settings={currentSettings}
+        onChangeLanguage={handleLanguageChange}
         onClaim={() => undefined}
         onCouponRedeem={async () => 'error'}
+        onSettingsChange={handleSettingsChange}
       />
     </>
   )
@@ -105,4 +141,86 @@ test('account overlay renders an error state when the current account fetch fail
 
   expect((await screen.findByRole('alert')).textContent).toContain('Could not load account')
   expect(screen.getAllByRole('button', { name: 'Close' }).length).toBeGreaterThan(0)
+})
+
+test('settings panel toggles persisted sound and hud preferences', () => {
+  const changes: SettingsState[] = []
+
+  render(
+    <NavigationProvider>
+      <Harness
+        settings={defaultSettings}
+        onSettingsChange={(nextSettings) => {
+          changes.push(nextSettings)
+        }}
+      />
+    </NavigationProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'open menu' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+
+  expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy()
+
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Sound' }))
+  fireEvent.click(screen.getByRole('checkbox', { name: 'HUD' }))
+
+  expect(changes).toEqual([
+    {
+      ...defaultSettings,
+      soundEnabled: false,
+    },
+    {
+      ...defaultSettings,
+      soundEnabled: false,
+      hudVisible: false,
+    },
+  ])
+})
+
+test('settings panel changes language through the persisted language path', () => {
+  const languageChanges: AppLanguage[] = []
+
+  render(
+    <NavigationProvider>
+      <Harness
+        currentLanguage="en"
+        onChangeLanguage={(nextLanguage) => {
+          languageChanges.push(nextLanguage)
+        }}
+      />
+    </NavigationProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'open menu' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+  fireEvent.click(screen.getByRole('radio', { name: '繁體中文' }))
+
+  expect(languageChanges).toEqual(['zh-TW'])
+})
+
+test('settings panel switches screen mode', () => {
+  const changes: SettingsState[] = []
+
+  render(
+    <NavigationProvider>
+      <Harness
+        settings={defaultSettings}
+        onSettingsChange={(nextSettings) => {
+          changes.push(nextSettings)
+        }}
+      />
+    </NavigationProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'open menu' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+  fireEvent.click(screen.getByRole('radio', { name: 'Focus' }))
+
+  expect(changes).toEqual([
+    {
+      ...defaultSettings,
+      screenMode: 'focus',
+    },
+  ])
 })

--- a/apps/extension/src/app/navigation/OverlayHost.tsx
+++ b/apps/extension/src/app/navigation/OverlayHost.tsx
@@ -2,18 +2,25 @@ import { AccountPanel } from '../components/AccountPanel'
 import { ClaimPanel } from '../components/ClaimPanel'
 import { CouponShopPanel } from '../components/CouponShopPanel'
 import { RaffleResultPanel } from '../components/RaffleResultPanel'
+import { SettingsPanel } from '../components/SettingsPanel'
 import { PlaceholderSurface } from './PlaceholderSurface'
 import { useNavigation } from './useNavigation'
 import type { CouponRedeemOutcome } from '../couponRedeem'
 import type { Overlay } from './types'
+import type { SettingsState } from '../../extension/types'
+import type { AppLanguage } from '../../i18n'
 
 interface OverlayHostProps {
   cpcBalance: number
+  currentLanguage: AppLanguage
   tcgBalance: number
   redeemedCouponIds: string[]
+  settings: SettingsState
   voucherCodes: Record<string, string>
+  onChangeLanguage: (language: AppLanguage) => void
   onClaim: (cpcAmount: number) => void
   onCouponRedeem: (couponId: string, cost: number) => Promise<CouponRedeemOutcome>
+  onSettingsChange: (settings: SettingsState) => void
 }
 
 const menuEntries: Array<{
@@ -166,11 +173,15 @@ const menuButtonStyle = {
 
 export function OverlayHost({
   cpcBalance,
+  currentLanguage,
   tcgBalance,
   redeemedCouponIds,
+  settings,
   voucherCodes,
+  onChangeLanguage,
   onClaim,
   onCouponRedeem,
+  onSettingsChange,
 }: OverlayHostProps) {
   const { state, popOverlay } = useNavigation()
 
@@ -215,6 +226,14 @@ export function OverlayHost({
             <MenuOverlay />
           ) : entry.kind === 'account' ? (
             <AccountPanel onBack={popOverlay} />
+          ) : entry.kind === 'settings' ? (
+            <SettingsPanel
+              currentLanguage={currentLanguage}
+              settings={settings}
+              onBack={popOverlay}
+              onChangeLanguage={onChangeLanguage}
+              onChange={onSettingsChange}
+            />
           ) : (
             <PlaceholderSurface
               eyebrow="Dev-only"

--- a/apps/extension/src/app/navigation/SceneRenderer.test.tsx
+++ b/apps/extension/src/app/navigation/SceneRenderer.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeAll, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 
-import { defaultHudDemoState } from '../../extension/types'
+import { defaultHudDemoState, defaultSettingsState } from '../../extension/types'
 import '../../i18n'
 import { NavigationProvider } from './NavigationProvider'
 import { SceneRenderer } from './SceneRenderer'
@@ -14,6 +14,10 @@ vi.mock('../components/LoginScreen', () => ({
       mock login
     </button>
   ),
+}))
+
+vi.mock('../components/MarioHUD', () => ({
+  MarioHUD: () => <div data-testid="mock-mario-hud">mock hud</div>,
 }))
 
 function StateProbe() {
@@ -28,6 +32,16 @@ function StateProbe() {
         {state.scene}:{String(state.flags.hasCompletedLogin)}
       </output>
     </>
+  )
+}
+
+function MiningProbe() {
+  const { goScene } = useNavigation()
+
+  return (
+    <button type="button" onClick={() => goScene('mining')}>
+      go mining
+    </button>
   )
 }
 
@@ -71,4 +85,22 @@ test('marks login as complete before entering loading scene', () => {
   fireEvent.click(screen.getByRole('button', { name: 'mock login' }))
 
   expect(screen.getByLabelText('navigation state').textContent).toBe('loading:true')
+})
+
+test('hides the mining hud when hudVisible is disabled', () => {
+  render(
+    <NavigationProvider>
+      <SceneRenderer
+        hudState={defaultHudDemoState}
+        settings={{ ...defaultSettingsState, hudVisible: false }}
+        onHudStateChange={() => undefined}
+      />
+      <MiningProbe />
+    </NavigationProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'go mining' }))
+
+  expect(screen.queryByTestId('mock-mario-hud')).toBeNull()
+  expect(screen.getByText('HUD Hidden')).toBeTruthy()
 })

--- a/apps/extension/src/app/navigation/SceneRenderer.tsx
+++ b/apps/extension/src/app/navigation/SceneRenderer.tsx
@@ -4,13 +4,14 @@ import { EntryScene } from '../components/EntryScene'
 import { LoadingScreen } from '../components/LoadingScreen'
 import { LoginScreen } from '../components/LoginScreen'
 import { MarioHUD } from '../components/MarioHUD'
-import type { HudDemoState } from '../../extension/types'
+import { defaultSettingsState, type HudDemoState, type SettingsState } from '../../extension/types'
 import { PlaceholderSurface } from './PlaceholderSurface'
 import { useNavigation } from './useNavigation'
 import type { OverlayEntry } from './types'
 
 interface SceneRendererProps {
   hudState: HudDemoState
+  settings?: SettingsState
   onHudStateChange: Dispatch<SetStateAction<HudDemoState>>
 }
 
@@ -27,7 +28,7 @@ function createHudOverlay(screen: HudNavigationTarget): OverlayEntry {
   }
 }
 
-export function SceneRenderer({ hudState, onHudStateChange }: SceneRendererProps) {
+export function SceneRenderer({ hudState, settings = defaultSettingsState, onHudStateChange }: SceneRendererProps) {
   const { state, goScene, pushOverlay, setFlag } = useNavigation()
 
   switch (state.scene) {
@@ -53,9 +54,21 @@ export function SceneRenderer({ hudState, onHudStateChange }: SceneRendererProps
         />
       )
     case 'mining':
+      if (!settings.hudVisible) {
+        return (
+          <PlaceholderSurface
+            eyebrow="Settings"
+            title="HUD Hidden"
+            body="The mining HUD is hidden by your display setting."
+          />
+        )
+      }
+
       return (
         <MarioHUD
           state={hudState}
+          effectsEnabled={settings.effectsEnabled}
+          soundEnabled={settings.soundEnabled}
           onStateChange={onHudStateChange}
           onNavigate={(screen) => pushOverlay(createHudOverlay(screen))}
         />

--- a/apps/extension/src/extension/storage.test.ts
+++ b/apps/extension/src/extension/storage.test.ts
@@ -6,6 +6,13 @@ import type { DemoState } from './types.ts'
 const STORAGE_KEY = 'tachigo.sidepanel.app-state.v3'
 const LEGACY_STORAGE_KEY = 'tachigo.sidepanel.demo-state.v2'
 
+const EXPECTED_DEFAULT_SETTINGS = {
+  soundEnabled: true,
+  effectsEnabled: true,
+  hudVisible: true,
+  screenMode: 'compact',
+} as const
+
 const EXPECTED_DEFAULT_DEMO_STATE: DemoState = {
   language: 'en',
   flags: {
@@ -23,6 +30,7 @@ const EXPECTED_DEFAULT_DEMO_STATE: DemoState = {
   },
   tcgBalance: 0,
   redeemedCouponIds: [],
+  settings: { ...EXPECTED_DEFAULT_SETTINGS },
 }
 
 type ChromeStorageCallbacks = {
@@ -132,6 +140,12 @@ test('loadDemoState returns sanitized chrome storage state without reading local
         },
         tcgBalance: -9,
         redeemedCouponIds: ['coupon-1', 7, 'coupon-2'],
+        settings: {
+          soundEnabled: false,
+          effectsEnabled: 1,
+          hudVisible: false,
+          screenMode: 'cinema',
+        },
       },
     }),
   })
@@ -156,6 +170,11 @@ test('loadDemoState returns sanitized chrome storage state without reading local
     },
     tcgBalance: 0,
     redeemedCouponIds: ['coupon-1', 'coupon-2'],
+    settings: {
+      ...EXPECTED_DEFAULT_SETTINGS,
+      soundEnabled: false,
+      hudVisible: false,
+    },
   })
   assert.equal(localStorage.reads, 0)
 })
@@ -181,6 +200,7 @@ test('loadDemoState falls back to legacy localStorage state when chrome storage 
     },
     tcgBalance: 12,
     redeemedCouponIds: ['bundle-120'],
+    settings: { ...EXPECTED_DEFAULT_SETTINGS },
   })
 
   const storage = await importStorageModule()
@@ -202,6 +222,7 @@ test('loadDemoState falls back to legacy localStorage state when chrome storage 
     },
     tcgBalance: 12,
     redeemedCouponIds: ['bundle-120'],
+    settings: { ...EXPECTED_DEFAULT_SETTINGS },
   })
   assert.equal(localStorage.reads, 2)
 })
@@ -289,6 +310,7 @@ test('loadDemoState migrates true v2 screen payloads into v3 state shape', async
     },
     tcgBalance: 20,
     redeemedCouponIds: ['tachiya-95'],
+    settings: { ...EXPECTED_DEFAULT_SETTINGS },
   }
   assert.deepEqual(migratedState, expectedState)
   assert.deepEqual(chromeStoredValue, expectedState)
@@ -328,6 +350,12 @@ test('saveDemoState falls back to localStorage when chrome storage write fails',
     },
     tcgBalance: 5,
     redeemedCouponIds: ['tachiya-95'],
+    settings: {
+      soundEnabled: false,
+      effectsEnabled: true,
+      hudVisible: true,
+      screenMode: 'focus',
+    },
   })
 
   assert.equal(localStorage.writes, 1)
@@ -348,6 +376,12 @@ test('saveDemoState falls back to localStorage when chrome storage write fails',
     },
     tcgBalance: 5,
     redeemedCouponIds: ['tachiya-95'],
+    settings: {
+      soundEnabled: false,
+      effectsEnabled: true,
+      hudVisible: true,
+      screenMode: 'focus',
+    },
   })
 })
 
@@ -381,6 +415,12 @@ test('saveDemoState mirrors state to localStorage after a successful chrome stor
     },
     tcgBalance: 5,
     redeemedCouponIds: ['tachiya-95'],
+    settings: {
+      soundEnabled: false,
+      effectsEnabled: true,
+      hudVisible: true,
+      screenMode: 'focus',
+    },
   })
 
   const expectedState = {
@@ -400,6 +440,12 @@ test('saveDemoState mirrors state to localStorage after a successful chrome stor
     },
     tcgBalance: 5,
     redeemedCouponIds: ['tachiya-95'],
+    settings: {
+      soundEnabled: false,
+      effectsEnabled: true,
+      hudVisible: true,
+      screenMode: 'focus',
+    },
   }
 
   assert.deepEqual(chromeStoredValue, expectedState)

--- a/apps/extension/src/extension/types.test.ts
+++ b/apps/extension/src/extension/types.test.ts
@@ -13,12 +13,14 @@ test('sanitizeDemoState returns fresh default objects instead of shared referenc
   first.hud.points = 99
   first.redeemedCouponIds.push('coupon-1')
   first.flags.hasCompletedLogin = true
+  first.settings.soundEnabled = false
 
   const second = types.sanitizeDemoState(null)
 
   assert.notEqual(first, second)
   assert.notEqual(first.hud, second.hud)
   assert.notEqual(first.flags, second.flags)
+  assert.notEqual(first.settings, second.settings)
   assert.deepEqual(second, {
     language: 'en',
     flags: {
@@ -36,6 +38,12 @@ test('sanitizeDemoState returns fresh default objects instead of shared referenc
     },
     tcgBalance: 0,
     redeemedCouponIds: [],
+    settings: {
+      soundEnabled: true,
+      effectsEnabled: true,
+      hudVisible: true,
+      screenMode: 'compact',
+    },
   })
 })
 
@@ -71,6 +79,27 @@ test('sanitizeDemoState ignores legacy screen state', async () => {
   const types = await importTypesModule()
   const result = types.sanitizeDemoState({ screen: 'raffle' })
   assert.equal('screen' in result, false)
+})
+
+test('sanitizeDemoState sanitizes extension settings and rejects unknown screen modes', async () => {
+  const types = await importTypesModule()
+
+  assert.deepEqual(
+    types.sanitizeDemoState({
+      settings: {
+        soundEnabled: false,
+        effectsEnabled: 'yes',
+        hudVisible: false,
+        screenMode: 'cinema',
+      },
+    }).settings,
+    {
+      soundEnabled: false,
+      effectsEnabled: true,
+      hudVisible: false,
+      screenMode: 'compact',
+    },
+  )
 })
 
 test('sanitizeHudDemoState normalizes negative zero to positive zero', async () => {

--- a/apps/extension/src/extension/types.ts
+++ b/apps/extension/src/extension/types.ts
@@ -26,6 +26,15 @@ export interface HudDemoState {
   chatCount: number
 }
 
+export type ScreenMode = 'compact' | 'focus'
+
+export interface SettingsState {
+  soundEnabled: boolean
+  effectsEnabled: boolean
+  hudVisible: boolean
+  screenMode: ScreenMode
+}
+
 export type CouponRedeemResult = 'success' | 'insufficient' | 'already_redeemed'
 
 export interface DemoState {
@@ -34,6 +43,7 @@ export interface DemoState {
   hud: HudDemoState
   tcgBalance: number
   redeemedCouponIds: string[]
+  settings: SettingsState
 }
 
 export const defaultHudDemoState: HudDemoState = {
@@ -45,12 +55,20 @@ export const defaultHudDemoState: HudDemoState = {
   chatCount: 0,
 }
 
+export const defaultSettingsState: SettingsState = {
+  soundEnabled: true,
+  effectsEnabled: true,
+  hudVisible: true,
+  screenMode: 'compact',
+}
+
 export const defaultDemoState: DemoState = {
   language: 'en',
   flags: { ...defaultNavigationFlags },
   hud: { ...defaultHudDemoState },
   tcgBalance: 0,
   redeemedCouponIds: [],
+  settings: { ...defaultSettingsState },
 }
 
 function createDefaultHudDemoState(): HudDemoState {
@@ -63,6 +81,7 @@ export function createDefaultDemoState(): DemoState {
     flags: { ...defaultDemoState.flags },
     hud: createDefaultHudDemoState(),
     redeemedCouponIds: [...defaultDemoState.redeemedCouponIds],
+    settings: { ...defaultDemoState.settings },
   }
 }
 
@@ -122,6 +141,25 @@ export function sanitizeNavigationFlags(value: unknown): NavigationFlags {
   }
 }
 
+export function sanitizeSettingsState(value: unknown): SettingsState {
+  if (!value || typeof value !== 'object') {
+    return { ...defaultSettingsState }
+  }
+
+  const candidate = value as Partial<SettingsState>
+
+  return {
+    soundEnabled:
+      typeof candidate.soundEnabled === 'boolean' ? candidate.soundEnabled : defaultSettingsState.soundEnabled,
+    effectsEnabled:
+      typeof candidate.effectsEnabled === 'boolean' ? candidate.effectsEnabled : defaultSettingsState.effectsEnabled,
+    hudVisible: typeof candidate.hudVisible === 'boolean' ? candidate.hudVisible : defaultSettingsState.hudVisible,
+    screenMode: candidate.screenMode === 'focus' || candidate.screenMode === 'compact'
+      ? candidate.screenMode
+      : defaultSettingsState.screenMode,
+  }
+}
+
 export function sanitizeDemoState(value: unknown): DemoState {
   if (!value || typeof value !== 'object') {
     return createDefaultDemoState()
@@ -144,5 +182,6 @@ export function sanitizeDemoState(value: unknown): DemoState {
     hud: sanitizeHudDemoState(candidate.hud),
     tcgBalance,
     redeemedCouponIds: [...redeemedCouponIds],
+    settings: sanitizeSettingsState(candidate.settings),
   }
 }

--- a/apps/extension/src/i18n/locales/en/common.json
+++ b/apps/extension/src/i18n/locales/en/common.json
@@ -113,6 +113,20 @@
       }
     }
   },
+  "settings": {
+    "eyebrow": "Control Deck",
+    "title": "Settings",
+    "language": "Language",
+    "sound": "Sound",
+    "effects": "Effects",
+    "hud": "HUD",
+    "screen": "Screen",
+    "screenModes": {
+      "compact": "Compact",
+      "focus": "Focus"
+    },
+    "back": "Back"
+  },
   "raffle_result": {
     "title": "RAFFLE RESULTS",
     "loading": "LOADING...",

--- a/apps/extension/src/i18n/locales/zh-CN/common.json
+++ b/apps/extension/src/i18n/locales/zh-CN/common.json
@@ -113,6 +113,20 @@
       }
     }
   },
+  "settings": {
+    "eyebrow": "控制面板",
+    "title": "设置",
+    "language": "语言",
+    "sound": "音效",
+    "effects": "特效",
+    "hud": "HUD",
+    "screen": "画面",
+    "screenModes": {
+      "compact": "精简",
+      "focus": "专注"
+    },
+    "back": "返回"
+  },
   "raffle_result": {
     "title": "抽奖结果",
     "loading": "加载中...",

--- a/apps/extension/src/i18n/locales/zh-TW/common.json
+++ b/apps/extension/src/i18n/locales/zh-TW/common.json
@@ -113,6 +113,20 @@
       }
     }
   },
+  "settings": {
+    "eyebrow": "控制面板",
+    "title": "設定",
+    "language": "語言",
+    "sound": "音效",
+    "effects": "特效",
+    "hud": "HUD",
+    "screen": "畫面",
+    "screenModes": {
+      "compact": "精簡",
+      "focus": "專注"
+    },
+    "back": "返回"
+  },
   "raffle_result": {
     "title": "抽獎結果",
     "loading": "載入中...",


### PR DESCRIPTION
## 什麼改動
- 新增 extension SettingsPanel overlay，接上既有 Gear Hub 的 `settings` 入口。
- 將 settings state 併入既有 DemoState / Chrome storage 持久化路徑。
- 讓語言、音效、視覺效果、HUD 顯示、screen mode 設定即時影響目前 extension shell / mining HUD。
- 補上 storage/type sanitize、settings panel interaction、HUD hidden focused tests。

## 為什麼
refs #746

#746 需要 settings 面板、設定持久化，以及開關即時生效。本 PR 只處理既有 extension frontend 狀態與 UI，不新增 backend contract、assets、LFS 或相依套件。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#746
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 backend / schema / API contract 變更
  - 不新增圖片、影片、LFS asset 或相依套件
  - 不重做整體 design system
  - 不做 ocean character / equipment / mission settings

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #746 Issue Delegation Plan：https://github.com/nurockplayer/tachigo/issues/746#issuecomment-4587177670
- Actual worker profile(s)：
  - controller：scope 決策、spec gate、worker review、lint 修正、完整驗證、PR 發布
  - frontend worker：bounded settings implementation and focused tests
- Model strength：
  - controller = high；frontend worker = medium
- Spawn directive(s)：
  - profile=frontend_worker model=gpt-5.3-codex reasoning=medium controller_fallback=denied fallback_reason=n/a task=implement-settings-panel issue=#746 scope=apps/extension only
- Verification evidence：
  - `pnpm --dir apps/extension exec vitest run src/extension/types.test.ts src/extension/storage.test.ts src/app/navigation/OverlayHost.test.tsx src/app/navigation/SceneRenderer.test.tsx`
  - `pnpm --dir apps/extension exec tsc -b --pretty false`
  - `pnpm --dir apps/extension lint`
  - `pnpm --dir apps/extension test`
  - `pnpm --dir apps/extension build`
  - `bash infra/scripts/check-typescript-only.sh --root .`
  - `rtk git --no-optional-locks diff --cached --check`
- Self-review / exception reason：
  - Controller reviewed worker output, added the missing language control required by #746, removed a lint-blocked synchronous effect state update, and adjusted HUD-hidden copy to avoid overclaiming background mining behavior.
- Worker session closeout：
  - Frontend worker returned results; controller integrated and verified the final patch.
- Workflow friction / follow-up split：
  - spec-injector is present but this checkout has no `.spec-injector/` config, so `spec plan --dry-run` and `spec workflow-check` returned `missing_fields=config`. Manual delegation plan and local verification evidence were used for this R2 PR. Threshold calibration ledger remains #664.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR open
- CodeRabbit：
  - Not reviewed yet at PR open
- chatgpt-codex-connector：
  - Not reviewed yet at PR open
- review_triage_ref：
  - Initial scope and worker plan recorded in #746 Issue Delegation Plan：https://github.com/nurockplayer/tachigo/issues/746#issuecomment-4587177670
- root_cause_gate_ref：
  - Latest-head rationale: settings state is stored through the existing DemoState / Chrome storage path, avoiding a second persistence system.
- finding_disposition_ref：
  - Initial disposition: no automated-review finding exists yet; controller review changes were applied before PR open.
- Final reviewer action：
  - Awaiting GitHub CI and human / automated review.

## Final merge gate
- Ready-to-merge decision：
  - Blocked until GitHub CI and human / automated review complete.
- Latest head SHA：
  - `b843ddcc3449c8f807efae32dacdf58dec168b6a`
- Required checks：
  - Local extension lint / tests / typecheck / build pass; GitHub CI will run after PR open.
- spec workflow-check evidence：
  - `spec workflow-check --phase start --issue 746` and `--phase commit --issue 746` failed locally with `missing_fields=config`; manual checklist used.
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/issues/746#issuecomment-4587177670

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 extension settings 面板並讓設定持久化且即時影響現有 extension shell。
- Approx changed lines：~600
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - #746 的完成條件是「各開關可調整並持久化」且「即時生效」。只做面板或只做 store 都無法獨立驗收；focused tests 必須與整合改動一起提交。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] AC 1：`settings` 面板提供語言 / 畫面 / 音效 / 特效 / HUD 顯示控制。
- [x] AC 2：設定透過既有 DemoState / Chrome storage path 持久化。
- [x] AC 3：設定即時生效；focused tests 與完整 `pnpm test` 通過。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm --dir apps/extension exec vitest run src/extension/types.test.ts src/extension/storage.test.ts src/app/navigation/OverlayHost.test.tsx src/app/navigation/SceneRenderer.test.tsx
PASS  4 files, 20 tests

pnpm --dir apps/extension exec tsc -b --pretty false
PASS

pnpm --dir apps/extension lint
PASS

pnpm --dir apps/extension test
PASS  22 files, 85 tests

pnpm --dir apps/extension build
PASS  existing Vite warning: main chunk exceeds 350 kB

bash infra/scripts/check-typescript-only.sh --root .
PASS

rtk git --no-optional-locks diff --cached --check
PASS
```

## 備註
此 PR 不新增或修改任何 LFS asset。為了驗證，worker 使用既有 lockfile 執行 `pnpm install --frozen-lockfile --ignore-scripts`，沒有改 lockfile。

## Notes for Claude Code Review
- `screenMode` 先控制 extension frame 高度，作為 #746「畫面」設定的薄切；沒有引入新的 layout/design-system 架構。
- `language` 沿用既有 `currentLanguage` / i18n / DemoState persistence path，沒有另建第二套 language setting。
- spec-injector local config 缺失，相關 gate 以 `missing_fields=config` 失敗；本 PR 以 issue delegation comment 與 local verification evidence 補足。
- build 通過，但 Vite 仍有既有 main chunk size warning。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 添加了设置面板，用户现可自定义声音、视觉效果、HUD 显示和屏幕模式（紧凑/焦点视图）。
  * 新增对设置项的持久化存储，用户配置会自动保存。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->