### PR TITLE
[backend] add ocean character schema

### DIFF
--- a/services/api/cmd/server/migration_test.go
+++ b/services/api/cmd/server/migration_test.go
@@ -122,6 +122,7 @@ func TestMigration023AddsOceanCharacterSchema(t *testing.T) {
 	for _, want := range []string{
 		"ADD COLUMN IF NOT EXISTS active_character",
 		"ADD COLUMN IF NOT EXISTS switch_cooldown_until",
+		"conrelid = 'users'::regclass",
 		"CREATE TABLE IF NOT EXISTS user_characters",
 		"chk_user_characters_character",
 		"chk_user_characters_stage",

--- a/services/api/cmd/server/migration_test.go
+++ b/services/api/cmd/server/migration_test.go
@@ -106,6 +106,38 @@ func TestMigrationDirectoryAtlasChecksumIsCurrent(t *testing.T) {
 	}
 }
 
+func TestMigration023AddsOceanCharacterSchema(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+
+	path := filepath.Join(filepath.Dir(file), "..", "..", "migrations", "023_user_characters_streamer_familiarity.sql")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+
+	sql := string(body)
+	for _, want := range []string{
+		"ADD COLUMN IF NOT EXISTS active_character",
+		"ADD COLUMN IF NOT EXISTS switch_cooldown_until",
+		"CREATE TABLE IF NOT EXISTS user_characters",
+		"chk_user_characters_character",
+		"chk_user_characters_stage",
+		"chk_user_characters_xp",
+		"idx_user_characters_user_character",
+		"CREATE TABLE IF NOT EXISTS streamer_familiarities",
+		"chk_streamer_familiarities_watch_seconds",
+		"idx_streamer_familiarities_user_channel",
+		"REFERENCES users(id) ON DELETE CASCADE",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("migration 023 missing %q", want)
+		}
+	}
+}
+
 func TestBackfillStreamerAgencyUserID_SingleAgencyChannel(t *testing.T) {
 	db := newAgencyMigrationTestDB(t)
 

--- a/services/api/internal/handlers/testutil_test.go
+++ b/services/api/internal/handlers/testutil_test.go
@@ -28,7 +28,8 @@ func migrateTestDB(db *gorm.DB) error {
 			role TEXT NOT NULL DEFAULT 'viewer',
 			is_active INTEGER NOT NULL DEFAULT 1,
 			email_verified INTEGER NOT NULL DEFAULT 0,
-			active_character TEXT NOT NULL DEFAULT 'crab',
+			active_character TEXT NOT NULL DEFAULT 'crab'
+				CHECK (active_character IN ('crab', 'dolphin', 'turtle', 'whale', 'capybara')),
 			switch_cooldown_until DATETIME,
 			created_at DATETIME,
 			updated_at DATETIME,

--- a/services/api/internal/handlers/testutil_test.go
+++ b/services/api/internal/handlers/testutil_test.go
@@ -28,6 +28,8 @@ func migrateTestDB(db *gorm.DB) error {
 			role TEXT NOT NULL DEFAULT 'viewer',
 			is_active INTEGER NOT NULL DEFAULT 1,
 			email_verified INTEGER NOT NULL DEFAULT 0,
+			active_character TEXT NOT NULL DEFAULT 'crab',
+			switch_cooldown_until DATETIME,
 			created_at DATETIME,
 			updated_at DATETIME,
 			deleted_at DATETIME

--- a/services/api/internal/models/streamer_familiarity.go
+++ b/services/api/internal/models/streamer_familiarity.go
@@ -1,0 +1,34 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// StreamerFamiliarity stores per-user watch familiarity for one streamer channel.
+type StreamerFamiliarity struct {
+	ID                     uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	UserID                 uuid.UUID  `gorm:"type:uuid;not null;uniqueIndex:idx_streamer_familiarities_user_channel,priority:1" json:"user_id"`
+	ChannelID              string     `gorm:"type:varchar(255);not null;uniqueIndex:idx_streamer_familiarities_user_channel,priority:2" json:"channel_id"`
+	CumulativeWatchSeconds int64      `gorm:"not null;default:0;check:chk_streamer_familiarities_watch_seconds,cumulative_watch_seconds >= 0" json:"cumulative_watch_seconds"`
+	LastWatchedAt          *time.Time `gorm:"type:timestamptz" json:"last_watched_at,omitempty"`
+	CreatedAt              time.Time  `json:"created_at"`
+	UpdatedAt              time.Time  `json:"updated_at"`
+
+	User User `gorm:"foreignKey:UserID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
+}
+
+func (StreamerFamiliarity) TableName() string { return "streamer_familiarities" }
+
+func (f *StreamerFamiliarity) BeforeCreate(tx *gorm.DB) error {
+	if f.ID == uuid.Nil {
+		id, err := uuidV7Func()
+		if err != nil {
+			id = uuid.New()
+		}
+		f.ID = id
+	}
+	return nil
+}

--- a/services/api/internal/models/user.go
+++ b/services/api/internal/models/user.go
@@ -17,17 +17,19 @@ const (
 )
 
 type User struct {
-	ID            uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	Username      *string        `gorm:"type:varchar(50);uniqueIndex"                   json:"username"`
-	Email         *string        `gorm:"type:varchar(255);uniqueIndex"                  json:"email"`
-	PasswordHash  *string        `gorm:"type:varchar(255)"                              json:"-"`
-	AvatarURL     *string        `gorm:"type:text"                                      json:"avatar_url"`
-	Role          UserRole       `gorm:"type:user_role;default:'viewer'"                json:"role"`
-	IsActive      bool           `gorm:"default:true"                                   json:"is_active"`
-	EmailVerified bool           `gorm:"default:false"                                  json:"email_verified"`
-	CreatedAt     time.Time      `                                                      json:"created_at"`
-	UpdatedAt     time.Time      `                                                      json:"updated_at"`
-	DeletedAt     gorm.DeletedAt `gorm:"index"                                          json:"-"`
+	ID                  uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Username            *string        `gorm:"type:varchar(50);uniqueIndex"                   json:"username"`
+	Email               *string        `gorm:"type:varchar(255);uniqueIndex"                  json:"email"`
+	PasswordHash        *string        `gorm:"type:varchar(255)"                              json:"-"`
+	AvatarURL           *string        `gorm:"type:text"                                      json:"avatar_url"`
+	Role                UserRole       `gorm:"type:user_role;default:'viewer'"                json:"role"`
+	IsActive            bool           `gorm:"default:true"                                   json:"is_active"`
+	EmailVerified       bool           `gorm:"default:false"                                  json:"email_verified"`
+	ActiveCharacter     CharacterKind  `gorm:"type:varchar(50);not null;default:'crab';check:chk_users_active_character,active_character IN ('crab','dolphin','turtle','whale','capybara')" json:"active_character"`
+	SwitchCooldownUntil *time.Time     `gorm:"type:timestamptz"                              json:"switch_cooldown_until,omitempty"`
+	CreatedAt           time.Time      `                                                      json:"created_at"`
+	UpdatedAt           time.Time      `                                                      json:"updated_at"`
+	DeletedAt           gorm.DeletedAt `gorm:"index"                                          json:"-"`
 
 	AuthProviders []AuthProvider    `gorm:"foreignKey:UserID" json:"auth_providers,omitempty"`
 	Addresses     []ShippingAddress `gorm:"foreignKey:UserID" json:"addresses,omitempty"`

--- a/services/api/internal/models/user_character.go
+++ b/services/api/internal/models/user_character.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type CharacterKind string
+
+const (
+	CharacterCrab     CharacterKind = "crab"
+	CharacterDolphin  CharacterKind = "dolphin"
+	CharacterTurtle   CharacterKind = "turtle"
+	CharacterWhale    CharacterKind = "whale"
+	CharacterCapybara CharacterKind = "capybara"
+)
+
+// UserCharacter stores a user's unlocked ocean character progression.
+type UserCharacter struct {
+	ID         uuid.UUID     `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	UserID     uuid.UUID     `gorm:"type:uuid;not null;uniqueIndex:idx_user_characters_user_character,priority:1" json:"user_id"`
+	Character  CharacterKind `gorm:"type:varchar(50);not null;uniqueIndex:idx_user_characters_user_character,priority:2;check:chk_user_characters_character,character IN ('crab','dolphin','turtle','whale','capybara')" json:"character"`
+	Unlocked   bool          `gorm:"not null;default:false" json:"unlocked"`
+	Stage      int           `gorm:"not null;default:1;check:chk_user_characters_stage,stage >= 1 AND stage <= 3" json:"stage"`
+	XP         int64         `gorm:"not null;default:0;check:chk_user_characters_xp,xp >= 0" json:"xp"`
+	UnlockedAt *time.Time    `gorm:"type:timestamptz" json:"unlocked_at,omitempty"`
+	CreatedAt  time.Time     `json:"created_at"`
+	UpdatedAt  time.Time     `json:"updated_at"`
+
+	User User `gorm:"foreignKey:UserID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
+}
+
+func (UserCharacter) TableName() string { return "user_characters" }
+
+func (c *UserCharacter) BeforeCreate(tx *gorm.DB) error {
+	if c.ID == uuid.Nil {
+		id, err := uuidV7Func()
+		if err != nil {
+			id = uuid.New()
+		}
+		c.ID = id
+	}
+	return nil
+}

--- a/services/api/internal/models/user_character_test.go
+++ b/services/api/internal/models/user_character_test.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestCharacterKindValues(t *testing.T) {
+	tests := []struct {
+		name string
+		got  CharacterKind
+		want string
+	}{
+		{name: "crab", got: CharacterCrab, want: "crab"},
+		{name: "dolphin", got: CharacterDolphin, want: "dolphin"},
+		{name: "turtle", got: CharacterTurtle, want: "turtle"},
+		{name: "whale", got: CharacterWhale, want: "whale"},
+		{name: "capybara", got: CharacterCapybara, want: "capybara"},
+	}
+
+	for _, tc := range tests {
+		if string(tc.got) != tc.want {
+			t.Fatalf("%s: want %q, got %q", tc.name, tc.want, tc.got)
+		}
+	}
+}
+
+func TestUserCharacterBeforeCreate_UsesFallbackUUIDWhenV7Fails(t *testing.T) {
+	orig := uuidV7Func
+	uuidV7Func = func() (uuid.UUID, error) {
+		return uuid.Nil, errors.New("boom")
+	}
+	t.Cleanup(func() { uuidV7Func = orig })
+
+	c := &UserCharacter{}
+	if err := c.BeforeCreate(nil); err != nil {
+		t.Fatalf("before create: %v", err)
+	}
+	if c.ID == uuid.Nil {
+		t.Fatalf("expected non-nil UUID fallback")
+	}
+}
+
+func TestStreamerFamiliarityBeforeCreate_UsesFallbackUUIDWhenV7Fails(t *testing.T) {
+	orig := uuidV7Func
+	uuidV7Func = func() (uuid.UUID, error) {
+		return uuid.Nil, errors.New("boom")
+	}
+	t.Cleanup(func() { uuidV7Func = orig })
+
+	f := &StreamerFamiliarity{}
+	if err := f.BeforeCreate(nil); err != nil {
+		t.Fatalf("before create: %v", err)
+	}
+	if f.ID == uuid.Nil {
+		t.Fatalf("expected non-nil UUID fallback")
+	}
+}

--- a/services/api/internal/router/router_test.go
+++ b/services/api/internal/router/router_test.go
@@ -446,7 +446,8 @@ func migrateTestDB(db *gorm.DB) error {
 			role TEXT NOT NULL DEFAULT 'viewer',
 			is_active INTEGER NOT NULL DEFAULT 1,
 			email_verified INTEGER NOT NULL DEFAULT 0,
-			active_character TEXT NOT NULL DEFAULT 'crab',
+			active_character TEXT NOT NULL DEFAULT 'crab'
+				CHECK (active_character IN ('crab', 'dolphin', 'turtle', 'whale', 'capybara')),
 			switch_cooldown_until DATETIME,
 			created_at DATETIME,
 			updated_at DATETIME,

--- a/services/api/internal/router/router_test.go
+++ b/services/api/internal/router/router_test.go
@@ -446,6 +446,8 @@ func migrateTestDB(db *gorm.DB) error {
 			role TEXT NOT NULL DEFAULT 'viewer',
 			is_active INTEGER NOT NULL DEFAULT 1,
 			email_verified INTEGER NOT NULL DEFAULT 0,
+			active_character TEXT NOT NULL DEFAULT 'crab',
+			switch_cooldown_until DATETIME,
 			created_at DATETIME,
 			updated_at DATETIME,
 			deleted_at DATETIME

--- a/services/api/internal/schema/models.go
+++ b/services/api/internal/schema/models.go
@@ -6,6 +6,8 @@ import "github.com/tachigo/tachigo/internal/models"
 func AtlasSchemaModels() []any {
 	return []any{
 		&models.User{},
+		&models.UserCharacter{},
+		&models.StreamerFamiliarity{},
 		&models.AuthProvider{},
 		&models.ShippingAddress{},
 		&models.RefreshToken{},

--- a/services/api/internal/services/testutil_pg_test.go
+++ b/services/api/internal/services/testutil_pg_test.go
@@ -127,6 +127,8 @@ func migratePGTestDB(db *gorm.DB) error {
 			role TEXT NOT NULL DEFAULT 'viewer' CHECK (role IN ('viewer', 'streamer', 'agency', 'admin')),
 			is_active BOOLEAN NOT NULL DEFAULT TRUE,
 			email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+			active_character TEXT NOT NULL DEFAULT 'crab' CHECK (active_character IN ('crab', 'dolphin', 'turtle', 'whale', 'capybara')),
+			switch_cooldown_until TIMESTAMPTZ,
 			created_at TIMESTAMPTZ,
 			updated_at TIMESTAMPTZ,
 			deleted_at TIMESTAMPTZ

--- a/services/api/internal/services/testutil_test.go
+++ b/services/api/internal/services/testutil_test.go
@@ -44,6 +44,8 @@ func migrateTestDB(db *gorm.DB) error {
 			role TEXT NOT NULL DEFAULT 'viewer',
 			is_active INTEGER NOT NULL DEFAULT 1,
 			email_verified INTEGER NOT NULL DEFAULT 0,
+			active_character TEXT NOT NULL DEFAULT 'crab',
+			switch_cooldown_until DATETIME,
 			created_at DATETIME,
 			updated_at DATETIME,
 			deleted_at DATETIME

--- a/services/api/internal/services/testutil_test.go
+++ b/services/api/internal/services/testutil_test.go
@@ -44,7 +44,8 @@ func migrateTestDB(db *gorm.DB) error {
 			role TEXT NOT NULL DEFAULT 'viewer',
 			is_active INTEGER NOT NULL DEFAULT 1,
 			email_verified INTEGER NOT NULL DEFAULT 0,
-			active_character TEXT NOT NULL DEFAULT 'crab',
+			active_character TEXT NOT NULL DEFAULT 'crab'
+				CHECK (active_character IN ('crab', 'dolphin', 'turtle', 'whale', 'capybara')),
 			switch_cooldown_until DATETIME,
 			created_at DATETIME,
 			updated_at DATETIME,

--- a/services/api/migrations/023_user_characters_streamer_familiarity.sql
+++ b/services/api/migrations/023_user_characters_streamer_familiarity.sql
@@ -1,0 +1,51 @@
+-- Ocean character progression and per-streamer familiarity state.
+-- Runtime behavior stays in services/handlers; this migration only adds schema.
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS active_character VARCHAR(50) NOT NULL DEFAULT 'crab',
+    ADD COLUMN IF NOT EXISTS switch_cooldown_until TIMESTAMPTZ;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_users_active_character'
+    ) THEN
+        ALTER TABLE users
+            ADD CONSTRAINT chk_users_active_character
+            CHECK (active_character IN ('crab', 'dolphin', 'turtle', 'whale', 'capybara'));
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS user_characters (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    character   VARCHAR(50)  NOT NULL,
+    unlocked    BOOLEAN      NOT NULL DEFAULT false,
+    stage       BIGINT       NOT NULL DEFAULT 1,
+    xp          BIGINT       NOT NULL DEFAULT 0,
+    unlocked_at TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_user_characters_character
+        CHECK (character IN ('crab', 'dolphin', 'turtle', 'whale', 'capybara')),
+    CONSTRAINT chk_user_characters_stage CHECK (stage >= 1 AND stage <= 3),
+    CONSTRAINT chk_user_characters_xp CHECK (xp >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_characters_user_character
+    ON user_characters (user_id, character);
+
+CREATE TABLE IF NOT EXISTS streamer_familiarities (
+    id                         UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id                    UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    channel_id                 VARCHAR(255) NOT NULL,
+    cumulative_watch_seconds   BIGINT       NOT NULL DEFAULT 0,
+    last_watched_at            TIMESTAMPTZ,
+    created_at                 TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at                 TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_streamer_familiarities_watch_seconds
+        CHECK (cumulative_watch_seconds >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_streamer_familiarities_user_channel
+    ON streamer_familiarities (user_id, channel_id);

--- a/services/api/migrations/023_user_characters_streamer_familiarity.sql
+++ b/services/api/migrations/023_user_characters_streamer_familiarity.sql
@@ -8,7 +8,10 @@ ALTER TABLE users
 DO $$
 BEGIN
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint WHERE conname = 'chk_users_active_character'
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_users_active_character'
+          AND conrelid = 'users'::regclass
     ) THEN
         ALTER TABLE users
             ADD CONSTRAINT chk_users_active_character

--- a/services/api/migrations/atlas.sum
+++ b/services/api/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Z7F979k17UMYFopCdzAzd2kFMkBNBl0xB1/gFtVpCGk=
+h1:FNaHR8K+IG3HBneCIjR/+9iUaJiTXRQhZoOOaQttbDk=
 001_init.sql h1:RXDyJb8ZsPCAiihSRadGfVmeVroOZ5Icv6TbGfg13yw=
 002_email_auth.sql h1:knuWN3/aXOfTZYjSa/JE/C6mMfJYcOBse+S8H8Oxcow=
 003_watch_points.sql h1:TZ7OpuYOFatMiffwJv4Tzq+JXP9G3BYUmHK89xEfZEM=
@@ -21,4 +21,4 @@ h1:Z7F979k17UMYFopCdzAzd2kFMkBNBl0xB1/gFtVpCGk=
 020_atlas_reconcile_current_schema.sql h1:ILRmsZcmeBBzeU6qDFiRjqTXUHgQG7LPB20Mg67or68=
 021_raffle_prize_tiers.sql h1:crrIPEjm9r59KoUwgdhwWlUrrq+OIUoQTvVhqf5jnHM=
 022_raffle_mode_fields.sql h1:xLoRRPQJiaG+7NgYPuHgzIcFPviyMS/Zls3wODqLewU=
-023_user_characters_streamer_familiarity.sql h1:Urh203nXzc2AKEM1KGgDyRfS3mKBT7NpkZjoO4frikU=
+023_user_characters_streamer_familiarity.sql h1:6AZb6gLvlPIdnQPk5a30wpYVlAsUEeG7KMzTJpSKlIw=

--- a/services/api/migrations/atlas.sum
+++ b/services/api/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:AIsVTzb6FUCPAEMxGkX7Mbw8CY2Yajo+CFuUYJOnP20=
+h1:Z7F979k17UMYFopCdzAzd2kFMkBNBl0xB1/gFtVpCGk=
 001_init.sql h1:RXDyJb8ZsPCAiihSRadGfVmeVroOZ5Icv6TbGfg13yw=
 002_email_auth.sql h1:knuWN3/aXOfTZYjSa/JE/C6mMfJYcOBse+S8H8Oxcow=
 003_watch_points.sql h1:TZ7OpuYOFatMiffwJv4Tzq+JXP9G3BYUmHK89xEfZEM=
@@ -21,3 +21,4 @@ h1:AIsVTzb6FUCPAEMxGkX7Mbw8CY2Yajo+CFuUYJOnP20=
 020_atlas_reconcile_current_schema.sql h1:ILRmsZcmeBBzeU6qDFiRjqTXUHgQG7LPB20Mg67or68=
 021_raffle_prize_tiers.sql h1:crrIPEjm9r59KoUwgdhwWlUrrq+OIUoQTvVhqf5jnHM=
 022_raffle_mode_fields.sql h1:xLoRRPQJiaG+7NgYPuHgzIcFPviyMS/Zls3wODqLewU=
+023_user_characters_streamer_familiarity.sql h1:Urh203nXzc2AKEM1KGgDyRfS3mKBT7NpkZjoO4frikU=


### PR DESCRIPTION
## 什麼改動
新增海洋角色系統所需的後端 schema 基礎：`users.active_character` / `users.switch_cooldown_until`、`user_characters`、`streamer_familiarities`，並把新 model 納入 Atlas schema loader。

## 為什麼
refs #750

角色挖礦系統需要 per-user 的角色擁有狀態與 per user x streamer 的熟悉度記帳。現有 `PointsLedger` 是 per-channel，不適合存全域角色資料。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#750
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - service / handler / 前端 / buff 邏輯
  - runtime AutoMigrate：目前專案以 Atlas migration 與 `internal/schema` 作為 schema source of truth，server startup DDL 已由既有測試禁止

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #750 controller-selected after #739-#743 were assessed as blocked or too broad
- Actual worker profile(s)：
  - controller + backend schema explorer
- Model strength：
  - controller = high；backend schema explorer = medium
- Spawn directive(s)：
  - profile=backend_schema_explorer model=gpt-5.3-codex-spark reasoning=medium controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `go test ./internal/models ./internal/schema ./cmd/server ./cmd/loader`
  - `go run ./cmd/loader/main.go > /tmp/tachigo-750-loader-schema.sql`
  - `rg -n "active_character|user_characters|streamer_familiarities|chk_users_active_character|idx_user_characters_user_character|idx_streamer_familiarities_user_channel" /tmp/tachigo-750-loader-schema.sql`
  - `go test ./...` in `services/api`
  - `rtk git --no-optional-locks diff --cached --check`
- Self-review / exception reason：
  - Self-review performed by controller before publish; no GitHub self-approval or self-review requested
- Worker session closeout：
  - Worker result read back; no extra worker task needed
- Workflow friction / follow-up split：
  - Infra friction: Atlas CLI is not installed locally, so `atlas.sum` was regenerated through the repo's existing `ariga.io/atlas/sql/migrate` package without adding dependencies. Follow-up split: n/a.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pending
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - initial latest-head triage at b626ce23bdfe6c766586ac71f57d015a1efca8e7; no review threads existed before first CI run; scope snapshot: https://github.com/nurockplayer/tachigo/pull/1014#issuecomment-4587269569
- root_cause_gate_ref：
  - not triggered at b626ce23bdfe6c766586ac71f57d015a1efca8e7 because this is the first reviewed head and no repeated finding exists; rationale: https://github.com/nurockplayer/tachigo/pull/1014#issuecomment-4587269569
- finding_disposition_ref：
  - none yet at b626ce23bdfe6c766586ac71f57d015a1efca8e7; no automated or human finding was available at initial publish time
- Final reviewer action：
  - pending human review; R4 PR intentionally does not use auto-ready

## Final merge gate
- Ready-to-merge decision：
  - blocked until R4 human review and CI complete
- Latest head SHA：
  - b626ce23bdfe6c766586ac71f57d015a1efca8e7
- Required checks：
  - pending GitHub checks
- spec workflow-check evidence：
  - local-only gate attempted; `spec plan 750 --repo . --dry-run --format prompt --verbose` failed because `.spec-injector/` is absent; `spec workflow-check --repo . --phase start --issue 750 --format text` failed with `missing_fields=config`
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add the Atlas migration and backend models for ocean character ownership and streamer familiarity state.
- Approx changed lines：~260
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [x] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Tests only validate the migration/model contract and update existing SQLite/Postgres test fixtures to match the added `users` columns.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] 新增 model `user_character.go`：`user_id` / `character` / `unlocked` / `stage` / `xp` / `unlocked_at`
- [x] 新增 per-user 全域狀態：`active_character` / `switch_cooldown_until`
- [x] 新增 model `streamer_familiarity.go`：`user_id` / `channel_id` / `cumulative_watch_seconds` / `last_watched_at`
- [x] 以 Atlas migration + schema loader 註冊取代 issue 中已過時的 runtime AutoMigrate wording
- [x] model / migration 單元測試與後端測試通過

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
go test ./internal/models ./internal/schema ./cmd/server ./cmd/loader
ok  	github.com/tachigo/tachigo/internal/models
?   	github.com/tachigo/tachigo/internal/schema	[no test files]
ok  	github.com/tachigo/tachigo/cmd/server
ok  	github.com/tachigo/tachigo/cmd/loader

go run ./cmd/loader/main.go > /tmp/tachigo-750-loader-schema.sql
rg -n "active_character|user_characters|streamer_familiarities|chk_users_active_character|idx_user_characters_user_character|idx_streamer_familiarities_user_channel" /tmp/tachigo-750-loader-schema.sql
matched expected users columns, tables, checks, indexes, and foreign keys

go test ./...
ok  	github.com/tachigo/tachigo/cmd/loader
ok  	github.com/tachigo/tachigo/cmd/server
ok  	github.com/tachigo/tachigo/docs
ok  	github.com/tachigo/tachigo/internal/config
ok  	github.com/tachigo/tachigo/internal/contract
ok  	github.com/tachigo/tachigo/internal/handlers
ok  	github.com/tachigo/tachigo/internal/metrics
ok  	github.com/tachigo/tachigo/internal/middleware
ok  	github.com/tachigo/tachigo/internal/models
ok  	github.com/tachigo/tachigo/internal/router
?   	github.com/tachigo/tachigo/internal/schema	[no test files]
ok  	github.com/tachigo/tachigo/internal/services
?   	github.com/tachigo/tachigo/internal/testutil	[no test files]
ok  	github.com/tachigo/tachigo/internal/tracing

rtk git --no-optional-locks diff --cached --check
pass
```

## 備註
This PR is intentionally opened without `auto-ready` because it is R4 schema/migration work.

## Notes for Claude Code Review
- Issue #750 still mentions `cmd/server/main.go AutoMigrate`, but current develop has migrated to Atlas as runtime schema source of truth and includes a server migration test that rejects startup DDL. This PR follows the current architecture instead of reintroducing AutoMigrate.
- The migration is additive only: new nullable/defaulted user columns, new tables, checks, FKs, and unique indexes. No destructive DDL.
