### PR TITLE
[backend] auto-create extension login users

### DIFF
--- a/services/api/internal/services/extension_service.go
+++ b/services/api/internal/services/extension_service.go
@@ -107,13 +107,8 @@ func (s *ExtensionService) VerifyReceiptJWT(receiptStr string) (*ReceiptClaims, 
 	return claims, nil
 }
 
-// LoginWithExtension looks up an existing tachigo account by Twitch user ID and
-// issues a tachigo token pair. The viewer must have already signed up on tachigo
-// and linked their Twitch account — this endpoint does not create new accounts.
-//
-// Returns ErrInvalidExtJWT if the JWT is invalid or the viewer has not authorized
-// the Extension (UserID is empty). Returns ErrUserNotFound if no tachigo account
-// is linked to the Twitch identity.
+// lookupExtensionUserContext looks up an existing tachigo account by Twitch
+// user ID. It is used by write paths that must not create accounts implicitly.
 func (s *ExtensionService) lookupExtensionUserContext(ctx context.Context, claims *ExtensionClaims) (*models.User, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -139,6 +134,17 @@ func (s *ExtensionService) lookupExtensionUserContext(ctx context.Context, claim
 	return &user, nil
 }
 
+func (s *ExtensionService) loginOrCreateExtensionUserContext(ctx context.Context, claims *ExtensionClaims) (*models.User, *TokenPair, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if claims.UserID == "" {
+		return nil, nil, ErrInvalidExtJWT
+	}
+
+	return s.authSvc.upsertOAuthUser(ctx, models.ProviderTwitch, claims.UserID, "", "", nil, nil)
+}
+
 func (s *ExtensionService) LoginWithExtension(extJWT string) (*models.User, *TokenPair, error) {
 	return s.LoginWithExtensionContext(context.Background(), extJWT)
 }
@@ -152,15 +158,11 @@ func (s *ExtensionService) LoginWithExtensionContext(ctx context.Context, extJWT
 	if err != nil {
 		return nil, nil, err
 	}
-	user, err := s.lookupExtensionUserContext(ctx, claims)
+	user, tokens, err := s.loginOrCreateExtensionUserContext(ctx, claims)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	tokens, err := s.authSvc.issueTokenPairContext(ctx, user)
-	if err != nil {
-		return nil, nil, err
-	}
 	return user, tokens, nil
 }
 

--- a/services/api/internal/services/extension_service_test.go
+++ b/services/api/internal/services/extension_service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -218,6 +219,28 @@ func TestCompleteTPointTransactionContext_UsesRequestContextForPointsWriteAndTok
 	}
 }
 
+func TestCompleteTPointTransaction_DoesNotAutoCreateExtensionUser(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	twitchID := "twitch-tpoint-unlinked"
+	extJWT := makeExtJWT(t, twitchID, "channel-tpoint-unlinked")
+	receipt := makeReceiptJWT(t, "tx-unlinked-001", twitchID, "TPOINT100", 100, "bits")
+
+	_, _, err := svc.CompleteTPointTransaction(extJWT, receipt, "TPOINT100")
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("want ErrUserNotFound, got %v", err)
+	}
+
+	var providerCount int64
+	if err := svc.db.Model(&models.AuthProvider{}).
+		Where("provider = ? AND provider_id = ?", models.ProviderTwitch, twitchID).
+		Count(&providerCount).Error; err != nil {
+		t.Fatalf("count auth providers: %v", err)
+	}
+	if providerCount != 0 {
+		t.Fatalf("want no auth provider, got %d", providerCount)
+	}
+}
+
 func TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue(t *testing.T) {
 	svc, _ := newExtSvc(t)
 	_, twitchID := seedTwitchUser(t, svc.db)
@@ -284,6 +307,143 @@ func TestLoginWithExtensionContext_UsesRequestContextForUserLookupAndTokenIssue(
 	}
 	if !seenRefreshTokenWrite {
 		t.Fatal("expected extension login refresh token write to carry request context")
+	}
+}
+
+func TestLoginWithExtension_CreatesAccountForNewTwitchUser(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	twitchID := "twitch-new-user"
+	extJWT := makeExtJWT(t, twitchID, "channel-login-create")
+
+	user, tokens, err := svc.LoginWithExtension(extJWT)
+	if err != nil {
+		t.Fatalf("LoginWithExtension: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user")
+	}
+	if tokens == nil {
+		t.Fatal("expected tokens")
+	}
+	if user.Role != models.RoleViewer {
+		t.Fatalf("want viewer role, got %q", user.Role)
+	}
+	if user.Username != nil {
+		t.Fatalf("extension auto-created user must not derive username from Twitch id, got %q", *user.Username)
+	}
+
+	var provider models.AuthProvider
+	if err := svc.db.Where("provider = ? AND provider_id = ?", models.ProviderTwitch, twitchID).First(&provider).Error; err != nil {
+		t.Fatalf("load auth provider: %v", err)
+	}
+	if provider.UserID != user.ID {
+		t.Fatalf("provider user_id mismatch: want %s, got %s", user.ID, provider.UserID)
+	}
+
+	var userCount int64
+	if err := svc.db.Model(&models.User{}).Where("id = ?", user.ID).Count(&userCount).Error; err != nil {
+		t.Fatalf("count user: %v", err)
+	}
+	if userCount != 1 {
+		t.Fatalf("want one user, got %d", userCount)
+	}
+
+	var refreshCount int64
+	if err := svc.db.Model(&models.RefreshToken{}).Where("user_id = ?", user.ID).Count(&refreshCount).Error; err != nil {
+		t.Fatalf("count refresh tokens: %v", err)
+	}
+	if refreshCount != 1 {
+		t.Fatalf("want one refresh token, got %d", refreshCount)
+	}
+}
+
+func TestLoginWithExtension_EmptyUserIDReturnsInvalidJWTAndDoesNotCreateAccount(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	extJWT := makeExtJWT(t, "", "channel-login-empty-user")
+
+	_, _, err := svc.LoginWithExtension(extJWT)
+	if !errors.Is(err, ErrInvalidExtJWT) {
+		t.Fatalf("want ErrInvalidExtJWT, got %v", err)
+	}
+
+	var userCount int64
+	if err := svc.db.Model(&models.User{}).Count(&userCount).Error; err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if userCount != 0 {
+		t.Fatalf("want no users, got %d", userCount)
+	}
+
+	var providerCount int64
+	if err := svc.db.Model(&models.AuthProvider{}).Count(&providerCount).Error; err != nil {
+		t.Fatalf("count auth providers: %v", err)
+	}
+	if providerCount != 0 {
+		t.Fatalf("want no auth providers, got %d", providerCount)
+	}
+}
+
+func TestLoginWithExtension_ConcurrentFirstLoginCreatesOneProvider(t *testing.T) {
+	svc, _ := newExtSvc(t)
+	sqlDB, err := svc.db.DB()
+	if err != nil {
+		t.Fatalf("db handle: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+
+	twitchID := "twitch-concurrent-user"
+	extJWT := makeExtJWT(t, twitchID, "channel-login-concurrent")
+
+	type result struct {
+		user *models.User
+		err  error
+	}
+	results := make([]result, 5)
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			user, _, err := svc.LoginWithExtension(extJWT)
+			results[idx] = result{user: user, err: err}
+		}(i)
+	}
+	wg.Wait()
+
+	var wantUserID uuid.UUID
+	for i, result := range results {
+		if result.err != nil {
+			t.Fatalf("login %d: %v", i, result.err)
+		}
+		if result.user == nil {
+			t.Fatalf("login %d: expected user", i)
+		}
+		if wantUserID == uuid.Nil {
+			wantUserID = result.user.ID
+			continue
+		}
+		if result.user.ID != wantUserID {
+			t.Fatalf("login %d returned user %s, want %s", i, result.user.ID, wantUserID)
+		}
+	}
+
+	var providerCount int64
+	if err := svc.db.Model(&models.AuthProvider{}).
+		Where("provider = ? AND provider_id = ?", models.ProviderTwitch, twitchID).
+		Count(&providerCount).Error; err != nil {
+		t.Fatalf("count auth providers: %v", err)
+	}
+	if providerCount != 1 {
+		t.Fatalf("want one provider, got %d", providerCount)
+	}
+
+	var userCount int64
+	if err := svc.db.Model(&models.User{}).Count(&userCount).Error; err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if userCount != 1 {
+		t.Fatalf("want one user, got %d", userCount)
 	}
 }
 


### PR DESCRIPTION
## 什麼改動
讓 Twitch Extension `LoginWithExtension` 在第一次看到有效 `user_id` 時自動建立 tachigo viewer account 與 Twitch `AuthProvider`，並發 token pair。

## 為什麼
refs #734

Extension MVP 需要使用者用 Twitch Extension JWT 登入後即可取得 tachigo 帳號；現有行為在查無 Twitch link 時回 `ErrUserNotFound`，會阻斷首次登入。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#734
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 DB-only claim/redeem
  - 不改前端
  - 不改 on-chain 行為
  - 不讓 `CompleteTPointTransaction` 自動建帳號；該寫入路徑仍要求既有 linked Twitch user

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #734 selected after #958 was found already covered by #1004 and several candidates were blocked/too broad
- Actual worker profile(s)：
  - controller + backend auth explorer
- Model strength：
  - controller = high；backend auth explorer = medium
- Spawn directive(s)：
  - profile=backend_auth_explorer model=gpt-5.3-codex-spark reasoning=medium controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `go test ./internal/services -run 'TestLoginWithExtension|TestCompleteTPointTransaction'`
  - `go test ./...` in `services/api`
  - `rtk git --no-optional-locks diff --cached --check`
- Self-review / exception reason：
  - Self-review performed by controller before publish; no GitHub self-approval or self-review requested
- Worker session closeout：
  - Worker result read back and closed; no additional worker task needed
- Workflow friction / follow-up split：
  - Infra friction: spec-injector repo config is absent in this checkout. Follow-up split: n/a.

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - pending
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - initial latest-head triage at 495d620461f656a3178f18f21f9b6829c855d02a; no review threads existed before first CI run
- root_cause_gate_ref：
  - not triggered at 495d620461f656a3178f18f21f9b6829c855d02a because this is the first reviewed head and no repeated finding exists
- finding_disposition_ref：
  - none yet at 495d620461f656a3178f18f21f9b6829c855d02a; no automated or human finding was available at initial publish time
- Final reviewer action：
  - pending human review; R4 PR intentionally does not use auto-ready

## Final merge gate
- Ready-to-merge decision：
  - blocked until R4 human review and CI complete
- Latest head SHA：
  - 495d620461f656a3178f18f21f9b6829c855d02a
- Required checks：
  - pending GitHub checks
- spec workflow-check evidence：
  - local-only gates attempted; `spec plan 734 --repo . --dry-run --format prompt --verbose` failed because `.spec-injector/` is absent; `spec workflow-check --repo . --phase start --issue 734 --format text` and `--phase commit` failed with `missing_fields=config`
- Evidence URL：
  - n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Auto-create a viewer account and Twitch provider record on first valid Extension login.
- Approx changed lines：~190
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - Tests are the regression coverage for the changed service behavior and no production surface beyond `ExtensionService` is changed.
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] `claims.UserID` empty remains `ErrInvalidExtJWT`
- [x] Missing Twitch `AuthProvider` on Extension login creates `User` + `AuthProvider` in the existing OAuth transaction path, then issues token pair
- [x] Auto-created Extension users keep `username` nil instead of using opaque Twitch ids
- [x] Concurrent first login returns one shared user/provider
- [x] Existing partial unique index is relied on; no schema change needed
- [x] Backend tests pass

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
go test ./internal/services -run 'TestLoginWithExtension|TestCompleteTPointTransaction'
ok  	github.com/tachigo/tachigo/internal/services	0.378s

go test ./...
ok  	github.com/tachigo/tachigo/cmd/loader
ok  	github.com/tachigo/tachigo/cmd/server
ok  	github.com/tachigo/tachigo/docs
ok  	github.com/tachigo/tachigo/internal/config
ok  	github.com/tachigo/tachigo/internal/contract
?   	github.com/tachigo/tachigo/internal/database	[no test files]
ok  	github.com/tachigo/tachigo/internal/handlers
ok  	github.com/tachigo/tachigo/internal/metrics
ok  	github.com/tachigo/tachigo/internal/middleware
ok  	github.com/tachigo/tachigo/internal/models
ok  	github.com/tachigo/tachigo/internal/router
?   	github.com/tachigo/tachigo/internal/schema	[no test files]
ok  	github.com/tachigo/tachigo/internal/services
?   	github.com/tachigo/tachigo/internal/testutil	[no test files]
ok  	github.com/tachigo/tachigo/internal/tracing

rtk git --no-optional-locks diff --cached --check
pass
```

## 備註
This PR is intentionally opened without `auto-ready` because it changes auth/login behavior and is R4.

## Notes for Claude Code Review
- The implementation reuses `AuthService.upsertOAuthUser`, so provider conflict recovery and token issuance stay on the existing OAuth transaction path.
- `username` is intentionally nil for Extension-created users; #734 permits nil and this avoids deriving usernames from Twitch ids or introducing username-collision failures.
- `CompleteTPointTransaction` still uses the lookup-only helper and has a regression test proving it does not create accounts implicitly.
