### PR TITLE
[frontend] add shop category flow

### DIFF
--- a/apps/extension/src/app/components/CouponShopPanel.tsx
+++ b/apps/extension/src/app/components/CouponShopPanel.tsx
@@ -8,6 +8,14 @@ import { renderCouponRedeemStatus } from './couponRedeemStatus'
 import { redeemCouponForPanel } from './redeemCouponForPanel'
 
 const couponMetas: DemoCouponMeta[] = demoCouponMetas
+const shopCategories = [
+  { key: 'tachiya', translationKey: 'tachiya', active: true },
+  { key: 'recruit', translationKey: 'recruit', active: false },
+  { key: 'gear', translationKey: 'gear', active: false },
+  { key: 'future', translationKey: 'future', active: false },
+] as const
+
+type ShopStep = 'categories' | 'market'
 
 interface CouponShopPanelProps {
   onBack: () => void
@@ -26,6 +34,7 @@ export function CouponShopPanel({
 }: CouponShopPanelProps) {
   const { t } = useTranslation()
   const tDyn = t as (key: string, options?: Record<string, unknown>) => string
+  const [shopStep, setShopStep] = useState<ShopStep>('categories')
   const [selectedId, setSelectedId] = useState(couponMetas[0]?.id ?? '')
   const [error, setError] = useState('')
   const [isRedeeming, setIsRedeeming] = useState(false)
@@ -106,11 +115,105 @@ export function CouponShopPanel({
           {t('coupon.back')}
         </button>
         <div style={{ fontSize: 8, color: '#b794ff', letterSpacing: '0.12em' }}>
-          {t('coupon.header')}
+          {shopStep === 'categories' ? t('coupon.categories.header') : t('coupon.header')}
         </div>
       </div>
 
-      <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {shopStep === 'categories' ? (
+        <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div
+            style={{
+              border: '1px solid rgba(125,211,252,0.22)',
+              borderRadius: 14,
+              padding: '16px 14px',
+              background:
+                'linear-gradient(180deg, rgba(14, 116, 144, 0.24) 0%, rgba(15, 23, 42, 0.68) 100%)',
+              boxShadow: '0 14px 34px rgba(2, 6, 23, 0.3)',
+            }}
+          >
+            <div style={{ fontSize: 7, color: '#67e8f9', letterSpacing: '0.14em', marginBottom: 8 }}>
+              {t('coupon.categories.eyebrow')}
+            </div>
+            <h2 style={{ margin: 0, color: '#fff7da', fontSize: 18, lineHeight: 1.5 }}>
+              {t('coupon.categories.title')}
+            </h2>
+            <p style={{ margin: '10px 0 0', fontFamily: 'var(--ui-font-family)', fontSize: 12, lineHeight: 1.55 }}>
+              {t('coupon.categories.subtitle')}
+            </p>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 10 }}>
+            {shopCategories.map((category) => {
+              const title = tDyn(`coupon.categories.cards.${category.translationKey}.title`)
+              const description = tDyn(`coupon.categories.cards.${category.translationKey}.description`)
+
+              return (
+                <button
+                  key={category.key}
+                  type="button"
+                  aria-label={title}
+                  onClick={() => {
+                    if (category.active) {
+                      setShopStep('market')
+                    }
+                  }}
+                  disabled={!category.active}
+                  style={{
+                    minHeight: 128,
+                    border: category.active
+                      ? '1px solid rgba(255, 211, 107, 0.46)'
+                      : '1px solid rgba(148, 163, 184, 0.16)',
+                    borderRadius: 12,
+                    padding: 12,
+                    background: category.active
+                      ? 'linear-gradient(155deg, rgba(255,211,107,0.2), rgba(88,28,135,0.28) 52%, rgba(8,47,73,0.72))'
+                      : 'linear-gradient(155deg, rgba(15,23,42,0.82), rgba(30,41,59,0.64))',
+                    color: category.active ? '#fff7da' : 'rgba(226,232,240,0.52)',
+                    cursor: category.active ? 'pointer' : 'not-allowed',
+                    textAlign: 'left',
+                    fontFamily: 'var(--pixel-font-family)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'space-between',
+                    gap: 12,
+                    boxShadow: category.active
+                      ? '0 0 22px rgba(255,211,107,0.16), inset 0 1px 0 rgba(255,255,255,0.12)'
+                      : 'inset 0 1px 0 rgba(255,255,255,0.06)',
+                  }}
+                >
+                  <span style={{ display: 'grid', gap: 8 }}>
+                    <span style={{ fontSize: 13, lineHeight: 1.35 }}>{title}</span>
+                    <span
+                      style={{
+                        fontFamily: 'var(--ui-font-family)',
+                        fontSize: 11,
+                        lineHeight: 1.45,
+                        color: category.active ? 'rgba(248,241,223,0.78)' : 'rgba(203,213,225,0.46)',
+                      }}
+                    >
+                      {description}
+                    </span>
+                  </span>
+                  <span
+                    style={{
+                      alignSelf: 'flex-start',
+                      borderRadius: 999,
+                      padding: '5px 7px',
+                      background: category.active ? 'rgba(255,211,107,0.18)' : 'rgba(148,163,184,0.1)',
+                      color: category.active ? '#ffd36b' : 'rgba(203,213,225,0.48)',
+                      fontSize: 6,
+                      letterSpacing: '0.1em',
+                    }}
+                  >
+                    {category.active ? t('coupon.categories.active') : t('coupon.categories.locked')}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      ) : (
+        <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div
           style={{
             border: '1px solid rgba(145,70,255,0.24)',
@@ -275,7 +378,8 @@ export function CouponShopPanel({
             )
           })}
         </div>
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/extension/src/app/navigation/OverlayHost.test.tsx
+++ b/apps/extension/src/app/navigation/OverlayHost.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
+import '../../i18n'
 import { NavigationProvider } from './NavigationProvider'
 import { OverlayHost } from './OverlayHost'
 import { useNavigation } from './useNavigation'
@@ -21,6 +22,9 @@ function Harness() {
     <>
       <button type="button" onClick={() => pushOverlay({ kind: 'menu' })}>
         open menu
+      </button>
+      <button type="button" onClick={() => pushOverlay({ kind: 'shop' })}>
+        open shop
       </button>
       <output aria-label="top overlay">{topOverlay}</output>
       <OverlayHost
@@ -105,4 +109,27 @@ test('account overlay renders an error state when the current account fetch fail
 
   expect((await screen.findByRole('alert')).textContent).toContain('Could not load account')
   expect(screen.getAllByRole('button', { name: 'Close' }).length).toBeGreaterThan(0)
+})
+
+test('shop opens category cards before entering the coupon market', () => {
+  render(
+    <NavigationProvider>
+      <Harness />
+    </NavigationProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'open shop' }))
+
+  expect(screen.getByLabelText('top overlay').textContent).toBe('shop')
+  expect(screen.getByRole('heading', { name: 'Choose a reward shelf' })).toBeTruthy()
+  expect(screen.queryByRole('button', { name: 'REDEEM' })).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Tachiya Coupon' }))
+
+  expect(screen.getByText('COUPON MARKET')).toBeTruthy()
+  expect(screen.getByRole('button', { name: 'REDEEM' })).toBeTruthy()
+
+  fireEvent.click(screen.getByRole('button', { name: '‹ BACK' }))
+
+  expect(screen.getByLabelText('top overlay').textContent).toBe('none')
 })

--- a/apps/extension/src/i18n/locales/en/common.json
+++ b/apps/extension/src/i18n/locales/en/common.json
@@ -65,6 +65,32 @@
     "header": "COUPON MARKET",
     "entry": "SHOP",
     "back": "‹ BACK",
+    "categories": {
+      "header": "REWARD COUNTER",
+      "eyebrow": "LUMI'S COUNTER",
+      "title": "Choose a reward shelf",
+      "subtitle": "Pick the Tachiya coupon card to open the market. Other shelves are preview slots for later drops.",
+      "active": "OPEN",
+      "locked": "LOCKED",
+      "cards": {
+        "tachiya": {
+          "title": "Tachiya Coupon",
+          "description": "Discount rewards for the current creator shop."
+        },
+        "recruit": {
+          "title": "Recruit",
+          "description": "Future character invitations and companions."
+        },
+        "gear": {
+          "title": "Gear",
+          "description": "Future equipment and mining upgrades."
+        },
+        "future": {
+          "title": "More Rewards",
+          "description": "Reserved for upcoming campaign rewards."
+        }
+      }
+    },
     "balanceLabel": "PLATFORM COIN",
     "subtitle": "Redeem your TCG for creator store discounts and shipping perks.",
     "featured": "FEATURED COUPON",

--- a/apps/extension/src/i18n/locales/zh-CN/common.json
+++ b/apps/extension/src/i18n/locales/zh-CN/common.json
@@ -65,6 +65,32 @@
     "header": "Coupon 兑换商城",
     "entry": "商城",
     "back": "‹ 返回",
+    "categories": {
+      "header": "奖励柜台",
+      "eyebrow": "LUMI 的柜台",
+      "title": "选择奖励分类",
+      "subtitle": "点选 Tachiya Coupon 卡片进入商城。其他分类先作为后续掉落的预览位置。",
+      "active": "可进入",
+      "locked": "未开放",
+      "cards": {
+        "tachiya": {
+          "title": "Tachiya Coupon",
+          "description": "本期创作者商城可用的折扣奖励。"
+        },
+        "recruit": {
+          "title": "角色招募",
+          "description": "后续角色邀请与伙伴内容。"
+        },
+        "gear": {
+          "title": "装备",
+          "description": "后续装备与挖矿升级内容。"
+        },
+        "future": {
+          "title": "更多奖励",
+          "description": "保留给未来活动奖励。"
+        }
+      }
+    },
     "balanceLabel": "平台币余额",
     "subtitle": "使用 TCG 兑换创作者商城折扣码与免运福利。",
     "featured": "本期主打",

--- a/apps/extension/src/i18n/locales/zh-TW/common.json
+++ b/apps/extension/src/i18n/locales/zh-TW/common.json
@@ -65,6 +65,32 @@
     "header": "Coupon 兌換商城",
     "entry": "商城",
     "back": "‹ 返回",
+    "categories": {
+      "header": "獎勵櫃檯",
+      "eyebrow": "LUMI 的櫃檯",
+      "title": "選擇獎勵分類",
+      "subtitle": "點選 Tachiya Coupon 卡片進入商城。其他分類先作為後續掉落的預覽位置。",
+      "active": "可進入",
+      "locked": "未開放",
+      "cards": {
+        "tachiya": {
+          "title": "Tachiya Coupon",
+          "description": "本期創作者商城可用的折扣獎勵。"
+        },
+        "recruit": {
+          "title": "角色招募",
+          "description": "後續角色邀請與夥伴內容。"
+        },
+        "gear": {
+          "title": "裝備",
+          "description": "後續裝備與挖礦升級內容。"
+        },
+        "future": {
+          "title": "更多獎勵",
+          "description": "保留給未來活動獎勵。"
+        }
+      }
+    },
     "balanceLabel": "平台幣餘額",
     "subtitle": "使用 TCG 兌換創作者商城折扣碼與免運福利。",
     "featured": "本期主打",


### PR DESCRIPTION
## 什麼改動
在現有 Coupon Shop overlay 前新增一層獎勵分類卡片入口：打開 shop 時先看到 Tachiya Coupon / 角色招募 / 裝備 / 更多獎勵分類，只有 Tachiya Coupon 可進入既有 coupon market，其餘分類保持 locked preview。

## 為什麼
refs #773

#773 的最新 shop flow 要求 `counter -> categoryCards -> market -> counter`。本 PR 先落地最小可驗證的 categoryCards -> market 前端流程，不新增素材、不碰後端、不改兌換 API。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#773
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增圖片 / LFS assets
  - 不做完整 Entry / Counter shop 場景素材
  - 不做大型 motion / 水流特效
  - 不改 ClaimPanel
  - 不改 coupon redemption API 或後端 contract
  - 不做 #741 / #742 的真實 claim / redeem 串接

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #773 未提供明確 worker delegation plan；依 AWP 規則以 controller 拆分最小前端切片。
- Actual worker profile(s)：
  - explorer worker Kuhn：read-only 評估 #758/#759/#760 是否比 #773 更適合下一個小 PR。
  - controller：實作 #773 categoryCards -> market 小切片。
- Model strength：
  - controller = high
  - explorer worker = low
- Spawn directive(s)：
  - profile=explorer model=inherited reasoning=low controller_fallback=no task=issue dependency triage for #758/#759/#760
  - profile=controller model=gpt-5.5 reasoning=high controller_fallback=yes fallback_reason=agent_thread_limit_when_splitting_773 task=implement #773 shop category flow slice
- Verification evidence：
  - `pnpm vitest run src/app/navigation/OverlayHost.test.tsx` pass
  - `pnpm exec tsc -b` pass
  - `pnpm lint` pass
  - `pnpm test` pass
  - `pnpm build` pass with existing Vite chunk-size warning
  - `pnpm check:i18n` pass
  - `git diff --check` pass
- Self-review / exception reason：
  - Controller read back full diff and confirmed no asset/LFS/backend/API changes.
- Worker session closeout：
  - Explorer worker result read back and session closed.
- Workflow friction / follow-up split：
  - Character-system tickets #758/#759/#760 were rejected for this cycle because they depend on backend character APIs that are not in develop. #773 was split to a small no-asset frontend flow slice to avoid dependency and LFS friction. threshold calibration ref: local-only `/tmp/tachigo-pr-773-threshold.json`.

## Review conversation closeout
- Unresolved threads：
  - 0 before PR creation
- CodeRabbit：
  - pending after PR creation
- chatgpt-codex-connector：
  - pending after PR creation
- review_triage_ref：
  - local-only `/tmp/tachigo-pr-773-findings.json`
- root_cause_gate_ref：
  - n/a; no repeated finding before PR creation
- finding_disposition_ref：
  - local-only `/tmp/tachigo-pr-773-findings.json`
- Final reviewer action：
  - pending automated and human review

## Final merge gate
- Ready-to-merge decision：
  - blocked until PR checks and reviewer signals complete
- Latest head SHA：
  - 9ce6e7b543a9e0282f9f1e05f10ac9bef9abcccc
- Required checks：
  - pass: Scope Police, PR metadata, commit messages, frontend build, supply-chain guardrails, TypeScript-only guardrail, workflow regression tests
- spec workflow-check evidence：
  - start gate failed local-only: `missing_fields=config` because repo has no `.spec-injector/`
  - commit gate failed local-only: `missing_fields=config` for the same repo config gap; manual checklist completed
- Evidence URL：
  - Scope Police pass: https://github.com/nurockplayer/tachigo/pull/1016#issuecomment-4587440986

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Add a category-card landing step before entering the existing Tachiya coupon market.
- Approx changed lines：~212
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - 測試只覆蓋本 PR 新增的 shop category flow，與前端行為變更不可分。
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Coupon flow 先呈現 categoryCards，再由 Tachiya Coupon 進入 market。
- [x] Tachiya Coupon active，其餘分類 locked / preview。
- [x] market 返回直接關閉 shop overlay，回到 counter/mining 外層。
- [x] UI text 全部走 i18n / CSS text，不燒進圖片。
- [x] 不新增 LFS assets；`pnpm test` 通過。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
pnpm vitest run src/app/navigation/OverlayHost.test.tsx
1 file passed, 2 tests passed

pnpm exec tsc -b
pass

pnpm lint
pass

pnpm test
22 files passed, 81 tests passed

pnpm build
pass; existing Vite chunk-size warning only

pnpm check:i18n
pass: 21 locale mappings, 95 keys

git diff --check
pass
```

## 備註
This PR intentionally does not add artwork. It only makes the existing shop overlay follow the first small part of #773's categoryCards -> market flow.

## Notes for Claude Code Review
- 請特別看 `CouponShopPanel` 內 `shopStep` 是否是足夠輕量的 local state；本 PR 沒有新增 route/overlay type，目的是避免跟未合併的 navigation PR 打架。
