### PR TITLE
[chore] document dashboard auth session boundary

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'architecture',
         'auth-architecture',
+        'dashboard-auth-session',
         'sequence-diagram',
         'watch-to-points-design',
         'tokenomics',

--- a/docs/dashboard-auth-session.md
+++ b/docs/dashboard-auth-session.md
@@ -1,0 +1,103 @@
+---
+title: Dashboard Auth And Session Boundary
+status: active
+owner: engineering
+last_reviewed: 2026-06-01
+source_of_truth: true
+code_areas:
+  - apps/dashboard
+  - services/api
+related_issues:
+  - 763
+---
+
+# Dashboard Auth And Session Boundary
+
+## Purpose
+
+This document records the current dashboard authentication, session restore, and
+frontend RBAC boundary. It is a current-state reference for issue #763 and does
+not introduce new auth behavior by itself.
+
+When this document conflicts with code, the code is the source of truth. Update
+this document in the same PR that changes dashboard auth, session persistence,
+or role-boundary behavior.
+
+## Current Runtime Contract
+
+The dashboard uses `apps/dashboard/src/services/api.ts` as its Axios client and
+`apps/dashboard/src/providers/authProvider.ts` as the Refine auth bridge.
+
+| Area | Current behavior |
+|---|---|
+| Login | `login()` posts to `/api/v1/auth/login` and stores the returned access token in the dashboard API client. |
+| Access token storage | The access token is kept in module memory only. The dashboard app does not persist it in `localStorage` or `sessionStorage`. |
+| Refresh/session state | The Axios client sends `withCredentials: true`. The refresh token is owned by the backend-managed httpOnly cookie. |
+| App bootstrap | `main.tsx` calls `restoreSession()` before rendering the app so a valid backend refresh cookie can restore an in-memory access token after reload. |
+| Silent refresh | A 401 response on an authenticated request triggers one deduped `/api/v1/auth/refresh` call, then retries the original request with the refreshed access token. |
+| Logout | `logout()` posts to `/api/v1/auth/logout` and clears the in-memory access token. |
+
+The dashboard should not start persisting refresh tokens or user payloads in
+browser storage without a dedicated auth migration PR.
+
+## Route And Role Boundary
+
+Dashboard page routing uses Refine's `<Authenticated>` wrapper around the main
+authenticated route tree in `apps/dashboard/src/App.tsx`. Unauthenticated users
+are redirected to `/login`.
+
+Frontend role handling is currently advisory:
+
+- `authProvider.getPermissions()` returns the role decoded from the current
+  access token.
+- `Layout` filters some navigation items by decoded role.
+- Some pages use the decoded role for local presentation decisions.
+
+The backend remains the source of truth for access control. Dashboard API routes
+under `/api/v1/dashboard/*` must still rely on backend JWT authentication,
+route-level role gates, and handler ownership checks documented in
+[`backend-permissions.md`](./backend-permissions.md).
+
+## Known Gaps For Issue #763
+
+Issue #763 is broader than this document. The current dashboard still needs
+dedicated implementation PRs for the remaining hardening work:
+
+| Gap | Expected follow-up |
+|---|---|
+| Route-level role guards | Add explicit frontend route guard behavior for dashboard pages whose visibility differs by role. |
+| Component-level RBAC | Keep role-sensitive controls hidden or disabled on the frontend while preserving backend enforcement. |
+| Session failure UX | Normalize expired-session, failed-refresh, and logout states so the user lands on `/login` predictably. |
+| API error handling | Normalize 401/403 handling across dashboard data providers and direct service calls. |
+| Regression coverage | Add tests for auth restore, expired session, wrong-role navigation, and backend-denied dashboard calls. |
+
+These follow-ups should not change backend role policy casually. Permission
+changes require a dedicated PR and an update to
+[`backend-permissions.md`](./backend-permissions.md).
+
+## Manual Verification Checklist
+
+Use this checklist when changing dashboard auth or session behavior:
+
+1. Login with valid dashboard credentials and confirm authenticated routes render.
+2. Reload an authenticated dashboard route and confirm the session is restored
+   when the backend refresh cookie is valid.
+3. Expire or remove the backend refresh cookie, reload, and confirm the app
+   redirects to `/login` without keeping a stale access token.
+4. Logout and confirm subsequent dashboard API calls do not include the old
+   access token.
+5. Use a `viewer` or otherwise unauthorized role and confirm backend dashboard
+   calls return 403 even if a frontend page or control is reachable.
+6. Confirm no dashboard auth change writes access tokens, refresh tokens, or
+   current-user payloads to `localStorage` or `sessionStorage`.
+
+## Non-Goals
+
+This document does not:
+
+- complete issue #763
+- change dashboard auth, route guard, or API behavior
+- define new backend permissions
+- change token lifetime, cookie attributes, or refresh semantics
+- replace [`auth-architecture.md`](./auth-architecture.md) or
+  [`backend-permissions.md`](./backend-permissions.md)

--- a/docs/dev-portal/source-index.md
+++ b/docs/dev-portal/source-index.md
@@ -37,6 +37,7 @@ related_repos:
 |---|---|
 | [architecture.md](/tachigo/architecture) | 系統整體架構與主要資料流 |
 | [auth-architecture.md](/tachigo/auth-architecture) | Auth 現況與 migration guardrails |
+| [dashboard-auth-session.md](/tachigo/dashboard-auth-session) | Dashboard auth/session restore 與 frontend RBAC 邊界現況 |
 | [backend-permissions.md](/tachigo/backend-permissions) | Backend role / permission 現況與變更 guardrails |
 | [auto-merge-policy.md](/tachigo/auto-merge-policy) | Auto-merge 與 approve 語義 |
 | [dependabot-update-policy.md](/tachigo/dependabot-update-policy) | Dependabot 更新政策 |


### PR DESCRIPTION
## 什麼改動
新增 `docs/dashboard-auth-session.md`，記錄 dashboard 目前的 login、in-memory access token、httpOnly cookie refresh、bootstrap session restore、401 silent refresh、logout 與 frontend RBAC 邊界。

同時把這份文件加入 Dev Portal source index 與 docs sidebar。

## 為什麼
refs #763

#763 要求 dashboard auth/session/RBAC hardening，其中一項 AC 是「Session lifecycle behavior is documented」。這個 PR 先補齊現況文件，並明確列出尚未完成的 route guard、component RBAC、API error handling、typed contracts 與 payload validation follow-up。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [x] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#763
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改 dashboard auth/runtime code
  - 不新增 route-level permission guards
  - 不新增 component-level RBAC checks
  - 不改 backend permissions / token / cookie behavior
  - 不宣稱完成 #763

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #763 has no dedicated delegation plan; scoped as a small docs-only slice for the documented-session-lifecycle AC.
- Actual worker profile(s)：
  - controller only
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller model=gpt-5-codex reasoning=high controller_fallback=used fallback_reason=small R0 docs-only change after higher-risk implementation PRs were already open and waiting review
- Verification evidence：
  - `spec workflow-check --repo . --phase start --issue 763 --format text` -> blocked: missing `.spec-injector/` config
  - `spec plan 763 --repo . --dry-run --format prompt --verbose` -> blocked: missing `.spec-injector/` config
  - `rtk git --no-optional-locks diff --check`
  - `pnpm --dir apps/docs test:frontmatter-validator`
  - `pnpm build:docs`
- Self-review / exception reason：
  - Self-review completed; no public PR review/approval/comment was posted.
- Worker session closeout：
  - n/a; no worker session was opened for this R0 docs-only slice.
- Workflow friction / follow-up split：
  - spec-injector local gate could not run because the repo/worktree has no `.spec-injector/` directory; this PR records the blocked local-only gate instead of initializing unrelated config. Remaining #763 implementation work is intentionally left for follow-up PRs.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - skipped by rate limit; status context is success and no actionable finding was produced
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - local verification listed in this PR body
- root_cause_gate_ref：
  - latest-head rationale: docs-only AC slice; no repeated finding triggered
- finding_disposition_ref：
  - n/a at PR creation
- Final reviewer action：
  - waiting for human review; no self-review/approval/comment posted

## Final merge gate
- Ready-to-merge decision：
  - blocked by required human review
- Latest head SHA：
  - 03a61b7e918b4b86c3792c37d5918a648b1e4c46
- Required checks：
  - pass: latest Scope Police run, CI checks, workflow regression tests, commit message checks, supply-chain guardrails, TypeScript-only guardrail
- spec workflow-check evidence：
  - blocked locally: missing `.spec-injector/` config in clean worktree
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/1018

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Document the current dashboard auth/session lifecycle and frontend RBAC boundary for #763.
- Approx changed lines：~110
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [ ] Refreshing the dashboard does not unexpectedly log users out
- [ ] Unauthorized pages/components are protected consistently
- [ ] Frontend/backend auth contracts are explicit and typed
- [x] Session lifecycle behavior is documented

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
rtk git --no-optional-locks diff --check
# pass

pnpm --dir apps/docs test:frontmatter-validator
# pass: 7 tests

pnpm build:docs
# pass: Docusaurus build generated static files

spec workflow-check --repo . --phase start --issue 763 --format text
# blocked: No .spec-injector/ directory found
```

## 備註
本 PR 只完成 #763 的文件化 AC，不關閉 #763。

## Notes for Claude Code Review
- 請特別確認這份文件是否準確描述目前 dashboard auth/session 實作，且沒有把 frontend RBAC 文件化寫成已完成的 enforcement。
