### PR TITLE
[backend] extend dashboard RBAC route matrix

### DIFF
--- a/services/api/internal/handlers/rbac_handler_test.go
+++ b/services/api/internal/handlers/rbac_handler_test.go
@@ -76,8 +76,28 @@ func newRBACTestEnv(t *testing.T) *rbacEnv {
 			middleware.RequireRole(models.RoleAgency, models.RoleAdmin),
 			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
 		)
+		dashboard.GET("/streamers/:streamer_id/stats",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		dashboard.POST("/streamers/register",
+			middleware.RequireRole(models.RoleStreamer),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		dashboard.GET("/streamers/channels",
+			middleware.RequireRole(models.RoleStreamer),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		dashboard.GET("/channels/:channel_id/stats",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
 		dashboard.GET("/channels/:channel_id/config",
 			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer, models.RoleAgency),
+			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
+		)
+		dashboard.PUT("/channels/:channel_id/config",
+			middleware.RequireRole(models.RoleAdmin, models.RoleStreamer),
 			func(c *gin.Context) { c.JSON(501, gin.H{"error": "not implemented"}) },
 		)
 	}
@@ -174,6 +194,24 @@ func eventOperatorRBACCases() []rbacMatrixCase {
 	}
 }
 
+func streamerOnlyRBACCases() []rbacMatrixCase {
+	return []rbacMatrixCase{
+		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+		{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
+		{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
+		{name: "admin forbidden", role: models.RoleAdmin, want: http.StatusForbidden},
+	}
+}
+
+func adminStreamerRBACCases() []rbacMatrixCase {
+	return []rbacMatrixCase{
+		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
+		{name: "streamer allowed", role: models.RoleStreamer, want: http.StatusNotImplemented},
+		{name: "agency forbidden", role: models.RoleAgency, want: http.StatusForbidden},
+		{name: "admin allowed", role: models.RoleAdmin, want: http.StatusNotImplemented},
+	}
+}
+
 func dashboardOperatorRBACCases() []rbacMatrixCase {
 	return []rbacMatrixCase{
 		{name: "viewer forbidden", role: models.RoleViewer, want: http.StatusForbidden},
@@ -235,11 +273,46 @@ func centralizedRBACMatrixRoutes() []rbacMatrixRoute {
 			cases:       agencyOperatorRBACCases(),
 		},
 		{
+			name:        "streamer stats allows dashboard operators",
+			method:      http.MethodGet,
+			routePath:   "/api/v1/dashboard/streamers/:streamer_id/stats",
+			requestPath: "/api/v1/dashboard/streamers/streamer_1/stats",
+			cases:       dashboardOperatorRBACCases(),
+		},
+		{
+			name:        "streamer self-register is streamer only",
+			method:      http.MethodPost,
+			routePath:   "/api/v1/dashboard/streamers/register",
+			requestPath: "/api/v1/dashboard/streamers/register",
+			cases:       streamerOnlyRBACCases(),
+		},
+		{
+			name:        "streamer channels list is streamer only",
+			method:      http.MethodGet,
+			routePath:   "/api/v1/dashboard/streamers/channels",
+			requestPath: "/api/v1/dashboard/streamers/channels",
+			cases:       streamerOnlyRBACCases(),
+		},
+		{
+			name:        "channel stats allows admin or streamer only",
+			method:      http.MethodGet,
+			routePath:   "/api/v1/dashboard/channels/:channel_id/stats",
+			requestPath: "/api/v1/dashboard/channels/ch_ctx/stats",
+			cases:       adminStreamerRBACCases(),
+		},
+		{
 			name:        "channel config read allows dashboard operators",
 			method:      http.MethodGet,
 			routePath:   "/api/v1/dashboard/channels/:channel_id/config",
 			requestPath: "/api/v1/dashboard/channels/ch_ctx/config",
 			cases:       dashboardOperatorRBACCases(),
+		},
+		{
+			name:        "channel config update allows admin or streamer only",
+			method:      http.MethodPut,
+			routePath:   "/api/v1/dashboard/channels/:channel_id/config",
+			requestPath: "/api/v1/dashboard/channels/ch_ctx/config",
+			cases:       adminStreamerRBACCases(),
 		},
 		{
 			name:        "create event allows event operators",


### PR DESCRIPTION
## 什麼改動
在 `services/api/internal/handlers/rbac_handler_test.go` 的 centralized RBAC matrix 裡補上 dashboard 非 raffle 路由的 route-level role gate 覆蓋：

- `GET /dashboard/streamers/:streamer_id/stats`
- `POST /dashboard/streamers/register`
- `GET /dashboard/streamers/channels`
- `GET /dashboard/channels/:channel_id/stats`
- `PUT /dashboard/channels/:channel_id/config`

## 為什麼
refs #646

#646 要求逐步建立 protected endpoint 的 RBAC regression matrix。這個 PR 只補一個小切片：讓 dashboard 非 raffle 的 route-level role gate 在中央 stub matrix 裡被覆蓋，避免 router/middleware refactor 時不小心放寬角色。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [x] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#646
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不改實際 router / middleware / handler 行為
  - 不改 permission policy
  - 不新增 ownership mismatch 或 cross-tenant fixture coverage
  - 不宣稱完成 #646 的 all protected endpoint coverage
  - 不新增「新增 protected route 必須有 matrix row」的 CI coverage gate

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #646 has no dedicated issue-body delegation plan; scoped as a small R1 tests-only slice of the existing centralized matrix.
- Actual worker profile(s)：
  - controller only
- Model strength：
  - controller = high
- Spawn directive(s)：
  - profile=controller model=gpt-5-codex reasoning=high controller_fallback=used fallback_reason=small single-file tests-only matrix extension with no runtime behavior change
- Verification evidence：
  - `spec workflow-check --repo . --phase start --issue 646 --format text` -> blocked: missing `.spec-injector/` config
  - `spec plan 646 --repo . --dry-run --format prompt --verbose` -> blocked: missing `.spec-injector/` config
  - `go test ./internal/handlers -run 'TestRBACMatrix'`
  - `go test ./internal/handlers`
  - `go test ./...`
  - `rtk git --no-optional-locks diff --check`
- Self-review / exception reason：
  - trivial/self-only exception: one test file, bounded matrix rows, no runtime behavior or policy change.
- Worker session closeout：
  - No worker session was opened for this trivial/self-only tests-only slice; controller read back diff and verification outputs.
- Workflow friction / follow-up split：
  - spec-injector local gate could not run because the repo/worktree has no `.spec-injector/` directory; this PR records the blocked local-only gate instead of initializing unrelated config. Remaining ownership and coverage-gate work stays in #646 follow-up slices.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - status check passed; automated review was skipped, no actionable finding posted for this head
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - local verification listed in this PR body
- root_cause_gate_ref：
  - latest-head rationale: tests-only route-level matrix extension; no repeated finding triggered
- finding_disposition_ref：
  - n/a at PR creation
- Final reviewer action：
  - waiting for required human review; no self-review, self-approval, or self-merge was performed

## Final merge gate
- Ready-to-merge decision：
  - blocked by required human review only; latest required checks passed
- Latest head SHA：
  - f20377d1bdfa28211d1c86a042a92974fd8924e2
- Required checks：
  - pass: PR commit messages, Scope police, Supply-chain guardrails, TypeScript-only guardrail, Workflow regression tests, Commit message regression tests, PR metadata check regression tests, CI scope router, Backend tests, Backend integration tests, Backend security scanners, Atlas migration tooling, Backend CI gate, auto-ready
- spec workflow-check evidence：
  - blocked locally: missing `.spec-injector/` config in clean worktree
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/1019

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Extend the centralized RBAC matrix with dashboard non-raffle route-level role gates.
- Approx changed lines：~75
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - n/a

## Acceptance Criteria
- [x] Create centralized RBAC ownership matrix tests
- [ ] Cover all protected admin / streamer / agency endpoints
- [ ] Cover ownership mismatch scenarios
- [x] Cover unauthenticated / wrong-role / allowed-role route-level access for the added dashboard rows
- [x] Add reusable permission test helpers
- [ ] CI fails when new protected routes lack RBAC coverage
- [x] Document expected authorization behavior source-of-truth

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
go test ./internal/handlers -run 'TestRBACMatrix'
# pass

go test ./internal/handlers
# pass

go test ./...
# pass

rtk git --no-optional-locks diff --check
# pass
```

## 備註
本 PR 只補 dashboard 非 raffle route-level gate matrix，不關閉 #646。

## Notes for Claude Code Review
- 請特別確認新增 matrix cases 是否準確對應 `services/api/internal/router/router.go` 的 dashboard route-level `RequireRole(...)`，且沒有把 ownership fixture coverage 混進這個小 PR。
