### PR TITLE
[infra] document deploy workflow planning

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -70,6 +70,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'atlas-migration-plan',
         'atlas-schema-reconciliation',
+        'deploy-workflow-planning',
         'non-web3-launch-readiness',
         'openapi-codegen-flow',
         'superpowers/specs/2026-05-14-project-atlas-design',

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@
 |---|---|
 | [`atlas-migration-plan.md`](atlas-migration-plan.md) | #463 Atlas migration 拆分實作計畫；不得單獨視為已完成狀態 |
 | [`atlas-schema-reconciliation.md`](atlas-schema-reconciliation.md) | #463 baseline 前 schema reconciliation evidence / procedure |
+| [`deploy-workflow-planning.md`](deploy-workflow-planning.md) | #212 deploy workflow planning；正式 workflow 實作拆到 #1020 |
 | [`non-web3-launch-readiness.md`](non-web3-launch-readiness.md) | 暫時捨棄 Web3 上鏈部分後的上線距離、Codex 自動化能力與真人介入層級 snapshot |
 | [`openapi-codegen-flow.md`](openapi-codegen-flow.md) | #401 OpenAPI → TypeScript contracts / codegen rollout 計畫 |
 

--- a/docs/deploy-workflow-planning.md
+++ b/docs/deploy-workflow-planning.md
@@ -1,0 +1,105 @@
+---
+title: Deploy workflow planning
+status: active
+owner: engineering
+last_reviewed: 2026-06-01
+source_of_truth: true
+code_areas:
+  - docs
+  - .github/workflows
+  - services/api
+  - apps/dashboard
+  - apps/extension
+related_repos:
+  - tachigo
+related_issues:
+  - 212
+  - 1020
+---
+
+# Deploy workflow planning
+
+This document closes the planning part of #212. It records the deploy workflow boundaries that should guide the implementation issue #1020. It does not create or modify deploy automation.
+
+## Current runbooks
+
+| Surface | Existing source | Current status |
+|---|---|---|
+| Backend staging API | [`backend-staging-deploy.md`](backend-staging-deploy.md) | Has staging API target, GitHub Environment name, approval expectation, Atlas migration step, smoke script, and rollback limits. |
+| Dashboard | [`dashboard-deployment.md`](dashboard-deployment.md) | Has Cloudflare Pages staging / production target, artifact contract, production API URL readback, smoke checklist, and rollback readback. |
+| Dev Portal | [`dev-portal/deployment.md`](dev-portal/deployment.md) | Has Cloudflare Pages manual setup, `develop` production branch model, preview readback, and rollback checklist for docs hosting only. |
+| Extension package | [`apps/extension/README.md`](https://github.com/nurockplayer/tachigo/blob/develop/apps/extension/README.md) | Has Chrome Web Store / sideload package checklist and production package readback. |
+| API schema changes | [`services/api/README.md`](https://github.com/nurockplayer/tachigo/blob/develop/services/api/README.md), [`atlas-schema-reconciliation.md`](atlas-schema-reconciliation.md) | Atlas owns schema migrations; API startup must not regain schema DDL ownership. |
+
+## Decisions
+
+### Deploy entrypoints
+
+The first repo-owned deploy workflow should be manual-first:
+
+| Environment | Initial trigger | Gate | Notes |
+|---|---|---|---|
+| Backend staging | `workflow_dispatch` with a commit SHA | GitHub Environment `staging-api` approval | Use the backend staging runbook and smoke script. |
+| Dashboard staging | `workflow_dispatch` with a commit SHA | Dashboard release owner approval | Build `apps/dashboard/dist` and deploy to the staging Pages project. |
+| Production | manual promotion after staging readback | GitHub Environment production approval | Do not connect this to auto-ready or auto-merge. |
+
+Release PR automation remains separate. A `develop -> main` release PR can identify the candidate commit, but deploy must still require explicit environment approval and smoke readback.
+
+### GitHub Environments
+
+Deploy implementation should use GitHub Environments for approval and secret scoping:
+
+| Environment | Owner | Required approval | Secret / variable scope |
+|---|---|---|---|
+| `staging-api` | backend release owner | yes | staging database URL, staging smoke token, staging API base URL |
+| `staging-dashboard` | dashboard release owner | yes | Cloudflare Pages deployment credentials and staging project name |
+| `production-api` | backend release owner | yes | production database URL, production API target, production smoke token |
+| `production-dashboard` | dashboard release owner | yes | production Pages credentials and production project name |
+
+Secrets must be configured by maintainers in GitHub / Cloudflare. AI agents may document expected names, but must not invent, rotate, or print secret values.
+
+### Migration strategy
+
+Backend deploy must keep the existing Atlas ownership model:
+
+1. Build the API image from the exact commit SHA selected for deployment.
+2. Run `atlas migrate apply --dir file://migrations --url "$ATLAS_DATABASE_URL"` before starting the API process, as described by the backend staging runbook and Docker entrypoint.
+3. Capture migration status as `applied`, `noop`, or `failed`.
+4. If migration fails before startup, abort the deploy and keep the previous image serving traffic.
+5. Destructive migrations require a separate maintainer-approved rollback plan and backup before deployment.
+
+The deploy workflow must not hide schema changes in server startup or Cloudflare configuration. Schema changes belong in `services/api/migrations/`.
+
+### Smoke and rollback
+
+Every deploy path needs a readback before promotion:
+
+| Surface | Minimum smoke readback | Rollback evidence |
+|---|---|---|
+| Backend API | deployment SHA, migration status, `GET /health`, `GET /readyz`, authenticated `GET /api/v1/users/me` | failed SHA, restored SHA, migration status, smoke output |
+| Dashboard | production package readback, login, authenticated routes, streamers, raffles, transactions, settings, network origin | rolled-back-from SHA, restored SHA, reason, smoke result |
+| Dev Portal | homepage, `llms.txt`, `manifest.json`, search, source index | deployment id / commit SHA, URL readback, checklist result |
+| Extension | production package readback, Chrome load-unpacked smoke, Twitch side panel smoke, API origin readback | package SHA, submission state, rollback / resubmission note |
+
+Smoke failures should stop promotion. Production rollback should prefer the previous known-good artifact or image and then rerun the same smoke checklist.
+
+## Implementation issue
+
+Follow-up implementation is tracked in #1020.
+
+#1020 should be an R4 workflow / release PR because it will modify `.github/workflows/**` and deployment behavior. It should not use `auto-ready`, and it should include workflow regression coverage for deploy workflow routing.
+
+## Explicit non-goals
+
+- Do not add `.github/workflows/deploy.yml` in this planning PR.
+- Do not configure GitHub secrets, GitHub Environments, Cloudflare projects, DNS, or database credentials in this PR.
+- Do not combine contract deploy / verify, testnet, or mainnet with the backend / dashboard deploy workflow.
+- Do not make release PR creation automatically deploy production.
+- Do not change Atlas migrations or API startup behavior here.
+
+## Acceptance readback for #212
+
+- Staging / production deploy entrypoints are decided.
+- GitHub Environments and approval gates are documented.
+- Secrets, migration, rollback, and smoke readback responsibilities are documented without exposing secret values.
+- Follow-up implementation issue #1020 exists for the actual deploy workflow.

--- a/docs/dev-portal/source-index.md
+++ b/docs/dev-portal/source-index.md
@@ -53,6 +53,7 @@ related_repos:
 |---|---|
 | [atlas-migration-plan.md](/tachigo/atlas-migration-plan) | #463 Atlas migration 拆分實作計畫；不得單獨視為已完成狀態 |
 | [atlas-schema-reconciliation.md](/tachigo/atlas-schema-reconciliation) | #463 baseline 前 schema reconciliation evidence / procedure |
+| [deploy-workflow-planning.md](/tachigo/deploy-workflow-planning) | #212 deploy workflow planning；正式 workflow 實作拆到 #1020 |
 | [non-web3-launch-readiness.md](/tachigo/non-web3-launch-readiness) | 暫時捨棄 Web3 上鏈部分後的上線距離、Codex 自動化能力與真人介入層級 snapshot |
 | [openapi-codegen-flow.md](/tachigo/openapi-codegen-flow) | #401 OpenAPI → TypeScript contracts / codegen rollout 計畫 |
 | [tachigo Dev Portal spec](/tachigo/superpowers/specs/2026-05-14-project-atlas-design) | #674 Dev Portal 設計規格；命名已避開 atlasgo tooling 混淆 |


### PR DESCRIPTION
## 什麼改動
新增 `docs/deploy-workflow-planning.md`，把 #212 的正式 deploy workflow planning 收斂成：

- 既有 backend staging、dashboard、Dev Portal、extension package 與 Atlas migration runbook 對照
- staging / production deploy entrypoint 與 GitHub Environment approval gate
- secrets / migration / rollback / smoke readback 邊界
- 後續 workflow 實作 issue #1020

並更新 `docs/README.md`、`docs/dev-portal/source-index.md`、`apps/docs/sidebars.ts`，讓 Dev Portal 能導覽到新文件。

## 為什麼
closes #212

#212 要先完成 deploy workflow planning，並避免把 deploy workflow 實作混進第一階段 CI hardening。這個 PR 只補 planning source of truth；實際 `.github/workflows/deploy.yml` 實作拆到 #1020。

## Release Context
- Release type：`n/a`

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [x] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#212
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不新增或修改 `.github/workflows/deploy.yml`
  - 不修改 GitHub secrets、GitHub Environments、Cloudflare projects、DNS 或 database credentials
  - 不改 Atlas migrations、API startup、release PR workflow 或 auto-ready / auto-merge behavior
  - 不把 contract deploy / verify、testnet 或 mainnet 混進一般 backend / dashboard deploy workflow

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #212 has no dedicated issue-body delegation plan; scoped as R0 planning docs and follow-up issue split.
- Actual worker profile(s)：
  - repo_scout: Confucius read-only scan for existing deploy docs / workflows / scope risks.
  - controller: scope decision, follow-up issue, docs patch, validation, PR closeout.
- Model strength：
  - repo_scout = inherited model, medium reasoning
  - controller = high
- Spawn directive(s)：
  - profile=repo_scout model=gpt-5-codex reasoning=medium controller_fallback=denied fallback_reason=n/a
- Verification evidence：
  - `spec plan 212 --repo . --dry-run --format prompt --verbose` -> blocked: missing `.spec-injector/` config
  - `spec workflow-check --repo . --phase start --issue 212 --format text` -> blocked: missing `.spec-injector/` config
  - `pnpm install --frozen-lockfile --ignore-scripts` -> local worktree dependency install only; no package or lockfile changes
  - `pnpm --dir apps/docs test:frontmatter-validator`
  - `pnpm build:docs`
  - `rtk git --no-optional-locks diff --check`
- Self-review / exception reason：
  - Controller reviewed worker scan, diff, docs build output, and scope boundaries; no self-review/approval will be posted on GitHub.
- Worker session closeout：
  - Confucius completed read-only scan; controller read back the result and no further worker task is needed.
- Workflow friction / follow-up split：
  - #1020 was opened for the actual deploy workflow implementation so this PR stays planning-only and avoids R4 workflow/runtime changes. spec-injector local gate could not run because this repo/worktree has no `.spec-injector/` directory; this PR records the blocked local-only gate instead of initializing unrelated config.

## Review conversation closeout
- Unresolved threads：
  - 0 at PR creation
- CodeRabbit：
  - status check passed; review comment reported organization usage/rate limit, no actionable inline finding was posted
- chatgpt-codex-connector：
  - n/a
- review_triage_ref：
  - local verification listed in this PR body
- root_cause_gate_ref：
  - latest-head rationale: R0 docs-only planning PR; workflow implementation split to #1020
- finding_disposition_ref：
  - no actionable finding posted for latest head
- Final reviewer action：
  - waiting for required human review; no self-review, self-approval, or self-merge was performed

## Final merge gate
- Ready-to-merge decision：
  - blocked by required human review only; latest required checks passed
- Latest head SHA：
  - 83ebd1126d7dcf47cd205d4c458c943c7c7309c6
- Required checks：
  - pass: PR commit messages, Scope police, Supply-chain guardrails, TypeScript-only guardrail, Workflow regression tests, PR metadata check regression tests, CI scope router, Backend CI gate, auto-ready
- spec workflow-check evidence：
  - blocked locally: missing `.spec-injector/` config in clean worktree
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/1021

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Document the deploy workflow planning decision for #212 and split implementation to #1020.
- Approx changed lines：~115
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #1020 tracks the deploy workflow implementation.

## Acceptance Criteria
- [x] 決定 staging / production deploy 入口
- [x] 決定 GitHub Environments 設定
- [x] 決定 secrets 與 approval policy
- [x] 產出 deploy workflow 實作 issue

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
pnpm --dir apps/docs test:frontmatter-validator
# pass: 7 tests

pnpm build:docs
# pass

rtk git --no-optional-locks diff --check
# pass
```

## 備註
本 PR 只完成 #212 的 planning / issue split，不實作 deploy workflow。`pnpm install --frozen-lockfile --ignore-scripts` 只用於補齊乾淨 worktree 的本機驗證依賴，沒有 package 或 lockfile diff。

## Notes for Claude Code Review
- 請確認 #1020 是否足以承接 workflow implementation，且本 PR 沒有把 R4 workflow / secrets / deploy runtime 內容混入 R0 docs-only 範圍。
