### PR TITLE
[infra] add staged deploy workflow scaffold

### DIFF
--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -31,6 +31,7 @@ const closeIssueOnDevelopMergeWorkflowPath = path.join(currentDir, 'close-issue-
 const dependencyInventoryWorkflowPath = path.join(currentDir, 'dependency-inventory.yml')
 const notifyRebaseNeededWorkflowPath = path.join(currentDir, 'notify-rebase-needed.yml')
 const releasePrWorkflowPath = path.join(currentDir, 'release-pr.yml')
+const deployWorkflowPath = path.join(currentDir, 'deploy.yml')
 const codeRabbitConfigPath = path.join(repoRoot, '.coderabbit.yaml')
 const claudePath = path.join(repoRoot, 'CLAUDE.md')
 const claudeConventionsPath = path.join(repoRoot, '.claude', 'rules', 'conventions.md')
@@ -2194,8 +2195,8 @@ test('docs/template-only PRs skip heavy product CI in CI scope router', async ()
   )
   assert.match(
     workflow,
-    /\^\\.github\\\/workflows\\\/ci\\.yml\$/,
-    'ci.yml changes must request backend integration validation',
+    /\^\\.github\\\/workflows\\\//,
+    'workflow file changes must request full CI validation',
   )
 })
 
@@ -2272,11 +2273,17 @@ test('CI scope router emits full CI outputs for workflow file PRs', async () => 
     prOverrides: { title: '[infra] Update CI regression coverage' },
     files: [{ filename: '.github/workflows/ci.test.ts', additions: 8, deletions: 2, status: 'modified' }],
   })
+  const deployWorkflow = await runCiScopeGateWorkflow({
+    prOverrides: { title: '[infra] Add staged deploy workflow' },
+    files: [{ filename: '.github/workflows/deploy.yml', additions: 80, deletions: 0, status: 'added' }],
+  })
 
   assert.deepEqual(ciRuntime.outputs, fullOutputs)
   assert.deepEqual(ciRegression.outputs, fullOutputs)
+  assert.deepEqual(deployWorkflow.outputs, fullOutputs)
   assert.equal(ciRuntime.notices.some((notice) => notice.includes('Skipping heavy')), false)
   assert.equal(ciRegression.notices.some((notice) => notice.includes('Skipping heavy')), false)
+  assert.equal(deployWorkflow.notices.some((notice) => notice.includes('Skipping heavy')), false)
 })
 
 test('CI scope router keeps workflow PRs in full CI when later checked acceptance criteria start with Normal', async () => {
@@ -2932,6 +2939,89 @@ test('release PR workflow marks generated release PRs as R4 risk', async () => {
   assert.match(jobBlock, /- \[ \] R2 frontend behavior/)
   assert.match(jobBlock, /- \[ \] R3 backend \/ API behavior/)
   assert.match(jobBlock, /- \[x\] R4 auth \/ permissions \/ security \/ schema \/ migration \/ secrets \/ payments \/ wallet \/ workflow \/ release/)
+})
+
+test('staged deploy workflow is manual-only and requires production confirmation', async () => {
+  const workflow = await readFile(deployWorkflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(deployWorkflowPath)
+  const targetInput = parsedWorkflow.on.workflow_dispatch.inputs.target
+  const confirmProductionInput = parsedWorkflow.on.workflow_dispatch.inputs.confirm_production
+  const preflightBlock = workflowJobBlock(workflow, 'preflight')
+
+  assert.equal(parsedWorkflow.name, 'Staged Deploy')
+  assert.deepEqual(Object.keys(parsedWorkflow.on), ['workflow_dispatch'])
+  assert.equal(parsedWorkflow.permissions.contents, 'read')
+  assert.equal(parsedWorkflow.permissions['pull-requests'], undefined)
+  assert.equal(parsedWorkflow.permissions.actions, undefined)
+  assert.equal(parsedWorkflow.concurrency.group, 'staged-deploy-${{ inputs.target }}')
+  assert.equal(targetInput.type, 'choice')
+  assert.deepEqual(targetInput.options, [
+    'staging-api',
+    'staging-dashboard',
+    'production-api',
+    'production-dashboard',
+  ])
+  assert.equal(parsedWorkflow.on.workflow_dispatch.inputs.deploy_sha.required, true)
+  assert.equal(confirmProductionInput.type, 'boolean')
+  assert.equal(confirmProductionInput.default, false)
+  assert.match(preflightBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.match(preflightBlock, /deploy_sha must be a full 40-character lowercase commit SHA/)
+  assert.match(preflightBlock, /confirm_production=true/)
+  assert.match(preflightBlock, /GitHub Environment approval/)
+  assert.doesNotMatch(workflow, /pull_request:/)
+  assert.doesNotMatch(workflow, /push:/)
+  assert.doesNotMatch(workflow, /schedule:/)
+  assert.doesNotMatch(workflow, /auto-ready/)
+})
+
+test('staged deploy workflow keeps deploy jobs behind environment gates', async () => {
+  const workflow = await readFile(deployWorkflowPath, 'utf8')
+  const parsedWorkflow = parseYaml(deployWorkflowPath)
+  const backendJob = parsedWorkflow.jobs['backend-api']
+  const dashboardJob = parsedWorkflow.jobs.dashboard
+  const backendBlock = workflowJobBlock(workflow, 'backend-api')
+  const dashboardBlock = workflowJobBlock(workflow, 'dashboard')
+
+  assert.equal(backendJob.environment.name, '${{ inputs.target }}')
+  assert.equal(dashboardJob.environment.name, '${{ inputs.target }}')
+  assert.equal(backendJob.needs[0], 'preflight')
+  assert.equal(dashboardJob.needs[0], 'preflight')
+  assert.equal(backendJob.if, "needs.preflight.outputs.is_api == 'true'")
+  assert.equal(dashboardJob.if, "needs.preflight.outputs.is_dashboard == 'true'")
+  assert.match(backendBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.match(dashboardBlock, pinnedActionRef('actions/checkout', 'v4'))
+  assert.match(backendBlock, /ref: \$\{\{ inputs\.deploy_sha \}\}/)
+  assert.match(dashboardBlock, /ref: \$\{\{ inputs\.deploy_sha \}\}/)
+})
+
+test('staged deploy workflow preserves backend migration and smoke contracts', async () => {
+  const workflow = await readFile(deployWorkflowPath, 'utf8')
+  const backendBlock = workflowJobBlock(workflow, 'backend-api')
+
+  assert.match(backendBlock, /docker build -t "tachigo-api:\$\{DEPLOYMENT_SHA\}" services\/api/)
+  assert.match(backendBlock, /ATLAS_DATABASE_URL environment secret is required/)
+  assert.match(backendBlock, /atlas migrate apply --dir file:\/\/migrations --url "\$ATLAS_DATABASE_URL"/)
+  assert.match(backendBlock, /MIGRATION_STATUS=applied/)
+  assert.match(backendBlock, /MIGRATION_STATUS=failed/)
+  assert.match(backendBlock, /infra\/scripts\/backend-staging-smoke\.sh/)
+  assert.match(backendBlock, /PRODUCTION_API_BASE_URL environment variable is required/)
+  assert.match(backendBlock, /PRODUCTION_AUTH_BEARER_TOKEN environment secret is required/)
+  assert.match(backendBlock, /Deploy the built image to the approved container target before smoke readback/)
+  assert.doesNotMatch(backendBlock, /BACKEND_DEPLOY_COMMAND/)
+})
+
+test('staged deploy workflow preserves dashboard artifact and smoke contracts', async () => {
+  const workflow = await readFile(deployWorkflowPath, 'utf8')
+  const dashboardBlock = workflowJobBlock(workflow, 'dashboard')
+
+  assert.match(dashboardBlock, /docker compose build dashboard/)
+  assert.match(dashboardBlock, /docker compose run --name tachigo-dashboard-package --no-deps dashboard pnpm package:production/)
+  assert.match(dashboardBlock, /docker cp tachigo-dashboard-package:\/app\/dist apps\/dashboard\/dist/)
+  assert.match(dashboardBlock, /CLOUDFLARE_PAGES_PROJECT environment variable is required/)
+  assert.match(dashboardBlock, /DASHBOARD_PUBLIC_URL environment variable is required/)
+  assert.match(dashboardBlock, /Upload apps\/dashboard\/dist to the approved Cloudflare Pages project/)
+  assert.match(dashboardBlock, /This workflow intentionally avoids adding a new third-party deploy action/)
+  assert.match(dashboardBlock, /curl -fsS "\$base_url\/" >\/tmp\/dashboard-index\.html/)
 })
 
 test('release cadence documentation matches the automated gate', async () => {

--- a/.github/workflows/ci.test.ts
+++ b/.github/workflows/ci.test.ts
@@ -3015,13 +3015,17 @@ test('staged deploy workflow preserves dashboard artifact and smoke contracts', 
   const dashboardBlock = workflowJobBlock(workflow, 'dashboard')
 
   assert.match(dashboardBlock, /docker compose build dashboard/)
-  assert.match(dashboardBlock, /docker compose run --name tachigo-dashboard-package --no-deps dashboard pnpm package:production/)
+  assert.match(dashboardBlock, /DASHBOARD_API_URL environment variable is required/)
+  assert.match(dashboardBlock, /-e VITE_TACHIGO_API_URL="\$DASHBOARD_API_URL"/)
+  assert.match(dashboardBlock, /dashboard sh -lc 'pnpm build && pnpm package:readback'/)
+  assert.doesNotMatch(dashboardBlock, /pnpm package:production/)
   assert.match(dashboardBlock, /docker cp tachigo-dashboard-package:\/app\/dist apps\/dashboard\/dist/)
   assert.match(dashboardBlock, /CLOUDFLARE_PAGES_PROJECT environment variable is required/)
   assert.match(dashboardBlock, /DASHBOARD_PUBLIC_URL environment variable is required/)
   assert.match(dashboardBlock, /Upload apps\/dashboard\/dist to the approved Cloudflare Pages project/)
   assert.match(dashboardBlock, /This workflow intentionally avoids adding a new third-party deploy action/)
-  assert.match(dashboardBlock, /curl -fsS "\$base_url\/" >\/tmp\/dashboard-index\.html/)
+  assert.match(dashboardBlock, /Run the dashboard smoke readback only after the manual Cloudflare Pages upload reports this deployment SHA/)
+  assert.doesNotMatch(dashboardBlock, /curl -fsS/)
 })
 
 test('release cadence documentation matches the automated gate', async () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,8 +258,7 @@ jobs:
               /^\.github\/workflows\/ci\.yml$/,
             ]
             const ciWorkflowPaths = [
-              /^\.github\/workflows\/ci\.yml$/,
-              /^\.github\/workflows\/ci\.test\.ts$/,
+              /^\.github\/workflows\//,
             ]
             const dockerComposePaths = [/^docker-compose(?:\..+)?\.ya?ml$/]
             const frontendWorkspacePaths = [

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,11 +197,18 @@ jobs:
       - name: Build dashboard image
         run: docker compose build dashboard
 
-      - name: Build production dashboard artifact
+      - name: Build dashboard artifact
+        env:
+          DASHBOARD_API_URL: ${{ vars.DASHBOARD_API_URL }}
         run: |
+          : "${DASHBOARD_API_URL:?DASHBOARD_API_URL environment variable is required}"
           docker rm -f tachigo-dashboard-package >/dev/null 2>&1 || true
           trap 'docker rm -f tachigo-dashboard-package >/dev/null 2>&1 || true' EXIT
-          docker compose run --name tachigo-dashboard-package --no-deps dashboard pnpm package:production
+          docker compose run \
+            --name tachigo-dashboard-package \
+            --no-deps \
+            -e VITE_TACHIGO_API_URL="$DASHBOARD_API_URL" \
+            dashboard sh -lc 'pnpm build && pnpm package:readback'
           rm -rf apps/dashboard/dist
           docker cp tachigo-dashboard-package:/app/dist apps/dashboard/dist
           docker rm -f tachigo-dashboard-package >/dev/null
@@ -209,29 +216,37 @@ jobs:
       - name: Record dashboard deployment handoff
         env:
           DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+          DASHBOARD_API_URL: ${{ vars.DASHBOARD_API_URL }}
           CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           DASHBOARD_PUBLIC_URL: ${{ vars.DASHBOARD_PUBLIC_URL }}
         run: |
+          : "${DASHBOARD_API_URL:?DASHBOARD_API_URL environment variable is required}"
           : "${CLOUDFLARE_PAGES_PROJECT:?CLOUDFLARE_PAGES_PROJECT environment variable is required}"
           : "${DASHBOARD_PUBLIC_URL:?DASHBOARD_PUBLIC_URL environment variable is required}"
           {
             echo "## Dashboard deployment handoff"
             echo ""
             echo "- Deployment SHA: $DEPLOYMENT_SHA"
+            echo "- Dashboard API URL: $DASHBOARD_API_URL"
             echo "- Artifact: apps/dashboard/dist"
             echo "- Cloudflare Pages project: $CLOUDFLARE_PAGES_PROJECT"
             echo "- Public URL: $DASHBOARD_PUBLIC_URL"
             echo ""
-            echo "Upload apps/dashboard/dist to the approved Cloudflare Pages project, then run the smoke readback below."
+            echo "Upload apps/dashboard/dist to the approved Cloudflare Pages project for this environment."
             echo "This workflow intentionally avoids adding a new third-party deploy action until maintainers approve the Cloudflare credential path."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run dashboard smoke readback
+      - name: Record dashboard smoke readback contract
         env:
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
           DASHBOARD_PUBLIC_URL: ${{ vars.DASHBOARD_PUBLIC_URL }}
         run: |
           : "${DASHBOARD_PUBLIC_URL:?DASHBOARD_PUBLIC_URL environment variable is required}"
-          base_url="${DASHBOARD_PUBLIC_URL%/}"
-          curl -fsS "$base_url/" >/tmp/dashboard-index.html
-          grep -Eq '<script|/assets/' /tmp/dashboard-index.html
-          printf 'dashboard smoke passed for %s\n' "$base_url"
+          {
+            echo "## Dashboard smoke readback contract"
+            echo ""
+            echo "- Public URL: ${DASHBOARD_PUBLIC_URL%/}"
+            echo "- Deployment SHA: $DEPLOYMENT_SHA"
+            echo "- Run the dashboard smoke readback only after the manual Cloudflare Pages upload reports this deployment SHA."
+            echo "- Verify the public page loads and references bundled assets from apps/dashboard/dist."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,237 @@
+name: Staged Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Deployment target"
+        required: true
+        type: choice
+        options:
+          - staging-api
+          - staging-dashboard
+          - production-api
+          - production-dashboard
+      deploy_sha:
+        description: "Exact git commit SHA to deploy"
+        required: true
+        type: string
+      confirm_production:
+        description: "Required for production targets"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: staged-deploy-${{ inputs.target }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  preflight:
+    timeout-minutes: 5
+    name: Deploy preflight
+    runs-on: ubuntu-latest
+    outputs:
+      is_api: ${{ steps.classify.outputs.is_api }}
+      is_dashboard: ${{ steps.classify.outputs.is_dashboard }}
+      is_production: ${{ steps.classify.outputs.is_production }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate deploy SHA
+        env:
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          case "$DEPLOYMENT_SHA" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+              ;;
+            *)
+              echo "deploy_sha must be a full 40-character lowercase commit SHA" >&2
+              exit 1
+              ;;
+          esac
+          git cat-file -e "$DEPLOYMENT_SHA^{commit}"
+
+      - name: Enforce production confirmation
+        if: startsWith(inputs.target, 'production-') && inputs.confirm_production != true
+        run: |
+          echo "Production deploys require confirm_production=true and GitHub Environment approval." >&2
+          exit 1
+
+      - name: Classify deployment target
+        id: classify
+        run: |
+          case "${{ inputs.target }}" in
+            staging-api|production-api)
+              echo "is_api=true" >> "$GITHUB_OUTPUT"
+              echo "is_dashboard=false" >> "$GITHUB_OUTPUT"
+              ;;
+            staging-dashboard|production-dashboard)
+              echo "is_api=false" >> "$GITHUB_OUTPUT"
+              echo "is_dashboard=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+          case "${{ inputs.target }}" in
+            production-*)
+              echo "is_production=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "is_production=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Write preflight summary
+        env:
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          {
+            echo "## Deploy preflight"
+            echo ""
+            echo "- Target: ${{ inputs.target }}"
+            echo "- Deployment SHA: $DEPLOYMENT_SHA"
+            echo "- Production: ${{ steps.classify.outputs.is_production }}"
+            echo "- Approval gate: GitHub Environment ${{ inputs.target }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  backend-api:
+    timeout-minutes: 30
+    name: Backend API deploy
+    needs: [preflight]
+    if: needs.preflight.outputs.is_api == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.target }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Build backend image
+        env:
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+        run: docker build -t "tachigo-api:${DEPLOYMENT_SHA}" services/api
+
+      - name: Apply Atlas migrations
+        env:
+          ATLAS_DATABASE_URL: ${{ secrets.ATLAS_DATABASE_URL }}
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          : "${ATLAS_DATABASE_URL:?ATLAS_DATABASE_URL environment secret is required}"
+          set +e
+          docker run --rm \
+            -e ATLAS_DATABASE_URL="$ATLAS_DATABASE_URL" \
+            "tachigo-api:${DEPLOYMENT_SHA}" \
+            atlas migrate apply --dir file://migrations --url "$ATLAS_DATABASE_URL"
+          migration_exit=$?
+          set -e
+          if [ "$migration_exit" -eq 0 ]; then
+            echo "MIGRATION_STATUS=applied" >> "$GITHUB_ENV"
+          else
+            echo "MIGRATION_STATUS=failed" >> "$GITHUB_ENV"
+            exit "$migration_exit"
+          fi
+
+      - name: Record backend deployment handoff
+        env:
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          {
+            echo "## Backend deployment handoff"
+            echo ""
+            echo "- Built image: tachigo-api:$DEPLOYMENT_SHA"
+            echo "- Migration status: $MIGRATION_STATUS"
+            echo "- Environment: ${{ inputs.target }}"
+            echo ""
+            echo "Deploy the built image to the approved container target before smoke readback."
+            echo "This workflow intentionally does not accept arbitrary deploy commands from secrets."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run staging API smoke readback
+        if: inputs.target == 'staging-api'
+        env:
+          STAGING_API_BASE_URL: ${{ vars.STAGING_API_BASE_URL }}
+          STAGING_AUTH_BEARER_TOKEN: ${{ secrets.STAGING_AUTH_BEARER_TOKEN }}
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+        run: infra/scripts/backend-staging-smoke.sh
+
+      - name: Run production API smoke readback
+        if: inputs.target == 'production-api'
+        env:
+          PRODUCTION_API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL }}
+          PRODUCTION_AUTH_BEARER_TOKEN: ${{ secrets.PRODUCTION_AUTH_BEARER_TOKEN }}
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          : "${PRODUCTION_API_BASE_URL:?PRODUCTION_API_BASE_URL environment variable is required}"
+          : "${PRODUCTION_AUTH_BEARER_TOKEN:?PRODUCTION_AUTH_BEARER_TOKEN environment secret is required}"
+          base_url="${PRODUCTION_API_BASE_URL%/}"
+          printf 'deployment_sha=%s\n' "$DEPLOYMENT_SHA"
+          printf 'migration_status=%s\n' "$MIGRATION_STATUS"
+          curl -fsS "$base_url/health" >/tmp/production-health.json
+          curl -fsS "$base_url/readyz" >/tmp/production-readyz.json
+          curl -fsS \
+            -H "Authorization: Bearer ${PRODUCTION_AUTH_BEARER_TOKEN}" \
+            "$base_url/api/v1/users/me" >/tmp/production-users-me.json
+          printf 'production api smoke passed\n'
+
+  dashboard:
+    timeout-minutes: 30
+    name: Dashboard deploy
+    needs: [preflight]
+    if: needs.preflight.outputs.is_dashboard == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.target }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Build dashboard image
+        run: docker compose build dashboard
+
+      - name: Build production dashboard artifact
+        run: |
+          docker rm -f tachigo-dashboard-package >/dev/null 2>&1 || true
+          trap 'docker rm -f tachigo-dashboard-package >/dev/null 2>&1 || true' EXIT
+          docker compose run --name tachigo-dashboard-package --no-deps dashboard pnpm package:production
+          rm -rf apps/dashboard/dist
+          docker cp tachigo-dashboard-package:/app/dist apps/dashboard/dist
+          docker rm -f tachigo-dashboard-package >/dev/null
+
+      - name: Record dashboard deployment handoff
+        env:
+          DEPLOYMENT_SHA: ${{ inputs.deploy_sha }}
+          CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+          DASHBOARD_PUBLIC_URL: ${{ vars.DASHBOARD_PUBLIC_URL }}
+        run: |
+          : "${CLOUDFLARE_PAGES_PROJECT:?CLOUDFLARE_PAGES_PROJECT environment variable is required}"
+          : "${DASHBOARD_PUBLIC_URL:?DASHBOARD_PUBLIC_URL environment variable is required}"
+          {
+            echo "## Dashboard deployment handoff"
+            echo ""
+            echo "- Deployment SHA: $DEPLOYMENT_SHA"
+            echo "- Artifact: apps/dashboard/dist"
+            echo "- Cloudflare Pages project: $CLOUDFLARE_PAGES_PROJECT"
+            echo "- Public URL: $DASHBOARD_PUBLIC_URL"
+            echo ""
+            echo "Upload apps/dashboard/dist to the approved Cloudflare Pages project, then run the smoke readback below."
+            echo "This workflow intentionally avoids adding a new third-party deploy action until maintainers approve the Cloudflare credential path."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run dashboard smoke readback
+        env:
+          DASHBOARD_PUBLIC_URL: ${{ vars.DASHBOARD_PUBLIC_URL }}
+        run: |
+          : "${DASHBOARD_PUBLIC_URL:?DASHBOARD_PUBLIC_URL environment variable is required}"
+          base_url="${DASHBOARD_PUBLIC_URL%/}"
+          curl -fsS "$base_url/" >/tmp/dashboard-index.html
+          grep -Eq '<script|/assets/' /tmp/dashboard-index.html
+          printf 'dashboard smoke passed for %s\n' "$base_url"


### PR DESCRIPTION
## 什麼改動
新增 manual-only staged deploy workflow scaffold，並補上 workflow-file PR 必須走 full CI 的 regression。

## 為什麼
#1020 追蹤 deploy workflow 實作；#1021 則先收斂 deploy planning。本 PR 先落地 bounded scaffold，不碰實際 secrets、帳號設定或自動 production promotion。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#1020
- Depends on PR：#1021 (merged 2026-06-01)
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不設定、旋轉或揭露 GitHub / Cloudflare / database secrets。
  - 不新增 Cloudflare deploy action、wrangler dependency，或任意 secret-driven deploy command。
  - 不執行 rollback command；rollback boundary 僅保留為 GitHub Environment-gated manual handoff/readback，實際 rollback executor deferred until maintainer-approved credential/tool path exists.
  - 不把 release PR workflow 改成自動 deploy trigger。
  - 不接 auto-ready / auto-merge；R4 需 human review / approval。
  - 不處理 contracts deploy / verify、testnet、mainnet、DNS 或 Cloudflare account setup。
  - 不把 schema DDL ownership 交回 API startup。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #1020 的 Issue Delegation Plan
- Actual worker profile(s)：
  - repo_scout / controller
- Model strength：
  - controller = high；repo_scout = medium
- Spawn directive(s)：
  - profile=repo_scout model=current-codex reasoning=medium controller_fallback=denied fallback_reason=n/a
  - profile=controller model=current-codex reasoning=high controller_fallback=allowed fallback_reason=bounded_workflow_write_scope
- Verification evidence：
  - spec plan 1020 --repo . --dry-run --format prompt --verbose：blocked by missing .spec-injector config after fetching #1020
  - spec workflow-check --repo . --phase start --issue 1020：status=fail missing_fields=config
  - node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts：107/107 pass
  - git diff --check：pass
- Self-review / exception reason：
  - Controller reviewed diff for manual-only trigger, environment gates, exact SHA checkout, secret boundary, Atlas migration path, dashboard artifact handoff, and CI scope router regression.
- Worker session closeout：
  - repo_scout result read back; worker session closed.
- Workflow friction / follow-up split：
  - spec-injector local-only gate is blocked because this repo/worktree has no .spec-injector config; no spec init/config was committed. External deploy executors remain intentionally outside this PR until maintainers approve credential/tool path.

## Review conversation closeout
- Unresolved threads：
  - latest human review requested ready-state plus deploy boundary evidence; PR is now ready, and this body records GitHub Environment, secret, rollback, and workflow regression evidence for re-review
- CodeRabbit：
  - status success; no actionable finding posted on latest head
- chatgpt-codex-connector：
  - n/a before first human-ready review
- review_triage_ref：
  - n/a; no review finding exists on latest head
- root_cause_gate_ref：
  - n/a; no repeated finding state
- finding_disposition_ref：
  - n/a; no findings to disposition
- Final reviewer action：
  - blocked by required human R4 re-review; no self-review, self-approval, or self-merge performed

## Final merge gate
- Ready-to-merge decision：
  - blocked by required human R4 re-review; dependency PR #1021 is merged and GitHub checks passed on latest head at prior readback
- Latest head SHA：
  - c1e7886b60a7b47e2f570f670a65d7965b17c77d
- Required checks：
  - pass: PR commit messages, Scope police, Supply-chain guardrails, TypeScript-only guardrail, Workflow regression tests, PR metadata check regression tests, CI scope router, Backend tests, Backend integration tests, Backend security scanners, Atlas migration tooling, Backend CI gate, Frontend build, Dashboard build, Contracts build, Contracts Slither report, Contracts gas snapshot report
- spec workflow-check evidence：
  - start gate failed locally with missing_fields=config because .spec-injector/ is absent; no generated config committed
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/1022

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增手動 staged deploy workflow scaffold 並鎖住 workflow PR 的 full CI routing。
- Approx changed lines：~330
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [ ] 是
  - [x] 否，原因：Depends on #1021 planning PR for deploy policy context.
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #1021 planning dependency

## Acceptance Criteria
- [x] workflow PR 使用 R4 risk class，且不加 `auto-ready`
- [x] `.github/workflows/deploy.yml` 只支援手動 `workflow_dispatch`
- [x] staging / production deploy path 使用 GitHub Environment approval gate
- [x] backend API path 使用 Atlas migration command 與 smoke readback contract
- [x] dashboard path 建立 production artifact 並記錄 Cloudflare Pages handoff / smoke readback contract
- [x] production path 需要 `confirm_production=true`，且不接 auto-ready / auto-merge
- [x] workflow regression 測試補上 deploy workflow 不被 CI metadata lane 誤判
- [ ] 實際 backend image deploy executor 與 Cloudflare Pages upload executor：deferred until #1021 planning and maintainer-approved credential/tool path are ready

## 超出範圍內容
無。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
spec plan 1020 --repo . --dry-run --format prompt --verbose
-> fetched #1020, then failed loading config:
No .spec-injector/ directory found in or above the worktree.

spec workflow-check --repo . --phase start --issue 1020
-> status=fail missing_fields=config

node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
-> tests 107, pass 107, fail 0

git diff --check
-> pass
```

## 備註
This PR is ready for R4 human review and intentionally does not use auto-ready. Dependency PR #1021 is merged; actual deploy executors remain deferred until maintainers approve credential and tool paths.

## Notes for Claude Code Review
- Please pay special attention to the intentionally bounded deploy handoff design: backend image deploy and Cloudflare Pages upload are not implemented as arbitrary secret commands because the approved credential/tool path is not yet repo-owned.
- The workflow file uses exact SHA checkout, manual dispatch only, GitHub Environment gates, and pinned checkout actions.
- CI scope router now treats every `.github/workflows/**` change as full CI, not only `ci.yml` / `ci.test.ts`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 新增手动部署工作流，支持分阶段与生产环境的 API 与仪表板部署，包含预检验证与自动化健康检查。

* **Tests**
  * 增强 CI 测试覆盖，验证工作流文件变更触发完整 CI 校验。

* **Chores**
  * 优化 CI 作用域检测逻辑，扩大工作流目录变更监控范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->