### PR TITLE
[backend] 抽獎模式切換與報名統計 API

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -106,6 +106,8 @@ export interface ModelsAuthProvider {
   user_id?: string;
 }
 
+export type ModelsCharacterKind = "crab" | "dolphin" | "turtle" | "whale" | "capybara";
+
 export type ModelsProviderType = "twitch" | "google" | "web3" | "email";
 
 export interface ModelsShippingAddress {
@@ -125,6 +127,7 @@ export interface ModelsShippingAddress {
 }
 
 export interface ModelsUser {
+  active_character?: ModelsCharacterKind;
   addresses?: Array<ModelsShippingAddress>;
   auth_providers?: Array<ModelsAuthProvider>;
   avatar_url?: string;
@@ -134,6 +137,7 @@ export interface ModelsUser {
   id?: string;
   is_active?: boolean;
   role?: ModelsUserRole;
+  switch_cooldown_until?: string;
   updated_at?: string;
   username?: string;
 }
@@ -373,6 +377,30 @@ export interface ApiOperations {
     response: HandlersResponse;
   };
   "POST /dashboard/raffles/{id}/entries/import-csv": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "PATCH /dashboard/raffles/{id}/entry": {
+    requestBody: {
+      entry_open?: boolean;
+    };
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "GET /dashboard/raffles/{id}/entry-stats": {
+    pathParams: {
+      id: string;
+    };
+    response: HandlersResponse;
+  };
+  "PATCH /dashboard/raffles/{id}/mode": {
+    requestBody: {
+      mode?: string;
+    };
     pathParams: {
       id: string;
     };

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -1326,6 +1326,199 @@ const docTemplate = `{
                 }
             }
         },
+        "/dashboard/raffles/{id}/entry": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Open or close raffle entry (Dashboard)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "entry_open flag",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "entry_open": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/entry-stats": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Get entry statistics for a raffle (Dashboard)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/mode": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Set raffle mode (Dashboard)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "mode: public | subscribers_only",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "mode": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/dashboard/raffles/{id}/snapshot": {
             "post": {
                 "security": [
@@ -2776,6 +2969,23 @@ const docTemplate = `{
                 }
             }
         },
+        "models.CharacterKind": {
+            "type": "string",
+            "enum": [
+                "crab",
+                "dolphin",
+                "turtle",
+                "whale",
+                "capybara"
+            ],
+            "x-enum-varnames": [
+                "CharacterCrab",
+                "CharacterDolphin",
+                "CharacterTurtle",
+                "CharacterWhale",
+                "CharacterCapybara"
+            ]
+        },
         "models.ProviderType": {
             "type": "string",
             "enum": [
@@ -2838,6 +3048,9 @@ const docTemplate = `{
         "models.User": {
             "type": "object",
             "properties": {
+                "active_character": {
+                    "$ref": "#/definitions/models.CharacterKind"
+                },
                 "addresses": {
                     "type": "array",
                     "items": {
@@ -2870,6 +3083,9 @@ const docTemplate = `{
                 },
                 "role": {
                     "$ref": "#/definitions/models.UserRole"
+                },
+                "switch_cooldown_until": {
+                    "type": "string"
                 },
                 "updated_at": {
                     "type": "string"

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -1320,6 +1320,199 @@
                 }
             }
         },
+        "/dashboard/raffles/{id}/entry": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Open or close raffle entry (Dashboard)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "entry_open flag",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "entry_open": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/entry-stats": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Get entry statistics for a raffle (Dashboard)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/dashboard/raffles/{id}/mode": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "raffles"
+                ],
+                "summary": "Set raffle mode (Dashboard)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Raffle ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "mode: public | subscribers_only",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "mode": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/dashboard/raffles/{id}/snapshot": {
             "post": {
                 "security": [
@@ -2770,6 +2963,23 @@
                 }
             }
         },
+        "models.CharacterKind": {
+            "type": "string",
+            "enum": [
+                "crab",
+                "dolphin",
+                "turtle",
+                "whale",
+                "capybara"
+            ],
+            "x-enum-varnames": [
+                "CharacterCrab",
+                "CharacterDolphin",
+                "CharacterTurtle",
+                "CharacterWhale",
+                "CharacterCapybara"
+            ]
+        },
         "models.ProviderType": {
             "type": "string",
             "enum": [
@@ -2832,6 +3042,9 @@
         "models.User": {
             "type": "object",
             "properties": {
+                "active_character": {
+                    "$ref": "#/definitions/models.CharacterKind"
+                },
                 "addresses": {
                     "type": "array",
                     "items": {
@@ -2864,6 +3077,9 @@
                 },
                 "role": {
                     "$ref": "#/definitions/models.UserRole"
+                },
+                "switch_cooldown_until": {
+                    "type": "string"
                 },
                 "updated_at": {
                     "type": "string"

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -164,6 +164,20 @@ definitions:
       user_id:
         type: string
     type: object
+  models.CharacterKind:
+    enum:
+    - crab
+    - dolphin
+    - turtle
+    - whale
+    - capybara
+    type: string
+    x-enum-varnames:
+    - CharacterCrab
+    - CharacterDolphin
+    - CharacterTurtle
+    - CharacterWhale
+    - CharacterCapybara
   models.ProviderType:
     enum:
     - twitch
@@ -207,6 +221,8 @@ definitions:
     type: object
   models.User:
     properties:
+      active_character:
+        $ref: '#/definitions/models.CharacterKind'
       addresses:
         items:
           $ref: '#/definitions/models.ShippingAddress'
@@ -229,6 +245,8 @@ definitions:
         type: boolean
       role:
         $ref: '#/definitions/models.UserRole'
+      switch_cooldown_until:
+        type: string
       updated_at:
         type: string
       username:
@@ -1177,6 +1195,128 @@ paths:
       security:
       - BearerAuth: []
       summary: Import participants from CSV
+      tags:
+      - raffles
+  /dashboard/raffles/{id}/entry:
+    patch:
+      consumes:
+      - application/json
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: entry_open flag
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            entry_open:
+              type: boolean
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Open or close raffle entry (Dashboard)
+      tags:
+      - raffles
+  /dashboard/raffles/{id}/entry-stats:
+    get:
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Get entry statistics for a raffle (Dashboard)
+      tags:
+      - raffles
+  /dashboard/raffles/{id}/mode:
+    patch:
+      consumes:
+      - application/json
+      parameters:
+      - description: Raffle ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 'mode: public | subscribers_only'
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            mode:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.Response'
+      security:
+      - BearerAuth: []
+      summary: Set raffle mode (Dashboard)
       tags:
       - raffles
   /dashboard/raffles/{id}/snapshot:

--- a/services/api/internal/handlers/raffle_handler.go
+++ b/services/api/internal/handlers/raffle_handler.go
@@ -763,6 +763,154 @@ func (h *RaffleHandler) DrawFromTier(c *gin.Context) {
 	created(c, gin.H{"draw": draw})
 }
 
+// SetMode godoc
+// @Summary      Set raffle mode (Dashboard)
+// @Tags         raffles
+// @Security     BearerAuth
+// @Accept       json
+// @Produce      json
+// @Param        id    path  string  true  "Raffle ID"
+// @Param        body  body  object{mode=string}  true  "mode: public | subscribers_only"
+// @Success      200  {object}  Response
+// @Failure      400  {object}  Response
+// @Failure      403  {object}  Response
+// @Failure      404  {object}  Response
+// @Failure      409  {object}  Response
+// @Router       /dashboard/raffles/{id}/mode [patch]
+func (h *RaffleHandler) SetMode(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+	raffleID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid raffle id")
+		return
+	}
+	var body struct {
+		Mode models.RaffleMode `json:"mode" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+	if body.Mode != models.RaffleModePublic && body.Mode != models.RaffleModeSubscribers {
+		badRequest(c, "mode must be 'public' or 'subscribers_only'")
+		return
+	}
+	raffle, err := h.raffleSvc.SetModeContext(c.Request.Context(), raffleID, userID, body.Mode)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrRaffleNotFound):
+			notFound(c, err.Error())
+		case errors.Is(err, services.ErrRaffleForbidden):
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: err.Error()})
+		case errors.Is(err, services.ErrRaffleNotDraft):
+			conflict(c, err.Error())
+		default:
+			log.Printf("SetMode: %v", err)
+			internal(c)
+		}
+		return
+	}
+	ok(c, gin.H{"raffle": raffle})
+}
+
+// SetEntryOpen godoc
+// @Summary      Open or close raffle entry (Dashboard)
+// @Tags         raffles
+// @Security     BearerAuth
+// @Accept       json
+// @Produce      json
+// @Param        id    path  string  true  "Raffle ID"
+// @Param        body  body  object{entry_open=bool}  true  "entry_open flag"
+// @Success      200  {object}  Response
+// @Failure      400  {object}  Response
+// @Failure      403  {object}  Response
+// @Failure      404  {object}  Response
+// @Failure      409  {object}  Response
+// @Router       /dashboard/raffles/{id}/entry [patch]
+func (h *RaffleHandler) SetEntryOpen(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+	raffleID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid raffle id")
+		return
+	}
+	var body struct {
+		EntryOpen *bool `json:"entry_open"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		badRequest(c, err.Error())
+		return
+	}
+	if body.EntryOpen == nil {
+		badRequest(c, "entry_open is required")
+		return
+	}
+	raffle, err := h.raffleSvc.SetEntryOpenContext(c.Request.Context(), raffleID, userID, *body.EntryOpen)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrRaffleNotFound):
+			notFound(c, err.Error())
+		case errors.Is(err, services.ErrRaffleForbidden):
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: err.Error()})
+		case errors.Is(err, services.ErrRaffleNotActive):
+			conflict(c, err.Error())
+		default:
+			log.Printf("SetEntryOpen: %v", err)
+			internal(c)
+		}
+		return
+	}
+	ok(c, gin.H{"raffle": raffle})
+}
+
+// GetEntryStats godoc
+// @Summary      Get entry statistics for a raffle (Dashboard)
+// @Tags         raffles
+// @Security     BearerAuth
+// @Produce      json
+// @Param        id  path  string  true  "Raffle ID"
+// @Success      200  {object}  Response
+// @Failure      403  {object}  Response
+// @Failure      404  {object}  Response
+// @Router       /dashboard/raffles/{id}/entry-stats [get]
+func (h *RaffleHandler) GetEntryStats(c *gin.Context) {
+	claims := middleware.MustClaims(c)
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		badRequest(c, "invalid user id")
+		return
+	}
+	raffleID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		badRequest(c, "invalid raffle id")
+		return
+	}
+	stats, err := h.raffleSvc.GetEntryStatsContext(c.Request.Context(), raffleID, userID)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrRaffleNotFound):
+			notFound(c, err.Error())
+		case errors.Is(err, services.ErrRaffleForbidden):
+			c.JSON(http.StatusForbidden, Response{Success: false, Error: err.Error()})
+		default:
+			log.Printf("GetEntryStats: %v", err)
+			internal(c)
+		}
+		return
+	}
+	ok(c, gin.H{"stats": stats})
+}
+
 // GetResult godoc
 // @Summary      Get drawn winners for a raffle (Extension)
 // @Tags         raffles

--- a/services/api/internal/handlers/raffle_handler_test.go
+++ b/services/api/internal/handlers/raffle_handler_test.go
@@ -162,6 +162,15 @@ func newRaffleTestEnv(t *testing.T) *raffleTestEnv {
 	dash.POST("/raffles/:id/prize-tiers/:tier_id/draws",
 		middleware.RequireRole(models.RoleStreamer),
 		raffleH.DrawFromTier)
+	dash.PATCH("/raffles/:id/mode",
+		middleware.RequireRole(models.RoleStreamer),
+		raffleH.SetMode)
+	dash.PATCH("/raffles/:id/entry",
+		middleware.RequireRole(models.RoleStreamer),
+		raffleH.SetEntryOpen)
+	dash.GET("/raffles/:id/entry-stats",
+		middleware.RequireRole(models.RoleStreamer),
+		raffleH.GetEntryStats)
 
 	return &raffleTestEnv{db: db, authSvc: authSvc, raffleSvc: raffleSvc, router: r}
 }
@@ -1670,6 +1679,470 @@ func TestPrizeTierHandler_DeleteTier_WithDrawsFails(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("delete with draws: want 409, got %d — %s", w.Code, w.Body.String())
+	}
+}
+
+// ── SetMode ──────────────────────────────────────────────────────────────────
+
+func TestRaffle_SetMode_Success(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "modehost1", "modehost1@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Mode Test"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	modeBody, _ := json.Marshal(map[string]string{"mode": "subscribers_only"})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/mode", bytes.NewReader(modeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	raffle := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})
+	if raffle["mode"] != "subscribers_only" {
+		t.Errorf("want mode=subscribers_only, got %v", raffle["mode"])
+	}
+}
+
+func TestRaffle_SetMode_InvalidMode(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "modehost2", "modehost2@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Mode Invalid"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	modeBody, _ := json.Marshal(map[string]string{"mode": "invalid_mode"})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/mode", bytes.NewReader(modeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_SetMode_Conflict_WhenNotDraft(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "modehost3", "modehost3@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Mode Active Test"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	// activate
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/activate", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("activate: want 200, got %d", w.Code)
+	}
+
+	modeBody, _ := json.Marshal(map[string]string{"mode": "subscribers_only"})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/mode", bytes.NewReader(modeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_SetMode_NotFound(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "modehost4", "modehost4@test.com", "pass1234")
+
+	modeBody, _ := json.Marshal(map[string]string{"mode": "public"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/00000000-0000-0000-0000-000000000001/mode", bytes.NewReader(modeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_SetMode_Forbidden(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	owner := env.registerStreamer(t, "modeowner", "modeowner@test.com", "pass1234")
+	other := env.registerStreamer(t, "modeother", "modeother@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Mode Forbidden"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(owner))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	modeBody, _ := json.Marshal(map[string]string{"mode": "subscribers_only"})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/mode", bytes.NewReader(modeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(other))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_SetMode_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "modectx", "modectx@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Mode Context"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	type ctxKey struct{}
+	countFn := installRaffleHandlerDBContextProbeForTables(t, env.db, ctxKey{}, "mode-ctx-val", "raffles")
+
+	modeBody, _ := json.Marshal(map[string]string{"mode": "subscribers_only"})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/mode", bytes.NewReader(modeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	req = req.WithContext(context.WithValue(req.Context(), ctxKey{}, "mode-ctx-val"))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if countFn() == 0 {
+		t.Error("SetMode did not propagate request context to DB queries")
+	}
+}
+
+// ── SetEntryOpen ─────────────────────────────────────────────────────────────
+
+func TestRaffle_SetEntryOpen_Success(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "entryhost1", "entryhost1@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Entry Open Test"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	// activate
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/activate", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("activate: want 200, got %d", w.Code)
+	}
+
+	entryBody, _ := json.Marshal(map[string]bool{"entry_open": true})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/entry", bytes.NewReader(entryBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	raffle := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})
+	if raffle["entry_open"] != true {
+		t.Errorf("want entry_open=true, got %v", raffle["entry_open"])
+	}
+}
+
+func TestRaffle_SetEntryOpen_MissingField(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "entryhost2", "entryhost2@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Entry Missing"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/entry", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_SetEntryOpen_Conflict_WhenNotActive(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "entryhost3", "entryhost3@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Entry Draft Test"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	entryBody, _ := json.Marshal(map[string]bool{"entry_open": true})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/entry", bytes.NewReader(entryBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_SetEntryOpen_NotFound(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "entryhost4", "entryhost4@test.com", "pass1234")
+
+	entryBody, _ := json.Marshal(map[string]bool{"entry_open": true})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/00000000-0000-0000-0000-000000000002/entry", bytes.NewReader(entryBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_SetEntryOpen_Forbidden(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	owner := env.registerStreamer(t, "entryowner", "entryowner@test.com", "pass1234")
+	other := env.registerStreamer(t, "entryother", "entryother@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Entry Forbidden"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(owner))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	entryBody, _ := json.Marshal(map[string]bool{"entry_open": true})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/entry", bytes.NewReader(entryBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(other))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_SetEntryOpen_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "entryctx", "entryctx@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Entry Ctx"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles/"+raffleID+"/activate", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	type ctxKey struct{}
+	countFn := installRaffleHandlerDBContextProbeForTables(t, env.db, ctxKey{}, "entry-ctx-val", "raffles")
+
+	entryBody, _ := json.Marshal(map[string]bool{"entry_open": true})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPatch, "/api/v1/dashboard/raffles/"+raffleID+"/entry", bytes.NewReader(entryBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	req = req.WithContext(context.WithValue(req.Context(), ctxKey{}, "entry-ctx-val"))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if countFn() == 0 {
+		t.Error("SetEntryOpen did not propagate request context to DB queries")
+	}
+}
+
+// ── GetEntryStats ─────────────────────────────────────────────────────────────
+
+func TestRaffle_GetEntryStats_Empty(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "statshost1", "statshost1@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Stats Empty"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/dashboard/raffles/"+raffleID+"/entry-stats", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	stats := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["stats"].(map[string]interface{})
+	if stats["total_joined"].(float64) != 0 {
+		t.Errorf("want total_joined=0, got %v", stats["total_joined"])
+	}
+	if stats["eligible_count"].(float64) != 0 {
+		t.Errorf("want eligible_count=0, got %v", stats["eligible_count"])
+	}
+	if stats["ineligible_count"].(float64) != 0 {
+		t.Errorf("want ineligible_count=0, got %v", stats["ineligible_count"])
+	}
+}
+
+func TestRaffle_GetEntryStats_WithEntries(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "statshost2", "statshost2@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Stats With Entries"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+	raffleUUID, _ := uuid.Parse(raffleID)
+
+	// Insert 2 eligible + 1 ineligible entry directly
+	_ = env.db.Exec(`INSERT INTO raffle_entries (id, raffle_id, twitch_login, display_name, eligible, ineligible_reason, created_at) VALUES (?, ?, 'user1', 'User1', 1, '', CURRENT_TIMESTAMP)`, uuid.New(), raffleUUID)
+	_ = env.db.Exec(`INSERT INTO raffle_entries (id, raffle_id, twitch_login, display_name, eligible, ineligible_reason, created_at) VALUES (?, ?, 'user2', 'User2', 1, '', CURRENT_TIMESTAMP)`, uuid.New(), raffleUUID)
+	_ = env.db.Exec(`INSERT INTO raffle_entries (id, raffle_id, twitch_login, display_name, eligible, ineligible_reason, created_at) VALUES (?, ?, 'user3', 'User3', 0, 'not_subscriber', CURRENT_TIMESTAMP)`, uuid.New(), raffleUUID)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/dashboard/raffles/"+raffleID+"/entry-stats", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	stats := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["stats"].(map[string]interface{})
+	if stats["total_joined"].(float64) != 3 {
+		t.Errorf("want total_joined=3, got %v", stats["total_joined"])
+	}
+	if stats["eligible_count"].(float64) != 2 {
+		t.Errorf("want eligible_count=2, got %v", stats["eligible_count"])
+	}
+	if stats["ineligible_count"].(float64) != 1 {
+		t.Errorf("want ineligible_count=1, got %v", stats["ineligible_count"])
+	}
+	reasons := stats["ineligible_reasons"].(map[string]interface{})
+	if reasons["not_subscriber"].(float64) != 1 {
+		t.Errorf("want ineligible_reasons.not_subscriber=1, got %v", reasons["not_subscriber"])
+	}
+}
+
+func TestRaffle_GetEntryStats_NotFound(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "statshost3", "statshost3@test.com", "pass1234")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/dashboard/raffles/00000000-0000-0000-0000-000000000003/entry-stats", nil)
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_GetEntryStats_Forbidden(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	owner := env.registerStreamer(t, "statsowner", "statsowner@test.com", "pass1234")
+	other := env.registerStreamer(t, "statsother", "statsother@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Stats Forbidden"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(owner))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/dashboard/raffles/"+raffleID+"/entry-stats", nil)
+	req.Header.Set("Authorization", bearer(other))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRaffle_GetEntryStats_UsesRequestContext(t *testing.T) {
+	env := newRaffleTestEnv(t)
+	token := env.registerStreamer(t, "statsctx", "statsctx@test.com", "pass1234")
+
+	body, _ := json.Marshal(map[string]string{"title": "Stats Ctx"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/dashboard/raffles", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer(token))
+	env.router.ServeHTTP(w, req)
+	raffleID := parseBody(t, w.Body.Bytes())["data"].(map[string]interface{})["raffle"].(map[string]interface{})["id"].(string)
+
+	type ctxKey struct{}
+	countFn := installRaffleHandlerDBContextProbeForTables(t, env.db, ctxKey{}, "stats-ctx-val", "raffle_entries")
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/dashboard/raffles/"+raffleID+"/entry-stats", nil)
+	req.Header.Set("Authorization", bearer(token))
+	req = req.WithContext(context.WithValue(req.Context(), ctxKey{}, "stats-ctx-val"))
+	env.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if countFn() == 0 {
+		t.Error("GetEntryStats did not propagate request context to DB queries")
 	}
 }
 

--- a/services/api/internal/router/router.go
+++ b/services/api/internal/router/router.go
@@ -283,6 +283,15 @@ func New(
 		dashboard.POST("/raffles/:id/prize-tiers/:tier_id/draws",
 			middleware.RequireRole(models.RoleStreamer),
 			raffleH.DrawFromTier)
+		dashboard.PATCH("/raffles/:id/mode",
+			middleware.RequireRole(models.RoleStreamer),
+			raffleH.SetMode)
+		dashboard.PATCH("/raffles/:id/entry",
+			middleware.RequireRole(models.RoleStreamer),
+			raffleH.SetEntryOpen)
+		dashboard.GET("/raffles/:id/entry-stats",
+			middleware.RequireRole(models.RoleStreamer),
+			raffleH.GetEntryStats)
 	}
 
 	dashboardAirdrop := v1.Group("/dashboard/channels/:channel_id")

--- a/services/api/internal/services/raffle_service.go
+++ b/services/api/internal/services/raffle_service.go
@@ -1224,6 +1224,115 @@ func (s *RaffleService) DrawFromTierContext(ctx context.Context, raffleID, tierI
 	return result, nil
 }
 
+// EntryStats holds aggregated entry statistics for a raffle.
+type EntryStats struct {
+	EligibleCount     int64            `json:"eligible_count"`
+	IneligibleCount   int64            `json:"ineligible_count"`
+	IneligibleReasons map[string]int64 `json:"ineligible_reasons"`
+	TotalJoined       int64            `json:"total_joined"`
+}
+
+func (s *RaffleService) SetMode(raffleID, userID uuid.UUID, mode models.RaffleMode) (*models.Raffle, error) {
+	return s.SetModeContext(context.Background(), raffleID, userID, mode)
+}
+
+func (s *RaffleService) SetModeContext(ctx context.Context, raffleID, userID uuid.UUID, mode models.RaffleMode) (*models.Raffle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	raffle, err := s.GetByIDContext(ctx, raffleID, userID)
+	if err != nil {
+		return nil, err
+	}
+	res := s.db.WithContext(ctx).Model(&models.Raffle{}).
+		Where("id = ? AND status = ?", raffle.ID, models.RaffleStatusDraft).
+		Update("mode", mode)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, ErrRaffleNotDraft
+	}
+	raffle.Mode = mode
+	return raffle, nil
+}
+
+func (s *RaffleService) SetEntryOpen(raffleID, userID uuid.UUID, open bool) (*models.Raffle, error) {
+	return s.SetEntryOpenContext(context.Background(), raffleID, userID, open)
+}
+
+func (s *RaffleService) SetEntryOpenContext(ctx context.Context, raffleID, userID uuid.UUID, open bool) (*models.Raffle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	raffle, err := s.GetByIDContext(ctx, raffleID, userID)
+	if err != nil {
+		return nil, err
+	}
+	res := s.db.WithContext(ctx).Model(&models.Raffle{}).
+		Where("id = ? AND status = ?", raffle.ID, models.RaffleStatusActive).
+		Update("entry_open", open)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, ErrRaffleNotActive
+	}
+	raffle.EntryOpen = open
+	return raffle, nil
+}
+
+func (s *RaffleService) GetEntryStats(raffleID, userID uuid.UUID) (*EntryStats, error) {
+	return s.GetEntryStatsContext(context.Background(), raffleID, userID)
+}
+
+func (s *RaffleService) GetEntryStatsContext(ctx context.Context, raffleID, userID uuid.UUID) (*EntryStats, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, err := s.GetByIDContext(ctx, raffleID, userID); err != nil {
+		return nil, err
+	}
+
+	var total int64
+	if err := s.db.WithContext(ctx).Model(&models.RaffleEntry{}).
+		Where("raffle_id = ?", raffleID).Count(&total).Error; err != nil {
+		return nil, err
+	}
+
+	var eligible int64
+	if err := s.db.WithContext(ctx).Model(&models.RaffleEntry{}).
+		Where("raffle_id = ? AND eligible = ?", raffleID, true).Count(&eligible).Error; err != nil {
+		return nil, err
+	}
+
+	type reasonCount struct {
+		IneligibleReason string
+		Count            int64
+	}
+	var rows []reasonCount
+	if err := s.db.WithContext(ctx).Model(&models.RaffleEntry{}).
+		Select("ineligible_reason, count(*) as count").
+		Where("raffle_id = ? AND eligible = ?", raffleID, false).
+		Group("ineligible_reason").Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	reasons := make(map[string]int64)
+	for _, r := range rows {
+		if r.IneligibleReason != "" {
+			reasons[r.IneligibleReason] = r.Count
+		}
+	}
+
+	return &EntryStats{
+		EligibleCount:     eligible,
+		IneligibleCount:   total - eligible,
+		IneligibleReasons: reasons,
+		TotalJoined:       total,
+	}, nil
+}
+
 func raffleWinnerEmailBody(expiresAt time.Time, claimLink string) string {
 	expiry := expiresAt.UTC().Format("2006-01-02 15:04 UTC")
 	return fmt.Sprintf(`<!DOCTYPE html>


### PR DESCRIPTION
## 什麼改動

新增三支 Dashboard raffle API：
- `PATCH /dashboard/raffles/:id/mode` — 切換抽獎模式（public / subscribers_only），僅 draft 狀態可切換
- `PATCH /dashboard/raffles/:id/entry` — 開放或關閉報名（entry_open），僅 active 狀態可操作
- `GET /dashboard/raffles/:id/entry-stats` — 回傳合格人數、排除人數及原因分布

## 為什麼

closes #988

直播主需要能在後台切換抽獎模式、控制報名開關，並即時查看報名統計。DB schema（mode、entry_open、eligible、ineligible_reason）已由 #985 完成，本 PR 補齊 service / handler / router 層。

## Release Context

- Release type：n/a

## Workflow Type

- [ ] Small / Medium
- [x] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [x] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#988
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不做 Extension join API 的 entry_open 檢查（已在 PR #1010 處理）
  - 不做 Dashboard 前端 UI（#990）
  - 不做 mode 切換後重新評估既有 entry 的訂閱資格

## Delegation Execution Log（非 Codex autonomous PR 可略過）

n/a

## Review conversation closeout

- Unresolved threads：0
- CodeRabbit：n/a（PR 剛開）
- chatgpt-codex-connector：n/a
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：n/a
- Final reviewer action：n/a

## Final merge gate

- Ready-to-merge decision：pending CI
- Latest head SHA：43e83e3
- Required checks：pending
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查

- 這個 PR 的單一句子目的：新增抽獎模式切換、報名開關與報名統計三支 Dashboard API
- Approx changed lines：~1311 行（其中 ~572 行為 `swag init` generated docs；實際業務邏輯 ~739 行，在 1000 行內）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [x] backend domain service
  - [x] API handler / router
    - [x] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - service + handler + router 是同一功能的三層，無法拆開獨立驗證；tests 是必要的 AC；swag docs 須與 router 變更同 PR（CLAUDE.md 規定）
- 若已拆分，相關 PR：n/a

## Acceptance Criteria

- [x] `go test ./...` 全過（17 個新測試 + 全套回歸）
- [x] draft 狀態可切換模式，active 狀態不可切換（返回 409）
- [x] entry_open 開關僅 active 狀態可操作（返回 409 when draft）
- [x] 統計 API 回傳 eligible_count / ineligible_count / ineligible_reasons / total_joined

## 超出範圍內容

無

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**

```
docker compose run --no-deps --rm app go test ./...
ok  github.com/tachigo/tachigo/internal/handlers  21.950s  (17 新測試全過)
ok  github.com/tachigo/tachigo/internal/services   2.966s
ok  github.com/tachigo/tachigo/internal/router     0.426s
全套 15 個 package，0 failures
```

## 備註

- `SetEntryOpen` 使用 `*bool` pointer 接收 entry_open，區分「欄位未傳 nil → 400」與「傳 false → 關閉報名」
- `GetEntryStats` 回傳 `ineligible_reasons: {}` 而非 `null`，client 不需 nil-check
- scope-exception 理由：1311 行中 572 行為 `swag init` generated docs（docs.go / swagger.json / swagger.yaml），實際業務邏輯 739 行符合 1000 行限制

## Notes for Claude Code Review

- `GetEntryStatsContext` 有 4 次 DB query（ownership + total + eligible + group ineligible），MVP 階段可接受
- `ineligible_count = total - eligible`，語意一致且確保兩者不偏差
