### PR TITLE
[frontend] Extension 面板報名按鈕

### DIFF
--- a/apps/extension/src/app/components/RaffleJoinButton.test.tsx
+++ b/apps/extension/src/app/components/RaffleJoinButton.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { joinRaffle } from '../../services/api'
+import { useTwitch } from '../../hooks/useTwitch'
+import { RaffleJoinButton } from './RaffleJoinButton'
+
+vi.mock('../../hooks/useTwitch')
+vi.mock('../../services/api', () => ({
+  joinRaffle: vi.fn(),
+}))
+
+const mockedUseTwitch = vi.mocked(useTwitch)
+const mockedJoinRaffle = vi.mocked(joinRaffle)
+
+function mockBackendReady(backendReady: boolean) {
+  mockedUseTwitch.mockReturnValue({
+    context: null,
+    jwt: '',
+    products: [],
+    tPointEnabled: false,
+    authError: null,
+    backendReady,
+  })
+}
+
+describe('RaffleJoinButton', () => {
+  beforeEach(() => {
+    mockBackendReady(true)
+    mockedJoinRaffle.mockResolvedValue({ status: 200 })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when backendReady is false', () => {
+    mockBackendReady(false)
+
+    const { container } = render(
+      <RaffleJoinButton raffleId="raffle-1" entryOpen raffleActive />,
+    )
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders nothing when raffleActive is false', () => {
+    const { container } = render(
+      <RaffleJoinButton raffleId="raffle-1" entryOpen raffleActive={false} />,
+    )
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('shows join button when raffle is active and entry is open', () => {
+    render(<RaffleJoinButton raffleId="raffle-1" entryOpen raffleActive />)
+
+    expect(screen.getByRole('button', { name: '我要抽獎' })).toBeTruthy()
+  })
+
+  it('shows closed text when raffle is active and entry is closed', () => {
+    render(<RaffleJoinButton raffleId="raffle-1" entryOpen={false} raffleActive />)
+
+    expect(screen.getByText('報名已截止')).toBeTruthy()
+  })
+
+  it('shows joined state after a 200 response', async () => {
+    mockedJoinRaffle.mockResolvedValue({ status: 200 })
+    render(<RaffleJoinButton raffleId="raffle-1" entryOpen raffleActive />)
+
+    fireEvent.click(screen.getByRole('button', { name: '我要抽獎' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '已加入 ✓' })).toBeTruthy()
+    })
+  })
+
+  it('shows not eligible state after a 403 response', async () => {
+    mockedJoinRaffle.mockResolvedValue({ status: 403 })
+    render(<RaffleJoinButton raffleId="raffle-1" entryOpen raffleActive />)
+
+    fireEvent.click(screen.getByRole('button', { name: '我要抽獎' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('需訂閱才能參加')).toBeTruthy()
+    })
+  })
+
+  it('shows joined state after a 409 response', async () => {
+    mockedJoinRaffle.mockResolvedValue({ status: 409 })
+    render(<RaffleJoinButton raffleId="raffle-1" entryOpen raffleActive />)
+
+    fireEvent.click(screen.getByRole('button', { name: '我要抽獎' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '已加入 ✓' })).toBeTruthy()
+    })
+  })
+})

--- a/apps/extension/src/app/components/RaffleJoinButton.tsx
+++ b/apps/extension/src/app/components/RaffleJoinButton.tsx
@@ -34,6 +34,11 @@ const buttonStyle = {
   padding: '10px 14px',
 } satisfies CSSProperties
 
+/**
+ * Displays a raffle join button for the Twitch Extension panel.
+ * Manages join state locally; renders nothing until the backend session is ready
+ * or when the raffle is not active.
+ */
 export function RaffleJoinButton({ raffleId, entryOpen, raffleActive }: RaffleJoinButtonProps) {
   const { backendReady } = useTwitch()
   const [joined, setJoined] = useState(false)

--- a/apps/extension/src/app/components/RaffleJoinButton.tsx
+++ b/apps/extension/src/app/components/RaffleJoinButton.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+import type { CSSProperties } from 'react'
+import { joinRaffle } from '../../services/api'
+import { useTwitch } from '../../hooks/useTwitch'
+
+interface RaffleJoinButtonProps {
+  raffleId: string
+  entryOpen: boolean
+  raffleActive: boolean
+}
+
+const wrapperStyle = {
+  background: '#0d0d1a',
+  fontFamily: 'var(--pixel-font-family)',
+  userSelect: 'none',
+} satisfies CSSProperties
+
+const mutedTextStyle = {
+  color: 'rgba(255,255,255,0.5)',
+  fontFamily: 'var(--pixel-font-family)',
+  fontSize: 8,
+  letterSpacing: '0.08em',
+} satisfies CSSProperties
+
+const buttonStyle = {
+  background: '#9146FF',
+  border: 'none',
+  borderRadius: 6,
+  color: '#ffffff',
+  cursor: 'pointer',
+  fontFamily: 'var(--pixel-font-family)',
+  fontSize: 9,
+  letterSpacing: '0.08em',
+  padding: '10px 14px',
+} satisfies CSSProperties
+
+export function RaffleJoinButton({ raffleId, entryOpen, raffleActive }: RaffleJoinButtonProps) {
+  const { backendReady } = useTwitch()
+  const [joined, setJoined] = useState(false)
+  const [notEligible, setNotEligible] = useState(false)
+  const [joining, setJoining] = useState(false)
+
+  if (!backendReady || !raffleActive) {
+    return null
+  }
+
+  if (joined) {
+    return (
+      <div style={wrapperStyle}>
+        <button type="button" disabled style={{ ...buttonStyle, cursor: 'default', opacity: 0.5 }}>
+          已加入 ✓
+        </button>
+      </div>
+    )
+  }
+
+  if (notEligible) {
+    return (
+      <div style={wrapperStyle}>
+        <span style={mutedTextStyle}>需訂閱才能參加</span>
+      </div>
+    )
+  }
+
+  if (!entryOpen) {
+    return (
+      <div style={wrapperStyle}>
+        <span style={mutedTextStyle}>報名已截止</span>
+      </div>
+    )
+  }
+
+  async function handleJoin() {
+    if (joining) {
+      return
+    }
+
+    setJoining(true)
+    const result = await joinRaffle(raffleId)
+    if (result.status === 200 || result.status === 409) {
+      setJoined(true)
+      return
+    }
+
+    if (result.status === 403) {
+      setNotEligible(true)
+      return
+    }
+
+    setJoining(false)
+  }
+
+  return (
+    <div style={wrapperStyle}>
+      <button
+        type="button"
+        disabled={joining}
+        onClick={() => {
+          void handleJoin()
+        }}
+        style={{ ...buttonStyle, opacity: joining ? 0.5 : 1 }}
+      >
+        我要抽獎
+      </button>
+    </div>
+  )
+}

--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -396,11 +396,18 @@ export async function getRaffleResult(raffleId: string): Promise<RaffleResultDra
   return data.data.draws
 }
 
+/**
+ * Join a raffle as the currently authenticated Extension viewer.
+ * Always resolves (never throws); returns the HTTP status code so callers
+ * can switch on 200 (joined), 403 (not eligible), 409 (already joined).
+ * Network errors and unexpected failures return status 500.
+ */
 export async function joinRaffle(raffleId: string): Promise<{ status: number }> {
   try {
     await client.post(`/api/v1/extension/raffles/${raffleId}/join`)
     return { status: 200 }
   } catch (err) {
+    // err.response is undefined on network errors; fall back to 500.
     if (axios.isAxiosError(err)) {
       return { status: err.response?.status ?? 500 }
     }

--- a/apps/extension/src/services/api.ts
+++ b/apps/extension/src/services/api.ts
@@ -395,3 +395,15 @@ export async function getRaffleResult(raffleId: string): Promise<RaffleResultDra
   )
   return data.data.draws
 }
+
+export async function joinRaffle(raffleId: string): Promise<{ status: number }> {
+  try {
+    await client.post(`/api/v1/extension/raffles/${raffleId}/join`)
+    return { status: 200 }
+  } catch (err) {
+    if (axios.isAxiosError(err)) {
+      return { status: err.response?.status ?? 500 }
+    }
+    return { status: 500 }
+  }
+}


### PR DESCRIPTION
## 什麼改動

新增 `RaffleJoinButton` 元件供 Twitch Extension 面板使用：
- 5 種狀態：idle（未開始）/ open（可報名）/ joined（已加入）/ not_eligible（非訂閱者）/ closed（報名截止）
- 呼叫 `POST /extension/raffles/:id/join`，處理 200 / 403 / 409
- 點擊後立即 disabled，防止重複送出
- 沿用現有 ocean theme 內聯樣式（`#0d0d1a` 背景、`#9146FF` 主色）
- `api.ts` 新增 `joinRaffle()` 函數

## 為什麼

closes #989

後端 join API（#987 / PR #1010）已 merge，前端元件補齊此功能。

## Release Context

- Release type：n/a

## Workflow Type

- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class

- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊

- Source of truth：#989
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不顯示報名人數（無公開 entry count API，另開 follow-up issue）
  - 不修改 Dashboard UI
  - 不做抽獎倒數動畫

## Delegation Execution Log（非 Codex autonomous PR 可略過）

n/a

## Review conversation closeout

- Unresolved threads：0
- CodeRabbit：n/a（PR 剛開）
- chatgpt-codex-connector：n/a
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：n/a
- Final reviewer action：n/a

## Final merge gate

- Ready-to-merge decision：pending CI
- Latest head SHA：9373a3a
- Required checks：pending
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查

- 這個 PR 的單一句子目的：新增 Extension 面板抽獎報名按鈕元件
- Approx changed lines：~220 行（元件 107 + 測試 101 + api.ts 12）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？n/a
- 若已拆分，相關 PR：n/a

## Acceptance Criteria

- [x] 各狀態 UI 正確顯示（6 個測試覆蓋）
- [x] 點擊後按鈕立即 disabled，不可重複觸發
- [x] 403 not_subscriber 顯示「需訂閱才能參加」
- [x] 元件有基本 unit test

## 超出範圍內容

報名人數顯示：目前沒有供 Extension viewer 呼叫的公開 entry count API，暫不實作，留待後續。

## 測試方式

- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**

```
pnpm --filter tachimint test --run
Test Files  23 passed (23)
Tests       90 passed (90)

pnpm --filter tachimint build
✓ built in 140ms
```

## 備註

- `idle` 狀態（`!raffleActive`）回傳 `null`（不顯示元件），比顯示灰字更符合 Extension 面板空間限制
- `joinRaffle()` 使用 `axios.isAxiosError` 而非 `instanceof`，與 `api.ts` 現有慣例一致

## Notes for Claude Code Review

- `useTwitch` mock 用 `mockReturnValue` 型別可能需確認是否與實際 hook 回傳型別完全對齊


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 發布說明

* **新功能**
  * 新增抽獎加入按鈕，使用者可點擊參加進行中的抽獎活動
  * 按鈕根據報名狀態和訂閱資格顯示相應文案（已加入、報名已截止、需訂閱才能參加）

* **測試**
  * 新增功能測試套件，驗證按鈕在各種交互情景下的正確行為

<!-- end of auto-generated comment: release notes by coderabbit.ai -->