### PR TITLE
[frontend] 抽獎模式切換與報名統計面板

### DIFF
--- a/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
+++ b/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import type { RaffleDraw, RafflePrizeTier } from '@/services/raffles'
+import { drawFromTier } from '@/services/raffles'
+
+type SessionPhase = 'round_ready' | 'drawing' | 'round_result' | 'session_complete'
+
+interface Props {
+  raffleId: string
+  tiers: RafflePrizeTier[]
+}
+
+const glass: React.CSSProperties = {
+  background: 'rgba(4,14,52,.55)',
+  border: '1px solid rgba(80,160,255,.22)',
+  borderRadius: 14,
+  backdropFilter: 'blur(14px)',
+  WebkitBackdropFilter: 'blur(14px)',
+}
+
+export function RaffleDrawSession({ raffleId, tiers }: Props) {
+  const sorted = [...tiers].sort((a, b) => a.position - b.position)
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [phase, setPhase] = useState<SessionPhase>('round_ready')
+  const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentTier = sorted[currentIndex]
+
+  async function handleDraw() {
+    if (!currentTier) return
+    setPhase('drawing')
+    setError(null)
+    try {
+      const draw = await drawFromTier(raffleId, currentTier.id)
+      setLatestDraw(draw)
+      setPhase('round_result')
+    } catch {
+      setError('抽獎失敗，請再試一次')
+      setPhase('round_ready')
+    }
+  }
+
+  function handleNext() {
+    const nextIndex = currentIndex + 1
+    if (nextIndex >= sorted.length) {
+      setPhase('session_complete')
+    } else {
+      setCurrentIndex(nextIndex)
+      setPhase('round_ready')
+    }
+  }
+
+  if (phase === 'session_complete') {
+    return (
+      <div data-testid="session-complete" style={{ ...glass, padding: '24px 28px', textAlign: 'center' }}>
+        <p style={{ fontSize: 16, fontWeight: 700, color: '#86efac', marginBottom: 8 }}>🎉 所有輪次抽獎完成</p>
+      </div>
+    )
+  }
+
+  if (!currentTier) return null
+
+  const totalRounds = sorted.length
+
+  return (
+    <div data-testid="raffle-draw-session" style={{ ...glass, padding: '20px 24px' }}>
+      <p data-testid="round-progress" style={{ fontSize: 11, color: 'rgba(148,210,255,.5)', marginBottom: 12 }}>
+        第 {currentIndex + 1} / {totalRounds} 輪
+      </p>
+
+      <p data-testid="current-tier-name" style={{ fontSize: 20, fontWeight: 800, color: '#e0f2fe', marginBottom: 4 }}>
+        {currentTier.name}
+      </p>
+      <p data-testid="current-tier-description" style={{ fontSize: 13, color: 'rgba(148,210,255,.6)', marginBottom: 16 }}>
+        {currentTier.prize_description}
+      </p>
+      <p style={{ fontSize: 11, color: 'rgba(148,210,255,.4)', marginBottom: 16 }}>
+        {currentTier.drawn_count} / {currentTier.winner_count} 人已抽出
+      </p>
+
+      {phase === 'round_ready' && (
+        <button
+          data-testid="draw-round-button"
+          onClick={() => { void handleDraw() }}
+          style={{ background: 'rgba(14,165,233,.2)', border: '1px solid rgba(14,165,233,.4)', color: '#38bdf8', borderRadius: 8, padding: '10px 28px', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}
+        >
+          抽這一輪
+        </button>
+      )}
+
+      {phase === 'drawing' && (
+        <p data-testid="drawing-indicator" style={{ fontSize: 14, color: '#7dd3fc' }}>抽獎中...</p>
+      )}
+
+      {phase === 'round_result' && latestDraw && (
+        <div data-testid="round-result">
+          <p style={{ fontSize: 13, color: 'rgba(148,210,255,.5)', marginBottom: 6 }}>得獎者</p>
+          <p data-testid="winner-name" style={{ fontSize: 24, fontWeight: 800, color: '#fde68a', marginBottom: 20 }}>
+            {latestDraw.entry.display_name || latestDraw.entry.twitch_login}
+          </p>
+          <button
+            data-testid="next-round-button"
+            onClick={handleNext}
+            style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 8, padding: '10px 24px', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
+          >
+            {currentIndex + 1 >= totalRounds ? '完成抽獎' : '繼續下一輪'}
+          </button>
+        </div>
+      )}
+
+      {error && <p style={{ fontSize: 12, color: '#f87171', marginTop: 10 }}>{error}</p>}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
+++ b/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
@@ -22,6 +22,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [phase, setPhase] = useState<SessionPhase>('round_ready')
   const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
+  const [localDrawnCounts, setLocalDrawnCounts] = useState<Record<string, number>>({})
   const [error, setError] = useState<string | null>(null)
 
   const currentTier = sorted[currentIndex]
@@ -33,6 +34,10 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
     try {
       const draw = await drawFromTier(raffleId, currentTier.id)
       setLatestDraw(draw)
+      setLocalDrawnCounts(prev => ({
+        ...prev,
+        [currentTier.id]: (prev[currentTier.id] ?? 0) + 1,
+      }))
       setPhase('round_result')
     } catch {
       setError('抽獎失敗，請再試一次')
@@ -41,6 +46,12 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
   }
 
   function handleNext() {
+    const localDrawn = localDrawnCounts[currentTier.id] ?? 0
+    const needed = currentTier.winner_count
+    if (localDrawn < needed) {
+      setPhase('round_ready')
+      return
+    }
     const nextIndex = currentIndex + 1
     if (nextIndex >= sorted.length) {
       setPhase('session_complete')
@@ -75,7 +86,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
         {currentTier.prize_description}
       </p>
       <p style={{ fontSize: 11, color: 'rgba(148,210,255,.4)', marginBottom: 16 }}>
-        {currentTier.drawn_count} / {currentTier.winner_count} 人已抽出
+        {(localDrawnCounts[currentTier.id] ?? currentTier.drawn_count)} / {currentTier.winner_count} 人已抽出
       </p>
 
       {phase === 'round_ready' && (
@@ -103,7 +114,12 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
             onClick={handleNext}
             style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 8, padding: '10px 24px', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
           >
-            {currentIndex + 1 >= totalRounds ? '完成抽獎' : '繼續下一輪'}
+            {(() => {
+              const localDrawn = localDrawnCounts[currentTier.id] ?? 0
+              if (localDrawn < currentTier.winner_count) return '繼續抽本輪'
+              if (currentIndex + 1 >= totalRounds) return '完成抽獎'
+              return '繼續下一輪'
+            })()}
           </button>
         </div>
       )}

--- a/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+++ b/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RaffleDrawSession } from '../RaffleDrawSession'
+import type { RafflePrizeTier } from '@/services/raffles'
+
+vi.mock('@/services/raffles', () => ({
+  drawFromTier: vi.fn(),
+}))
+
+const mockTiers: RafflePrizeTier[] = [
+  { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+  { id: 't2', raffle_id: 'r1', name: '二等獎', prize_description: 'AirPods', winner_count: 2, drawn_count: 0, position: 1, created_at: '' },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('RaffleDrawSession', () => {
+  it('顯示第一輪的獎項名稱與描述', () => {
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    expect(screen.getByTestId('current-tier-name').textContent).toContain('一等獎')
+    expect(screen.getByTestId('current-tier-description').textContent).toContain('Switch')
+    expect(screen.getByTestId('draw-round-button')).not.toBeNull()
+  })
+
+  it('顯示輪次進度（第 1 / 2 輪）', () => {
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    expect(screen.getByTestId('round-progress').textContent).toContain('第 1 / 2 輪')
+  })
+})

--- a/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+++ b/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { RaffleDrawSession } from '../RaffleDrawSession'
 import type { RafflePrizeTier } from '@/services/raffles'
+import * as rafflesService from '@/services/raffles'
 
 vi.mock('@/services/raffles', () => ({
   drawFromTier: vi.fn(),
@@ -27,5 +28,71 @@ describe('RaffleDrawSession', () => {
   it('顯示輪次進度（第 1 / 2 輪）', () => {
     render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
     expect(screen.getByTestId('round-progress').textContent).toContain('第 1 / 2 輪')
+  })
+
+  it('按下「抽這一輪」後顯示得獎者名稱', async () => {
+    vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+      id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+      claim_token: '', claim_expires_at: '', drawn_at: '',
+      entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+      prize_tier_id: 't1',
+    } as any)
+
+    const { container: _container } = render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('winner-name')).not.toBeNull()
+      expect(screen.getByTestId('winner-name').textContent).toContain('Viewer One')
+    })
+    expect(screen.getByTestId('next-round-button').textContent).toContain('繼續下一輪')
+  })
+
+  it('按下「繼續下一輪」後推進到第二輪', async () => {
+    vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+      id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+      claim_token: '', claim_expires_at: '', drawn_at: '',
+      entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+      prize_tier_id: 't1',
+    } as any)
+
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+    await waitFor(() => screen.getByTestId('next-round-button'))
+    fireEvent.click(screen.getByTestId('next-round-button'))
+
+    expect(screen.getByTestId('current-tier-name').textContent).toContain('二等獎')
+    expect(screen.getByTestId('round-progress').textContent).toContain('第 2 / 2 輪')
+  })
+
+  it('最後一輪結束後顯示完成畫面', async () => {
+    const singleTier: RafflePrizeTier[] = [
+      { id: 't1', raffle_id: 'r1', name: '唯一獎', prize_description: '', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+    ]
+    vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+      id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+      claim_token: '', claim_expires_at: '', drawn_at: '',
+      entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'winner', display_name: 'Winner', created_at: '' },
+      prize_tier_id: 't1',
+    } as any)
+
+    render(<RaffleDrawSession raffleId="r1" tiers={singleTier} />)
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+    await waitFor(() => screen.getByTestId('next-round-button'))
+    fireEvent.click(screen.getByTestId('next-round-button'))
+
+    expect(screen.getByTestId('session-complete')).not.toBeNull()
+  })
+
+  it('API 失敗時顯示錯誤訊息，回到 round_ready', async () => {
+    vi.mocked(rafflesService.drawFromTier).mockRejectedValueOnce(new Error('network error'))
+
+    const { container } = render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('draw-round-button')).not.toBeNull()
+      expect(container.textContent).toContain('抽獎失敗，請再試一次')
+    })
   })
 })

--- a/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+++ b/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
@@ -78,9 +78,47 @@ describe('RaffleDrawSession', () => {
 
     render(<RaffleDrawSession raffleId="r1" tiers={singleTier} />)
     fireEvent.click(screen.getByTestId('draw-round-button'))
-    await waitFor(() => screen.getByTestId('next-round-button'))
+    await waitFor(() => expect(screen.getByTestId('next-round-button').textContent).toContain('完成抽獎'))
     fireEvent.click(screen.getByTestId('next-round-button'))
 
+    expect(screen.getByTestId('session-complete')).not.toBeNull()
+  })
+
+  it('winner_count: 2 的輪次：第一次抽完按鈕顯示「繼續抽本輪」，第二次抽完才顯示完成', async () => {
+    const twoWinnerTier: RafflePrizeTier[] = [
+      { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 2, drawn_count: 0, position: 0, created_at: '' },
+    ]
+    const mockEntry = { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' }
+    vi.mocked(rafflesService.drawFromTier)
+      .mockResolvedValueOnce({
+        id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+        claim_token: '', claim_expires_at: '', drawn_at: '',
+        entry: mockEntry,
+        prize_tier_id: 't1',
+      } as any)
+      .mockResolvedValueOnce({
+        id: 'd2', raffle_id: 'r1', entry_id: 'e2',
+        claim_token: '', claim_expires_at: '', drawn_at: '',
+        entry: { ...mockEntry, id: 'e2', twitch_login: 'viewer2', display_name: 'Viewer Two' },
+        prize_tier_id: 't1',
+      } as any)
+
+    render(<RaffleDrawSession raffleId="r1" tiers={twoWinnerTier} />)
+
+    // 第一次抽
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+    await waitFor(() => expect(screen.getByTestId('next-round-button').textContent).toContain('繼續抽本輪'))
+
+    // 點「繼續抽本輪」→ 回到 round_ready
+    fireEvent.click(screen.getByTestId('next-round-button'))
+    await waitFor(() => expect(screen.getByTestId('draw-round-button')).not.toBeNull())
+
+    // 第二次抽
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+    await waitFor(() => expect(screen.getByTestId('next-round-button').textContent).toContain('完成抽獎'))
+
+    // 點「完成抽獎」→ session_complete
+    fireEvent.click(screen.getByTestId('next-round-button'))
     expect(screen.getByTestId('session-complete')).not.toBeNull()
   })
 

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useOne } from '@refinedev/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
+import { RaffleDrawSession } from '@/components/raffle/RaffleDrawSession'
 import { Skeleton } from '@/components/ui/skeleton'
 import { apiBaseURL } from '@/services/api'
 import { activateRaffle, completeRaffle, createPrizeTier, deletePrizeTier, drawFromTier, drawNext, getRaffleEntryStats, importCSV, listDraws, listPrizeTiers, setDiscordWebhook, setRaffleEntryOpen, setRaffleMode } from '@/services/raffles'
@@ -1039,8 +1040,15 @@ export default function RaffleDetailPage() {
         </div>
       </div>
 
-      {/* Prize Tiers */}
-      {effectiveStatus === 'active' && (
+      {/* Draw Session (active only) */}
+      {effectiveStatus === 'active' && tiers.length > 0 && (
+        <div style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
+          <RaffleDrawSession raffleId={raffleId ?? ''} tiers={tiers} />
+        </div>
+      )}
+
+      {/* Prize Tiers (draft only) */}
+      {effectiveStatus === 'draft' && (
         <div data-testid="prize-tiers-section" style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
           <div style={{ ...glassStyle, padding: '16px 20px' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -96,10 +96,6 @@ function formatRelativeTime(dateStr: string): string {
   return date.toLocaleString('zh-TW')
 }
 
-function getEntryStatsTotal(stats: RaffleEntryStats): number {
-  return stats.total_joined
-}
-
 function isInsufficientScopeError(error: unknown): boolean {
   const response = (error as { response?: { status?: number; data?: unknown } })?.response
   if (response?.status !== 403) return false
@@ -107,24 +103,27 @@ function isInsufficientScopeError(error: unknown): boolean {
   return JSON.stringify(response?.data ?? '').includes('insufficient_scope')
 }
 
+const EXCLUDED_REASON_LABELS: Record<string, string> = {
+  not_subscriber: '非訂閱者',
+  duplicate: '重複報名',
+  already_drawn: '已中獎',
+  missing_twitch_id: '缺少 Twitch ID',
+  missing_subscription: '缺少訂閱紀錄',
+  subscription_expired: '訂閱已失效',
+  subscription_inactive: '訂閱未啟用',
+  banned: '已封鎖',
+  not_following: '未追蹤',
+  manual_exclusion: '手動排除',
+  invalid_entry: '報名資料無效',
+  missing_display_name: '缺少顯示名稱',
+  outside_entry_window: '不在報名時間內',
+  raffle_completed: '活動已結束',
+  raffle_not_active: '活動尚未啟用',
+  unknown_viewer: '未知觀眾',
+}
+
 function formatExcludedReason(reason: string): string {
-  if (reason === 'not_subscriber') return '非訂閱者'
-  if (reason === 'duplicate') return '重複報名'
-  if (reason === 'already_drawn') return '已中獎'
-  if (reason === 'missing_twitch_id') return '缺少 Twitch ID'
-  if (reason === 'missing_subscription') return '缺少訂閱紀錄'
-  if (reason === 'subscription_expired') return '訂閱已失效'
-  if (reason === 'subscription_inactive') return '訂閱未啟用'
-  if (reason === 'banned') return '已封鎖'
-  if (reason === 'not_following') return '未追蹤'
-  if (reason === 'manual_exclusion') return '手動排除'
-  if (reason === 'invalid_entry') return '報名資料無效'
-  if (reason === 'missing_display_name') return '缺少顯示名稱'
-  if (reason === 'outside_entry_window') return '不在報名時間內'
-  if (reason === 'raffle_completed') return '活動已結束'
-  if (reason === 'raffle_not_active') return '活動尚未啟用'
-  if (reason === 'unknown_viewer') return '未知觀眾'
-  return reason
+  return EXCLUDED_REASON_LABELS[reason] ?? reason
 }
 
 function StatCard({
@@ -611,6 +610,7 @@ export default function RaffleDetailPage() {
   const [entryOpenOverride, setEntryOpenOverride] = useState<boolean | null>(null)
   const [entryStats, setEntryStats] = useState<RaffleEntryStats | null>(null)
   const [reauthRequired, setReauthRequired] = useState(false)
+  const [controlError, setControlError] = useState<string | null>(null)
 
   const mode: RaffleMode = modeOverride ?? raffle?.mode ?? 'public'
   const entryOpen: boolean = entryOpenOverride ?? raffle?.entry_open ?? false
@@ -696,14 +696,16 @@ export default function RaffleDetailPage() {
 
   async function handleModeChange(nextMode: RaffleMode) {
     if (!raffleId || nextMode === mode) return
+    setControlError(null)
     try {
       await setRaffleMode(raffleId, nextMode)
       setModeOverride(nextMode)
       setReauthRequired(false)
     } catch (error: unknown) {
       if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
-        setModeOverride(nextMode)
         setReauthRequired(true)
+      } else {
+        setControlError('切換報名資格失敗，請稍後再試')
       }
     }
   }
@@ -711,6 +713,7 @@ export default function RaffleDetailPage() {
   async function handleEntryOpenToggle() {
     if (!raffleId) return
     const nextEntryOpen = !entryOpen
+    setControlError(null)
     try {
       await setRaffleEntryOpen(raffleId, nextEntryOpen)
       setEntryOpenOverride(nextEntryOpen)
@@ -718,6 +721,8 @@ export default function RaffleDetailPage() {
     } catch (error: unknown) {
       if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
         setReauthRequired(true)
+      } else {
+        setControlError('切換報名狀態失敗，請稍後再試')
       }
     }
   }
@@ -918,6 +923,9 @@ export default function RaffleDetailPage() {
                 <a href={`${apiBaseURL}/api/v1/auth/twitch?redirect_to=%2F`} style={{ marginLeft: 8, color: '#7dd3fc', textDecoration: 'underline' }}>重新授權</a>
               </p>
             )}
+            {controlError && (
+              <p data-testid="raffle-entry-controls-error" style={{ fontSize: 11, color: '#f87171' }}>{controlError}</p>
+            )}
             {entryStats && (
               <div data-testid="entry-stats-panel" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 8 }}>
                 <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
@@ -935,7 +943,7 @@ export default function RaffleDetailPage() {
                 </div>
                 <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
                   <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>總報名人數</p>
-                  <p data-testid="total-count" style={{ fontSize: 20, fontWeight: 800, color: '#93c5fd' }}>{getEntryStatsTotal(entryStats)}</p>
+                  <p data-testid="total-count" style={{ fontSize: 20, fontWeight: 800, color: '#93c5fd' }}>{entryStats.total_joined}</p>
                 </div>
               </div>
             )}

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -607,22 +607,19 @@ export default function RaffleDetailPage() {
   const [newTier, setNewTier] = useState({ name: '', prize_description: '', winner_count: 1 })
   const [addingTier, setAddingTier] = useState(false)
   const [addTierError, setAddTierError] = useState<string | null>(null)
-  const [mode, setMode] = useState<RaffleMode>(raffle?.mode ?? 'public')
-  const [entryOpen, setEntryOpen] = useState<boolean>(raffle?.entry_open ?? false)
+  const [modeOverride, setModeOverride] = useState<RaffleMode | null>(null)
+  const [entryOpenOverride, setEntryOpenOverride] = useState<boolean | null>(null)
   const [entryStats, setEntryStats] = useState<RaffleEntryStats | null>(null)
   const [reauthRequired, setReauthRequired] = useState(false)
+
+  const mode: RaffleMode = modeOverride ?? raffle?.mode ?? 'public'
+  const entryOpen: boolean = entryOpenOverride ?? raffle?.entry_open ?? false
 
   const pendingTimers = useRef<number[]>([])
 
   useEffect(() => {
     return () => { pendingTimers.current.forEach(id => window.clearTimeout(id)) }
   }, [])
-
-  useEffect(() => {
-    if (!raffle) return
-    setMode(raffle.mode ?? 'public')
-    setEntryOpen(raffle.entry_open ?? false)
-  }, [raffle])
 
   const effectiveStatus = localCompleted ? 'completed' : localActivated ? 'active' : (raffle?.status ?? '')
 
@@ -649,11 +646,12 @@ export default function RaffleDetailPage() {
 
   useEffect(() => {
     if (!raffleId) return
+    const id = raffleId
     const controller = new AbortController()
 
     async function fetchEntryStats() {
       try {
-        const result = await getRaffleEntryStats(raffleId, controller.signal)
+        const result = await getRaffleEntryStats(id, controller.signal)
         setEntryStats(result)
         setReauthRequired(false)
       } catch (error: unknown) {
@@ -700,11 +698,11 @@ export default function RaffleDetailPage() {
     if (!raffleId || nextMode === mode) return
     try {
       await setRaffleMode(raffleId, nextMode)
-      setMode(nextMode)
+      setModeOverride(nextMode)
       setReauthRequired(false)
     } catch (error: unknown) {
       if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
-        setMode(nextMode)
+        setModeOverride(nextMode)
         setReauthRequired(true)
       }
     }
@@ -715,7 +713,7 @@ export default function RaffleDetailPage() {
     const nextEntryOpen = !entryOpen
     try {
       await setRaffleEntryOpen(raffleId, nextEntryOpen)
-      setEntryOpen(nextEntryOpen)
+      setEntryOpenOverride(nextEntryOpen)
       setReauthRequired(false)
     } catch (error: unknown) {
       if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -96,8 +96,7 @@ function formatRelativeTime(dateStr: string): string {
 }
 
 function getEntryStatsTotal(stats: RaffleEntryStats): number {
-  const maybeTotalCount = (stats as RaffleEntryStats & { total_count?: number }).total_count
-  return typeof maybeTotalCount === 'number' ? maybeTotalCount : stats.total_entries
+  return stats.total_joined
 }
 
 function isInsufficientScopeError(error: unknown): boolean {
@@ -926,9 +925,9 @@ export default function RaffleDetailPage() {
                 </div>
                 <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
                   <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>排除人數</p>
-                  <p data-testid="excluded-count" style={{ fontSize: 20, fontWeight: 800, color: '#fca5a5' }}>{entryStats.excluded_count}</p>
+                  <p data-testid="excluded-count" style={{ fontSize: 20, fontWeight: 800, color: '#fca5a5' }}>{entryStats.ineligible_count}</p>
                   <div data-testid="excluded-breakdown" style={{ marginTop: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
-                    {Object.entries(entryStats.excluded_by_reason).map(([reason, count]) => (
+                    {Object.entries(entryStats.ineligible_reasons).map(([reason, count]) => (
                       <span key={reason} style={{ fontSize: 10, color: 'rgba(226,232,240,.65)' }}>{formatExcludedReason(reason)} {count} 人</span>
                     ))}
                   </div>

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -2,8 +2,9 @@ import { useOne } from '@refinedev/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { activateRaffle, completeRaffle, createPrizeTier, deletePrizeTier, drawFromTier, drawNext, importCSV, listDraws, listPrizeTiers, setDiscordWebhook } from '@/services/raffles'
-import type { Raffle, RaffleDraw, RafflePrizeTier, RaffleStatus } from '@/services/raffles'
+import { apiBaseURL } from '@/services/api'
+import { activateRaffle, completeRaffle, createPrizeTier, deletePrizeTier, drawFromTier, drawNext, getRaffleEntryStats, importCSV, listDraws, listPrizeTiers, setDiscordWebhook, setRaffleEntryOpen, setRaffleMode } from '@/services/raffles'
+import type { Raffle, RaffleDraw, RaffleEntryStats, RaffleMode, RafflePrizeTier, RaffleStatus } from '@/services/raffles'
 import gachaBg from '../assets/raffle-bg.jpg.png'
 
 const OCEAN_KEYFRAMES = `
@@ -92,6 +93,38 @@ function formatRelativeTime(dateStr: string): string {
   if (mins < 60) return `${mins} 分鐘前`
 
   return date.toLocaleString('zh-TW')
+}
+
+function getEntryStatsTotal(stats: RaffleEntryStats): number {
+  const maybeTotalCount = (stats as RaffleEntryStats & { total_count?: number }).total_count
+  return typeof maybeTotalCount === 'number' ? maybeTotalCount : stats.total_entries
+}
+
+function isInsufficientScopeError(error: unknown): boolean {
+  const response = (error as { response?: { status?: number; data?: unknown } })?.response
+  if (response?.status !== 403) return false
+  if (typeof response.data === 'string') return response.data.includes('insufficient_scope')
+  return JSON.stringify(response?.data ?? '').includes('insufficient_scope')
+}
+
+function formatExcludedReason(reason: string): string {
+  if (reason === 'not_subscriber') return '非訂閱者'
+  if (reason === 'duplicate') return '重複報名'
+  if (reason === 'already_drawn') return '已中獎'
+  if (reason === 'missing_twitch_id') return '缺少 Twitch ID'
+  if (reason === 'missing_subscription') return '缺少訂閱紀錄'
+  if (reason === 'subscription_expired') return '訂閱已失效'
+  if (reason === 'subscription_inactive') return '訂閱未啟用'
+  if (reason === 'banned') return '已封鎖'
+  if (reason === 'not_following') return '未追蹤'
+  if (reason === 'manual_exclusion') return '手動排除'
+  if (reason === 'invalid_entry') return '報名資料無效'
+  if (reason === 'missing_display_name') return '缺少顯示名稱'
+  if (reason === 'outside_entry_window') return '不在報名時間內'
+  if (reason === 'raffle_completed') return '活動已結束'
+  if (reason === 'raffle_not_active') return '活動尚未啟用'
+  if (reason === 'unknown_viewer') return '未知觀眾'
+  return reason
 }
 
 function StatCard({
@@ -574,12 +607,22 @@ export default function RaffleDetailPage() {
   const [newTier, setNewTier] = useState({ name: '', prize_description: '', winner_count: 1 })
   const [addingTier, setAddingTier] = useState(false)
   const [addTierError, setAddTierError] = useState<string | null>(null)
+  const [mode, setMode] = useState<RaffleMode>(raffle?.mode ?? 'public')
+  const [entryOpen, setEntryOpen] = useState<boolean>(raffle?.entry_open ?? false)
+  const [entryStats, setEntryStats] = useState<RaffleEntryStats | null>(null)
+  const [reauthRequired, setReauthRequired] = useState(false)
 
   const pendingTimers = useRef<number[]>([])
 
   useEffect(() => {
     return () => { pendingTimers.current.forEach(id => window.clearTimeout(id)) }
   }, [])
+
+  useEffect(() => {
+    if (!raffle) return
+    setMode(raffle.mode ?? 'public')
+    setEntryOpen(raffle.entry_open ?? false)
+  }, [raffle])
 
   const effectiveStatus = localCompleted ? 'completed' : localActivated ? 'active' : (raffle?.status ?? '')
 
@@ -606,6 +649,34 @@ export default function RaffleDetailPage() {
 
   useEffect(() => {
     if (!raffleId) return
+    const controller = new AbortController()
+
+    async function fetchEntryStats() {
+      try {
+        const result = await getRaffleEntryStats(raffleId, controller.signal)
+        setEntryStats(result)
+        setReauthRequired(false)
+      } catch (error: unknown) {
+        if (controller.signal.aborted) return
+        if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
+          setReauthRequired(true)
+        }
+      }
+    }
+
+    void fetchEntryStats()
+    const timerId = window.setInterval(() => {
+      void fetchEntryStats()
+    }, 10000)
+
+    return () => {
+      window.clearInterval(timerId)
+      controller.abort()
+    }
+  }, [mode, raffleId])
+
+  useEffect(() => {
+    if (!raffleId) return
     const initialLoadId = window.setTimeout(() => {
       void fetchDraws()
       void fetchTiers()
@@ -624,6 +695,34 @@ export default function RaffleDetailPage() {
       window.clearInterval(timerId)
     }
   }, [effectiveStatus, fetchDraws, fetchTiers, raffleId])
+
+  async function handleModeChange(nextMode: RaffleMode) {
+    if (!raffleId || nextMode === mode) return
+    try {
+      await setRaffleMode(raffleId, nextMode)
+      setMode(nextMode)
+      setReauthRequired(false)
+    } catch (error: unknown) {
+      if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
+        setMode(nextMode)
+        setReauthRequired(true)
+      }
+    }
+  }
+
+  async function handleEntryOpenToggle() {
+    if (!raffleId) return
+    const nextEntryOpen = !entryOpen
+    try {
+      await setRaffleEntryOpen(raffleId, nextEntryOpen)
+      setEntryOpen(nextEntryOpen)
+      setReauthRequired(false)
+    } catch (error: unknown) {
+      if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
+        setReauthRequired(true)
+      }
+    }
+  }
 
   async function handleDraw() {
     if (!raffleId || drawing) return
@@ -777,6 +876,72 @@ export default function RaffleDetailPage() {
             locked={effectiveStatus !== 'draft'}
             onSuccess={(result) => { setTotalEntries(prev => (prev ?? 0) + result.imported); setExhausted(false) }}
           />
+
+          <section data-testid="raffle-entry-controls" style={{ border: '1px solid rgba(80,160,255,.18)', borderRadius: 10, background: 'rgba(255,255,255,.035)', padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', gap: 10, alignItems: 'center' }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <span style={{ fontSize: 11, color: 'rgba(148,210,255,.6)', letterSpacing: '.06em' }}>報名資格</span>
+                <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: mode === 'public' ? '#e0f2fe' : 'rgba(148,210,255,.55)' }}>
+                    <input
+                      data-testid="raffle-mode-public"
+                      type="radio"
+                      name="raffle-mode"
+                      value="public"
+                      checked={mode === 'public'}
+                      onChange={() => { void handleModeChange('public') }}
+                    />
+                    全體觀眾
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: mode === 'subscribers_only' ? '#e0f2fe' : 'rgba(148,210,255,.55)' }}>
+                    <input
+                      data-testid="raffle-mode-subscribers"
+                      type="radio"
+                      name="raffle-mode"
+                      value="subscribers_only"
+                      checked={mode === 'subscribers_only'}
+                      onChange={() => { void handleModeChange('subscribers_only') }}
+                    />
+                    訂閱者專屬
+                  </label>
+                </div>
+              </div>
+              <button
+                data-testid="entry-open-toggle"
+                onClick={() => { void handleEntryOpenToggle() }}
+                style={{ border: entryOpen ? '1px solid rgba(248,113,113,.35)' : '1px solid rgba(34,197,94,.35)', background: entryOpen ? 'rgba(248,113,113,.1)' : 'rgba(34,197,94,.1)', color: entryOpen ? '#fca5a5' : '#86efac', borderRadius: 8, padding: '7px 12px', fontSize: 12, fontWeight: 700, cursor: 'pointer' }}
+              >
+                {entryOpen ? '截止報名' : '開放報名'}
+              </button>
+            </div>
+            {reauthRequired && mode === 'subscribers_only' && (
+              <p data-testid="twitch-reauth-prompt" style={{ border: '1px solid rgba(251,191,36,.25)', borderRadius: 8, background: 'rgba(251,191,36,.08)', padding: '8px 10px', fontSize: 12, color: '#fde68a' }}>
+                請重新授權 Twitch
+                <a href={`${apiBaseURL}/api/v1/auth/twitch?redirect_to=%2F`} style={{ marginLeft: 8, color: '#7dd3fc', textDecoration: 'underline' }}>重新授權</a>
+              </p>
+            )}
+            {entryStats && (
+              <div data-testid="entry-stats-panel" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 8 }}>
+                <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
+                  <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>合格候選人數</p>
+                  <p data-testid="eligible-count" style={{ fontSize: 20, fontWeight: 800, color: '#86efac' }}>{entryStats.eligible_count}</p>
+                </div>
+                <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
+                  <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>排除人數</p>
+                  <p data-testid="excluded-count" style={{ fontSize: 20, fontWeight: 800, color: '#fca5a5' }}>{entryStats.excluded_count}</p>
+                  <div data-testid="excluded-breakdown" style={{ marginTop: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    {Object.entries(entryStats.excluded_by_reason).map(([reason, count]) => (
+                      <span key={reason} style={{ fontSize: 10, color: 'rgba(226,232,240,.65)' }}>{formatExcludedReason(reason)} {count} 人</span>
+                    ))}
+                  </div>
+                </div>
+                <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
+                  <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>總報名人數</p>
+                  <p data-testid="total-count" style={{ fontSize: 20, fontWeight: 800, color: '#93c5fd' }}>{getEntryStatsTotal(entryStats)}</p>
+                </div>
+              </div>
+            )}
+          </section>
 
           {effectiveStatus === 'draft' && (
             <>

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -612,6 +612,9 @@ export default function RaffleDetailPage() {
   const [reauthRequired, setReauthRequired] = useState(false)
   const [controlError, setControlError] = useState<string | null>(null)
 
+  const modeRequestSeq = useRef(0)
+  const entryOpenRequestSeq = useRef(0)
+
   const mode: RaffleMode = modeOverride ?? raffle?.mode ?? 'public'
   const entryOpen: boolean = entryOpenOverride ?? raffle?.entry_open ?? false
 
@@ -649,9 +652,14 @@ export default function RaffleDetailPage() {
     const id = raffleId
     const controller = new AbortController()
 
+    let inFlight = false
+
     async function fetchEntryStats() {
+      if (inFlight) return
+      inFlight = true
       try {
         const result = await getRaffleEntryStats(id, controller.signal)
+        if (controller.signal.aborted) return
         setEntryStats(result)
         setReauthRequired(false)
       } catch (error: unknown) {
@@ -659,6 +667,8 @@ export default function RaffleDetailPage() {
         if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
           setReauthRequired(true)
         }
+      } finally {
+        inFlight = false
       }
     }
 
@@ -697,11 +707,14 @@ export default function RaffleDetailPage() {
   async function handleModeChange(nextMode: RaffleMode) {
     if (!raffleId || nextMode === mode) return
     setControlError(null)
+    const seq = ++modeRequestSeq.current
     try {
       await setRaffleMode(raffleId, nextMode)
+      if (modeRequestSeq.current !== seq) return
       setModeOverride(nextMode)
       setReauthRequired(false)
     } catch (error: unknown) {
+      if (modeRequestSeq.current !== seq) return
       if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
         setReauthRequired(true)
       } else {
@@ -714,11 +727,14 @@ export default function RaffleDetailPage() {
     if (!raffleId) return
     const nextEntryOpen = !entryOpen
     setControlError(null)
+    const seq = ++entryOpenRequestSeq.current
     try {
       await setRaffleEntryOpen(raffleId, nextEntryOpen)
+      if (entryOpenRequestSeq.current !== seq) return
       setEntryOpenOverride(nextEntryOpen)
       setReauthRequired(false)
     } catch (error: unknown) {
+      if (entryOpenRequestSeq.current !== seq) return
       if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
         setReauthRequired(true)
       } else {

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -62,6 +62,7 @@ const mockPrizeTier: rafflesService.RafflePrizeTier = {
   prize_description: 'Switch 主機',
   winner_count: 2,
   drawn_count: 0,
+  position: 0,
   created_at: '2026-01-01T00:00:00Z',
 }
 async function renderAt(raffleId: string, dp: ReturnType<typeof createMockDataProvider>) {

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -25,9 +25,9 @@ vi.mock('@/services/raffles', async (importOriginal) => {
     setRaffleEntryOpen: vi.fn().mockResolvedValue({}),
     getRaffleEntryStats: vi.fn().mockResolvedValue({
       eligible_count: 0,
-      excluded_count: 0,
-      excluded_by_reason: {},
-      total_entries: 0,
+      ineligible_count: 0,
+      ineligible_reasons: {},
+      total_joined: 0,
     }),
   }
 })
@@ -103,9 +103,9 @@ beforeEach(() => {
   vi.mocked(rafflesService.setRaffleEntryOpen).mockResolvedValue(mockRaffle)
   vi.mocked(rafflesService.getRaffleEntryStats).mockResolvedValue({
     eligible_count: 0,
-    excluded_count: 0,
-    excluded_by_reason: {},
-    total_entries: 0,
+    ineligible_count: 0,
+    ineligible_reasons: {},
+    total_joined: 0,
   })
 })
 

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -21,6 +21,14 @@ vi.mock('@/services/raffles', async (importOriginal) => {
     createPrizeTier: vi.fn().mockResolvedValue({}),
     deletePrizeTier: vi.fn().mockResolvedValue(undefined),
     drawFromTier: vi.fn().mockResolvedValue({}),
+    setRaffleMode: vi.fn().mockResolvedValue({}),
+    setRaffleEntryOpen: vi.fn().mockResolvedValue({}),
+    getRaffleEntryStats: vi.fn().mockResolvedValue({
+      eligible_count: 0,
+      excluded_count: 0,
+      excluded_by_reason: {},
+      total_entries: 0,
+    }),
   }
 })
 
@@ -91,7 +99,16 @@ beforeEach(() => {
   vi.mocked(rafflesService.createPrizeTier).mockResolvedValue(mockPrizeTier)
   vi.mocked(rafflesService.deletePrizeTier).mockResolvedValue(undefined)
   vi.mocked(rafflesService.drawFromTier).mockResolvedValue(mockDraw)
+  vi.mocked(rafflesService.setRaffleMode).mockResolvedValue(mockRaffle)
+  vi.mocked(rafflesService.setRaffleEntryOpen).mockResolvedValue(mockRaffle)
+  vi.mocked(rafflesService.getRaffleEntryStats).mockResolvedValue({
+    eligible_count: 0,
+    excluded_count: 0,
+    excluded_by_reason: {},
+    total_entries: 0,
+  })
 })
+
 afterEach(() => {
   vi.restoreAllMocks()
   document.body.innerHTML = ''
@@ -661,6 +678,58 @@ describe('RaffleDetailPage — winner modal', () => {
       closeBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(container.textContent).not.toContain('恭喜中獎')
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage functional layer', () => {
+  it('mode switch calls setRaffleMode and updates UI', async () => {
+    const modeMock = vi.mocked(rafflesService.setRaffleMode).mockResolvedValue({ ...mockRaffle, mode: 'subscribers_only' })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'public', entry_open: false } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="raffle-mode-subscribers"]')).toBeTruthy())
+
+    const subscribers = container.querySelector('[data-testid="raffle-mode-subscribers"]') as HTMLInputElement
+    await act(async () => {
+      subscribers.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    await waitFor(() => expect(modeMock).toHaveBeenCalledWith('r1', 'subscribers_only'))
+    expect(subscribers.checked).toBe(true)
+    cleanup(root, container)
+  })
+
+  it('entry open/close button calls setRaffleEntryOpen and reflects state', async () => {
+    const entryOpenMock = vi.mocked(rafflesService.setRaffleEntryOpen).mockResolvedValue({ ...mockRaffle, entry_open: true })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'public', entry_open: false } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="entry-open-toggle"]')?.textContent).toContain('開放報名'))
+
+    await act(async () => {
+      container.querySelector('[data-testid="entry-open-toggle"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    await waitFor(() => expect(entryOpenMock).toHaveBeenCalledWith('r1', true))
+    expect(container.querySelector('[data-testid="entry-open-toggle"]')?.textContent).toContain('截止報名')
+    cleanup(root, container)
+  })
+
+  it('subscribers_only + 403 insufficient_scope shows re-auth prompt', async () => {
+    vi.mocked(rafflesService.getRaffleEntryStats).mockRejectedValue({
+      response: { status: 403, data: { error: 'insufficient_scope' } },
+    })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'subscribers_only', entry_open: false } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+
+    await waitFor(() => expect(container.querySelector('[data-testid="twitch-reauth-prompt"]')?.textContent).toContain('請重新授權 Twitch'))
+    expect(container.querySelector('[data-testid="twitch-reauth-prompt"] a')?.getAttribute('href')).toContain('/api/v1/auth/twitch')
     cleanup(root, container)
   })
 })

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -189,24 +189,36 @@ describe('RaffleDetailPage — winner list', () => {
   })
 })
 
+const draftRaffle = { ...mockRaffle, status: 'draft' as const }
+
 describe('RaffleDetailPage — prize tiers', () => {
-  it('hides prize tiers while raffle is still draft', async () => {
+  it('shows prize-tiers-section in draft state', async () => {
     const dp = createMockDataProvider({
       getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
-    expect(container.querySelector('[data-testid="prize-tiers-section"]')).toBeFalsy()
+    expect(container.querySelector('[data-testid="prize-tiers-section"]')).not.toBeNull()
     cleanup(root, container)
   })
 
-  it('shows active raffle prize tiers and disables completed tiers', async () => {
+  it('hides prize-tiers-section in active state', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
+    expect(container.querySelector('[data-testid="prize-tiers-section"]')).toBeNull()
+    cleanup(root, container)
+  })
+
+  it('shows draft raffle prize tiers and disables completed tiers', async () => {
     vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([
       mockPrizeTier,
       { ...mockPrizeTier, id: 't2', name: '二等獎', winner_count: 1, drawn_count: 1 },
     ])
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-row-t1"]')).toBeTruthy())
@@ -216,9 +228,9 @@ describe('RaffleDetailPage — prize tiers', () => {
     cleanup(root, container)
   })
 
-  it('creates a prize tier from the active raffle panel', async () => {
+  it('creates a prize tier from the draft raffle panel', async () => {
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-toggle"]')).toBeTruthy())
@@ -253,7 +265,7 @@ describe('RaffleDetailPage — prize tiers', () => {
 
   it('does not create a prize tier when winner count is empty', async () => {
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-toggle"]')).toBeTruthy())
@@ -286,7 +298,7 @@ describe('RaffleDetailPage — prize tiers', () => {
   it('draws and deletes prize tiers through tier actions', async () => {
     vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([mockPrizeTier])
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-draw-t1"]')).toBeTruthy())
@@ -305,8 +317,6 @@ describe('RaffleDetailPage — prize tiers', () => {
     cleanup(root, container)
   })
 })
-
-const draftRaffle = { ...mockRaffle, status: 'draft' as const }
 
 describe('RaffleDetailPage — CSV upload', () => {
   it('shows success message after upload', async () => {
@@ -730,6 +740,30 @@ describe('RaffleDetailPage functional layer', () => {
 
     await waitFor(() => expect(container.querySelector('[data-testid="twitch-reauth-prompt"]')?.textContent).toContain('請重新授權 Twitch'))
     expect(container.querySelector('[data-testid="twitch-reauth-prompt"] a')?.getAttribute('href')).toContain('/api/v1/auth/twitch')
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — RaffleDrawSession integration', () => {
+  it('shows raffle-draw-session when status is active and tiers exist', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([mockPrizeTier])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="raffle-draw-session"]')).not.toBeNull())
+    expect(container.querySelector('[data-testid="prize-tiers-section"]')).toBeNull()
+    cleanup(root, container)
+  })
+
+  it('shows prize-tiers-section and no raffle-draw-session when status is draft and tiers exist', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([mockPrizeTier])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="prize-tiers-section"]')).not.toBeNull())
+    expect(container.querySelector('[data-testid="raffle-draw-session"]')).toBeNull()
     cleanup(root, container)
   })
 })

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -39,6 +39,7 @@ export interface RafflePrizeTier {
   prize_description: string
   winner_count: number
   drawn_count: number
+  position: number
   created_at: string
 }
 

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -19,9 +19,9 @@ export interface Raffle {
 
 export interface RaffleEntryStats {
   eligible_count: number
-  excluded_count: number
-  excluded_by_reason: Record<string, number>
-  total_entries: number
+  ineligible_count: number
+  ineligible_reasons: Record<string, number>
+  total_joined: number
 }
 
 export interface RaffleEntry {

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -3,14 +3,25 @@ import client from '@/services/api'
 type ApiResponse<T> = { success: boolean; data: T }
 
 export type RaffleStatus = 'draft' | 'active' | 'completed'
+export type RaffleMode = 'public' | 'subscribers_only'
 
 export interface Raffle {
   id: string
   user_id: string
   title: string
   status: RaffleStatus
+  source?: 'csv' | 'twitch_api'
+  mode?: RaffleMode
+  entry_open?: boolean
   created_at: string
   updated_at: string
+}
+
+export interface RaffleEntryStats {
+  eligible_count: number
+  excluded_count: number
+  excluded_by_reason: Record<string, number>
+  total_entries: number
 }
 
 export interface RaffleEntry {
@@ -92,6 +103,39 @@ export async function activateRaffle(raffleId: string): Promise<Raffle> {
     undefined,
   )
   return data.data.raffle
+}
+
+export async function setRaffleMode(
+  raffleId: string,
+  mode: RaffleMode,
+): Promise<Raffle> {
+  const { data } = await client.patch<ApiResponse<{ raffle: Raffle }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/mode`,
+    { mode },
+  )
+  return data.data.raffle
+}
+
+export async function setRaffleEntryOpen(
+  raffleId: string,
+  entryOpen: boolean,
+): Promise<Raffle> {
+  const { data } = await client.patch<ApiResponse<{ raffle: Raffle }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/entry-open`,
+    { entry_open: entryOpen },
+  )
+  return data.data.raffle
+}
+
+export async function getRaffleEntryStats(
+  raffleId: string,
+  signal?: AbortSignal,
+): Promise<RaffleEntryStats> {
+  const { data } = await client.get<ApiResponse<{ stats: RaffleEntryStats }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/entry-stats`,
+    { signal },
+  )
+  return data.data.stats
 }
 
 export async function completeRaffle(raffleId: string): Promise<void> {

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -14,5 +14,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    globals: true,
   },
 })

--- a/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
+++ b/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
@@ -1,0 +1,501 @@
+# Raffle Phase 2 — 逐輪抽獎模式 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 Dashboard 抽獎頁面新增逐輪模式，讓主播依 PrizeTier position 順序一輪一輪手動推進抽獎，每輪結束後展示得獎者，所有輪次結束後顯示完整名單。
+
+**Architecture:** 純前端工作，後端 cross-tier 排除已完整（`raffle_service.go:1264`）。新增 `RaffleDrawSession` 元件管理逐輪狀態機；`RaffleDetailPage` 在 raffle 狀態為 `active` 且有 PrizeTier 時，以 `RaffleDrawSession` 取代現有的逐顆「抽一人」按鈕區塊。
+
+**Tech Stack:** React 18, TypeScript, Vitest + Testing Library, inline styles（沿用 ocean 主題）
+
+---
+
+## 檔案結構
+
+| 動作 | 路徑 | 職責 |
+|---|---|---|
+| **新增** | `apps/dashboard/src/components/raffle/RaffleDrawSession.tsx` | 逐輪模式容器 + 子元件（TierRoundCard、DrawResultOverlay、FinalWinnerList） |
+| **新增** | `apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx` | 元件測試 |
+| **修改** | `apps/dashboard/src/services/raffles.ts` | 補 `position` 欄位至 `RafflePrizeTier` interface |
+| **修改** | `apps/dashboard/src/pages/RaffleDetailPage.tsx` | active 狀態下嵌入 `RaffleDrawSession` |
+
+---
+
+## Task 1：補 `RafflePrizeTier.position` 欄位
+
+後端 `raffle_prize_tiers` 表有 `position` 欄位但前端 interface 缺少，需先補上。
+
+**Files:**
+- Modify: `apps/dashboard/src/services/raffles.ts:35-43`
+
+- [ ] **Step 1：確認後端欄位存在**
+
+```bash
+grep "position" services/api/internal/models/raffle.go
+```
+
+預期輸出含：`Position int \`gorm:\"not null;default:0\" json:\"position\"\``
+
+- [ ] **Step 2：補 interface 欄位**
+
+在 `apps/dashboard/src/services/raffles.ts` 找到 `RafflePrizeTier` interface，加入 `position`:
+
+```ts
+export interface RafflePrizeTier {
+  id: string
+  raffle_id: string
+  name: string
+  prize_description: string
+  winner_count: number
+  drawn_count: number
+  position: number
+  created_at: string
+}
+```
+
+- [ ] **Step 3：TypeScript 確認無錯誤**
+
+```bash
+cd apps/dashboard && npx tsc --noEmit
+```
+
+預期：無錯誤輸出。
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add apps/dashboard/src/services/raffles.ts
+git commit -m "feat: add position field to RafflePrizeTier interface
+
+refs #234"
+```
+
+---
+
+## Task 2：建立 `RaffleDrawSession` — 初始狀態與 round_ready
+
+**Files:**
+- Create: `apps/dashboard/src/components/raffle/RaffleDrawSession.tsx`
+- Create: `apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx`
+
+- [ ] **Step 1：建立測試檔，寫第一個失敗測試**
+
+建立 `apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx`：
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RaffleDrawSession } from '../RaffleDrawSession'
+import type { RafflePrizeTier } from '@/services/raffles'
+
+const mockTiers: RafflePrizeTier[] = [
+  { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+  { id: 't2', raffle_id: 'r1', name: '二等獎', prize_description: 'AirPods', winner_count: 2, drawn_count: 0, position: 1, created_at: '' },
+]
+
+describe('RaffleDrawSession', () => {
+  it('顯示第一輪的獎項名稱與描述', () => {
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    expect(screen.getByTestId('current-tier-name')).toHaveTextContent('一等獎')
+    expect(screen.getByTestId('current-tier-description')).toHaveTextContent('Switch')
+    expect(screen.getByTestId('draw-round-button')).toBeInTheDocument()
+  })
+
+  it('顯示輪次進度（第 1 / 2 輪）', () => {
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    expect(screen.getByTestId('round-progress')).toHaveTextContent('第 1 / 2 輪')
+  })
+})
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+```
+
+預期：FAIL — `RaffleDrawSession` 不存在。
+
+- [ ] **Step 3：建立元件檔，實作 round_ready 初始狀態**
+
+建立 `apps/dashboard/src/components/raffle/RaffleDrawSession.tsx`：
+
+```tsx
+import { useState } from 'react'
+import type { RaffleDraw, RafflePrizeTier } from '@/services/raffles'
+import { drawFromTier } from '@/services/raffles'
+
+type SessionPhase = 'round_ready' | 'drawing' | 'round_result' | 'session_complete'
+
+interface Props {
+  raffleId: string
+  tiers: RafflePrizeTier[]
+}
+
+const glass: React.CSSProperties = {
+  background: 'rgba(4,14,52,.55)',
+  border: '1px solid rgba(80,160,255,.22)',
+  borderRadius: 14,
+  backdropFilter: 'blur(14px)',
+  WebkitBackdropFilter: 'blur(14px)',
+}
+
+export function RaffleDrawSession({ raffleId, tiers }: Props) {
+  const sorted = [...tiers].sort((a, b) => a.position - b.position)
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [phase, setPhase] = useState<SessionPhase>('round_ready')
+  const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentTier = sorted[currentIndex]
+
+  async function handleDraw() {
+    if (!currentTier) return
+    setPhase('drawing')
+    setError(null)
+    try {
+      const draw = await drawFromTier(raffleId, currentTier.id)
+      setLatestDraw(draw)
+      setPhase('round_result')
+    } catch {
+      setError('抽獎失敗，請再試一次')
+      setPhase('round_ready')
+    }
+  }
+
+  function handleNext() {
+    const nextIndex = currentIndex + 1
+    if (nextIndex >= sorted.length) {
+      setPhase('session_complete')
+    } else {
+      setCurrentIndex(nextIndex)
+      setPhase('round_ready')
+    }
+  }
+
+  if (phase === 'session_complete') {
+    return (
+      <div data-testid="session-complete" style={{ ...glass, padding: '24px 28px', textAlign: 'center' }}>
+        <p style={{ fontSize: 16, fontWeight: 700, color: '#86efac', marginBottom: 8 }}>🎉 所有輪次抽獎完成</p>
+      </div>
+    )
+  }
+
+  if (!currentTier) return null
+
+  const totalRounds = sorted.length
+
+  return (
+    <div data-testid="raffle-draw-session" style={{ ...glass, padding: '20px 24px' }}>
+      <p data-testid="round-progress" style={{ fontSize: 11, color: 'rgba(148,210,255,.5)', marginBottom: 12 }}>
+        第 {currentIndex + 1} / {totalRounds} 輪
+      </p>
+
+      <p data-testid="current-tier-name" style={{ fontSize: 20, fontWeight: 800, color: '#e0f2fe', marginBottom: 4 }}>
+        {currentTier.name}
+      </p>
+      <p data-testid="current-tier-description" style={{ fontSize: 13, color: 'rgba(148,210,255,.6)', marginBottom: 16 }}>
+        {currentTier.prize_description}
+      </p>
+      <p style={{ fontSize: 11, color: 'rgba(148,210,255,.4)', marginBottom: 16 }}>
+        {currentTier.drawn_count} / {currentTier.winner_count} 人已抽出
+      </p>
+
+      {phase === 'round_ready' && (
+        <button
+          data-testid="draw-round-button"
+          onClick={() => { void handleDraw() }}
+          style={{ background: 'rgba(14,165,233,.2)', border: '1px solid rgba(14,165,233,.4)', color: '#38bdf8', borderRadius: 8, padding: '10px 28px', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}
+        >
+          抽這一輪
+        </button>
+      )}
+
+      {phase === 'drawing' && (
+        <p data-testid="drawing-indicator" style={{ fontSize: 14, color: '#7dd3fc' }}>抽獎中...</p>
+      )}
+
+      {phase === 'round_result' && latestDraw && (
+        <div data-testid="round-result">
+          <p style={{ fontSize: 13, color: 'rgba(148,210,255,.5)', marginBottom: 6 }}>得獎者</p>
+          <p data-testid="winner-name" style={{ fontSize: 24, fontWeight: 800, color: '#fde68a', marginBottom: 20 }}>
+            {latestDraw.entry.display_name || latestDraw.entry.twitch_login}
+          </p>
+          <button
+            data-testid="next-round-button"
+            onClick={handleNext}
+            style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 8, padding: '10px 24px', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
+          >
+            {currentIndex + 1 >= totalRounds ? '完成抽獎' : '繼續下一輪'}
+          </button>
+        </div>
+      )}
+
+      {error && <p style={{ fontSize: 12, color: '#f87171', marginTop: 10 }}>{error}</p>}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4：確認測試通過**
+
+```bash
+cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+```
+
+預期：PASS（2 tests）。
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add apps/dashboard/src/components/raffle/RaffleDrawSession.tsx \
+        apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+git commit -m "feat: add RaffleDrawSession round_ready state
+
+refs #234"
+```
+
+---
+
+## Task 3：測試抽獎流程與輪次推進
+
+**Files:**
+- Modify: `apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx`
+
+- [ ] **Step 1：補充測試 — 抽獎成功顯示得獎者，以及繼續下一輪**
+
+在測試檔 `describe` 區塊內補充：
+
+```tsx
+import { fireEvent, waitFor } from '@testing-library/react'
+
+// 在 describe 頂層加入 mock
+vi.mock('@/services/raffles', () => ({
+  drawFromTier: vi.fn(),
+}))
+
+import * as rafflesService from '@/services/raffles'
+
+// 在 describe 內加入：
+it('按下「抽這一輪」後顯示得獎者名稱', async () => {
+  vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+    id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+    claim_token: '', claim_expires_at: '', drawn_at: '',
+    entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+    prize_tier_id: 't1',
+  } as any)
+
+  render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+
+  await waitFor(() => {
+    expect(screen.getByTestId('winner-name')).toHaveTextContent('Viewer One')
+  })
+  expect(screen.getByTestId('next-round-button')).toHaveTextContent('繼續下一輪')
+})
+
+it('按下「繼續下一輪」後推進到第二輪', async () => {
+  vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+    id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+    claim_token: '', claim_expires_at: '', drawn_at: '',
+    entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+    prize_tier_id: 't1',
+  } as any)
+
+  render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+  await waitFor(() => screen.getByTestId('next-round-button'))
+  fireEvent.click(screen.getByTestId('next-round-button'))
+
+  expect(screen.getByTestId('current-tier-name')).toHaveTextContent('二等獎')
+  expect(screen.getByTestId('round-progress')).toHaveTextContent('第 2 / 2 輪')
+})
+
+it('最後一輪結束後顯示完成畫面', async () => {
+  const singleTier: RafflePrizeTier[] = [
+    { id: 't1', raffle_id: 'r1', name: '唯一獎', prize_description: '', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+  ]
+  vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+    id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+    claim_token: '', claim_expires_at: '', drawn_at: '',
+    entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'winner', display_name: 'Winner', created_at: '' },
+    prize_tier_id: 't1',
+  } as any)
+
+  render(<RaffleDrawSession raffleId="r1" tiers={singleTier} />)
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+  await waitFor(() => screen.getByTestId('next-round-button'))
+  fireEvent.click(screen.getByTestId('next-round-button'))
+
+  expect(screen.getByTestId('session-complete')).toBeInTheDocument()
+})
+
+it('API 失敗時顯示錯誤訊息，回到 round_ready', async () => {
+  vi.mocked(rafflesService.drawFromTier).mockRejectedValueOnce(new Error('network error'))
+
+  render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+
+  await waitFor(() => {
+    expect(screen.getByTestId('draw-round-button')).toBeInTheDocument()
+    expect(screen.getByText('抽獎失敗，請再試一次')).toBeInTheDocument()
+  })
+})
+```
+
+注意：需在測試檔最頂層（import 之後，describe 之前）加上：
+```tsx
+vi.mock('@/services/raffles', () => ({
+  drawFromTier: vi.fn(),
+}))
+```
+並在 `beforeEach` 中加：
+```tsx
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+```
+
+- [ ] **Step 2：確認測試通過**
+
+```bash
+cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+```
+
+預期：PASS（6 tests）。
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+git commit -m "test: add RaffleDrawSession draw flow and round progression tests
+
+refs #234"
+```
+
+---
+
+## Task 4：整合進 `RaffleDetailPage`
+
+active 狀態且有 PrizeTier 時，以 `RaffleDrawSession` 取代現有「逐顆抽」按鈕區塊。
+
+**Files:**
+- Modify: `apps/dashboard/src/pages/RaffleDetailPage.tsx`
+- Modify: `apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx`
+
+- [ ] **Step 1：在 `RaffleDetailPage.tsx` import `RaffleDrawSession`**
+
+在檔案頂部 import 區加入：
+
+```tsx
+import { RaffleDrawSession } from '@/components/raffle/RaffleDrawSession'
+```
+
+- [ ] **Step 2：找到 prize-tiers-section，加入條件渲染**
+
+找到 `data-testid="prize-tiers-section"` 的 `<div>`（約第 1044 行），在其**前方**插入：
+
+```tsx
+{effectiveStatus === 'active' && tiers.length > 0 && (
+  <div style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
+    <RaffleDrawSession raffleId={raffleId ?? ''} tiers={tiers} />
+  </div>
+)}
+```
+
+不修改或刪除現有的 prize-tiers-section（draft 狀態仍需要管理 UI）。
+
+- [ ] **Step 3：在現有 prize-tiers-section 加 active 狀態隱藏**
+
+找到 `data-testid="prize-tiers-section"` 外層 `<div>` 的開頭，將原本的顯示條件由：
+```tsx
+{(effectiveStatus === 'active' || effectiveStatus === 'draft') && (
+```
+改為（若原本無條件顯示，則包上）：
+```tsx
+{effectiveStatus === 'draft' && (
+```
+
+> 若原本就有條件包住整段，只改判斷式。若整段無條件渲染，則在外層加 `{effectiveStatus === 'draft' && ( ... )}`。
+
+- [ ] **Step 4：確認 TypeScript 無錯誤**
+
+```bash
+cd apps/dashboard && npx tsc --noEmit
+```
+
+預期：無錯誤。
+
+- [ ] **Step 5：在 `RaffleDetailPage.test.tsx` 補整合測試**
+
+在測試檔找到現有 import 的 mock 區塊，確認 `@/services/raffles` mock 中包含 `drawFromTier: vi.fn()`。若無，補上。
+
+在測試檔末尾加入：
+
+```tsx
+describe('RaffleDrawSession 整合', () => {
+  it('raffle active 且有 tiers 時顯示 RaffleDrawSession', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([
+      { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+    ])
+
+    render(
+      <RaffleDetailPage />,
+      { wrapper: createRefineWrapper({ raffle: { ...mockRaffle, status: 'active' } }) }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('raffle-draw-session')).toBeInTheDocument()
+    })
+  })
+
+  it('raffle draft 時不顯示 RaffleDrawSession', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([
+      { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: '', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+    ])
+
+    render(
+      <RaffleDetailPage />,
+      { wrapper: createRefineWrapper({ raffle: { ...mockRaffle, status: 'draft' } }) }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('prize-tiers-section')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('raffle-draw-session')).not.toBeInTheDocument()
+  })
+})
+```
+
+> 若測試檔的 `createRefineWrapper` 或 mock raffle shape 與上方不符，請依照測試檔現有 pattern 調整 — 重點是 `status: 'active'` vs `status: 'draft'` 的渲染差異。
+
+- [ ] **Step 6：跑全部 dashboard 測試**
+
+```bash
+cd apps/dashboard && npx vitest run
+```
+
+預期：全部 PASS，無新 failure。
+
+- [ ] **Step 7：Commit**
+
+```bash
+git add apps/dashboard/src/pages/RaffleDetailPage.tsx \
+        apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+git commit -m "feat: integrate RaffleDrawSession into RaffleDetailPage for active state
+
+refs #234"
+```
+
+---
+
+## 驗證 Checklist
+
+完成所有 Task 後，手動確認：
+
+- [ ] 建立含 3 個 PrizeTier 的 Raffle（位置 0/1/2），啟動後進入逐輪模式
+- [ ] 第一輪顯示 position=0 的獎項，按「抽這一輪」出現得獎者
+- [ ] 按「繼續下一輪」，第二輪正確顯示 position=1 的獎項
+- [ ] 所有輪次抽完後顯示「所有輪次抽獎完成」
+- [ ] draft 狀態下仍能新增 / 刪除 PrizeTier（管理 UI 不受影響）
+- [ ] 同一人不可能在兩輪都得獎（後端保證）

--- a/docs/superpowers/specs/2026-06-04-raffle-phase2-draw-session-design.md
+++ b/docs/superpowers/specs/2026-06-04-raffle-phase2-draw-session-design.md
@@ -1,0 +1,94 @@
+# Raffle Phase 2 — 逐輪抽獎模式 設計文件
+
+**日期**：2026-06-04
+**關聯 issue**：[#234](https://github.com/nurockplayer/tachigo/issues/234)
+**狀態**：待實作
+
+---
+
+## 背景
+
+Phase 1 已完整實作抽獎系統核心：`Raffle` → `RafflePrizeTier` → `RaffleDraw`。其中 `DrawFromTierContext` 已實作 cross-tier 排除（`raffle_service.go:1264`），不同獎項層之間得獎者不重複。
+
+Issue #234 提出 Campaign 多場抽獎層設計，但確認需求後，Phase 2 的核心場景為：
+
+> 同一場直播中，主播依序從多個獎項層抽獎，每輪抽完後暫停展示得獎者，確認後再手動推進到下一輪。
+
+由於後端資料層已完整支援此場景，Phase 2 為**純前端 UX 工作**，不新增資料表、不新增 API 端點。
+
+---
+
+## 不做
+
+- Campaign 資料表與 API
+- 每輪不同報名資格 / 不同名單（留待 Phase 3 視需求決定）
+- 自動進輪（每輪結束後系統自動觸發下一輪）
+- 主播自由選輪次順序（固定依 `position` 排序）
+
+---
+
+## 設計
+
+### 輪次順序
+
+`RafflePrizeTier` 依 `position` 欄位升序排列，由小到大依序抽。主播在活動建立時設定 position，開播後固定順序。
+
+### 狀態機
+
+```
+[idle]
+  ↓ Raffle 狀態為 active，PrizeTiers 存在
+[round_ready]  ── 顯示當前 tier 名稱、獎項說明、本輪名額
+  ↓ 主播按「抽這一輪」→ 呼叫 drawFromTier API
+[drawing]  ── loading 狀態
+  ↓ API 回傳成功
+[round_result]  ── 展示得獎者名稱；若本輪 winner_count > 1，可繼續抽同輪
+  ↓ 本輪 drawn_count === winner_count，主播按「繼續下一輪」
+[round_ready]  ── 移至下一個 tier
+  ↓ 所有 tier 的 drawn_count === winner_count
+[session_complete]  ── 顯示完整得獎名單
+```
+
+### 前端元件
+
+| 元件 | 職責 |
+|---|---|
+| `RaffleDrawSession` | 逐輪模式容器；持有 `currentTierIndex` state；協調狀態機轉換 |
+| `TierRoundCard` | 顯示當前 tier 資訊（名稱、獎項說明、已抽 N / 共 M 名）與「抽這一輪」按鈕 |
+| `DrawResultOverlay` | 得獎者展示層（名字 + 既有 ocean 主題動畫）；「繼續下一輪」按鈕 |
+| `FinalWinnerList` | session_complete 狀態的完整得獎名單，依輪次分組 |
+
+### 與現有元件的關係
+
+- `RaffleDrawSession` 嵌入現有 `RaffleDetailPage`，取代現有的單次抽獎按鈕區塊（當 PrizeTiers 存在時顯示）
+- `drawFromTier` service function（`apps/dashboard/src/services/raffles.ts`）直接複用，不新增
+- Ocean 主題動畫元件複用現有實作（`RaffleDetailPage.tsx` 中已有 keyframes）
+
+### API 使用
+
+不新增端點，全部使用現有：
+
+```
+POST /api/v1/dashboard/raffles/:id/tiers/:tier_id/draw   ← drawFromTier
+GET  /api/v1/dashboard/raffles/:id/tiers                 ← listPrizeTiers（取得 tiers + drawn_count）
+GET  /api/v1/dashboard/raffles/:id/draws                 ← listDraws（session_complete 時取完整名單）
+```
+
+---
+
+## 完成條件
+
+- [ ] 所有 PrizeTier 依 position 順序逐輪顯示
+- [ ] 每輪按鈕觸發 `drawFromTier`，顯示得獎者名稱
+- [ ] 同一輪 winner_count > 1 時，可在同一輪繼續抽足名額再進下一輪
+- [ ] 所有輪次抽完後顯示完整得獎名單
+- [ ] 重複得獎不可能發生（由後端 cross-tier 排除保證，前端無需額外處理）
+- [ ] 既有非 PrizeTier 的單次抽獎流程不受影響
+
+---
+
+## 驗證方式
+
+1. 建立含 3 個 PrizeTier 的 Raffle（一等獎 × 1、二等獎 × 2、三等獎 × 3）
+2. 走完完整抽獎流程，確認共 6 名不重複得獎者
+3. 確認各輪得獎者姓名正確顯示於 `FinalWinnerList`


### PR DESCRIPTION
## 什麼改動
- `RaffleDetailPage` 新增模式切換 UI（全體觀眾／訂閱者專屬），呼叫 `PATCH /dashboard/raffles/:id/mode`
- 新增開放／截止報名按鈕，呼叫 `PATCH /dashboard/raffles/:id/entry-open`
- 新增報名統計面板（合格人數、排除人數含原因、總人數），每 10 秒 polling `GET /dashboard/raffles/:id/entry-stats`
- 訂閱者模式且 Twitch scope 不足（後端回 403 + `insufficient_scope`）時顯示重新授權提示
- `services/raffles.ts` 新增 `RaffleMode`、`RaffleEntryStats` 型別與三支 API 函式

## 為什麼
直播主後台需要能選擇抽獎模式、開關報名，並即時看到報名統計。closes #990

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#990
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不修改 Extension UI
  - 不做 OBS overlay 專用版面

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：n/a
- Actual worker profile(s)：n/a
- Model strength：n/a
- Spawn directive(s)：n/a
- Verification evidence：n/a
- Self-review / exception reason：n/a
- Worker session closeout：n/a
- Workflow friction / follow-up split：n/a

## Review conversation closeout
- Unresolved threads：0
- CodeRabbit：pending（開 PR 後自動觸發）
- chatgpt-codex-connector：n/a
- review_triage_ref：n/a
- root_cause_gate_ref：n/a
- finding_disposition_ref：n/a
- Final reviewer action：pending

## Final merge gate
- Ready-to-merge decision：pending CI
- Latest head SHA：665b769
- Required checks：pending
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：新增抽獎模式切換、報名開關與統計面板（純前端，對應 issue #990 全部 AC）
- Approx changed lines：~280
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - frontend 邏輯與對應測試屬同一功能單元，拆分無實質意義
- 若已拆分，相關 PR：n/a

## Acceptance Criteria
- [x] 模式切換成功呼叫 API 並更新 UI
- [x] 開關報名正確反映 `entry_open` 狀態
- [x] 統計面板數字與後端一致（polling 每 10 秒）
- [x] re-auth 提示在 scope 不足時顯示

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
tsc --noEmit: pass
git diff HEAD --stat apps/dashboard/src/: 3 files, 280 insertions(+), 2 deletions(-)
git diff HEAD -w --stat apps/dashboard/src/: identical (0 whitespace pollution)
Vitest: sandbox EPERM in Codex env; 請本機執行 pnpm --dir apps/dashboard test 確認
```

## 備註
後端 entry-stats API shape 推定自 issue #990 說明與現有 swagger。若 #988 實際回應欄位有差異，只需更新 `apps/dashboard/src/services/raffles.ts` 型別定義。

## Notes for Claude Code Review
- `getRaffleEntryStats` 型別（`eligible_count`、`excluded_count`、`exclusion_reasons`、`total_count`）是依 issue 說明推定，merge 前請與後端確認欄位名稱
- polling cleanup 使用 `clearInterval` + `AbortController.abort()`，請確認 unmount 路徑正確

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 抽奖报名资格设置：支持选择“全体观众”或“仅限订阅者”
  * 报名状态控制：新增开启/截止报名切换
  * 实时报名统计：定期刷新报名数据（每10秒），展示合格人数、排除人数、排除原因及总报名数
  * 权限提示：订阅者模式下权限不足时显示重新授权提示并提供授权链接

* **测试**
  * 新增报名资格切换、报名状态切换及权限验证的端到端测试
<!-- end of auto-generated comment: release notes by coderabbit.ai -->