### PR TITLE
[frontend] 抽獎模式 — Dashboard 模式切換與報名統計面板

### DIFF
--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -607,22 +607,19 @@ export default function RaffleDetailPage() {
   const [newTier, setNewTier] = useState({ name: '', prize_description: '', winner_count: 1 })
   const [addingTier, setAddingTier] = useState(false)
   const [addTierError, setAddTierError] = useState<string | null>(null)
-  const [mode, setMode] = useState<RaffleMode>(raffle?.mode ?? 'public')
-  const [entryOpen, setEntryOpen] = useState<boolean>(raffle?.entry_open ?? false)
+  const [modeOverride, setModeOverride] = useState<RaffleMode | null>(null)
+  const [entryOpenOverride, setEntryOpenOverride] = useState<boolean | null>(null)
   const [entryStats, setEntryStats] = useState<RaffleEntryStats | null>(null)
   const [reauthRequired, setReauthRequired] = useState(false)
+
+  const mode: RaffleMode = modeOverride ?? raffle?.mode ?? 'public'
+  const entryOpen: boolean = entryOpenOverride ?? raffle?.entry_open ?? false
 
   const pendingTimers = useRef<number[]>([])
 
   useEffect(() => {
     return () => { pendingTimers.current.forEach(id => window.clearTimeout(id)) }
   }, [])
-
-  useEffect(() => {
-    if (!raffle) return
-    setMode(raffle.mode ?? 'public')
-    setEntryOpen(raffle.entry_open ?? false)
-  }, [raffle])
 
   const effectiveStatus = localCompleted ? 'completed' : localActivated ? 'active' : (raffle?.status ?? '')
 
@@ -649,11 +646,12 @@ export default function RaffleDetailPage() {
 
   useEffect(() => {
     if (!raffleId) return
+    const id = raffleId
     const controller = new AbortController()
 
     async function fetchEntryStats() {
       try {
-        const result = await getRaffleEntryStats(raffleId, controller.signal)
+        const result = await getRaffleEntryStats(id, controller.signal)
         setEntryStats(result)
         setReauthRequired(false)
       } catch (error: unknown) {
@@ -700,11 +698,11 @@ export default function RaffleDetailPage() {
     if (!raffleId || nextMode === mode) return
     try {
       await setRaffleMode(raffleId, nextMode)
-      setMode(nextMode)
+      setModeOverride(nextMode)
       setReauthRequired(false)
     } catch (error: unknown) {
       if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
-        setMode(nextMode)
+        setModeOverride(nextMode)
         setReauthRequired(true)
       }
     }
@@ -715,7 +713,7 @@ export default function RaffleDetailPage() {
     const nextEntryOpen = !entryOpen
     try {
       await setRaffleEntryOpen(raffleId, nextEntryOpen)
-      setEntryOpen(nextEntryOpen)
+      setEntryOpenOverride(nextEntryOpen)
       setReauthRequired(false)
     } catch (error: unknown) {
       if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -663,6 +663,7 @@ export default function RaffleDetailPage() {
         const result = await getRaffleEntryStats(id, controller.signal)
         if (controller.signal.aborted) return
         setEntryStats(result)
+        setTotalEntries(result.total_joined)
         setStatsReauthRequired(false)
       } catch (error: unknown) {
         if (controller.signal.aborted) return

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -611,6 +611,9 @@ export default function RaffleDetailPage() {
   const [reauthRequired, setReauthRequired] = useState(false)
   const [controlError, setControlError] = useState<string | null>(null)
 
+  const modeRequestSeq = useRef(0)
+  const entryOpenRequestSeq = useRef(0)
+
   const mode: RaffleMode = modeOverride ?? raffle?.mode ?? 'public'
   const entryOpen: boolean = entryOpenOverride ?? raffle?.entry_open ?? false
 
@@ -648,9 +651,14 @@ export default function RaffleDetailPage() {
     const id = raffleId
     const controller = new AbortController()
 
+    let inFlight = false
+
     async function fetchEntryStats() {
+      if (inFlight) return
+      inFlight = true
       try {
         const result = await getRaffleEntryStats(id, controller.signal)
+        if (controller.signal.aborted) return
         setEntryStats(result)
         setReauthRequired(false)
       } catch (error: unknown) {
@@ -658,6 +666,8 @@ export default function RaffleDetailPage() {
         if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
           setReauthRequired(true)
         }
+      } finally {
+        inFlight = false
       }
     }
 
@@ -696,11 +706,14 @@ export default function RaffleDetailPage() {
   async function handleModeChange(nextMode: RaffleMode) {
     if (!raffleId || nextMode === mode) return
     setControlError(null)
+    const seq = ++modeRequestSeq.current
     try {
       await setRaffleMode(raffleId, nextMode)
+      if (modeRequestSeq.current !== seq) return
       setModeOverride(nextMode)
       setReauthRequired(false)
     } catch (error: unknown) {
+      if (modeRequestSeq.current !== seq) return
       if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
         setReauthRequired(true)
       } else {
@@ -713,11 +726,14 @@ export default function RaffleDetailPage() {
     if (!raffleId) return
     const nextEntryOpen = !entryOpen
     setControlError(null)
+    const seq = ++entryOpenRequestSeq.current
     try {
       await setRaffleEntryOpen(raffleId, nextEntryOpen)
+      if (entryOpenRequestSeq.current !== seq) return
       setEntryOpenOverride(nextEntryOpen)
       setReauthRequired(false)
     } catch (error: unknown) {
+      if (entryOpenRequestSeq.current !== seq) return
       if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
         setReauthRequired(true)
       } else {

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -96,8 +96,7 @@ function formatRelativeTime(dateStr: string): string {
 }
 
 function getEntryStatsTotal(stats: RaffleEntryStats): number {
-  const maybeTotalCount = (stats as RaffleEntryStats & { total_count?: number }).total_count
-  return typeof maybeTotalCount === 'number' ? maybeTotalCount : stats.total_entries
+  return stats.total_joined
 }
 
 function isInsufficientScopeError(error: unknown): boolean {
@@ -926,9 +925,9 @@ export default function RaffleDetailPage() {
                 </div>
                 <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
                   <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>排除人數</p>
-                  <p data-testid="excluded-count" style={{ fontSize: 20, fontWeight: 800, color: '#fca5a5' }}>{entryStats.excluded_count}</p>
+                  <p data-testid="excluded-count" style={{ fontSize: 20, fontWeight: 800, color: '#fca5a5' }}>{entryStats.ineligible_count}</p>
                   <div data-testid="excluded-breakdown" style={{ marginTop: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
-                    {Object.entries(entryStats.excluded_by_reason).map(([reason, count]) => (
+                    {Object.entries(entryStats.ineligible_reasons).map(([reason, count]) => (
                       <span key={reason} style={{ fontSize: 10, color: 'rgba(226,232,240,.65)' }}>{formatExcludedReason(reason)} {count} 人</span>
                     ))}
                   </div>

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -2,8 +2,9 @@ import { useOne } from '@refinedev/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { activateRaffle, completeRaffle, createPrizeTier, deletePrizeTier, drawFromTier, drawNext, importCSV, listDraws, listPrizeTiers, setDiscordWebhook } from '@/services/raffles'
-import type { Raffle, RaffleDraw, RafflePrizeTier, RaffleStatus } from '@/services/raffles'
+import { apiBaseURL } from '@/services/api'
+import { activateRaffle, completeRaffle, createPrizeTier, deletePrizeTier, drawFromTier, drawNext, getRaffleEntryStats, importCSV, listDraws, listPrizeTiers, setDiscordWebhook, setRaffleEntryOpen, setRaffleMode } from '@/services/raffles'
+import type { Raffle, RaffleDraw, RaffleEntryStats, RaffleMode, RafflePrizeTier, RaffleStatus } from '@/services/raffles'
 import gachaBg from '../assets/raffle-bg.jpg.png'
 
 const OCEAN_KEYFRAMES = `
@@ -92,6 +93,38 @@ function formatRelativeTime(dateStr: string): string {
   if (mins < 60) return `${mins} 分鐘前`
 
   return date.toLocaleString('zh-TW')
+}
+
+function getEntryStatsTotal(stats: RaffleEntryStats): number {
+  const maybeTotalCount = (stats as RaffleEntryStats & { total_count?: number }).total_count
+  return typeof maybeTotalCount === 'number' ? maybeTotalCount : stats.total_entries
+}
+
+function isInsufficientScopeError(error: unknown): boolean {
+  const response = (error as { response?: { status?: number; data?: unknown } })?.response
+  if (response?.status !== 403) return false
+  if (typeof response.data === 'string') return response.data.includes('insufficient_scope')
+  return JSON.stringify(response?.data ?? '').includes('insufficient_scope')
+}
+
+function formatExcludedReason(reason: string): string {
+  if (reason === 'not_subscriber') return '非訂閱者'
+  if (reason === 'duplicate') return '重複報名'
+  if (reason === 'already_drawn') return '已中獎'
+  if (reason === 'missing_twitch_id') return '缺少 Twitch ID'
+  if (reason === 'missing_subscription') return '缺少訂閱紀錄'
+  if (reason === 'subscription_expired') return '訂閱已失效'
+  if (reason === 'subscription_inactive') return '訂閱未啟用'
+  if (reason === 'banned') return '已封鎖'
+  if (reason === 'not_following') return '未追蹤'
+  if (reason === 'manual_exclusion') return '手動排除'
+  if (reason === 'invalid_entry') return '報名資料無效'
+  if (reason === 'missing_display_name') return '缺少顯示名稱'
+  if (reason === 'outside_entry_window') return '不在報名時間內'
+  if (reason === 'raffle_completed') return '活動已結束'
+  if (reason === 'raffle_not_active') return '活動尚未啟用'
+  if (reason === 'unknown_viewer') return '未知觀眾'
+  return reason
 }
 
 function StatCard({
@@ -574,12 +607,22 @@ export default function RaffleDetailPage() {
   const [newTier, setNewTier] = useState({ name: '', prize_description: '', winner_count: 1 })
   const [addingTier, setAddingTier] = useState(false)
   const [addTierError, setAddTierError] = useState<string | null>(null)
+  const [mode, setMode] = useState<RaffleMode>(raffle?.mode ?? 'public')
+  const [entryOpen, setEntryOpen] = useState<boolean>(raffle?.entry_open ?? false)
+  const [entryStats, setEntryStats] = useState<RaffleEntryStats | null>(null)
+  const [reauthRequired, setReauthRequired] = useState(false)
 
   const pendingTimers = useRef<number[]>([])
 
   useEffect(() => {
     return () => { pendingTimers.current.forEach(id => window.clearTimeout(id)) }
   }, [])
+
+  useEffect(() => {
+    if (!raffle) return
+    setMode(raffle.mode ?? 'public')
+    setEntryOpen(raffle.entry_open ?? false)
+  }, [raffle])
 
   const effectiveStatus = localCompleted ? 'completed' : localActivated ? 'active' : (raffle?.status ?? '')
 
@@ -606,6 +649,34 @@ export default function RaffleDetailPage() {
 
   useEffect(() => {
     if (!raffleId) return
+    const controller = new AbortController()
+
+    async function fetchEntryStats() {
+      try {
+        const result = await getRaffleEntryStats(raffleId, controller.signal)
+        setEntryStats(result)
+        setReauthRequired(false)
+      } catch (error: unknown) {
+        if (controller.signal.aborted) return
+        if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
+          setReauthRequired(true)
+        }
+      }
+    }
+
+    void fetchEntryStats()
+    const timerId = window.setInterval(() => {
+      void fetchEntryStats()
+    }, 10000)
+
+    return () => {
+      window.clearInterval(timerId)
+      controller.abort()
+    }
+  }, [mode, raffleId])
+
+  useEffect(() => {
+    if (!raffleId) return
     const initialLoadId = window.setTimeout(() => {
       void fetchDraws()
       void fetchTiers()
@@ -624,6 +695,34 @@ export default function RaffleDetailPage() {
       window.clearInterval(timerId)
     }
   }, [effectiveStatus, fetchDraws, fetchTiers, raffleId])
+
+  async function handleModeChange(nextMode: RaffleMode) {
+    if (!raffleId || nextMode === mode) return
+    try {
+      await setRaffleMode(raffleId, nextMode)
+      setMode(nextMode)
+      setReauthRequired(false)
+    } catch (error: unknown) {
+      if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
+        setMode(nextMode)
+        setReauthRequired(true)
+      }
+    }
+  }
+
+  async function handleEntryOpenToggle() {
+    if (!raffleId) return
+    const nextEntryOpen = !entryOpen
+    try {
+      await setRaffleEntryOpen(raffleId, nextEntryOpen)
+      setEntryOpen(nextEntryOpen)
+      setReauthRequired(false)
+    } catch (error: unknown) {
+      if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
+        setReauthRequired(true)
+      }
+    }
+  }
 
   async function handleDraw() {
     if (!raffleId || drawing) return
@@ -777,6 +876,72 @@ export default function RaffleDetailPage() {
             locked={effectiveStatus !== 'draft'}
             onSuccess={(result) => { setTotalEntries(prev => (prev ?? 0) + result.imported); setExhausted(false) }}
           />
+
+          <section data-testid="raffle-entry-controls" style={{ border: '1px solid rgba(80,160,255,.18)', borderRadius: 10, background: 'rgba(255,255,255,.035)', padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', gap: 10, alignItems: 'center' }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <span style={{ fontSize: 11, color: 'rgba(148,210,255,.6)', letterSpacing: '.06em' }}>報名資格</span>
+                <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: mode === 'public' ? '#e0f2fe' : 'rgba(148,210,255,.55)' }}>
+                    <input
+                      data-testid="raffle-mode-public"
+                      type="radio"
+                      name="raffle-mode"
+                      value="public"
+                      checked={mode === 'public'}
+                      onChange={() => { void handleModeChange('public') }}
+                    />
+                    全體觀眾
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: mode === 'subscribers_only' ? '#e0f2fe' : 'rgba(148,210,255,.55)' }}>
+                    <input
+                      data-testid="raffle-mode-subscribers"
+                      type="radio"
+                      name="raffle-mode"
+                      value="subscribers_only"
+                      checked={mode === 'subscribers_only'}
+                      onChange={() => { void handleModeChange('subscribers_only') }}
+                    />
+                    訂閱者專屬
+                  </label>
+                </div>
+              </div>
+              <button
+                data-testid="entry-open-toggle"
+                onClick={() => { void handleEntryOpenToggle() }}
+                style={{ border: entryOpen ? '1px solid rgba(248,113,113,.35)' : '1px solid rgba(34,197,94,.35)', background: entryOpen ? 'rgba(248,113,113,.1)' : 'rgba(34,197,94,.1)', color: entryOpen ? '#fca5a5' : '#86efac', borderRadius: 8, padding: '7px 12px', fontSize: 12, fontWeight: 700, cursor: 'pointer' }}
+              >
+                {entryOpen ? '截止報名' : '開放報名'}
+              </button>
+            </div>
+            {reauthRequired && mode === 'subscribers_only' && (
+              <p data-testid="twitch-reauth-prompt" style={{ border: '1px solid rgba(251,191,36,.25)', borderRadius: 8, background: 'rgba(251,191,36,.08)', padding: '8px 10px', fontSize: 12, color: '#fde68a' }}>
+                請重新授權 Twitch
+                <a href={`${apiBaseURL}/api/v1/auth/twitch?redirect_to=%2F`} style={{ marginLeft: 8, color: '#7dd3fc', textDecoration: 'underline' }}>重新授權</a>
+              </p>
+            )}
+            {entryStats && (
+              <div data-testid="entry-stats-panel" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 8 }}>
+                <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
+                  <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>合格候選人數</p>
+                  <p data-testid="eligible-count" style={{ fontSize: 20, fontWeight: 800, color: '#86efac' }}>{entryStats.eligible_count}</p>
+                </div>
+                <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
+                  <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>排除人數</p>
+                  <p data-testid="excluded-count" style={{ fontSize: 20, fontWeight: 800, color: '#fca5a5' }}>{entryStats.excluded_count}</p>
+                  <div data-testid="excluded-breakdown" style={{ marginTop: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    {Object.entries(entryStats.excluded_by_reason).map(([reason, count]) => (
+                      <span key={reason} style={{ fontSize: 10, color: 'rgba(226,232,240,.65)' }}>{formatExcludedReason(reason)} {count} 人</span>
+                    ))}
+                  </div>
+                </div>
+                <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
+                  <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>總報名人數</p>
+                  <p data-testid="total-count" style={{ fontSize: 20, fontWeight: 800, color: '#93c5fd' }}>{getEntryStatsTotal(entryStats)}</p>
+                </div>
+              </div>
+            )}
+          </section>
 
           {effectiveStatus === 'draft' && (
             <>

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -608,8 +608,11 @@ export default function RaffleDetailPage() {
   const [modeOverride, setModeOverride] = useState<RaffleMode | null>(null)
   const [entryOpenOverride, setEntryOpenOverride] = useState<boolean | null>(null)
   const [entryStats, setEntryStats] = useState<RaffleEntryStats | null>(null)
-  const [reauthRequired, setReauthRequired] = useState(false)
+  const [statsReauthRequired, setStatsReauthRequired] = useState(false)
+  const [controlReauthRequired, setControlReauthRequired] = useState(false)
   const [controlError, setControlError] = useState<string | null>(null)
+  const [modeChanging, setModeChanging] = useState(false)
+  const [entryOpenChanging, setEntryOpenChanging] = useState(false)
 
   const modeRequestSeq = useRef(0)
   const entryOpenRequestSeq = useRef(0)
@@ -660,11 +663,11 @@ export default function RaffleDetailPage() {
         const result = await getRaffleEntryStats(id, controller.signal)
         if (controller.signal.aborted) return
         setEntryStats(result)
-        setReauthRequired(false)
+        setStatsReauthRequired(false)
       } catch (error: unknown) {
         if (controller.signal.aborted) return
         if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
-          setReauthRequired(true)
+          setStatsReauthRequired(true)
         }
       } finally {
         inFlight = false
@@ -704,26 +707,30 @@ export default function RaffleDetailPage() {
   }, [effectiveStatus, fetchDraws, fetchTiers, raffleId])
 
   async function handleModeChange(nextMode: RaffleMode) {
-    if (!raffleId || nextMode === mode) return
+    if (!raffleId || nextMode === mode || modeChanging) return
+    setModeChanging(true)
     setControlError(null)
     const seq = ++modeRequestSeq.current
     try {
       await setRaffleMode(raffleId, nextMode)
       if (modeRequestSeq.current !== seq) return
       setModeOverride(nextMode)
-      setReauthRequired(false)
+      setControlReauthRequired(false)
     } catch (error: unknown) {
       if (modeRequestSeq.current !== seq) return
       if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
-        setReauthRequired(true)
+        setControlReauthRequired(true)
       } else {
         setControlError('切換報名資格失敗，請稍後再試')
       }
+    } finally {
+      setModeChanging(false)
     }
   }
 
   async function handleEntryOpenToggle() {
-    if (!raffleId) return
+    if (!raffleId || entryOpenChanging) return
+    setEntryOpenChanging(true)
     const nextEntryOpen = !entryOpen
     setControlError(null)
     const seq = ++entryOpenRequestSeq.current
@@ -731,13 +738,16 @@ export default function RaffleDetailPage() {
       await setRaffleEntryOpen(raffleId, nextEntryOpen)
       if (entryOpenRequestSeq.current !== seq) return
       setEntryOpenOverride(nextEntryOpen)
+      setControlReauthRequired(false)
     } catch (error: unknown) {
       if (entryOpenRequestSeq.current !== seq) return
       if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
-        setReauthRequired(true)
+        setControlReauthRequired(true)
       } else {
         setControlError('切換報名狀態失敗，請稍後再試')
       }
+    } finally {
+      setEntryOpenChanging(false)
     }
   }
 
@@ -906,6 +916,7 @@ export default function RaffleDetailPage() {
                       name="raffle-mode"
                       value="public"
                       checked={mode === 'public'}
+                      disabled={modeChanging}
                       onChange={() => { void handleModeChange('public') }}
                     />
                     全體觀眾
@@ -917,6 +928,7 @@ export default function RaffleDetailPage() {
                       name="raffle-mode"
                       value="subscribers_only"
                       checked={mode === 'subscribers_only'}
+                      disabled={modeChanging}
                       onChange={() => { void handleModeChange('subscribers_only') }}
                     />
                     訂閱者專屬
@@ -926,15 +938,16 @@ export default function RaffleDetailPage() {
               <button
                 data-testid="entry-open-toggle"
                 onClick={() => { void handleEntryOpenToggle() }}
-                style={{ border: entryOpen ? '1px solid rgba(248,113,113,.35)' : '1px solid rgba(34,197,94,.35)', background: entryOpen ? 'rgba(248,113,113,.1)' : 'rgba(34,197,94,.1)', color: entryOpen ? '#fca5a5' : '#86efac', borderRadius: 8, padding: '7px 12px', fontSize: 12, fontWeight: 700, cursor: 'pointer' }}
+                disabled={entryOpenChanging}
+                style={{ border: entryOpen ? '1px solid rgba(248,113,113,.35)' : '1px solid rgba(34,197,94,.35)', background: entryOpen ? 'rgba(248,113,113,.1)' : 'rgba(34,197,94,.1)', color: entryOpen ? '#fca5a5' : '#86efac', borderRadius: 8, padding: '7px 12px', fontSize: 12, fontWeight: 700, cursor: entryOpenChanging ? 'not-allowed' : 'pointer' }}
               >
                 {entryOpen ? '截止報名' : '開放報名'}
               </button>
             </div>
-            {reauthRequired && mode === 'subscribers_only' && (
+            {(statsReauthRequired || controlReauthRequired) && mode === 'subscribers_only' && (
               <p data-testid="twitch-reauth-prompt" style={{ border: '1px solid rgba(251,191,36,.25)', borderRadius: 8, background: 'rgba(251,191,36,.08)', padding: '8px 10px', fontSize: 12, color: '#fde68a' }}>
                 請重新授權 Twitch
-                <a href={`${apiBaseURL}/api/v1/auth/twitch?redirect_to=%2F`} style={{ marginLeft: 8, color: '#7dd3fc', textDecoration: 'underline' }}>重新授權</a>
+                <a href={`${apiBaseURL}/api/v1/auth/twitch?redirect_to=${encodeURIComponent(window.location.pathname)}`} style={{ marginLeft: 8, color: '#7dd3fc', textDecoration: 'underline' }}>重新授權</a>
               </p>
             )}
             {controlError && (

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -95,10 +95,6 @@ function formatRelativeTime(dateStr: string): string {
   return date.toLocaleString('zh-TW')
 }
 
-function getEntryStatsTotal(stats: RaffleEntryStats): number {
-  return stats.total_joined
-}
-
 function isInsufficientScopeError(error: unknown): boolean {
   const response = (error as { response?: { status?: number; data?: unknown } })?.response
   if (response?.status !== 403) return false
@@ -106,24 +102,27 @@ function isInsufficientScopeError(error: unknown): boolean {
   return JSON.stringify(response?.data ?? '').includes('insufficient_scope')
 }
 
+const EXCLUDED_REASON_LABELS: Record<string, string> = {
+  not_subscriber: '非訂閱者',
+  duplicate: '重複報名',
+  already_drawn: '已中獎',
+  missing_twitch_id: '缺少 Twitch ID',
+  missing_subscription: '缺少訂閱紀錄',
+  subscription_expired: '訂閱已失效',
+  subscription_inactive: '訂閱未啟用',
+  banned: '已封鎖',
+  not_following: '未追蹤',
+  manual_exclusion: '手動排除',
+  invalid_entry: '報名資料無效',
+  missing_display_name: '缺少顯示名稱',
+  outside_entry_window: '不在報名時間內',
+  raffle_completed: '活動已結束',
+  raffle_not_active: '活動尚未啟用',
+  unknown_viewer: '未知觀眾',
+}
+
 function formatExcludedReason(reason: string): string {
-  if (reason === 'not_subscriber') return '非訂閱者'
-  if (reason === 'duplicate') return '重複報名'
-  if (reason === 'already_drawn') return '已中獎'
-  if (reason === 'missing_twitch_id') return '缺少 Twitch ID'
-  if (reason === 'missing_subscription') return '缺少訂閱紀錄'
-  if (reason === 'subscription_expired') return '訂閱已失效'
-  if (reason === 'subscription_inactive') return '訂閱未啟用'
-  if (reason === 'banned') return '已封鎖'
-  if (reason === 'not_following') return '未追蹤'
-  if (reason === 'manual_exclusion') return '手動排除'
-  if (reason === 'invalid_entry') return '報名資料無效'
-  if (reason === 'missing_display_name') return '缺少顯示名稱'
-  if (reason === 'outside_entry_window') return '不在報名時間內'
-  if (reason === 'raffle_completed') return '活動已結束'
-  if (reason === 'raffle_not_active') return '活動尚未啟用'
-  if (reason === 'unknown_viewer') return '未知觀眾'
-  return reason
+  return EXCLUDED_REASON_LABELS[reason] ?? reason
 }
 
 function StatCard({
@@ -610,6 +609,7 @@ export default function RaffleDetailPage() {
   const [entryOpenOverride, setEntryOpenOverride] = useState<boolean | null>(null)
   const [entryStats, setEntryStats] = useState<RaffleEntryStats | null>(null)
   const [reauthRequired, setReauthRequired] = useState(false)
+  const [controlError, setControlError] = useState<string | null>(null)
 
   const mode: RaffleMode = modeOverride ?? raffle?.mode ?? 'public'
   const entryOpen: boolean = entryOpenOverride ?? raffle?.entry_open ?? false
@@ -695,14 +695,16 @@ export default function RaffleDetailPage() {
 
   async function handleModeChange(nextMode: RaffleMode) {
     if (!raffleId || nextMode === mode) return
+    setControlError(null)
     try {
       await setRaffleMode(raffleId, nextMode)
       setModeOverride(nextMode)
       setReauthRequired(false)
     } catch (error: unknown) {
       if (nextMode === 'subscribers_only' && isInsufficientScopeError(error)) {
-        setModeOverride(nextMode)
         setReauthRequired(true)
+      } else {
+        setControlError('切換報名資格失敗，請稍後再試')
       }
     }
   }
@@ -710,6 +712,7 @@ export default function RaffleDetailPage() {
   async function handleEntryOpenToggle() {
     if (!raffleId) return
     const nextEntryOpen = !entryOpen
+    setControlError(null)
     try {
       await setRaffleEntryOpen(raffleId, nextEntryOpen)
       setEntryOpenOverride(nextEntryOpen)
@@ -717,6 +720,8 @@ export default function RaffleDetailPage() {
     } catch (error: unknown) {
       if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {
         setReauthRequired(true)
+      } else {
+        setControlError('切換報名狀態失敗，請稍後再試')
       }
     }
   }
@@ -917,6 +922,9 @@ export default function RaffleDetailPage() {
                 <a href={`${apiBaseURL}/api/v1/auth/twitch?redirect_to=%2F`} style={{ marginLeft: 8, color: '#7dd3fc', textDecoration: 'underline' }}>重新授權</a>
               </p>
             )}
+            {controlError && (
+              <p data-testid="raffle-entry-controls-error" style={{ fontSize: 11, color: '#f87171' }}>{controlError}</p>
+            )}
             {entryStats && (
               <div data-testid="entry-stats-panel" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 8 }}>
                 <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
@@ -934,7 +942,7 @@ export default function RaffleDetailPage() {
                 </div>
                 <div style={{ borderRadius: 8, background: 'rgba(255,255,255,.04)', padding: 8 }}>
                   <p style={{ fontSize: 10, color: 'rgba(148,210,255,.5)', marginBottom: 3 }}>總報名人數</p>
-                  <p data-testid="total-count" style={{ fontSize: 20, fontWeight: 800, color: '#93c5fd' }}>{getEntryStatsTotal(entryStats)}</p>
+                  <p data-testid="total-count" style={{ fontSize: 20, fontWeight: 800, color: '#93c5fd' }}>{entryStats.total_joined}</p>
                 </div>
               </div>
             )}

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -731,7 +731,6 @@ export default function RaffleDetailPage() {
       await setRaffleEntryOpen(raffleId, nextEntryOpen)
       if (entryOpenRequestSeq.current !== seq) return
       setEntryOpenOverride(nextEntryOpen)
-      setReauthRequired(false)
     } catch (error: unknown) {
       if (entryOpenRequestSeq.current !== seq) return
       if (mode === 'subscribers_only' && isInsufficientScopeError(error)) {

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -87,6 +87,10 @@ function cleanup(root: Root, container: HTMLDivElement) {
   })
   container.remove()
 }
+function statValue(container: HTMLElement, label: string): string | null {
+  const labelEl = Array.from(container.querySelectorAll('p')).find(p => p.textContent === label)
+  return (labelEl?.nextElementSibling as HTMLElement | null)?.textContent ?? null
+}
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {})
   vi.mocked(rafflesService.listDraws).mockResolvedValue([])
@@ -353,11 +357,18 @@ describe('RaffleDetailPage — CSV upload', () => {
 describe('RaffleDetailPage — draw button', () => {
   it('calls drawNext when clicked', async () => {
     const drawMock = vi.mocked(rafflesService.drawNext).mockResolvedValue(mockDraw)
+    vi.mocked(rafflesService.getRaffleEntryStats).mockResolvedValue({
+      eligible_count: 1,
+      ineligible_count: 0,
+      ineligible_reasons: {},
+      total_joined: 1,
+    })
     const dp = createMockDataProvider({
       getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="draw-btn"]')).toBeTruthy())
+    await waitFor(() => expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(false))
 
     await act(async () => {
       container.querySelector('[data-testid="draw-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
@@ -645,11 +656,18 @@ describe('RaffleDetailPage — winner modal', () => {
   it('shows winner modal after draw completes', async () => {
     vi.mocked(rafflesService.drawNext).mockResolvedValue(mockDraw)
     vi.mocked(rafflesService.listDraws).mockResolvedValue([mockDraw])
+    vi.mocked(rafflesService.getRaffleEntryStats).mockResolvedValue({
+      eligible_count: 2,
+      ineligible_count: 0,
+      ineligible_reasons: {},
+      total_joined: 2,
+    })
     const dp = createMockDataProvider({
       getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="draw-btn"]')).toBeTruthy())
+    await waitFor(() => expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(false))
 
     await act(async () => {
       container.querySelector('[data-testid="draw-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
@@ -662,11 +680,18 @@ describe('RaffleDetailPage — winner modal', () => {
   it('closes modal when 繼續抽獎 button clicked', async () => {
     vi.mocked(rafflesService.drawNext).mockResolvedValue(mockDraw)
     vi.mocked(rafflesService.listDraws).mockResolvedValue([mockDraw])
+    vi.mocked(rafflesService.getRaffleEntryStats).mockResolvedValue({
+      eligible_count: 2,
+      ineligible_count: 0,
+      ineligible_reasons: {},
+      total_joined: 2,
+    })
     const dp = createMockDataProvider({
       getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="draw-btn"]')).toBeTruthy())
+    await waitFor(() => expect((container.querySelector('[data-testid="draw-btn"]') as HTMLButtonElement).disabled).toBe(false))
 
     await act(async () => {
       container.querySelector('[data-testid="draw-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
@@ -730,6 +755,25 @@ describe('RaffleDetailPage functional layer', () => {
 
     await waitFor(() => expect(container.querySelector('[data-testid="twitch-reauth-prompt"]')?.textContent).toContain('請重新授權 Twitch'))
     expect(container.querySelector('[data-testid="twitch-reauth-prompt"] a')?.getAttribute('href')).toContain('/api/v1/auth/twitch')
+    cleanup(root, container)
+  })
+
+  it('syncs total entries and remaining count from entry stats', async () => {
+    vi.mocked(rafflesService.listDraws).mockResolvedValue([mockDraw, { ...mockDraw, id: 'd2' }])
+    vi.mocked(rafflesService.getRaffleEntryStats).mockResolvedValue({
+      eligible_count: 8,
+      ineligible_count: 2,
+      ineligible_reasons: {},
+      total_joined: 10,
+    })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'public', entry_open: true } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+
+    await waitFor(() => expect(container.querySelector('[data-testid="entry-stats-panel"]')).toBeTruthy())
+    await waitFor(() => expect(statValue(container, '匯入人數')).toBe('10'))
+    expect(statValue(container, '剩餘')).toBe('8')
     cleanup(root, container)
   })
 })

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -776,4 +776,67 @@ describe('RaffleDetailPage functional layer', () => {
     expect(statValue(container, '剩餘')).toBe('8')
     cleanup(root, container)
   })
+
+  it('entry-open toggle 403 sets controlReauthRequired and shows re-auth prompt', async () => {
+    vi.mocked(rafflesService.setRaffleEntryOpen).mockRejectedValue({
+      response: { status: 403, data: { error: 'insufficient_scope' } },
+    })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'subscribers_only', entry_open: false } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="entry-open-toggle"]')).toBeTruthy())
+    expect(container.querySelector('[data-testid="twitch-reauth-prompt"]')).toBeFalsy()
+
+    await act(async () => {
+      container.querySelector('[data-testid="entry-open-toggle"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    await waitFor(() => expect(container.querySelector('[data-testid="twitch-reauth-prompt"]')?.textContent).toContain('請重新授權 Twitch'))
+    cleanup(root, container)
+  })
+
+  it('disables mode radios while modeChanging and entry-open button while entryOpenChanging', async () => {
+    let resolveMode: (value: rafflesService.Raffle) => void = () => {}
+    vi.mocked(rafflesService.setRaffleMode).mockImplementation(() => new Promise<rafflesService.Raffle>((resolve) => { resolveMode = resolve }))
+    let resolveEntryOpen: (value: rafflesService.Raffle) => void = () => {}
+    vi.mocked(rafflesService.setRaffleEntryOpen).mockImplementation(() => new Promise<rafflesService.Raffle>((resolve) => { resolveEntryOpen = resolve }))
+
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'public', entry_open: false } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="raffle-mode-subscribers"]')).toBeTruthy())
+
+    const publicRadio = container.querySelector('[data-testid="raffle-mode-public"]') as HTMLInputElement
+    const subscribersRadio = container.querySelector('[data-testid="raffle-mode-subscribers"]') as HTMLInputElement
+    const entryToggle = container.querySelector('[data-testid="entry-open-toggle"]') as HTMLButtonElement
+
+    await act(async () => {
+      subscribersRadio.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(subscribersRadio.disabled).toBe(true))
+    expect(publicRadio.disabled).toBe(true)
+    expect(entryToggle.disabled).toBe(false)
+
+    await act(async () => {
+      resolveMode({ ...mockRaffle, mode: 'subscribers_only' })
+    })
+    await waitFor(() => expect(subscribersRadio.disabled).toBe(false))
+
+    await act(async () => {
+      entryToggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await waitFor(() => expect(entryToggle.disabled).toBe(true))
+    expect(subscribersRadio.disabled).toBe(false)
+    expect(publicRadio.disabled).toBe(false)
+
+    await act(async () => {
+      resolveEntryOpen({ ...mockRaffle, mode: 'subscribers_only', entry_open: true })
+    })
+    await waitFor(() => expect(entryToggle.disabled).toBe(false))
+
+    cleanup(root, container)
+  })
 })

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -25,9 +25,9 @@ vi.mock('@/services/raffles', async (importOriginal) => {
     setRaffleEntryOpen: vi.fn().mockResolvedValue({}),
     getRaffleEntryStats: vi.fn().mockResolvedValue({
       eligible_count: 0,
-      excluded_count: 0,
-      excluded_by_reason: {},
-      total_entries: 0,
+      ineligible_count: 0,
+      ineligible_reasons: {},
+      total_joined: 0,
     }),
   }
 })
@@ -103,9 +103,9 @@ beforeEach(() => {
   vi.mocked(rafflesService.setRaffleEntryOpen).mockResolvedValue(mockRaffle)
   vi.mocked(rafflesService.getRaffleEntryStats).mockResolvedValue({
     eligible_count: 0,
-    excluded_count: 0,
-    excluded_by_reason: {},
-    total_entries: 0,
+    ineligible_count: 0,
+    ineligible_reasons: {},
+    total_joined: 0,
   })
 })
 

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -21,6 +21,14 @@ vi.mock('@/services/raffles', async (importOriginal) => {
     createPrizeTier: vi.fn().mockResolvedValue({}),
     deletePrizeTier: vi.fn().mockResolvedValue(undefined),
     drawFromTier: vi.fn().mockResolvedValue({}),
+    setRaffleMode: vi.fn().mockResolvedValue({}),
+    setRaffleEntryOpen: vi.fn().mockResolvedValue({}),
+    getRaffleEntryStats: vi.fn().mockResolvedValue({
+      eligible_count: 0,
+      excluded_count: 0,
+      excluded_by_reason: {},
+      total_entries: 0,
+    }),
   }
 })
 
@@ -91,7 +99,16 @@ beforeEach(() => {
   vi.mocked(rafflesService.createPrizeTier).mockResolvedValue(mockPrizeTier)
   vi.mocked(rafflesService.deletePrizeTier).mockResolvedValue(undefined)
   vi.mocked(rafflesService.drawFromTier).mockResolvedValue(mockDraw)
+  vi.mocked(rafflesService.setRaffleMode).mockResolvedValue(mockRaffle)
+  vi.mocked(rafflesService.setRaffleEntryOpen).mockResolvedValue(mockRaffle)
+  vi.mocked(rafflesService.getRaffleEntryStats).mockResolvedValue({
+    eligible_count: 0,
+    excluded_count: 0,
+    excluded_by_reason: {},
+    total_entries: 0,
+  })
 })
+
 afterEach(() => {
   vi.restoreAllMocks()
   document.body.innerHTML = ''
@@ -661,6 +678,58 @@ describe('RaffleDetailPage — winner modal', () => {
       closeBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(container.textContent).not.toContain('恭喜中獎')
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage functional layer', () => {
+  it('mode switch calls setRaffleMode and updates UI', async () => {
+    const modeMock = vi.mocked(rafflesService.setRaffleMode).mockResolvedValue({ ...mockRaffle, mode: 'subscribers_only' })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'public', entry_open: false } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="raffle-mode-subscribers"]')).toBeTruthy())
+
+    const subscribers = container.querySelector('[data-testid="raffle-mode-subscribers"]') as HTMLInputElement
+    await act(async () => {
+      subscribers.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    await waitFor(() => expect(modeMock).toHaveBeenCalledWith('r1', 'subscribers_only'))
+    expect(subscribers.checked).toBe(true)
+    cleanup(root, container)
+  })
+
+  it('entry open/close button calls setRaffleEntryOpen and reflects state', async () => {
+    const entryOpenMock = vi.mocked(rafflesService.setRaffleEntryOpen).mockResolvedValue({ ...mockRaffle, entry_open: true })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'public', entry_open: false } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="entry-open-toggle"]')?.textContent).toContain('開放報名'))
+
+    await act(async () => {
+      container.querySelector('[data-testid="entry-open-toggle"]')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    await waitFor(() => expect(entryOpenMock).toHaveBeenCalledWith('r1', true))
+    expect(container.querySelector('[data-testid="entry-open-toggle"]')?.textContent).toContain('截止報名')
+    cleanup(root, container)
+  })
+
+  it('subscribers_only + 403 insufficient_scope shows re-auth prompt', async () => {
+    vi.mocked(rafflesService.getRaffleEntryStats).mockRejectedValue({
+      response: { status: 403, data: { error: 'insufficient_scope' } },
+    })
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue({ ...mockRaffle, mode: 'subscribers_only', entry_open: false } as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+
+    await waitFor(() => expect(container.querySelector('[data-testid="twitch-reauth-prompt"]')?.textContent).toContain('請重新授權 Twitch'))
+    expect(container.querySelector('[data-testid="twitch-reauth-prompt"] a')?.getAttribute('href')).toContain('/api/v1/auth/twitch')
     cleanup(root, container)
   })
 })

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -10,7 +10,7 @@ export interface Raffle {
   user_id: string
   title: string
   status: RaffleStatus
-  source?: 'csv' | 'twitch_api'
+  source?: 'csv' | 'twitch_api' | 'extension_button'
   mode?: RaffleMode
   entry_open?: boolean
   created_at: string

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -19,9 +19,9 @@ export interface Raffle {
 
 export interface RaffleEntryStats {
   eligible_count: number
-  excluded_count: number
-  excluded_by_reason: Record<string, number>
-  total_entries: number
+  ineligible_count: number
+  ineligible_reasons: Record<string, number>
+  total_joined: number
 }
 
 export interface RaffleEntry {

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -3,14 +3,25 @@ import client from '@/services/api'
 type ApiResponse<T> = { success: boolean; data: T }
 
 export type RaffleStatus = 'draft' | 'active' | 'completed'
+export type RaffleMode = 'public' | 'subscribers_only'
 
 export interface Raffle {
   id: string
   user_id: string
   title: string
   status: RaffleStatus
+  source?: 'csv' | 'twitch_api'
+  mode?: RaffleMode
+  entry_open?: boolean
   created_at: string
   updated_at: string
+}
+
+export interface RaffleEntryStats {
+  eligible_count: number
+  excluded_count: number
+  excluded_by_reason: Record<string, number>
+  total_entries: number
 }
 
 export interface RaffleEntry {
@@ -92,6 +103,39 @@ export async function activateRaffle(raffleId: string): Promise<Raffle> {
     undefined,
   )
   return data.data.raffle
+}
+
+export async function setRaffleMode(
+  raffleId: string,
+  mode: RaffleMode,
+): Promise<Raffle> {
+  const { data } = await client.patch<ApiResponse<{ raffle: Raffle }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/mode`,
+    { mode },
+  )
+  return data.data.raffle
+}
+
+export async function setRaffleEntryOpen(
+  raffleId: string,
+  entryOpen: boolean,
+): Promise<Raffle> {
+  const { data } = await client.patch<ApiResponse<{ raffle: Raffle }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/entry-open`,
+    { entry_open: entryOpen },
+  )
+  return data.data.raffle
+}
+
+export async function getRaffleEntryStats(
+  raffleId: string,
+  signal?: AbortSignal,
+): Promise<RaffleEntryStats> {
+  const { data } = await client.get<ApiResponse<{ stats: RaffleEntryStats }>>(
+    `/api/v1/dashboard/raffles/${raffleId}/entry-stats`,
+    { signal },
+  )
+  return data.data.stats
 }
 
 export async function completeRaffle(raffleId: string): Promise<void> {

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -121,7 +121,7 @@ export async function setRaffleEntryOpen(
   entryOpen: boolean,
 ): Promise<Raffle> {
   const { data } = await client.patch<ApiResponse<{ raffle: Raffle }>>(
-    `/api/v1/dashboard/raffles/${raffleId}/entry-open`,
+    `/api/v1/dashboard/raffles/${raffleId}/entry`,
     { entry_open: entryOpen },
   )
   return data.data.raffle


### PR DESCRIPTION
## 什麼改動
為 `RaffleDetailPage` 新增抽獎模式切換、開放/截止報名切換，以及報名統計面板：
- 模式切換 UI（全體觀眾 / 訂閱者專屬），呼叫 `setRaffleMode`
- 開放/截止報名切換按鈕，呼叫 `setRaffleEntryOpen`
- 報名統計面板：合格人數、排除人數（含原因）、總報名人數，每 10 秒 polling `getRaffleEntryStats`
- token scope 不足時顯示「請重新授權 Twitch」提示
- 切換失敗時顯示錯誤提示（`controlError`），並修正競態：mode/entry 切換與統計輪詢加入序號 / in-flight guard，避免較舊回應覆寫較新狀態

## 為什麼
closes #990 — 直播主在後台需要能選擇抽獎模式、開關報名，並即時看到報名統計。

> 本 PR 取代已關閉的 #1034：原分支 `feat/raffle-mode-dashboard-990` 混入了 #234 Phase 2（`RaffleDrawSession`）的改動，diff 超過 1000 行而被 scope police 自動關閉。本 PR 從最新 `develop` 重新開出，只包含 #990 相關的 5 個 commit（cherry-pick 自原分支，逐一驗證乾淨套用），不含任何 #234 內容。

## Release Context
- Release type：n/a

## Workflow Type
- 非 Codex task PR：n/a

## PR Risk Class
- [x] R2 frontend behavior

## Scope 對齊
- Source of truth：#990
- Depends on PR：none
- Backend contract already in develop:
  - [x] yes
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
- 本 PR 明確不做：
  - 不修改 Extension UI
  - 不做 OBS overlay 專用版面
  - 不含 #234 Phase 2（`RaffleDrawSession`）的任何改動

## Delegation Execution Log
n/a（非 Codex autonomous PR）

## Review conversation closeout
n/a（非 autonomous PR）

## Final merge gate
- Ready-to-merge decision：pending（待 CI）
- Latest head SHA：d45d591
- Required checks：pending
- spec workflow-check evidence：n/a
- Evidence URL：n/a

## PR 拆分檢查
- 這個 PR 的單一句子目的：為 Dashboard 抽獎頁新增模式切換、開放報名切換與報名統計面板
- Approx changed lines：~301（3 files changed, 301 insertions(+), 2 deletions(-)）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
- 本 PR 是否同時包含以下多個層級？
  - [x] frontend integration
  - [x] tests
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？前端功能與其對應測試屬於同一個可獨立驗證的行為變更，不適合拆分
- 若已拆分，相關 PR：#234 Phase 2（`RaffleDrawSession`）將於本 PR merge 後另開獨立 PR

## Acceptance Criteria
- [x] `RaffleDetailPage` 新增模式切換 UI（radio）：全體觀眾 / 訂閱者專屬
- [x] 新增「開放報名」/「截止報名」切換按鈕
- [x] 新增統計面板（合格人數 / 排除人數含原因 / 總報名人數）
- [x] 統計每 10 秒 polling 一次 `GET /dashboard/raffles/:id/entry-stats`
- [x] Mode 2 且 token scope 不足時顯示「請重新授權 Twitch」提示
- [x] 模式切換成功呼叫 API 並更新 UI
- [x] 開關報名正確反映 `entry_open` 狀態
- [x] 統計面板數字與後端一致
- [x] re-auth 提示在 scope 不足時顯示

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
tsc -b --noEmit                         → 無錯誤
vitest run RaffleDetailPage.test.tsx    → Test Files 1 passed (1) / Tests 36 passed (36)
```

## 備註
本 PR 內容與已關閉的 #1034 相同邏輯，差異只在於從乾淨的 `develop` 重新開分支、移除混入的 #234 Phase 2 改動。5 個 commit 透過 cherry-pick 逐一驗證套用乾淨（含 2 個 auto-merge，無衝突）。

## Notes for Claude Code Review
- 此 PR 取代 #1034，內容相同但 scope 已修正乾淨，請參考 #1034 的 review 歷史（已修正其中提出的兩個 race condition blocker：mode/entry 切換 in-flight guard、entry stats polling overlapping request 防護）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新特性**
  * 管理区新增抽奖报名控制面板：切换公开/订阅者模式、开启/截止报名
  * 实时报名资格统计展示（合格/排除/总入池）并列出排除原因
  * 自动轮询统计并在权限不足时提示并引导 Twitch 重新授权
* **测试**
  * 扩展抽奖详情页功能层测试，覆盖模式切换、报名开关、权限不足与统计同步
<!-- end of auto-generated comment: release notes by coderabbit.ai -->