### PR TITLE
[frontend] Raffle Phase 2 — 逐輪抽獎模式設計文件

### DIFF
--- a/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
+++ b/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
@@ -56,7 +56,7 @@ export interface RafflePrizeTier {
 - [ ] **Step 3：TypeScript 確認無錯誤**
 
 ```bash
-cd apps/dashboard && npx tsc --noEmit
+pnpm --filter ./apps/dashboard exec tsc --noEmit
 ```
 
 預期：無錯誤輸出。
@@ -111,7 +111,7 @@ describe('RaffleDrawSession', () => {
 - [ ] **Step 2：確認測試失敗**
 
 ```bash
-cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+pnpm --filter ./apps/dashboard exec vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
 ```
 
 預期：FAIL — `RaffleDrawSession` 不存在。
@@ -121,9 +121,9 @@ cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSe
 建立 `apps/dashboard/src/components/raffle/RaffleDrawSession.tsx`：
 
 ```tsx
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import type { RaffleDraw, RafflePrizeTier } from '@/services/raffles'
-import { drawFromTier } from '@/services/raffles'
+import { drawFromTier, listDraws } from '@/services/raffles'
 
 type SessionPhase = 'round_ready' | 'drawing' | 'round_result' | 'session_complete'
 
@@ -140,14 +140,42 @@ const glass: React.CSSProperties = {
   WebkitBackdropFilter: 'blur(14px)',
 }
 
+function FinalWinnerList({ tiers, draws }: { tiers: RafflePrizeTier[]; draws: RaffleDraw[] }) {
+  return (
+    <div data-testid="final-winner-list" style={{ textAlign: 'left' }}>
+      {tiers.map(tier => {
+        const tierDraws = draws.filter(d => d.prize_tier_id === tier.id)
+        return (
+          <div key={tier.id} style={{ marginBottom: 16 }}>
+            <p style={{ fontSize: 13, fontWeight: 700, color: '#7dd3fc', marginBottom: 6 }}>{tier.name}</p>
+            {tierDraws.map(draw => (
+              <p key={draw.id} style={{ fontSize: 14, color: '#fde68a', marginBottom: 4 }}>
+                {draw.entry.display_name || draw.entry.twitch_login}
+              </p>
+            ))}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
 export function RaffleDrawSession({ raffleId, tiers }: Props) {
   const sorted = [...tiers].sort((a, b) => a.position - b.position)
   const [currentIndex, setCurrentIndex] = useState(0)
   const [phase, setPhase] = useState<SessionPhase>('round_ready')
+  const [drawnInCurrentTier, setDrawnInCurrentTier] = useState(0)
   const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
+  const [allDraws, setAllDraws] = useState<RaffleDraw[]>([])
   const [error, setError] = useState<string | null>(null)
 
   const currentTier = sorted[currentIndex]
+
+  useEffect(() => {
+    if (phase === 'session_complete') {
+      listDraws(raffleId).then(setAllDraws).catch(() => {})
+    }
+  }, [phase, raffleId])
 
   async function handleDraw() {
     if (!currentTier) return
@@ -156,6 +184,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
     try {
       const draw = await drawFromTier(raffleId, currentTier.id)
       setLatestDraw(draw)
+      setDrawnInCurrentTier(prev => prev + 1)
       setPhase('round_result')
     } catch {
       setError('抽獎失敗，請再試一次')
@@ -164,19 +193,26 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
   }
 
   function handleNext() {
+    if (drawnInCurrentTier < currentTier.winner_count) {
+      // 本輪尚未抽滿，留在當前 tier
+      setPhase('round_ready')
+      return
+    }
     const nextIndex = currentIndex + 1
     if (nextIndex >= sorted.length) {
       setPhase('session_complete')
     } else {
       setCurrentIndex(nextIndex)
+      setDrawnInCurrentTier(0)
       setPhase('round_ready')
     }
   }
 
   if (phase === 'session_complete') {
     return (
-      <div data-testid="session-complete" style={{ ...glass, padding: '24px 28px', textAlign: 'center' }}>
-        <p style={{ fontSize: 16, fontWeight: 700, color: '#86efac', marginBottom: 8 }}>🎉 所有輪次抽獎完成</p>
+      <div data-testid="session-complete" style={{ ...glass, padding: '24px 28px' }}>
+        <p style={{ fontSize: 16, fontWeight: 700, color: '#86efac', marginBottom: 16 }}>🎉 所有輪次抽獎完成</p>
+        <FinalWinnerList tiers={sorted} draws={allDraws} />
       </div>
     )
   }
@@ -184,6 +220,9 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
   if (!currentTier) return null
 
   const totalRounds = sorted.length
+  const tierComplete = drawnInCurrentTier >= currentTier.winner_count
+  const isLastTier = currentIndex + 1 >= totalRounds
+  const nextLabel = !tierComplete ? '繼續抽本輪' : isLastTier ? '完成抽獎' : '繼續下一輪'
 
   return (
     <div data-testid="raffle-draw-session" style={{ ...glass, padding: '20px 24px' }}>
@@ -198,7 +237,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
         {currentTier.prize_description}
       </p>
       <p style={{ fontSize: 11, color: 'rgba(148,210,255,.4)', marginBottom: 16 }}>
-        {currentTier.drawn_count} / {currentTier.winner_count} 人已抽出
+        {drawnInCurrentTier} / {currentTier.winner_count} 人已抽出
       </p>
 
       {phase === 'round_ready' && (
@@ -226,7 +265,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
             onClick={handleNext}
             style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 8, padding: '10px 24px', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
           >
-            {currentIndex + 1 >= totalRounds ? '完成抽獎' : '繼續下一輪'}
+            {nextLabel}
           </button>
         </div>
       )}
@@ -240,7 +279,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
 - [ ] **Step 4：確認測試通過**
 
 ```bash
-cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+pnpm --filter ./apps/dashboard exec vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
 ```
 
 預期：PASS（2 tests）。
@@ -397,7 +436,7 @@ beforeEach(() => {
 - [ ] **Step 2：確認測試通過**
 
 ```bash
-cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+pnpm --filter ./apps/dashboard exec vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
 ```
 
 預期：PASS（7 tests）。
@@ -462,7 +501,7 @@ import { RaffleDrawSession } from '@/components/raffle/RaffleDrawSession'
 - [ ] **Step 4：確認 TypeScript 無錯誤**
 
 ```bash
-cd apps/dashboard && npx tsc --noEmit
+pnpm --filter ./apps/dashboard exec tsc --noEmit
 ```
 
 預期：無錯誤。
@@ -513,7 +552,7 @@ describe('RaffleDrawSession 整合', () => {
 - [ ] **Step 6：跑全部 dashboard 測試**
 
 ```bash
-cd apps/dashboard && npx vitest run
+pnpm --filter ./apps/dashboard exec vitest run
 ```
 
 預期：全部 PASS，無新 failure。

--- a/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
+++ b/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
@@ -330,6 +330,44 @@ it('最後一輪結束後顯示完成畫面', async () => {
   expect(screen.getByTestId('session-complete')).toBeInTheDocument()
 })
 
+it('winner_count: 2 的輪次：第一次抽完按鈕顯示「繼續抽本輪」，第二次抽完才顯示完成', async () => {
+  const twoWinnerTier: RafflePrizeTier[] = [
+    { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 2, drawn_count: 0, position: 0, created_at: '' },
+  ]
+  const mockEntry = { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' }
+  vi.mocked(rafflesService.drawFromTier)
+    .mockResolvedValueOnce({
+      id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+      claim_token: '', claim_expires_at: '', drawn_at: '',
+      entry: mockEntry,
+      prize_tier_id: 't1',
+    } as any)
+    .mockResolvedValueOnce({
+      id: 'd2', raffle_id: 'r1', entry_id: 'e2',
+      claim_token: '', claim_expires_at: '', drawn_at: '',
+      entry: { ...mockEntry, id: 'e2', twitch_login: 'viewer2', display_name: 'Viewer Two' },
+      prize_tier_id: 't1',
+    } as any)
+
+  render(<RaffleDrawSession raffleId="r1" tiers={twoWinnerTier} />)
+
+  // 第一次抽
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+  await waitFor(() => expect(screen.getByTestId('next-round-button').textContent).toContain('繼續抽本輪'))
+
+  // 點「繼續抽本輪」→ 回到 round_ready
+  fireEvent.click(screen.getByTestId('next-round-button'))
+  await waitFor(() => expect(screen.getByTestId('draw-round-button')).not.toBeNull())
+
+  // 第二次抽
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+  await waitFor(() => expect(screen.getByTestId('next-round-button').textContent).toContain('完成抽獎'))
+
+  // 點「完成抽獎」→ session_complete
+  fireEvent.click(screen.getByTestId('next-round-button'))
+  expect(screen.getByTestId('session-complete')).not.toBeNull()
+})
+
 it('API 失敗時顯示錯誤訊息，回到 round_ready', async () => {
   vi.mocked(rafflesService.drawFromTier).mockRejectedValueOnce(new Error('network error'))
 
@@ -362,7 +400,7 @@ beforeEach(() => {
 cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
 ```
 
-預期：PASS（6 tests）。
+預期：PASS（7 tests）。
 
 - [ ] **Step 3：Commit**
 
@@ -405,18 +443,21 @@ import { RaffleDrawSession } from '@/components/raffle/RaffleDrawSession'
 
 不修改或刪除現有的 prize-tiers-section（draft 狀態仍需要管理 UI）。
 
-- [ ] **Step 3：在現有 prize-tiers-section 加 active 狀態隱藏**
+- [ ] **Step 3：將現有 prize-tiers-section 改為只在 draft 狀態顯示**
 
-找到 `data-testid="prize-tiers-section"` 外層 `<div>` 的開頭，將原本的顯示條件由：
+由於 Step 2 已讓 `RaffleDrawSession` 在 `active` 狀態顯示，原本只在 `active` 顯示的 prize-tiers-section（獎項層管理 UI）改為只在 `draft` 狀態顯示，避免兩個區塊同時出現。
+
+找到 `data-testid="prize-tiers-section"` 外層 `<div>` 的條件渲染，將：
+
 ```tsx
-{(effectiveStatus === 'active' || effectiveStatus === 'draft') && (
+{effectiveStatus === 'active' && (
 ```
-改為（若原本無條件顯示，則包上）：
+
+改為：
+
 ```tsx
 {effectiveStatus === 'draft' && (
 ```
-
-> 若原本就有條件包住整段，只改判斷式。若整段無條件渲染，則在外層加 `{effectiveStatus === 'draft' && ( ... )}`。
 
 - [ ] **Step 4：確認 TypeScript 無錯誤**
 

--- a/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
+++ b/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
@@ -1,0 +1,501 @@
+# Raffle Phase 2 — 逐輪抽獎模式 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 Dashboard 抽獎頁面新增逐輪模式，讓主播依 PrizeTier position 順序一輪一輪手動推進抽獎，每輪結束後展示得獎者，所有輪次結束後顯示完整名單。
+
+**Architecture:** 純前端工作，後端 cross-tier 排除已完整（`raffle_service.go:1264`）。新增 `RaffleDrawSession` 元件管理逐輪狀態機；`RaffleDetailPage` 在 raffle 狀態為 `active` 且有 PrizeTier 時，以 `RaffleDrawSession` 取代現有的逐顆「抽一人」按鈕區塊。
+
+**Tech Stack:** React 18, TypeScript, Vitest + Testing Library, inline styles（沿用 ocean 主題）
+
+---
+
+## 檔案結構
+
+| 動作 | 路徑 | 職責 |
+|---|---|---|
+| **新增** | `apps/dashboard/src/components/raffle/RaffleDrawSession.tsx` | 逐輪模式容器 + 子元件（TierRoundCard、DrawResultOverlay、FinalWinnerList） |
+| **新增** | `apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx` | 元件測試 |
+| **修改** | `apps/dashboard/src/services/raffles.ts` | 補 `position` 欄位至 `RafflePrizeTier` interface |
+| **修改** | `apps/dashboard/src/pages/RaffleDetailPage.tsx` | active 狀態下嵌入 `RaffleDrawSession` |
+
+---
+
+## Task 1：補 `RafflePrizeTier.position` 欄位
+
+後端 `raffle_prize_tiers` 表有 `position` 欄位但前端 interface 缺少，需先補上。
+
+**Files:**
+- Modify: `apps/dashboard/src/services/raffles.ts:35-43`
+
+- [ ] **Step 1：確認後端欄位存在**
+
+```bash
+grep "position" services/api/internal/models/raffle.go
+```
+
+預期輸出含：`Position int \`gorm:\"not null;default:0\" json:\"position\"\``
+
+- [ ] **Step 2：補 interface 欄位**
+
+在 `apps/dashboard/src/services/raffles.ts` 找到 `RafflePrizeTier` interface，加入 `position`:
+
+```ts
+export interface RafflePrizeTier {
+  id: string
+  raffle_id: string
+  name: string
+  prize_description: string
+  winner_count: number
+  drawn_count: number
+  position: number
+  created_at: string
+}
+```
+
+- [ ] **Step 3：TypeScript 確認無錯誤**
+
+```bash
+cd apps/dashboard && npx tsc --noEmit
+```
+
+預期：無錯誤輸出。
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add apps/dashboard/src/services/raffles.ts
+git commit -m "feat: add position field to RafflePrizeTier interface
+
+refs #234"
+```
+
+---
+
+## Task 2：建立 `RaffleDrawSession` — 初始狀態與 round_ready
+
+**Files:**
+- Create: `apps/dashboard/src/components/raffle/RaffleDrawSession.tsx`
+- Create: `apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx`
+
+- [ ] **Step 1：建立測試檔，寫第一個失敗測試**
+
+建立 `apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx`：
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RaffleDrawSession } from '../RaffleDrawSession'
+import type { RafflePrizeTier } from '@/services/raffles'
+
+const mockTiers: RafflePrizeTier[] = [
+  { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+  { id: 't2', raffle_id: 'r1', name: '二等獎', prize_description: 'AirPods', winner_count: 2, drawn_count: 0, position: 1, created_at: '' },
+]
+
+describe('RaffleDrawSession', () => {
+  it('顯示第一輪的獎項名稱與描述', () => {
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    expect(screen.getByTestId('current-tier-name')).toHaveTextContent('一等獎')
+    expect(screen.getByTestId('current-tier-description')).toHaveTextContent('Switch')
+    expect(screen.getByTestId('draw-round-button')).toBeInTheDocument()
+  })
+
+  it('顯示輪次進度（第 1 / 2 輪）', () => {
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    expect(screen.getByTestId('round-progress')).toHaveTextContent('第 1 / 2 輪')
+  })
+})
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+```
+
+預期：FAIL — `RaffleDrawSession` 不存在。
+
+- [ ] **Step 3：建立元件檔，實作 round_ready 初始狀態**
+
+建立 `apps/dashboard/src/components/raffle/RaffleDrawSession.tsx`：
+
+```tsx
+import { useState } from 'react'
+import type { RaffleDraw, RafflePrizeTier } from '@/services/raffles'
+import { drawFromTier } from '@/services/raffles'
+
+type SessionPhase = 'round_ready' | 'drawing' | 'round_result' | 'session_complete'
+
+interface Props {
+  raffleId: string
+  tiers: RafflePrizeTier[]
+}
+
+const glass: React.CSSProperties = {
+  background: 'rgba(4,14,52,.55)',
+  border: '1px solid rgba(80,160,255,.22)',
+  borderRadius: 14,
+  backdropFilter: 'blur(14px)',
+  WebkitBackdropFilter: 'blur(14px)',
+}
+
+export function RaffleDrawSession({ raffleId, tiers }: Props) {
+  const sorted = [...tiers].sort((a, b) => a.position - b.position)
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [phase, setPhase] = useState<SessionPhase>('round_ready')
+  const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentTier = sorted[currentIndex]
+
+  async function handleDraw() {
+    if (!currentTier) return
+    setPhase('drawing')
+    setError(null)
+    try {
+      const draw = await drawFromTier(raffleId, currentTier.id)
+      setLatestDraw(draw)
+      setPhase('round_result')
+    } catch {
+      setError('抽獎失敗，請再試一次')
+      setPhase('round_ready')
+    }
+  }
+
+  function handleNext() {
+    const nextIndex = currentIndex + 1
+    if (nextIndex >= sorted.length) {
+      setPhase('session_complete')
+    } else {
+      setCurrentIndex(nextIndex)
+      setPhase('round_ready')
+    }
+  }
+
+  if (phase === 'session_complete') {
+    return (
+      <div data-testid="session-complete" style={{ ...glass, padding: '24px 28px', textAlign: 'center' }}>
+        <p style={{ fontSize: 16, fontWeight: 700, color: '#86efac', marginBottom: 8 }}>🎉 所有輪次抽獎完成</p>
+      </div>
+    )
+  }
+
+  if (!currentTier) return null
+
+  const totalRounds = sorted.length
+
+  return (
+    <div data-testid="raffle-draw-session" style={{ ...glass, padding: '20px 24px' }}>
+      <p data-testid="round-progress" style={{ fontSize: 11, color: 'rgba(148,210,255,.5)', marginBottom: 12 }}>
+        第 {currentIndex + 1} / {totalRounds} 輪
+      </p>
+
+      <p data-testid="current-tier-name" style={{ fontSize: 20, fontWeight: 800, color: '#e0f2fe', marginBottom: 4 }}>
+        {currentTier.name}
+      </p>
+      <p data-testid="current-tier-description" style={{ fontSize: 13, color: 'rgba(148,210,255,.6)', marginBottom: 16 }}>
+        {currentTier.prize_description}
+      </p>
+      <p style={{ fontSize: 11, color: 'rgba(148,210,255,.4)', marginBottom: 16 }}>
+        {currentTier.drawn_count} / {currentTier.winner_count} 人已抽出
+      </p>
+
+      {phase === 'round_ready' && (
+        <button
+          data-testid="draw-round-button"
+          onClick={() => { void handleDraw() }}
+          style={{ background: 'rgba(14,165,233,.2)', border: '1px solid rgba(14,165,233,.4)', color: '#38bdf8', borderRadius: 8, padding: '10px 28px', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}
+        >
+          抽這一輪
+        </button>
+      )}
+
+      {phase === 'drawing' && (
+        <p data-testid="drawing-indicator" style={{ fontSize: 14, color: '#7dd3fc' }}>抽獎中...</p>
+      )}
+
+      {phase === 'round_result' && latestDraw && (
+        <div data-testid="round-result">
+          <p style={{ fontSize: 13, color: 'rgba(148,210,255,.5)', marginBottom: 6 }}>得獎者</p>
+          <p data-testid="winner-name" style={{ fontSize: 24, fontWeight: 800, color: '#fde68a', marginBottom: 20 }}>
+            {latestDraw.entry.display_name || latestDraw.entry.twitch_login}
+          </p>
+          <button
+            data-testid="next-round-button"
+            onClick={handleNext}
+            style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 8, padding: '10px 24px', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
+          >
+            {currentIndex + 1 >= totalRounds ? '完成抽獎' : '繼續下一輪'}
+          </button>
+        </div>
+      )}
+
+      {error && <p style={{ fontSize: 12, color: '#f87171', marginTop: 10 }}>{error}</p>}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4：確認測試通過**
+
+```bash
+cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+```
+
+預期：PASS（2 tests）。
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add apps/dashboard/src/components/raffle/RaffleDrawSession.tsx \
+        apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+git commit -m "feat: add RaffleDrawSession round_ready state
+
+refs #234"
+```
+
+---
+
+## Task 3：測試抽獎流程與輪次推進
+
+**Files:**
+- Modify: `apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx`
+
+- [ ] **Step 1：補充測試 — 抽獎成功顯示得獎者，以及繼續下一輪**
+
+在測試檔 `describe` 區塊內補充：
+
+```tsx
+import { fireEvent, waitFor } from '@testing-library/react'
+
+// 在 describe 頂層加入 mock
+vi.mock('@/services/raffles', () => ({
+  drawFromTier: vi.fn(),
+}))
+
+import * as rafflesService from '@/services/raffles'
+
+// 在 describe 內加入：
+it('按下「抽這一輪」後顯示得獎者名稱', async () => {
+  vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+    id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+    claim_token: '', claim_expires_at: '', drawn_at: '',
+    entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+    prize_tier_id: 't1',
+  } as any)
+
+  render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+
+  await waitFor(() => {
+    expect(screen.getByTestId('winner-name')).toHaveTextContent('Viewer One')
+  })
+  expect(screen.getByTestId('next-round-button')).toHaveTextContent('繼續下一輪')
+})
+
+it('按下「繼續下一輪」後推進到第二輪', async () => {
+  vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+    id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+    claim_token: '', claim_expires_at: '', drawn_at: '',
+    entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+    prize_tier_id: 't1',
+  } as any)
+
+  render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+  await waitFor(() => screen.getByTestId('next-round-button'))
+  fireEvent.click(screen.getByTestId('next-round-button'))
+
+  expect(screen.getByTestId('current-tier-name')).toHaveTextContent('二等獎')
+  expect(screen.getByTestId('round-progress')).toHaveTextContent('第 2 / 2 輪')
+})
+
+it('最後一輪結束後顯示完成畫面', async () => {
+  const singleTier: RafflePrizeTier[] = [
+    { id: 't1', raffle_id: 'r1', name: '唯一獎', prize_description: '', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+  ]
+  vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+    id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+    claim_token: '', claim_expires_at: '', drawn_at: '',
+    entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'winner', display_name: 'Winner', created_at: '' },
+    prize_tier_id: 't1',
+  } as any)
+
+  render(<RaffleDrawSession raffleId="r1" tiers={singleTier} />)
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+  await waitFor(() => screen.getByTestId('next-round-button'))
+  fireEvent.click(screen.getByTestId('next-round-button'))
+
+  expect(screen.getByTestId('session-complete')).toBeInTheDocument()
+})
+
+it('API 失敗時顯示錯誤訊息，回到 round_ready', async () => {
+  vi.mocked(rafflesService.drawFromTier).mockRejectedValueOnce(new Error('network error'))
+
+  render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+  fireEvent.click(screen.getByTestId('draw-round-button'))
+
+  await waitFor(() => {
+    expect(screen.getByTestId('draw-round-button')).toBeInTheDocument()
+    expect(screen.getByText('抽獎失敗，請再試一次')).toBeInTheDocument()
+  })
+})
+```
+
+注意：需在測試檔最頂層（import 之後，describe 之前）加上：
+```tsx
+vi.mock('@/services/raffles', () => ({
+  drawFromTier: vi.fn(),
+}))
+```
+並在 `beforeEach` 中加：
+```tsx
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+```
+
+- [ ] **Step 2：確認測試通過**
+
+```bash
+cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+```
+
+預期：PASS（6 tests）。
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+git commit -m "test: add RaffleDrawSession draw flow and round progression tests
+
+refs #234"
+```
+
+---
+
+## Task 4：整合進 `RaffleDetailPage`
+
+active 狀態且有 PrizeTier 時，以 `RaffleDrawSession` 取代現有「逐顆抽」按鈕區塊。
+
+**Files:**
+- Modify: `apps/dashboard/src/pages/RaffleDetailPage.tsx`
+- Modify: `apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx`
+
+- [ ] **Step 1：在 `RaffleDetailPage.tsx` import `RaffleDrawSession`**
+
+在檔案頂部 import 區加入：
+
+```tsx
+import { RaffleDrawSession } from '@/components/raffle/RaffleDrawSession'
+```
+
+- [ ] **Step 2：找到 prize-tiers-section，加入條件渲染**
+
+找到 `data-testid="prize-tiers-section"` 的 `<div>`（約第 1044 行），在其**前方**插入：
+
+```tsx
+{effectiveStatus === 'active' && tiers.length > 0 && (
+  <div style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
+    <RaffleDrawSession raffleId={raffleId ?? ''} tiers={tiers} />
+  </div>
+)}
+```
+
+不修改或刪除現有的 prize-tiers-section（draft 狀態仍需要管理 UI）。
+
+- [ ] **Step 3：在現有 prize-tiers-section 加 active 狀態隱藏**
+
+找到 `data-testid="prize-tiers-section"` 外層 `<div>` 的開頭，將原本的顯示條件由：
+```tsx
+{(effectiveStatus === 'active' || effectiveStatus === 'draft') && (
+```
+改為（若原本無條件顯示，則包上）：
+```tsx
+{effectiveStatus === 'draft' && (
+```
+
+> 若原本就有條件包住整段，只改判斷式。若整段無條件渲染，則在外層加 `{effectiveStatus === 'draft' && ( ... )}`。
+
+- [ ] **Step 4：確認 TypeScript 無錯誤**
+
+```bash
+cd apps/dashboard && npx tsc --noEmit
+```
+
+預期：無錯誤。
+
+- [ ] **Step 5：在 `RaffleDetailPage.test.tsx` 補整合測試**
+
+在測試檔找到現有 import 的 mock 區塊，確認 `@/services/raffles` mock 中包含 `drawFromTier: vi.fn()`。若無，補上。
+
+在測試檔末尾加入：
+
+```tsx
+describe('RaffleDrawSession 整合', () => {
+  it('raffle active 且有 tiers 時顯示 RaffleDrawSession', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([
+      { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+    ])
+
+    render(
+      <RaffleDetailPage />,
+      { wrapper: createRefineWrapper({ raffle: { ...mockRaffle, status: 'active' } }) }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('raffle-draw-session')).toBeInTheDocument()
+    })
+  })
+
+  it('raffle draft 時不顯示 RaffleDrawSession', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([
+      { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: '', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+    ])
+
+    render(
+      <RaffleDetailPage />,
+      { wrapper: createRefineWrapper({ raffle: { ...mockRaffle, status: 'draft' } }) }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('prize-tiers-section')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('raffle-draw-session')).not.toBeInTheDocument()
+  })
+})
+```
+
+> 若測試檔的 `createRefineWrapper` 或 mock raffle shape 與上方不符，請依照測試檔現有 pattern 調整 — 重點是 `status: 'active'` vs `status: 'draft'` 的渲染差異。
+
+- [ ] **Step 6：跑全部 dashboard 測試**
+
+```bash
+cd apps/dashboard && npx vitest run
+```
+
+預期：全部 PASS，無新 failure。
+
+- [ ] **Step 7：Commit**
+
+```bash
+git add apps/dashboard/src/pages/RaffleDetailPage.tsx \
+        apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+git commit -m "feat: integrate RaffleDrawSession into RaffleDetailPage for active state
+
+refs #234"
+```
+
+---
+
+## 驗證 Checklist
+
+完成所有 Task 後，手動確認：
+
+- [ ] 建立含 3 個 PrizeTier 的 Raffle（位置 0/1/2），啟動後進入逐輪模式
+- [ ] 第一輪顯示 position=0 的獎項，按「抽這一輪」出現得獎者
+- [ ] 按「繼續下一輪」，第二輪正確顯示 position=1 的獎項
+- [ ] 所有輪次抽完後顯示「所有輪次抽獎完成」
+- [ ] draft 狀態下仍能新增 / 刪除 PrizeTier（管理 UI 不受影響）
+- [ ] 同一人不可能在兩輪都得獎（後端保證）

--- a/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
+++ b/docs/superpowers/plans/2026-06-04-raffle-phase2-draw-session.md
@@ -67,7 +67,7 @@ cd apps/dashboard && npx tsc --noEmit
 git add apps/dashboard/src/services/raffles.ts
 git commit -m "feat: add position field to RafflePrizeTier interface
 
-refs #234"
+refs #1043"
 ```
 
 ---
@@ -252,7 +252,7 @@ git add apps/dashboard/src/components/raffle/RaffleDrawSession.tsx \
         apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
 git commit -m "feat: add RaffleDrawSession round_ready state
 
-refs #234"
+refs #1043"
 ```
 
 ---
@@ -370,7 +370,7 @@ cd apps/dashboard && npx vitest run src/components/raffle/__tests__/RaffleDrawSe
 git add apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
 git commit -m "test: add RaffleDrawSession draw flow and round progression tests
 
-refs #234"
+refs #1043"
 ```
 
 ---
@@ -484,7 +484,7 @@ git add apps/dashboard/src/pages/RaffleDetailPage.tsx \
         apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
 git commit -m "feat: integrate RaffleDrawSession into RaffleDetailPage for active state
 
-refs #234"
+refs #1043"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-06-04-raffle-phase2-draw-session-design.md
+++ b/docs/superpowers/specs/2026-06-04-raffle-phase2-draw-session-design.md
@@ -1,7 +1,7 @@
 # Raffle Phase 2 — 逐輪抽獎模式 設計文件
 
 **日期**：2026-06-04
-**關聯 issue**：[#234](https://github.com/nurockplayer/tachigo/issues/234)
+**關聯 issue**：原始討論 [#234](https://github.com/nurockplayer/tachigo/issues/234)（已收斂為本設計，Campaign 層不另行實作）；實作追蹤 [#1043](https://github.com/nurockplayer/tachigo/issues/1043)
 **狀態**：待實作
 
 ---

--- a/docs/superpowers/specs/2026-06-04-raffle-phase2-draw-session-design.md
+++ b/docs/superpowers/specs/2026-06-04-raffle-phase2-draw-session-design.md
@@ -1,0 +1,94 @@
+# Raffle Phase 2 — 逐輪抽獎模式 設計文件
+
+**日期**：2026-06-04
+**關聯 issue**：[#234](https://github.com/nurockplayer/tachigo/issues/234)
+**狀態**：待實作
+
+---
+
+## 背景
+
+Phase 1 已完整實作抽獎系統核心：`Raffle` → `RafflePrizeTier` → `RaffleDraw`。其中 `DrawFromTierContext` 已實作 cross-tier 排除（`raffle_service.go:1264`），不同獎項層之間得獎者不重複。
+
+Issue #234 提出 Campaign 多場抽獎層設計，但確認需求後，Phase 2 的核心場景為：
+
+> 同一場直播中，主播依序從多個獎項層抽獎，每輪抽完後暫停展示得獎者，確認後再手動推進到下一輪。
+
+由於後端資料層已完整支援此場景，Phase 2 為**純前端 UX 工作**，不新增資料表、不新增 API 端點。
+
+---
+
+## 不做
+
+- Campaign 資料表與 API
+- 每輪不同報名資格 / 不同名單（留待 Phase 3 視需求決定）
+- 自動進輪（每輪結束後系統自動觸發下一輪）
+- 主播自由選輪次順序（固定依 `position` 排序）
+
+---
+
+## 設計
+
+### 輪次順序
+
+`RafflePrizeTier` 依 `position` 欄位升序排列，由小到大依序抽。主播在活動建立時設定 position，開播後固定順序。
+
+### 狀態機
+
+```
+[idle]
+  ↓ Raffle 狀態為 active，PrizeTiers 存在
+[round_ready]  ── 顯示當前 tier 名稱、獎項說明、本輪名額
+  ↓ 主播按「抽這一輪」→ 呼叫 drawFromTier API
+[drawing]  ── loading 狀態
+  ↓ API 回傳成功
+[round_result]  ── 展示得獎者名稱；若本輪 winner_count > 1，可繼續抽同輪
+  ↓ 本輪 drawn_count === winner_count，主播按「繼續下一輪」
+[round_ready]  ── 移至下一個 tier
+  ↓ 所有 tier 的 drawn_count === winner_count
+[session_complete]  ── 顯示完整得獎名單
+```
+
+### 前端元件
+
+| 元件 | 職責 |
+|---|---|
+| `RaffleDrawSession` | 逐輪模式容器；持有 `currentTierIndex` state；協調狀態機轉換 |
+| `TierRoundCard` | 顯示當前 tier 資訊（名稱、獎項說明、已抽 N / 共 M 名）與「抽這一輪」按鈕 |
+| `DrawResultOverlay` | 得獎者展示層（名字 + 既有 ocean 主題動畫）；「繼續下一輪」按鈕 |
+| `FinalWinnerList` | session_complete 狀態的完整得獎名單，依輪次分組 |
+
+### 與現有元件的關係
+
+- `RaffleDrawSession` 嵌入現有 `RaffleDetailPage`，取代現有的單次抽獎按鈕區塊（當 PrizeTiers 存在時顯示）
+- `drawFromTier` service function（`apps/dashboard/src/services/raffles.ts`）直接複用，不新增
+- Ocean 主題動畫元件複用現有實作（`RaffleDetailPage.tsx` 中已有 keyframes）
+
+### API 使用
+
+不新增端點，全部使用現有：
+
+```
+POST /api/v1/dashboard/raffles/:id/tiers/:tier_id/draw   ← drawFromTier
+GET  /api/v1/dashboard/raffles/:id/tiers                 ← listPrizeTiers（取得 tiers + drawn_count）
+GET  /api/v1/dashboard/raffles/:id/draws                 ← listDraws（session_complete 時取完整名單）
+```
+
+---
+
+## 完成條件
+
+- [ ] 所有 PrizeTier 依 position 順序逐輪顯示
+- [ ] 每輪按鈕觸發 `drawFromTier`，顯示得獎者名稱
+- [ ] 同一輪 winner_count > 1 時，可在同一輪繼續抽足名額再進下一輪
+- [ ] 所有輪次抽完後顯示完整得獎名單
+- [ ] 重複得獎不可能發生（由後端 cross-tier 排除保證，前端無需額外處理）
+- [ ] 既有非 PrizeTier 的單次抽獎流程不受影響
+
+---
+
+## 驗證方式
+
+1. 建立含 3 個 PrizeTier 的 Raffle（一等獎 × 1、二等獎 × 2、三等獎 × 3）
+2. 走完完整抽獎流程，確認共 6 名不重複得獎者
+3. 確認各輪得獎者姓名正確顯示於 `FinalWinnerList`

--- a/docs/superpowers/specs/2026-06-04-raffle-phase2-draw-session-design.md
+++ b/docs/superpowers/specs/2026-06-04-raffle-phase2-draw-session-design.md
@@ -35,7 +35,7 @@ Issue #234 提出 Campaign 多場抽獎層設計，但確認需求後，Phase 2 
 
 ### 狀態機
 
-```
+```text
 [idle]
   ↓ Raffle 狀態為 active，PrizeTiers 存在
 [round_ready]  ── 顯示當前 tier 名稱、獎項說明、本輪名額
@@ -68,7 +68,7 @@ Issue #234 提出 Campaign 多場抽獎層設計，但確認需求後，Phase 2 
 
 不新增端點，全部使用現有：
 
-```
+```text
 POST /api/v1/dashboard/raffles/:id/tiers/:tier_id/draw   ← drawFromTier
 GET  /api/v1/dashboard/raffles/:id/tiers                 ← listPrizeTiers（取得 tiers + drawn_count）
 GET  /api/v1/dashboard/raffles/:id/draws                 ← listDraws（session_complete 時取完整名單）


### PR DESCRIPTION
## 什麼改動
新增 Raffle Phase 2「逐輪抽獎模式（RaffleDrawSession）」的設計文件與實作計畫，並把原本掛在 #234 的設計決策，改為對齊到新的實作追蹤票 #1043。

## 為什麼
這兩份文件原本標記 `refs #234`，但 #234 是 `[discussion]` 票，內容是「Campaign 多場抽獎層」且明確寫「不做決策、不實作」，跟這兩份文件描述的「同場直播依序逐輪抽獎」是不同主題。已開新票 #1043「[frontend] Raffle Phase 2 — 逐輪抽獎模式（RaffleDrawSession）」作為實作 source of truth，本 PR 把文件 retag 過去，並在設計文件的「關聯 issue」欄位同時保留 #234 的歷史脈絡（討論已收斂）與 #1043 的實作追蹤連結。

refs #1043

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [x] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#1043
- Depends on PR: none
- Backend contract already in develop:
  - [ ] yes
  - [ ] no
  - n/a — 純文件 PR，不涉及任何程式碼或 API 變更
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Campaign 資料表與 API
  - 每輪不同報名資格 / 不同名單（留待 Phase 3 視需求決定）
  - 自動進輪（每輪結束後系統自動觸發下一輪）
  - 主播自由選輪次順序（固定依 `position` 排序）

## OpenSpec SDD
- OpenSpec change：
  - n/a，原因：沿用既有 `docs/superpowers/specs|plans/` 格式（這兩份文件早於 OpenSpec SDD 流程建立），轉換為 `openspec/changes/` 格式列為獨立 follow-up，非本 PR scope
- Proposal / design / tasks reviewed：
  - [ ] yes
  - [ ] no
  - [x] n/a，原因：同上，沿用既有格式，OpenSpec 轉換為獨立 follow-up
- Delta specs included or updated：
  - [ ] yes
  - [ ] no
  - [x] n/a，原因：同上
- Acceptance Criteria 對齊 `tasks.md`：
  - [ ] yes
  - [ ] no
  - [x] n/a，原因：同上，純文件無對應 tasks.md
- Archive / sync status：
  - n/a，原因：同上

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- n/a — 非 Codex autonomous PR

## Review conversation closeout
- n/a — 非 autonomous PR

## Final merge gate
- n/a — 非 autonomous PR

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 新增 RaffleDrawSession 設計與實作計畫文件，並對齊到 issue #1043
- Approx changed lines：~595（595 insertions, 0 deletions，純新增文件 + 5 行 issue 參照更新）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a（只勾選 docs 一項）
- 若已拆分，相關 PR：
  - 拆分自原計畫；程式碼實作見另一個 PR（`feat/raffle-draw-session-1043`，closes #1043）

## Acceptance Criteria
- n/a — 純文件 PR，無對應功能性 AC；功能 AC 對齊在程式碼實作 PR（closes #1043）

## 超出範圍內容
無

## 測試方式
- [ ] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```
n/a — 純文件變更，無測試
```

## 備註
原本這兩份文件以 `refs #234` 提交於 `feat/raffle-mode-dashboard-990`（該分支因混入兩個不相關 issue 的改動、diff 過大已被 scope police 擋下，原 PR #1034 已關閉）。本 PR 是從最新 `develop` 重新 cherry-pick 並 retag 到 #1043 的結果，原分支保留未刪除。

## Notes for Claude Code Review
- 文件內容本身（設計/狀態機/元件規劃）沒有變動，只調整了「關聯 issue」欄位與 4 處範例 commit message 裡的 issue 編號（#234 → #1043）
- 設計文件的「不做」段落已同步列在本 PR body 的「本 PR 明確不做」


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在抽奖第二阶段加入「逐轮抽奖」体验方案：按阶层位置依序逐轮推进，包含从准备到结果展示，再到同轮继续/进入下一轮，直至完成的完整流程。

* **文档**
  * 新增抽奖第二阶段（Raffle Phase 2）逐轮抽奖模式的实现计划文档。
  * 新增抽奖第二阶段（Raffle Phase 2）的前端 UX/状态机设计文档，补充组件划分、流程与验证步骤。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->