### PR TITLE
[frontend] Raffle Phase 2 — RaffleDrawSession 逐輪抽獎模式

### DIFF
--- a/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
+++ b/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import type { RaffleDraw, RafflePrizeTier } from '@/services/raffles'
+import { drawFromTier } from '@/services/raffles'
+
+type SessionPhase = 'round_ready' | 'drawing' | 'round_result' | 'session_complete'
+
+interface Props {
+  raffleId: string
+  tiers: RafflePrizeTier[]
+}
+
+const glass: React.CSSProperties = {
+  background: 'rgba(4,14,52,.55)',
+  border: '1px solid rgba(80,160,255,.22)',
+  borderRadius: 14,
+  backdropFilter: 'blur(14px)',
+  WebkitBackdropFilter: 'blur(14px)',
+}
+
+export function RaffleDrawSession({ raffleId, tiers }: Props) {
+  const sorted = [...tiers].sort((a, b) => a.position - b.position)
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [phase, setPhase] = useState<SessionPhase>('round_ready')
+  const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentTier = sorted[currentIndex]
+
+  async function handleDraw() {
+    if (!currentTier) return
+    setPhase('drawing')
+    setError(null)
+    try {
+      const draw = await drawFromTier(raffleId, currentTier.id)
+      setLatestDraw(draw)
+      setPhase('round_result')
+    } catch {
+      setError('抽獎失敗，請再試一次')
+      setPhase('round_ready')
+    }
+  }
+
+  function handleNext() {
+    const nextIndex = currentIndex + 1
+    if (nextIndex >= sorted.length) {
+      setPhase('session_complete')
+    } else {
+      setCurrentIndex(nextIndex)
+      setPhase('round_ready')
+    }
+  }
+
+  if (phase === 'session_complete') {
+    return (
+      <div data-testid="session-complete" style={{ ...glass, padding: '24px 28px', textAlign: 'center' }}>
+        <p style={{ fontSize: 16, fontWeight: 700, color: '#86efac', marginBottom: 8 }}>🎉 所有輪次抽獎完成</p>
+      </div>
+    )
+  }
+
+  if (!currentTier) return null
+
+  const totalRounds = sorted.length
+
+  return (
+    <div data-testid="raffle-draw-session" style={{ ...glass, padding: '20px 24px' }}>
+      <p data-testid="round-progress" style={{ fontSize: 11, color: 'rgba(148,210,255,.5)', marginBottom: 12 }}>
+        第 {currentIndex + 1} / {totalRounds} 輪
+      </p>
+
+      <p data-testid="current-tier-name" style={{ fontSize: 20, fontWeight: 800, color: '#e0f2fe', marginBottom: 4 }}>
+        {currentTier.name}
+      </p>
+      <p data-testid="current-tier-description" style={{ fontSize: 13, color: 'rgba(148,210,255,.6)', marginBottom: 16 }}>
+        {currentTier.prize_description}
+      </p>
+      <p style={{ fontSize: 11, color: 'rgba(148,210,255,.4)', marginBottom: 16 }}>
+        {currentTier.drawn_count} / {currentTier.winner_count} 人已抽出
+      </p>
+
+      {phase === 'round_ready' && (
+        <button
+          data-testid="draw-round-button"
+          onClick={() => { void handleDraw() }}
+          style={{ background: 'rgba(14,165,233,.2)', border: '1px solid rgba(14,165,233,.4)', color: '#38bdf8', borderRadius: 8, padding: '10px 28px', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}
+        >
+          抽這一輪
+        </button>
+      )}
+
+      {phase === 'drawing' && (
+        <p data-testid="drawing-indicator" style={{ fontSize: 14, color: '#7dd3fc' }}>抽獎中...</p>
+      )}
+
+      {phase === 'round_result' && latestDraw && (
+        <div data-testid="round-result">
+          <p style={{ fontSize: 13, color: 'rgba(148,210,255,.5)', marginBottom: 6 }}>得獎者</p>
+          <p data-testid="winner-name" style={{ fontSize: 24, fontWeight: 800, color: '#fde68a', marginBottom: 20 }}>
+            {latestDraw.entry.display_name || latestDraw.entry.twitch_login}
+          </p>
+          <button
+            data-testid="next-round-button"
+            onClick={handleNext}
+            style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 8, padding: '10px 24px', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
+          >
+            {currentIndex + 1 >= totalRounds ? '完成抽獎' : '繼續下一輪'}
+          </button>
+        </div>
+      )}
+
+      {error && <p style={{ fontSize: 12, color: '#f87171', marginTop: 10 }}>{error}</p>}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
+++ b/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
@@ -22,6 +22,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [phase, setPhase] = useState<SessionPhase>('round_ready')
   const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
+  const [localDrawnCounts, setLocalDrawnCounts] = useState<Record<string, number>>({})
   const [error, setError] = useState<string | null>(null)
 
   const currentTier = sorted[currentIndex]
@@ -33,6 +34,10 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
     try {
       const draw = await drawFromTier(raffleId, currentTier.id)
       setLatestDraw(draw)
+      setLocalDrawnCounts(prev => ({
+        ...prev,
+        [currentTier.id]: (prev[currentTier.id] ?? 0) + 1,
+      }))
       setPhase('round_result')
     } catch {
       setError('抽獎失敗，請再試一次')
@@ -41,6 +46,12 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
   }
 
   function handleNext() {
+    const localDrawn = localDrawnCounts[currentTier.id] ?? 0
+    const needed = currentTier.winner_count
+    if (localDrawn < needed) {
+      setPhase('round_ready')
+      return
+    }
     const nextIndex = currentIndex + 1
     if (nextIndex >= sorted.length) {
       setPhase('session_complete')
@@ -75,7 +86,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
         {currentTier.prize_description}
       </p>
       <p style={{ fontSize: 11, color: 'rgba(148,210,255,.4)', marginBottom: 16 }}>
-        {currentTier.drawn_count} / {currentTier.winner_count} 人已抽出
+        {(localDrawnCounts[currentTier.id] ?? currentTier.drawn_count)} / {currentTier.winner_count} 人已抽出
       </p>
 
       {phase === 'round_ready' && (
@@ -103,7 +114,12 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
             onClick={handleNext}
             style={{ background: 'rgba(34,197,94,.15)', border: '1px solid rgba(34,197,94,.3)', color: '#4ade80', borderRadius: 8, padding: '10px 24px', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
           >
-            {currentIndex + 1 >= totalRounds ? '完成抽獎' : '繼續下一輪'}
+            {(() => {
+              const localDrawn = localDrawnCounts[currentTier.id] ?? 0
+              if (localDrawn < currentTier.winner_count) return '繼續抽本輪'
+              if (currentIndex + 1 >= totalRounds) return '完成抽獎'
+              return '繼續下一輪'
+            })()}
           </button>
         </div>
       )}

--- a/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
+++ b/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { RaffleDraw, RafflePrizeTier } from '@/services/raffles'
 import { drawFromTier } from '@/services/raffles'
 
@@ -18,7 +18,7 @@ const glass: React.CSSProperties = {
 }
 
 export function RaffleDrawSession({ raffleId, tiers }: Props) {
-  const sorted = [...tiers].sort((a, b) => a.position - b.position)
+  const sorted = useMemo(() => [...tiers].sort((a, b) => a.position - b.position), [tiers])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [phase, setPhase] = useState<SessionPhase>('round_ready')
   const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
@@ -28,7 +28,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
   const currentTier = sorted[currentIndex]
 
   async function handleDraw() {
-    if (!currentTier) return
+    if (!currentTier || phase === 'drawing') return
     setPhase('drawing')
     setError(null)
     try {
@@ -48,7 +48,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
   function handleNext() {
     const localDrawn = localDrawnCounts[currentTier.id] ?? 0
     const needed = currentTier.winner_count
-    if (localDrawn < needed) {
+    if (localDrawn + currentTier.drawn_count < needed) {
       setPhase('round_ready')
       return
     }
@@ -86,7 +86,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
         {currentTier.prize_description}
       </p>
       <p style={{ fontSize: 11, color: 'rgba(148,210,255,.4)', marginBottom: 16 }}>
-        {(localDrawnCounts[currentTier.id] ?? currentTier.drawn_count)} / {currentTier.winner_count} 人已抽出
+        {(localDrawnCounts[currentTier.id] ?? 0) + currentTier.drawn_count} / {currentTier.winner_count} 人已抽出
       </p>
 
       {phase === 'round_ready' && (
@@ -116,7 +116,7 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
           >
             {(() => {
               const localDrawn = localDrawnCounts[currentTier.id] ?? 0
-              if (localDrawn < currentTier.winner_count) return '繼續抽本輪'
+              if (localDrawn + currentTier.drawn_count < currentTier.winner_count) return '繼續抽本輪'
               if (currentIndex + 1 >= totalRounds) return '完成抽獎'
               return '繼續下一輪'
             })()}

--- a/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
+++ b/apps/dashboard/src/components/raffle/RaffleDrawSession.tsx
@@ -19,8 +19,12 @@ const glass: React.CSSProperties = {
 
 export function RaffleDrawSession({ raffleId, tiers }: Props) {
   const sorted = useMemo(() => [...tiers].sort((a, b) => a.position - b.position), [tiers])
-  const [currentIndex, setCurrentIndex] = useState(0)
-  const [phase, setPhase] = useState<SessionPhase>('round_ready')
+  const firstPendingIndex = useMemo(
+    () => sorted.findIndex(t => t.drawn_count < t.winner_count),
+    [sorted],
+  )
+  const [currentIndex, setCurrentIndex] = useState(firstPendingIndex === -1 ? 0 : firstPendingIndex)
+  const [phase, setPhase] = useState<SessionPhase>(firstPendingIndex === -1 ? 'session_complete' : 'round_ready')
   const [latestDraw, setLatestDraw] = useState<RaffleDraw | null>(null)
   const [localDrawnCounts, setLocalDrawnCounts] = useState<Record<string, number>>({})
   const [error, setError] = useState<string | null>(null)
@@ -52,7 +56,13 @@ export function RaffleDrawSession({ raffleId, tiers }: Props) {
       setPhase('round_ready')
       return
     }
-    const nextIndex = currentIndex + 1
+    let nextIndex = currentIndex + 1
+    while (
+      nextIndex < sorted.length &&
+      sorted[nextIndex].drawn_count + (localDrawnCounts[sorted[nextIndex].id] ?? 0) >= sorted[nextIndex].winner_count
+    ) {
+      nextIndex += 1
+    }
     if (nextIndex >= sorted.length) {
       setPhase('session_complete')
     } else {

--- a/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+++ b/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RaffleDrawSession } from '../RaffleDrawSession'
+import type { RafflePrizeTier } from '@/services/raffles'
+
+vi.mock('@/services/raffles', () => ({
+  drawFromTier: vi.fn(),
+}))
+
+const mockTiers: RafflePrizeTier[] = [
+  { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+  { id: 't2', raffle_id: 'r1', name: '二等獎', prize_description: 'AirPods', winner_count: 2, drawn_count: 0, position: 1, created_at: '' },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('RaffleDrawSession', () => {
+  it('顯示第一輪的獎項名稱與描述', () => {
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    expect(screen.getByTestId('current-tier-name').textContent).toContain('一等獎')
+    expect(screen.getByTestId('current-tier-description').textContent).toContain('Switch')
+    expect(screen.getByTestId('draw-round-button')).not.toBeNull()
+  })
+
+  it('顯示輪次進度（第 1 / 2 輪）', () => {
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    expect(screen.getByTestId('round-progress').textContent).toContain('第 1 / 2 輪')
+  })
+})

--- a/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+++ b/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
@@ -36,9 +36,9 @@ describe('RaffleDrawSession', () => {
       claim_token: '', claim_expires_at: '', drawn_at: '',
       entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
       prize_tier_id: 't1',
-    } as any)
+    })
 
-    const { container: _container } = render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
     fireEvent.click(screen.getByTestId('draw-round-button'))
 
     await waitFor(() => {
@@ -54,7 +54,7 @@ describe('RaffleDrawSession', () => {
       claim_token: '', claim_expires_at: '', drawn_at: '',
       entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
       prize_tier_id: 't1',
-    } as any)
+    })
 
     render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
     fireEvent.click(screen.getByTestId('draw-round-button'))
@@ -74,7 +74,7 @@ describe('RaffleDrawSession', () => {
       claim_token: '', claim_expires_at: '', drawn_at: '',
       entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'winner', display_name: 'Winner', created_at: '' },
       prize_tier_id: 't1',
-    } as any)
+    })
 
     render(<RaffleDrawSession raffleId="r1" tiers={singleTier} />)
     fireEvent.click(screen.getByTestId('draw-round-button'))
@@ -95,13 +95,13 @@ describe('RaffleDrawSession', () => {
         claim_token: '', claim_expires_at: '', drawn_at: '',
         entry: mockEntry,
         prize_tier_id: 't1',
-      } as any)
+      })
       .mockResolvedValueOnce({
         id: 'd2', raffle_id: 'r1', entry_id: 'e2',
         claim_token: '', claim_expires_at: '', drawn_at: '',
         entry: { ...mockEntry, id: 'e2', twitch_login: 'viewer2', display_name: 'Viewer Two' },
         prize_tier_id: 't1',
-      } as any)
+      })
 
     render(<RaffleDrawSession raffleId="r1" tiers={twoWinnerTier} />)
 

--- a/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+++ b/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { RaffleDrawSession } from '../RaffleDrawSession'
 import type { RafflePrizeTier } from '@/services/raffles'
+import * as rafflesService from '@/services/raffles'
 
 vi.mock('@/services/raffles', () => ({
   drawFromTier: vi.fn(),
@@ -27,5 +28,71 @@ describe('RaffleDrawSession', () => {
   it('顯示輪次進度（第 1 / 2 輪）', () => {
     render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
     expect(screen.getByTestId('round-progress').textContent).toContain('第 1 / 2 輪')
+  })
+
+  it('按下「抽這一輪」後顯示得獎者名稱', async () => {
+    vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+      id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+      claim_token: '', claim_expires_at: '', drawn_at: '',
+      entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+      prize_tier_id: 't1',
+    } as any)
+
+    const { container: _container } = render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('winner-name')).not.toBeNull()
+      expect(screen.getByTestId('winner-name').textContent).toContain('Viewer One')
+    })
+    expect(screen.getByTestId('next-round-button').textContent).toContain('繼續下一輪')
+  })
+
+  it('按下「繼續下一輪」後推進到第二輪', async () => {
+    vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+      id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+      claim_token: '', claim_expires_at: '', drawn_at: '',
+      entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' },
+      prize_tier_id: 't1',
+    } as any)
+
+    render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+    await waitFor(() => screen.getByTestId('next-round-button'))
+    fireEvent.click(screen.getByTestId('next-round-button'))
+
+    expect(screen.getByTestId('current-tier-name').textContent).toContain('二等獎')
+    expect(screen.getByTestId('round-progress').textContent).toContain('第 2 / 2 輪')
+  })
+
+  it('最後一輪結束後顯示完成畫面', async () => {
+    const singleTier: RafflePrizeTier[] = [
+      { id: 't1', raffle_id: 'r1', name: '唯一獎', prize_description: '', winner_count: 1, drawn_count: 0, position: 0, created_at: '' },
+    ]
+    vi.mocked(rafflesService.drawFromTier).mockResolvedValueOnce({
+      id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+      claim_token: '', claim_expires_at: '', drawn_at: '',
+      entry: { id: 'e1', raffle_id: 'r1', twitch_login: 'winner', display_name: 'Winner', created_at: '' },
+      prize_tier_id: 't1',
+    } as any)
+
+    render(<RaffleDrawSession raffleId="r1" tiers={singleTier} />)
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+    await waitFor(() => screen.getByTestId('next-round-button'))
+    fireEvent.click(screen.getByTestId('next-round-button'))
+
+    expect(screen.getByTestId('session-complete')).not.toBeNull()
+  })
+
+  it('API 失敗時顯示錯誤訊息，回到 round_ready', async () => {
+    vi.mocked(rafflesService.drawFromTier).mockRejectedValueOnce(new Error('network error'))
+
+    const { container } = render(<RaffleDrawSession raffleId="r1" tiers={mockTiers} />)
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('draw-round-button')).not.toBeNull()
+      expect(container.textContent).toContain('抽獎失敗，請再試一次')
+    })
   })
 })

--- a/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
+++ b/apps/dashboard/src/components/raffle/__tests__/RaffleDrawSession.test.tsx
@@ -78,9 +78,47 @@ describe('RaffleDrawSession', () => {
 
     render(<RaffleDrawSession raffleId="r1" tiers={singleTier} />)
     fireEvent.click(screen.getByTestId('draw-round-button'))
-    await waitFor(() => screen.getByTestId('next-round-button'))
+    await waitFor(() => expect(screen.getByTestId('next-round-button').textContent).toContain('完成抽獎'))
     fireEvent.click(screen.getByTestId('next-round-button'))
 
+    expect(screen.getByTestId('session-complete')).not.toBeNull()
+  })
+
+  it('winner_count: 2 的輪次：第一次抽完按鈕顯示「繼續抽本輪」，第二次抽完才顯示完成', async () => {
+    const twoWinnerTier: RafflePrizeTier[] = [
+      { id: 't1', raffle_id: 'r1', name: '一等獎', prize_description: 'Switch', winner_count: 2, drawn_count: 0, position: 0, created_at: '' },
+    ]
+    const mockEntry = { id: 'e1', raffle_id: 'r1', twitch_login: 'viewer1', display_name: 'Viewer One', created_at: '' }
+    vi.mocked(rafflesService.drawFromTier)
+      .mockResolvedValueOnce({
+        id: 'd1', raffle_id: 'r1', entry_id: 'e1',
+        claim_token: '', claim_expires_at: '', drawn_at: '',
+        entry: mockEntry,
+        prize_tier_id: 't1',
+      } as any)
+      .mockResolvedValueOnce({
+        id: 'd2', raffle_id: 'r1', entry_id: 'e2',
+        claim_token: '', claim_expires_at: '', drawn_at: '',
+        entry: { ...mockEntry, id: 'e2', twitch_login: 'viewer2', display_name: 'Viewer Two' },
+        prize_tier_id: 't1',
+      } as any)
+
+    render(<RaffleDrawSession raffleId="r1" tiers={twoWinnerTier} />)
+
+    // 第一次抽
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+    await waitFor(() => expect(screen.getByTestId('next-round-button').textContent).toContain('繼續抽本輪'))
+
+    // 點「繼續抽本輪」→ 回到 round_ready
+    fireEvent.click(screen.getByTestId('next-round-button'))
+    await waitFor(() => expect(screen.getByTestId('draw-round-button')).not.toBeNull())
+
+    // 第二次抽
+    fireEvent.click(screen.getByTestId('draw-round-button'))
+    await waitFor(() => expect(screen.getByTestId('next-round-button').textContent).toContain('完成抽獎'))
+
+    // 點「完成抽獎」→ session_complete
+    fireEvent.click(screen.getByTestId('next-round-button'))
     expect(screen.getByTestId('session-complete')).not.toBeNull()
   })
 

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -1132,17 +1132,19 @@ export default function RaffleDetailPage() {
 
           <DiscordWebhookPanel raffleId={raffle.id} />
 
-          <DrawControls
-            status={effectiveStatus}
-            exhausted={exhausted || remaining === 0}
-            drawing={drawing}
-            confirmEnd={confirmEnd}
-            ending={ending}
-            onDraw={() => { void handleDraw() }}
-            onRequestEnd={() => setConfirmEnd(true)}
-            onConfirmEnd={() => { void handleConfirmEnd() }}
-            onCancelEnd={() => setConfirmEnd(false)}
-          />
+          {!(effectiveStatus === 'active' && tiers.length > 0) && (
+            <DrawControls
+              status={effectiveStatus}
+              exhausted={exhausted || remaining === 0}
+              drawing={drawing}
+              confirmEnd={confirmEnd}
+              ending={ending}
+              onDraw={() => { void handleDraw() }}
+              onRequestEnd={() => setConfirmEnd(true)}
+              onConfirmEnd={() => { void handleConfirmEnd() }}
+              onCancelEnd={() => setConfirmEnd(false)}
+            />
+          )}
         </div>
       </details>
 
@@ -1188,21 +1190,23 @@ export default function RaffleDetailPage() {
             modalPrize={modalPrize}
             onCloseModal={() => { setModalWinner(null); setModalPrize(null) }}
           />
-          <button
-            data-testid="draw-btn"
-            disabled={effectiveStatus === 'completed' || exhausted || remaining === 0 || drawing}
-            onClick={() => { void handleDraw() }}
-            style={{
-              padding: '13px 60px', borderRadius: 50, border: 'none',
-              background: 'linear-gradient(90deg,#0ea5e9,#2563eb)',
-              color: '#e0f2fe', fontSize: 'clamp(15px,2.2vw,20px)', fontWeight: 900,
-              letterSpacing: '.12em', cursor: 'pointer',
-              boxShadow: '0 0 35px rgba(14,165,233,.75),0 0 70px rgba(14,165,233,.2),0 4px 16px rgba(0,0,0,.5)',
-              opacity: (effectiveStatus === 'completed' || exhausted || remaining === 0 || drawing) ? .5 : 1,
-            }}
-          >
-            {drawing ? '抽獎中...' : '開始抽獎'}
-          </button>
+          {!(effectiveStatus === 'active' && tiers.length > 0) && (
+            <button
+              data-testid="draw-btn"
+              disabled={effectiveStatus === 'completed' || exhausted || remaining === 0 || drawing}
+              onClick={() => { void handleDraw() }}
+              style={{
+                padding: '13px 60px', borderRadius: 50, border: 'none',
+                background: 'linear-gradient(90deg,#0ea5e9,#2563eb)',
+                color: '#e0f2fe', fontSize: 'clamp(15px,2.2vw,20px)', fontWeight: 900,
+                letterSpacing: '.12em', cursor: 'pointer',
+                boxShadow: '0 0 35px rgba(14,165,233,.75),0 0 70px rgba(14,165,233,.2),0 4px 16px rgba(0,0,0,.5)',
+                opacity: (effectiveStatus === 'completed' || exhausted || remaining === 0 || drawing) ? .5 : 1,
+              }}
+            >
+              {drawing ? '抽獎中...' : '開始抽獎'}
+            </button>
+          )}
           <div style={{ fontSize: 11, color: 'rgba(148,210,255,.5)', textAlign: 'center' }}>
             將從參加者中隨機抽出一位幸運觀眾！
           </div>

--- a/apps/dashboard/src/pages/RaffleDetailPage.tsx
+++ b/apps/dashboard/src/pages/RaffleDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useOne } from '@refinedev/core'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
+import { RaffleDrawSession } from '@/components/raffle/RaffleDrawSession'
 import { Skeleton } from '@/components/ui/skeleton'
 import { apiBaseURL } from '@/services/api'
 import { activateRaffle, completeRaffle, createPrizeTier, deletePrizeTier, drawFromTier, drawNext, getRaffleEntryStats, importCSV, listDraws, listPrizeTiers, setDiscordWebhook, setRaffleEntryOpen, setRaffleMode } from '@/services/raffles'
@@ -1221,8 +1222,15 @@ export default function RaffleDetailPage() {
         </div>
       </div>
 
-      {/* Prize Tiers */}
-      {effectiveStatus === 'active' && (
+      {/* Draw Session (active only) */}
+      {effectiveStatus === 'active' && tiers.length > 0 && (
+        <div style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
+          <RaffleDrawSession raffleId={raffleId ?? ''} tiers={tiers} />
+        </div>
+      )}
+
+      {/* Prize Tiers (draft only) */}
+      {effectiveStatus === 'draft' && (
         <div data-testid="prize-tiers-section" style={{ maxWidth: 1300, margin: '0 auto 2rem', padding: '0 16px' }}>
           <div style={{ ...glassStyle, padding: '16px 20px' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -861,6 +861,8 @@ describe('RaffleDetailPage — RaffleDrawSession integration', () => {
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="raffle-draw-session"]')).not.toBeNull())
     expect(container.querySelector('[data-testid="prize-tiers-section"]')).toBeNull()
+    expect(container.querySelector('[data-testid="draw-btn"]')).toBeNull()
+    expect(container.querySelector('[data-testid="mgmt-draw-btn"]')).toBeNull()
     cleanup(root, container)
   })
 

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -62,6 +62,7 @@ const mockPrizeTier: rafflesService.RafflePrizeTier = {
   prize_description: 'Switch 主機',
   winner_count: 2,
   drawn_count: 0,
+  position: 0,
   created_at: '2026-01-01T00:00:00Z',
 }
 async function renderAt(raffleId: string, dp: ReturnType<typeof createMockDataProvider>) {

--- a/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/RaffleDetailPage.test.tsx
@@ -193,24 +193,36 @@ describe('RaffleDetailPage — winner list', () => {
   })
 })
 
+const draftRaffle = { ...mockRaffle, status: 'draft' as const }
+
 describe('RaffleDetailPage — prize tiers', () => {
-  it('hides prize tiers while raffle is still draft', async () => {
+  it('shows prize-tiers-section in draft state', async () => {
     const dp = createMockDataProvider({
       getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
-    expect(container.querySelector('[data-testid="prize-tiers-section"]')).toBeFalsy()
+    expect(container.querySelector('[data-testid="prize-tiers-section"]')).not.toBeNull()
     cleanup(root, container)
   })
 
-  it('shows active raffle prize tiers and disables completed tiers', async () => {
+  it('hides prize-tiers-section in active state', async () => {
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.textContent).toContain('春季抽獎'))
+    expect(container.querySelector('[data-testid="prize-tiers-section"]')).toBeNull()
+    cleanup(root, container)
+  })
+
+  it('shows draft raffle prize tiers and disables completed tiers', async () => {
     vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([
       mockPrizeTier,
       { ...mockPrizeTier, id: 't2', name: '二等獎', winner_count: 1, drawn_count: 1 },
     ])
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-row-t1"]')).toBeTruthy())
@@ -220,9 +232,9 @@ describe('RaffleDetailPage — prize tiers', () => {
     cleanup(root, container)
   })
 
-  it('creates a prize tier from the active raffle panel', async () => {
+  it('creates a prize tier from the draft raffle panel', async () => {
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-toggle"]')).toBeTruthy())
@@ -257,7 +269,7 @@ describe('RaffleDetailPage — prize tiers', () => {
 
   it('does not create a prize tier when winner count is empty', async () => {
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-toggle"]')).toBeTruthy())
@@ -290,7 +302,7 @@ describe('RaffleDetailPage — prize tiers', () => {
   it('draws and deletes prize tiers through tier actions', async () => {
     vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([mockPrizeTier])
     const dp = createMockDataProvider({
-      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
     })
     const { container, root } = await renderAt('r1', dp)
     await waitFor(() => expect(container.querySelector('[data-testid="prize-tier-draw-t1"]')).toBeTruthy())
@@ -309,8 +321,6 @@ describe('RaffleDetailPage — prize tiers', () => {
     cleanup(root, container)
   })
 })
-
-const draftRaffle = { ...mockRaffle, status: 'draft' as const }
 
 describe('RaffleDetailPage — CSV upload', () => {
   it('shows success message after upload', async () => {
@@ -837,6 +847,30 @@ describe('RaffleDetailPage functional layer', () => {
     })
     await waitFor(() => expect(entryToggle.disabled).toBe(false))
 
+    cleanup(root, container)
+  })
+})
+
+describe('RaffleDetailPage — RaffleDrawSession integration', () => {
+  it('shows raffle-draw-session when status is active and tiers exist', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([mockPrizeTier])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(mockRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="raffle-draw-session"]')).not.toBeNull())
+    expect(container.querySelector('[data-testid="prize-tiers-section"]')).toBeNull()
+    cleanup(root, container)
+  })
+
+  it('shows prize-tiers-section and no raffle-draw-session when status is draft and tiers exist', async () => {
+    vi.mocked(rafflesService.listPrizeTiers).mockResolvedValue([mockPrizeTier])
+    const dp = createMockDataProvider({
+      getOne: { raffles: vi.fn().mockResolvedValue(draftRaffle as BaseRecord) },
+    })
+    const { container, root } = await renderAt('r1', dp)
+    await waitFor(() => expect(container.querySelector('[data-testid="prize-tiers-section"]')).not.toBeNull())
+    expect(container.querySelector('[data-testid="raffle-draw-session"]')).toBeNull()
     cleanup(root, container)
   })
 })

--- a/apps/dashboard/src/services/raffles.ts
+++ b/apps/dashboard/src/services/raffles.ts
@@ -39,6 +39,7 @@ export interface RafflePrizeTier {
   prize_description: string
   winner_count: number
   drawn_count: number
+  position: number
   created_at: string
 }
 

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -14,5 +14,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    globals: true,
   },
 })


### PR DESCRIPTION
## 什麼改動
新增 `RaffleDrawSession` 元件，實作 Raffle Phase 2「逐輪抽獎模式」：依 `position` 排序逐一顯示 PrizeTier，按鈕呼叫既有 `drawFromTier` API 抽獎並顯示得獎者；同一輪 `winner_count > 1` 時可連續抽到額滿才進下一輪；並整合進 `RaffleDetailPage`（`active` 狀態且有 PrizeTiers 時顯示 RaffleDrawSession，原本只在 `active` 顯示的「Prize Tiers」設定區塊改為僅在 `draft` 顯示）。

## 為什麼
closes #1043

設計文件與實作計畫見另一個 PR（#1044，`docs/raffle-draw-session-1043-design`）。原始 7 個 commit 因混入不相關 issue #990 的改動、整體 diff 達 1269 行被 scope police 擋下；#990 部分已透過 PR #1038 merge 進 develop。本 PR 是把剩餘的 5 個 RaffleDrawSession 實作 commit，從最新 develop 重新 cherry-pick、把 `refs #234`（主題不符的 discussion 票）改標為 `refs #1043` / `closes #1043`，並處理與已 merge PR #1038 的整合後的結果。

## Release Context
- Release type：n/a

## Workflow Type
- [x] Small / Medium
- [ ] Test-Driven / Debug Loop
- [ ] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [x] R2 frontend behavior
- [ ] R3 backend / API behavior
- [ ] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#1043
- Depends on PR: none
- Backend contract already in develop:
  - [x] yes
  - [ ] no
  （未新增或修改任何 API endpoint，沿用既有 `drawFromTier`、`listPrizeTiers`、`listDraws`）
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - Campaign 資料表與 API
  - 每輪不同報名資格 / 不同名單（留待 Phase 3 視需求決定）
  - 自動進輪（每輪結束後系統自動觸發下一輪）
  - 主播自由選輪次順序（固定依 `position` 排序）

## OpenSpec SDD
- OpenSpec change：
  - n/a，原因：設計文件沿用既有 `docs/superpowers/specs|plans/` 格式（見 PR #1044），轉換為 `openspec/changes/` 格式列為獨立 follow-up，非本 PR scope
- Proposal / design / tasks reviewed：
  - [ ] yes
  - [ ] no
  - [x] n/a，原因：同上
- Delta specs included or updated：
  - [ ] yes
  - [ ] no
  - [x] n/a，原因：同上
- Acceptance Criteria 對齊 `tasks.md`：
  - [ ] yes
  - [ ] no
  - [x] n/a，原因：同上，沿用 issue #1043「完成條件」作為本 PR 的 Acceptance Criteria
- Archive / sync status：
  - n/a，原因：同上

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- n/a — 非 Codex autonomous PR

## Review conversation closeout
- n/a — 非 autonomous PR

## Final merge gate
- n/a — 非 autonomous PR

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - 實作 RaffleDrawSession 逐輪抽獎元件並整合進 RaffleDetailPage（closes #1043）
- Approx changed lines：~335（323 insertions, 12 deletions；`git diff --stat origin/develop...HEAD`）
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
  - [x] frontend integration
  - [x] tests
  - [ ] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - frontend integration 與其對應測試是同一個行為變更（RaffleDrawSession 元件本體 + 整合進 RaffleDetailPage + 兩者的測試），拆開會讓任一半都無法獨立驗證。另含 `apps/dashboard/vitest.config.ts` 新增 `globals: true,`（1 行），屬於本次測試所需的設定調整，符合 CLAUDE.md「Trivial 附帶修」（< 10 行、直接關聯本 PR scope）。
- 若已拆分，相關 PR：
  - 設計文件見 #1044（`docs/raffle-draw-session-1043-design`）

## Acceptance Criteria
對齊 issue #1043「完成條件」：
- [x] 所有 PrizeTier 依 position 順序逐輪顯示
- [x] 每輪按鈕觸發 `drawFromTier`，顯示得獎者名稱
- [x] 同一輪 `winner_count > 1` 時，可在同一輪繼續抽足名額再進下一輪
- [ ] 所有輪次抽完後顯示完整得獎名單 — 目前 `session_complete` 階段只顯示「🎉 所有輪次抽獎完成」提示文字，未列出各輪得獎者明細（設計文件中的 `FinalWinnerList` 元件未實作）。詳見「超出範圍內容」。
- [x] 重複得獎不可能發生（由後端 cross-tier 排除保證，前端無額外處理）
- [x] 既有非 PrizeTier 的單次抽獎流程不受影響（`draft` 狀態維持原「Prize Tiers」設定區塊，既有測試已更新並通過）

## 超出範圍內容
- issue #1043「完成條件」中的「所有輪次抽完後顯示完整得獎名單」未實作：`session_complete` 階段僅顯示完成提示文字，未依輪次列出得獎者明細。這是被重建的原始 commit 本身就未涵蓋的部分，建議另開小型 follow-up issue/PR 補上 `FinalWinnerList`（可用既有 `listDraws` API 取得完整名單，不需新增後端 API）。
- `apps/dashboard/vitest.config.ts` 新增 `globals: true,`（1 行）：本次 RaffleDrawSession 測試需要的 vitest 設定調整，視為 trivial 附帶修，已隨本 PR commit。

## 測試方式
- [x] 本地測試過
- [x] 有寫 / 更新測試

**驗證結果**
```
$ npx vitest run
 Test Files  18 passed (18)
      Tests  146 passed (146)

$ npx tsc -b --noEmit
（無輸出，type check 乾淨）
```

## 備註
- 本 PR 的 5 個 commit 原本存在於 `feat/raffle-mode-dashboard-990`（origin 上保留未刪除），原本標 `refs #234`（discussion 票、主題為不相關的 Campaign 多場抽獎層，與本 PR 內容不符），現已從最新 `develop` 重新 cherry-pick 到 `feat/raffle-draw-session-1043`，並改標 `refs #1043` / `closes #1043`，保留原作者與原時間戳記。
- cherry-pick 過程中 `RaffleDetailPage.tsx` 與其測試檔與已 merge 的 PR #1038（模式切換 / 報名統計面板）自動合併成功，無衝突；PR #1038 既有邏輯（`controlReauthRequired` / `statsReauthRequired`、`modeChanging` / `entryOpenChanging` guard 等）與本 PR 的 RaffleDrawSession 整合並存，互不影響。

## Notes for Claude Code Review
- 請特別注意 Acceptance Criteria 中「完整得獎名單」未實作的落差，已在「超出範圍內容」說明；這是原始 commit 本身的範圍，非本次 cherry-pick 新增的縮減，建議確認是否需要立即補上或開 follow-up issue。
- `RaffleDetailPage.tsx` 的「Prize Tiers」設定區塊顯示條件由 `active` 改為 `draft`（原 commit 3882ef5 設計即如此：`active` 顯示 RaffleDrawSession，`draft` 顯示 Prize Tiers 設定），對應測試已同步更新。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增分轮抽奖会话功能，支持按顺序逐轮进行抽奖。
  * 抽奖过程中实时显示获奖者信息、轮次进度和错误提示。

* **改进**
  * 活跃状态下显示抽奖会话模块；草稿状态下显示奖项编辑面板。

* **测试**
  * 添加分轮抽奖及页面集成的完整测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->