### PR TITLE
[infra] archive OpenSpec SDD workflow

### DIFF
--- a/openspec/changes/introduce-openspec-sdd-workflow/.openspec.yaml
+++ b/openspec/changes/introduce-openspec-sdd-workflow/.openspec.yaml
@@ -1,3 +1,8 @@
 schema: spec-driven
 issue: "https://github.com/nurockplayer/tachigo/issues/1039"
-status: proposed
+status: archived
+accepted_pr: "https://github.com/nurockplayer/tachigo/pull/1040"
+merged_at: "2026-06-15T12:51:29Z"
+archived_at: "2026-06-18"
+living_specs:
+  - openspec/specs/workflow/spec.md

--- a/openspec/changes/introduce-openspec-sdd-workflow/archive.md
+++ b/openspec/changes/introduce-openspec-sdd-workflow/archive.md
@@ -1,0 +1,13 @@
+# Archive Evidence
+
+- Source issue: <https://github.com/nurockplayer/tachigo/issues/1039>
+- Accepted PR: <https://github.com/nurockplayer/tachigo/pull/1040>
+- Merge commit: `bb5c2ae3c25a851b0d7670fc43f3ee2a1b802bd6`
+- Living spec: `openspec/specs/workflow/spec.md`
+
+## Verification
+
+- PR #1040 merged into `develop` on 2026-06-15.
+- PR #1040 completed the OpenSpec SDD workflow docs, scaffold, agent instructions, PR template fields, docs indexes, and CI regression coverage.
+- Review threads for PR #1040 are resolved.
+- Required checks for PR #1040 passed before merge.

--- a/openspec/specs/workflow/spec.md
+++ b/openspec/specs/workflow/spec.md
@@ -1,0 +1,21 @@
+# Workflow Spec
+
+## Requirements
+
+### Requirement: Feature work uses OpenSpec artifacts
+
+New feature or behavior-change implementation MUST use an OpenSpec change as the proposal, specs, design, and tasks source of truth unless the PR documents an explicit exception.
+
+#### Scenario: Agent starts feature implementation
+- Given a GitHub source issue exists
+- When an agent starts implementation
+- Then the agent references `openspec/changes/<change-id>/` artifacts before editing runtime code
+
+### Requirement: OpenSpec complements existing gates
+
+OpenSpec MUST NOT replace spec-injector local-only gates, PR Scope Police, or human review.
+
+#### Scenario: Autonomous PR uses OpenSpec
+- Given an autonomous PR has an OpenSpec change
+- When the PR reaches commit or merge gate
+- Then the PR still follows `spec workflow-check` evidence requirements when applicable


### PR DESCRIPTION
## 什麼改動
- 將已合併的 `introduce-openspec-sdd-workflow` change 標記為 archived。
- 新增 `openspec/specs/workflow/spec.md`，把已採納的 OpenSpec workflow delta sync 成 living spec。
- 新增 `archive.md`，保留 #1040 merge、issue、living spec 與驗證證據。

## 為什麼
- closes #1039
- #1040 已導入 OpenSpec SDD workflow 並合併，但 PR body 記錄 archive / sync 狀態為 merge 後處理。
- `docs/ai/openspec-workflow.md` 要求 change 完成且 PR merge 後，將採納的 delta specs sync 到 `openspec/specs/` 並保留 archive evidence。

## Release Context
- Release type：n/a

## Workflow Type
- [ ] Small / Medium
- [ ] Test-Driven / Debug Loop
- [x] Architecture / High Risk

## PR Risk Class
- [ ] R0 docs / template / metadata only
- [ ] R1 tests / CI / tooling only
- [ ] R2 frontend behavior
- [ ] R3 backend / API behavior
- [x] R4 auth / permissions / security / schema / migration / secrets / payments / wallet / workflow / release

## Scope 對齊
- Source of truth：#1039；`openspec/changes/introduce-openspec-sdd-workflow/`；#1040 post-merge archive requirement
- Depends on PR：#1040
- Backend contract already in develop:
  - [x] yes
  - [ ] no
- If no, this PR is:
  - [ ] stacked on dependency branch
  - [ ] intentionally blocked until dependency merges
- 本 PR 是否完全在 source of truth 範圍內？
  - [x] 是
  - [ ] 否，已另開 issue / PR 處理超出部分
- 本 PR 明確不做：
  - 不安裝 OpenSpec CLI
  - 不新增 dependency / lockfile
  - 不修改 runtime product behavior
  - 不改 spec-injector 或 PR gate 行為

## OpenSpec SDD
- OpenSpec change：
  - `openspec/changes/introduce-openspec-sdd-workflow/`
- Proposal / design / tasks reviewed：
  - [x] yes
  - [ ] no
  - [ ] n/a，原因：
- Delta specs included or updated：
  - [x] yes
  - [ ] no
  - [ ] n/a，原因：
- Acceptance Criteria 對齊 `tasks.md`：
  - [ ] yes
  - [ ] no
  - [x] n/a，原因：archive-only follow-up；#1040 的 `tasks.md` 已完成並含 Verification Evidence，本 PR 只執行 merge 後 archive / sync。
- Archive / sync status：
  - synced to `openspec/specs/workflow/spec.md`；archive evidence at `openspec/changes/introduce-openspec-sdd-workflow/archive.md`。

## Delegation Execution Log（非 Codex autonomous PR 可略過）
- Source issue delegation plan：
  - #1039；依 DeepSeek-first delegation，使用 DeepSeek 做 merged PR / issue completion 與 archive patch first-pass audit。
- Actual worker profile(s)：
  - controller / deepseek_worker
- Model strength：
  - controller = high；deepseek_worker = low-cost read-only analysis
- Spawn directive(s)：
  - profile=deepseek_worker model=deepseek-v4-flash reasoning=low controller_fallback=denied fallback_reason=n/a task=PR #1040 completion audit and OpenSpec archive plan
- Verification evidence：
  - `node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts`：104/104 passed
  - `git diff --check`：pass
- Self-review / exception reason：
  - 已完成 self-review；DeepSeek 輸出僅作線索，controller 已用本機檔案與 GitHub metadata 驗證。
- Worker session closeout：
  - DeepSeek read-only output 已讀回；未採用其 hallucinated 檔名，採用已驗證的 repo 路徑。
- Workflow friction / follow-up split：
  - #1040 merge 後 archive / sync 是 OpenSpec workflow 的收尾動作；本 PR 將收尾獨立成小型 follow-up，避免修改已合併 PR。

## Review conversation closeout
- Unresolved threads：
  - 0
- CodeRabbit：
  - `coderabbit review --agent --base origin/develop -c AGENTS.md`：0 issues
- chatgpt-codex-connector：
  - n/a（initial PR）
- review_triage_ref：
  - n/a（非 autonomous PR）
- root_cause_gate_ref：
  - n/a（非 autonomous PR）
- finding_disposition_ref：
  - n/a（非 autonomous PR）
- Final reviewer action：
  - ready for human review；CodeRabbit 0 issues，無 unresolved review threads

## Final merge gate
- Ready-to-merge decision：
  - blocked by human review；CI / Scope Police pass，CodeRabbit 0 issues，R4 workflow archive PR 不使用 auto-ready
- Latest head SHA：
  - 0cdce3e86d30129e4fa688a60c9affa5089aae03
- Required checks：
  - pass：Scope police、Workflow regression tests、Supply-chain guardrails、TypeScript-only guardrail、Commit message regression tests、PR metadata check regression tests、PR commit messages、Backend CI gate
- spec workflow-check evidence：
  - n/a（非 spec-injector autonomous PR；OpenSpec archive evidence 位於 `openspec/changes/introduce-openspec-sdd-workflow/archive.md`）
- Evidence URL：
  - https://github.com/nurockplayer/tachigo/pull/1047

## PR 拆分檢查
- 這個 PR 的單一句子目的：
  - Archive #1039 的 OpenSpec SDD change，並將已採納 workflow requirements sync 到 living specs。
- Approx changed lines：~40
- 本 PR 是否可獨立 review，不需要理解未合併的其他 PR？
  - [x] 是
  - [ ] 否，原因：
- 本 PR 是否同時包含以下多個層級？
  - [ ] migration / schema
  - [ ] backend domain service
  - [ ] API handler / router
    - [ ] 已執行 `swag init` 並將 `services/api/docs/` 變更一起 commit
  - [ ] frontend integration
  - [ ] tests
  - [x] docs
  - [ ] refactor / cleanup
- 若勾選兩項以上，為什麼這些變更需要放在同一個 PR？
  - n/a
- 若已拆分，相關 PR：
  - #1040 introduced the workflow；this PR archives/syncs it after merge。

## Acceptance Criteria
- [x] AC 1：將 `openspec/changes/introduce-openspec-sdd-workflow/.openspec.yaml` 標記為 archived，並記錄 accepted PR / merged timestamp / living spec path。
- [x] AC 2：新增 `openspec/specs/workflow/spec.md` 作為已採納 OpenSpec workflow living spec。
- [x] AC 3：新增 `archive.md`，保留 #1039、#1040、merge commit、living spec 與驗證證據。

## 超出範圍內容
無

## 測試方式
- [x] 本地測試過
- [ ] 有寫 / 更新測試

**驗證結果**
```text
node --experimental-strip-types --no-warnings --test .github/workflows/ci.test.ts
pass: 104/104

git diff --check
pass
```

## 備註
此 PR 不使用 `auto-ready`，因為它屬於 R4 workflow policy / OpenSpec archive 收尾，需要 human review。

## Notes for Claude Code Review
- 請確認 living spec 只包含已採納行為，沒有把 proposal/design/task 細節直接搬入 `openspec/specs/`。
- 請確認 archive evidence 足以關閉 #1039，且沒有導入 OpenSpec CLI 或 dependency。
